### PR TITLE
Use the 'latest' tag when deploying to cloud run through terraform

### DIFF
--- a/.github/actions/buildAndPush/action.yml
+++ b/.github/actions/buildAndPush/action.yml
@@ -7,17 +7,10 @@ inputs:
   image-path:
     description: 'Location to where image should be pushed'
     required: true
-outputs:
-  image-digest:
-    description: 'Digest of image pushed to GCR'
-    value: ${{ steps.get-image-digest.outputs.image-digest }}
 runs:
   using: "composite"
   steps:
     - run: docker build -t ${{ inputs.image-path }} -f ${{ inputs.dockerfile }} .
       shell: bash
     - run: docker push ${{ inputs.image-path }}
-      shell: bash
-    - id: get-image-digest
-      run: echo "::set-output name=image-digest::$(gcloud container images describe ${{ inputs.image-path }} --format='value(image_summary.digest)')"
       shell: bash

--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -76,11 +76,6 @@ jobs:
           terraform apply -auto-approve -var-file=test/test.tfvars \
           -var 'gcp_credentials=${{ secrets.TEST_DEPLOYER_SA_KEY }}' \
           -var 'project_id=${{ secrets.TEST_PROJECT_ID }}' \
-          -var 'ingestion_image_digest=${{ steps.ingestion.outputs.image-digest }}' \
-          -var 'gcs_to_bq_image_digest=${{ steps.gcstobq.outputs.image-digest }}' \
-          -var 'data_server_image_digest=${{ steps.serving.outputs.image-digest }}' \
-          -var 'exporter_image_digest=${{ steps.exporter.outputs.image-digest }}' \
-          -var 'aggregator_image_digest=${{ steps.aggregator.outputs.image-digest }}'
           data_server_url=$(terraform output data_server_url)
           echo "::set-output name=data_server_url::$data_server_url"
       - name: Airflow Environment Variables

--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -23,31 +23,26 @@ jobs:
       - name: Set Up Docker to Use gcloud Credentials
         run: gcloud auth configure-docker -q
       - name: Build and Push Data Serving Image
-        id: serving
         uses: ./.github/actions/buildAndPush
         with:
           dockerfile: 'data_server/Dockerfile'
           image-path: 'gcr.io/${{ secrets.TEST_PROJECT_ID }}/data-server'
       - name: Build and Push Data Ingestion Image
-        id: ingestion
         uses: ./.github/actions/buildAndPush
         with:
           dockerfile: 'run_ingestion/Dockerfile'
           image-path: 'gcr.io/${{ secrets.TEST_PROJECT_ID }}/data-ingestion'  
       - name: Build and Push GCS to BQ Image
-        id: gcstobq
         uses: ./.github/actions/buildAndPush
         with:
           dockerfile: 'run_gcs_to_bq/Dockerfile'
           image-path: 'gcr.io/${{ secrets.TEST_PROJECT_ID }}/gcs-to-bq'
       - name: Build and Push Exporter Image
-        id: exporter
         uses: ./.github/actions/buildAndPush
         with:
           dockerfile: 'exporter/Dockerfile'
           image-path: 'gcr.io/${{ secrets.TEST_PROJECT_ID }}/exporter'
       - name: Build and Push Aggregator Image
-        id: aggregator
         uses: ./.github/actions/buildAndPush
         with:
           dockerfile: 'aggregator/Dockerfile'

