### PR TITLE
Use terraform outputs for the airflow service endpoint env vars

### DIFF
--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -83,15 +83,23 @@ jobs:
           -var 'aggregator_image_digest=${{ steps.aggregator.outputs.image-digest }}'
           data_server_url=$(terraform output data_server_url)
           echo "::set-output name=data_server_url::$data_server_url"
+          ingestion_url=$(terraform output ingestion_url)
+          echo "::set-output name=ingestion_url::$ingestion_url"
+          gcs_to_bq_url=$(terraform output gcs_to_bq_url)
+          echo "::set-output name=gcs_to_bq_url::$gcs_to_bq_url"
+          exporter_url=$(terraform output exporter_url)
+          echo "::set-output name=exporter_url::$exporter_url"
+          aggregator_url=$(terraform output aggregator_url)
+          echo "::set-output name=aggregator_url::$aggregator_url"
       - name: Airflow Environment Variables
         id: airflow-environment-variables
         if: github.ref == 'refs/heads/master' && github.event_name == 'push'
         continue-on-error: true
         run: |
           gcloud composer environments update data-ingestion-environment \
-          --update-env-variables=AIRFLOW_VAR_INGEST_TO_GCS_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_GCS_SERVICE_ENDPOINT }} \
-          --update-env-variables=AIRFLOW_VAR_GCS_TO_BQ_SERVICE_ENDPOINT=${{ secrets.TEST_INGEST_BQ_SERVICE_ENDPOINT }} \
-          --update-env-variables=AIRFLOW_VAR_EXPORTER_SERVICE_ENDPOINT=${{ secrets.TEST_EXPORTER_SERVICE_ENDPOINT }} \
+          --update-env-variables=AIRFLOW_VAR_INGEST_TO_GCS_SERVICE_ENDPOINT=${{ steps.terraform.outputs.ingestion_url }} \
+          --update-env-variables=AIRFLOW_VAR_GCS_TO_BQ_SERVICE_ENDPOINT=${{ steps.terraform.outputs.gcs_to_bq_url }} \
+          --update-env-variables=AIRFLOW_VAR_EXPORTER_SERVICE_ENDPOINT=${{ steps.terraform.outputs.exporter_url }} \
           --update-env-variables=AIRFLOW_VAR_GCS_LANDING_BUCKET=msm-test-landing-bucket \
           --update-env-variables=AIRFLOW_VAR_GCS_MANUAL_UPLOADS_BUCKET=msm-test-manual-data-bucket \
           --location=us-central1

--- a/config/run.tf
+++ b/config/run.tf
@@ -209,4 +209,21 @@ output "data_server_url" {
   value = google_cloud_run_service.data_server_service.status.0.url
 }
 
+# Output the URLs of the pipeline services for use in Airflow.
+output "ingestion_url" {
+    value = google_cloud_run_service.ingestion_service.status.0.url
+}
+
+output "gcs_to_bq_url" {
+    value = google_cloud_run_service.gcs_to_bq_service.status.0.url
+}
+
+output "exporter_url" {
+    value = google_cloud_run_service.exporter_service.status.0.url
+}
+
+output "aggregator_url" {
+    value = google_cloud_run_service.aggregator_service.status.0.url
+}
+
 /* [END] Cloud Run Setup */


### PR DESCRIPTION
The reduces the number of secrets needed to be stored (and manually added/updated) in the repo. 