### PR TITLE
Adds /dataset route to dataserver

### DIFF
--- a/data_server/main.py
+++ b/data_server/main.py
@@ -28,8 +28,11 @@ def get_metadata():
         return 'Internal server error: {}'.format(err), 500
 
     def generate_response(data: bytes):
+        next_row = b'['
         for row in data.splitlines():
-            yield row + b'\n'
+            yield next_row
+            next_row = row + b','
+        yield next_row.rstrip(b',') + b']'
     headers = Headers()
     headers.add('Content-Disposition', 'attachment',
                 filename=os.environ.get('METADATA_FILENAME'))
@@ -51,8 +54,11 @@ def get_dataset():
         return 'Dataset {} not found'.format(dataset_name), 404
 
     def generate_response(data: bytes):
+        next_row = b'['
         for row in dataset.splitlines():
-            yield row + b'\n'
+            yield next_row
+            next_row = row + b','
+        yield next_row.rstrip(b',') + b']'
     headers = Headers()
     headers.add('Content-Disposition', 'attachment', filename=dataset_name)
     headers.add('Access-Control-Allow-Origin', '*')

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -62,7 +62,7 @@ def get_dataset():
     headers = Headers()
     headers.add('Content-Disposition', 'attachment', filename=dataset_name)
     headers.add('Access-Control-Allow-Origin', '*')
-    headers.add('Vary', 'Origin')
+    headers.add('Vary', 'Accept-Encoding, Origin')
     return Response(generate_response(dataset), mimetype='application/json',
                     headers=headers)
 

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -55,6 +55,8 @@ def get_dataset():
             yield row + b'\n'
     headers = Headers()
     headers.add('Content-Disposition', 'attachment', filename=dataset_name)
+    headers.add('Access-Control-Allow-Origin', '*')
+    headers.add('Vary', 'Origin')
     return Response(generate_response(dataset), mimetype='application/json',
                     headers=headers)
 

--- a/data_server/test_data_server.py
+++ b/data_server/test_data_server.py
@@ -67,7 +67,7 @@ def testGetMetadata(mock_func: mock.MagicMock, client: FlaskClient):
     try:
         json.loads(response.data)
     except json.decoder.JSONDecodeError as err:
-        pytest.fail(err)
+        pytest.fail(err.msg)
 
 
 @mock.patch('data_server.gcs_utils.download_blob_as_bytes',
@@ -107,7 +107,7 @@ def testGetDataset_DataExists(mock_func: mock.MagicMock, client: FlaskClient):
     try:
         json.loads(response.data)
     except json.decoder.JSONDecodeError as err:
-        pytest.fail(err)
+        pytest.fail(err.msg)
 
 
 @mock.patch('data_server.gcs_utils.download_blob_as_bytes',

--- a/data_server/test_data_server.py
+++ b/data_server/test_data_server.py
@@ -1,3 +1,4 @@
+import json
 import os
 from unittest import mock
 
@@ -11,14 +12,21 @@ from main import app, cache
 os.environ['GCS_BUCKET'] = 'test'
 os.environ['METADATA_FILENAME'] = 'test_data.ndjson'
 
-test_data = b"""
-{"label1":"value1","label2":["value2a","value2b","value2c"],"label3":"value3"}
-{"label1":"value2","label2":["value3a","value2b","value2c"],"label3":"value6"}
-{"label1":"value3","label2":["value4a","value2b","value2c"],"label3":"value9"}
-{"label1":"value4","label2":["value5a","value2b","value2c"],"label3":"value12"}
-{"label1":"value5","label2":["value6a","value2b","value2c"],"label3":"value15"}
-{"label1":"value6","label2":["value7a","value2b","value2c"],"label3":"value18"}
-"""
+test_data = (
+    b'{"label1":"value1","label2":["value2a","value2b"],"label3":"value3"}\n'
+    b'{"label1":"value2","label2":["value3a","value2b"],"label3":"value6"}\n'
+    b'{"label1":"value3","label2":["value4a","value2b"],"label3":"value9"}\n'
+    b'{"label1":"value4","label2":["value5a","value2b"],"label3":"value12"}\n'
+    b'{"label1":"value5","label2":["value6a","value2b"],"label3":"value15"}\n'
+    b'{"label1":"value6","label2":["value7a","value2b"],"label3":"value18"}\n')
+
+test_data_json = (
+    b'[{"label1":"value1","label2":["value2a","value2b"],"label3":"value3"},'
+    b'{"label1":"value2","label2":["value3a","value2b"],"label3":"value6"},'
+    b'{"label1":"value3","label2":["value4a","value2b"],"label3":"value9"},'
+    b'{"label1":"value4","label2":["value5a","value2b"],"label3":"value12"},'
+    b'{"label1":"value5","label2":["value6a","value2b"],"label3":"value15"},'
+    b'{"label1":"value6","label2":["value7a","value2b"],"label3":"value18"}]')
 
 
 def get_test_data(gcs_bucket: str, filename: str):
@@ -54,7 +62,12 @@ def testGetMetadata(mock_func: mock.MagicMock, client: FlaskClient):
     assert response.status_code == 200
     assert (response.headers.get('Content-Disposition') ==
             'attachment; filename=test_data.ndjson')
-    assert response.data == test_data
+    assert response.data == test_data_json
+    # Make sure that the response is valid json
+    try:
+        json.loads(response.data)
+    except json.decoder.JSONDecodeError as err:
+        pytest.fail(err)
 
 
 @mock.patch('data_server.gcs_utils.download_blob_as_bytes',
@@ -89,7 +102,12 @@ def testGetDataset_DataExists(mock_func: mock.MagicMock, client: FlaskClient):
     assert response.status_code == 200
     assert (response.headers.get('Content-Disposition') ==
            'attachment; filename=test_dataset')
-    assert response.data == test_data
+    assert response.data == test_data_json
+    # Make sure that the response is valid json
+    try:
+        json.loads(response.data)
+    except json.decoder.JSONDecodeError as err:
+        pytest.fail(err)
 
 
 @mock.patch('data_server.gcs_utils.download_blob_as_bytes',


### PR DESCRIPTION
This is a very basic implementation that simply requests the given dataset name from GCS on every invocation. Note that it doesn't use the cache because I have reservations about the viability of that implementation, though I think it is okay for metadata.