### PR TITLE
Prefixes Airflow variables to be recognized by the webserver

### DIFF
--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -78,10 +78,10 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         run: |
           gcloud composer environments update data-ingestion-environment \
-          --update-env-variables=INGEST_TO_GCS_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_GCS_SERVICE_ENDPOINT }} \
-          --update-env-variables=GCS_TO_BQ_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_BQ_SERVICE_ENDPOINT }} \
-          --update-env-variables=EXPORTER_SERVICE_ENDPOINT=${{ secrets.TEST_EXPORTER_SERVICE_ENDPOINT }} \
-          --update-env-variables=GCS_LANDING_BUCKET=msm-test-landing-bucket \
+          --update-env-variables=AIRFLOW_VAR_INGEST_TO_GCS_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_GCS_SERVICE_ENDPOINT }} \
+          --update-env-variables=AIRFLOW_VAR_GCS_TO_BQ_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_BQ_SERVICE_ENDPOINT }} \
+          --update-env-variables=AIRFLOW_VAR_EXPORTER_SERVICE_ENDPOINT=${{ secrets.TEST_EXPORTER_SERVICE_ENDPOINT }} \
+          --update-env-variables=AIRFLOW_VAR_GCS_LANDING_BUCKET=msm-test-landing-bucket \
           --location=us-central1
       - name: Upload Airflow DAG
         id: upload-dags


### PR DESCRIPTION
As of Airflow 1.10.10, the naming convention requires the environment variable be prefixed with "AIRFLOW_VAR_" 

https://airflow.apache.org/docs/apache-airflow/stable/concepts.html#storing-variables-in-environment-variables