--- a/config/run.tf
+++ b/config/run.tf
@@ -35,7 +35,7 @@ resource "google_cloud_run_service" "ingestion_service" {
   template {
     spec {
       containers {
-        image = format("gcr.io/%s/%s@%s", var.project_id, var.ingestion_image_name, var.ingestion_image_digest)
+        image = format("gcr.io/%s/%s:latest", var.project_id, var.ingestion_image_name)
         env {
           name  = "PROJECT_ID"
           value = var.project_id
@@ -85,7 +85,7 @@ resource "google_cloud_run_service" "gcs_to_bq_service" {
   template {
     spec {
       containers {
-        image = format("gcr.io/%s/%s@%s", var.project_id, var.gcs_to_bq_image_name, var.gcs_to_bq_image_digest)
+        image = format("gcr.io/%s/%s:latest", var.project_id, var.gcs_to_bq_image_name)
         env {
           # Name of BQ dataset that we will add the tables to. This currently points to the main BQ dataset.
           name  = "DATASET_NAME"
@@ -127,7 +127,7 @@ resource "google_cloud_run_service" "data_server_service" {
   template {
     spec {
       containers {
-        image = format("gcr.io/%s/%s@%s", var.project_id, var.data_server_image_name, var.data_server_image_digest)
+        image = format("gcr.io/%s/%s:latest", var.project_id, var.data_server_image_name)
         env {
           # GCS bucket from where the data tables are read.
           name  = "GCS_BUCKET"
@@ -154,7 +154,7 @@ resource "google_cloud_run_service" "exporter_service" {
   template {
     spec {
       containers {
-        image = format("gcr.io/%s/%s@%s", var.project_id, var.exporter_image_name, var.exporter_image_digest)
+        image = format("gcr.io/%s/%s:latest", var.project_id, var.exporter_image_name)
         env {
           # GCP project that contains the dataset we are exporting from.
           name  = "PROJECT_ID"
@@ -186,7 +186,7 @@ resource "google_cloud_run_service" "aggregator_service" {
   template {
     spec {
       containers {
-        image = format("gcr.io/%s/%s@%s", var.project_id, var.aggregator_image_name, var.aggregator_image_digest)
+        image = format("gcr.io/%s/%s:latest", var.project_id, var.aggregator_image_name)
         env {
           # GCP project that contains the dataset we are querying.
           name  = "PROJECT_ID"

--- a/config/variables.tf
+++ b/config/variables.tf
@@ -78,11 +78,6 @@ variable "ingestion_image_name" {
   type        = string
 }
 
-variable "ingestion_image_digest" {
-  description = "Digest of container image for the Cloud Run ingestion service"
-  type        = string
-}
-
 variable "ingestion_subscription_name" {
   description = "Name of push subscription that invokes the ingestion service"
   type        = string
@@ -111,11 +106,6 @@ variable "gcs_to_bq_service_name" {
 
 variable "gcs_to_bq_image_name" {
   description = "Name of container image for the Cloud Run GCS-to-BQ service"
-  type        = string
-}
-
-variable "gcs_to_bq_image_digest" {
-  description = "Digest of container image for the Cloud Run GCS-to-BQ service"
   type        = string
 }
 
@@ -150,11 +140,6 @@ variable "data_server_image_name" {
   type        = string
 }
 
-variable "data_server_image_digest" {
-  description = "Digest of container image for the Cloud Run data server service"
-  type        = string
-}
-
 variable "data_server_runner_identity_id" {
   description = "Account id of the service account used when running the data server service"
   type        = string
@@ -176,11 +161,6 @@ variable "exporter_image_name" {
   type        = string
 }
 
-variable "exporter_image_digest" {
-  description = "Digest of container image for the Cloud Run exporter service"
-  type        = string
-}
-
 variable "exporter_runner_identity_id" {
   description = "Account id of the service account used when running the exporter service"
   type        = string
@@ -199,11 +179,6 @@ variable "aggregator_service_name" {
 
 variable "aggregator_image_name" {
   description = "Name of container image for the Cloud Run aggregator service"
-  type        = string
-}
-
-variable "aggregator_image_digest" {
-  description = "Digest of container image for the Cloud Run aggregator service"
   type        = string
 }
 


### PR DESCRIPTION
I originally used the digest in hopes that terraform would recognize when a container had not changed and thus not redeploy the service. However, terraform seems to redeploy the service anyway. This simplifies the configuration without changing behavior. 