### PR TITLE
Get token for compute service account to make request to cloud run services

### DIFF
--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -69,7 +69,6 @@ jobs:
           terraform apply -auto-approve -var-file=test/test.tfvars \
           -var 'gcp_credentials=${{ secrets.TEST_DEPLOYER_SA_KEY }}' \
           -var 'project_id=${{ secrets.TEST_PROJECT_ID }}' \
-          -var 'project_number=${{ secrets.TEST_PROJECT_NUMBER }}' \
           -var 'ingestion_image_digest=${{ steps.ingestion.outputs.image-digest }}' \
           -var 'gcs_to_bq_image_digest=${{ steps.gcstobq.outputs.image-digest }}' \
           -var 'data_server_image_digest=${{ steps.serving.outputs.image-digest }}' \

--- a/airflow/dags/util.py
+++ b/airflow/dags/util.py
@@ -21,9 +21,9 @@ def create_exporter_operator(task_id: str, payload: dict, dag: DAG) -> PythonOpe
 def service_request(url: str, data: dict):
     # Set up metadata server request
     # See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
-    metadata_server_token_url = 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience='
+    token_url = 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience='
 
-    token_request_url = metadata_server_token_url + url
+    token_request_url = token_url + url
     token_request_headers = {'Metadata-Flavor': 'Google'}
 
     # Fetch the token for the default compute service account

--- a/airflow/dags/util.py
+++ b/airflow/dags/util.py
@@ -19,11 +19,27 @@ def create_exporter_operator(task_id: str, payload: dict, dag: DAG) -> PythonOpe
 
 
 def service_request(url: str, data: dict):
+ # Set up metadata server request
+    # See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
+    metadata_server_token_url = 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience='
+
+    token_request_url = metadata_server_token_url + url
+    token_request_headers = {'Metadata-Flavor': 'Google'}
+
+    # Fetch the token for the default compute service account
+    token_response = requests.get(token_request_url, headers=token_request_headers)
+    jwt = token_response.content.decode("utf-8")
+
+    # Provide the token in the request to the receiving service
+    receiving_service_headers = {'Authorization': f'bearer {jwt}'}
+
     try:
-        resp = requests.post(url, json=data)
+        resp = requests.post(url, json=data, headers=receiving_service_headers)
         resp.raise_for_status()
     except requests.exceptions.HTTPError as err:
         raise Exception('Failed response code: {}'.format(err))
+
+
 
 
 def create_request_operator(task_id: str, url: str, payload: dict, dag: DAG) -> PythonOperator:

--- a/airflow/dags/util.py
+++ b/airflow/dags/util.py
@@ -19,7 +19,7 @@ def create_exporter_operator(task_id: str, payload: dict, dag: DAG) -> PythonOpe
 
 
 def service_request(url: str, data: dict):
- # Set up metadata server request
+    # Set up metadata server request
     # See https://cloud.google.com/compute/docs/instances/verifying-instance-identity#request_signature
     metadata_server_token_url = 'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience='
 
@@ -38,8 +38,6 @@ def service_request(url: str, data: dict):
         resp.raise_for_status()
     except requests.exceptions.HTTPError as err:
         raise Exception('Failed response code: {}'.format(err))
-
-
 
 
 def create_request_operator(task_id: str, url: str, payload: dict, dag: DAG) -> PythonOperator:

--- a/config/serviceaccounts.tf
+++ b/config/serviceaccounts.tf
@@ -120,11 +120,3 @@ resource "google_project_iam_member" "exporter_runner_binding" {
   role    = google_project_iam_custom_role.exporter_runner_role.id
   member  = format("serviceAccount:%s", google_service_account.exporter_runner_identity.email)
 }
-
-# Give the Default Compute Service Account (used by Cloud Composer) the run.invoker role on the project so that it 
-# can make requests to the ingestion pipeline services.
-resource "google_project_iam_member" "default_compute_invoker_binding" {
-    project = var.project_id
-    role = "roles/run.invoker"
-    member = format("serviceAccount:%s-compute@developer.gserviceaccount.com", var.project_number)
-}

