### PR TITLE
Use new gcloud action

### DIFF
--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -15,9 +15,9 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v2
       - name: Set Up gcloud
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
-          version: '290.0.1'
+          export_default_credentials: true
           service_account_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - name: Set Up Docker to Use gcloud Credentials


### PR DESCRIPTION
A warning in the workflow output requested the move to the new action.

Export credentials as an env var for later steps.
Use latest version of gcloud.