--- a/config/serviceaccounts.tf
+++ b/config/serviceaccounts.tf
@@ -112,7 +112,8 @@ resource "google_project_iam_custom_role" "exporter_runner_role" {
   title       = "Exporter Runner"
   description = "Allows reading from BQ and writing to GCS buckets."
   permissions = ["storage.objects.create", "storage.objects.delete", "storage.objects.get", "storage.objects.list",
-  "storage.objects.update", "storage.buckets.get", "bigquery.jobs.create", "bigquery.tables.export"]
+  "storage.objects.update", "storage.buckets.get", "bigquery.jobs.create", "bigquery.tables.export", 
+  "bigquery.datasets.get"]
 }
 
 resource "google_project_iam_member" "exporter_runner_binding" {

--- a/config/variables.tf
+++ b/config/variables.tf
@@ -4,11 +4,6 @@ variable "project_id" {
   type        = string
 }
 
-variable "project_number" {
-  description = "Google Project Number"
-  type        = string
-}
-
 variable "manual_uploads_project_id" {
   description = "The project ID for manual data uploads"
   type        = string

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -12,7 +12,12 @@ def export_dataset_tables():
     """Exports the tables in the given dataset to GCS.
 
        Request form must include the dataset name."""
-    dataset_name = request.form['dataset_name']
+    data = request.get_json()
+
+    if data.get('dataset_name') == None:
+        return ('Request must include dataset name.', 400)
+    
+    dataset_name = data['dataset_name']
     project_id = os.environ.get('PROJECT_ID')
     export_bucket = os.environ.get('EXPORT_BUCKET')
     dataset_id = "{}.{}".format(project_id, dataset_name)

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -14,9 +14,9 @@ def export_dataset_tables():
        Request form must include the dataset name."""
     data = request.get_json()
 
-    if data.get('dataset_name') == None:
+    if data.get('dataset_name') is None:
         return ('Request must include dataset name.', 400)
-    
+
     dataset_name = data['dataset_name']
     project_id = os.environ.get('PROJECT_ID')
     export_bucket = os.environ.get('EXPORT_BUCKET')

--- a/exporter/test_exporter.py
+++ b/exporter/test_exporter.py
@@ -32,14 +32,14 @@ def testExportDatasetTables(client: FlaskClient):
         mock_bq_instance.list_tables.return_value = test_tables
 
         dataset_name = {'dataset_name': 'my-dataset'}
-        response = client.post('/', data=dataset_name)
+        response = client.post('/', json=dataset_name)
 
         assert response.status_code == 204
         assert mock_bq_instance.extract_table.call_count == 3
 
 
 def testExportDatasetTables_InvalidInput(client: FlaskClient):
-    response = client.post('/', data='')
+    response = client.post('/', json={})
     assert response.status_code == 400
 
 
@@ -50,7 +50,7 @@ def testExportDatasetTables_NoTables(client: FlaskClient):
         mock_bq_instance.list_tables.return_value = iter(())
 
         dataset_name = {'dataset_name': 'my-dataset'}
-        response = client.post('/', data=dataset_name)
+        response = client.post('/', json=dataset_name)
 
         assert response.status_code == 500
 
@@ -65,6 +65,6 @@ def testExportDatasetTables_ExtractJobFailure(client: FlaskClient):
         mock_extract_job.result.side_effect = google.cloud.exceptions.InternalServerError('Internal')
 
         dataset_name = {'dataset_name': 'my-dataset'}
-        response = client.post('/', data=dataset_name)
+        response = client.post('/', json=dataset_name)
 
         assert response.status_code == 500


### PR DESCRIPTION
This change also fixes how the exporter handles request input.

Additionally, remove the invoker role binding for the default compute service account. It turns out this isn't necessary because the service account already has the project editor role which inherits the invoker role. 
