### PR TITLE
Support serving csv files in addition to json

### DIFF
--- a/data_server/main.py
+++ b/data_server/main.py
@@ -68,7 +68,7 @@ def get_dataset():
         return Response(dataset, mimetype='text/csv', headers=headers)
     
     return Response(generate_response(dataset), mimetype='application/json',
-                        headers=headers)
+                    headers=headers)
         
 
 if __name__ == "__main__":

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -69,7 +69,7 @@ def get_dataset():
     
     return Response(generate_response(dataset), mimetype='application/json',
                     headers=headers)
-        
+
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -63,9 +63,13 @@ def get_dataset():
     headers.add('Content-Disposition', 'attachment', filename=dataset_name)
     headers.add('Access-Control-Allow-Origin', '*')
     headers.add('Vary', 'Accept-Encoding, Origin')
+    
+    if dataset_name.endswith('.csv'):
+        return Response(dataset, mimetype='text/csv', headers=headers)
+    
     return Response(generate_response(dataset), mimetype='application/json',
-                    headers=headers)
-
+                        headers=headers)
+        
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -63,7 +63,7 @@ def get_dataset():
     headers.add('Content-Disposition', 'attachment', filename=dataset_name)
     headers.add('Access-Control-Allow-Origin', '*')
     headers.add('Vary', 'Accept-Encoding, Origin')
-    
+
     if dataset_name.endswith('.csv'):
         return Response(dataset, mimetype='text/csv', headers=headers)
 

--- a/data_server/main.py
+++ b/data_server/main.py
@@ -66,7 +66,7 @@ def get_dataset():
     
     if dataset_name.endswith('.csv'):
         return Response(dataset, mimetype='text/csv', headers=headers)
-    
+
     return Response(generate_response(dataset), mimetype='application/json',
                     headers=headers)
 

--- a/data_server/test_data_server.py
+++ b/data_server/test_data_server.py
@@ -29,8 +29,7 @@ test_data_json = (
     b'{"label1":"value6","label2":["value7a","value2b"],"label3":"value18"}]')
 
 test_data_csv = (
-    b'label1,label2,label3\nvalueA,valueB,valueC\nvalueD,valueE,valueF\n'
-)
+    b'label1,label2,label3\nvalueA,valueB,valueC\nvalueD,valueE,valueF\n')
 
 
 def get_test_data(gcs_bucket: str, filename: str):

--- a/data_server/test_data_server.py
+++ b/data_server/test_data_server.py
@@ -28,11 +28,21 @@ test_data_json = (
     b'{"label1":"value5","label2":["value6a","value2b"],"label3":"value15"},'
     b'{"label1":"value6","label2":["value7a","value2b"],"label3":"value18"}]')
 
+test_data_csv = (
+    b'label1,label2,label3\nvalueA,valueB,valueC\nvalueD,valueE,valueF\n'
+)
+
 
 def get_test_data(gcs_bucket: str, filename: str):
     """Returns the contents of filename as a bytes object. Meant to be used to
     patch gcs_utils.download_blob_as_bytes."""
     return test_data
+
+
+def get_test_data_csv(gcs_bucket: str, filename: str):
+    """Returns the contents of filename.csv as a bytes object. Meant to be used to
+    patch gcs_utils.download_blob_as_bytes."""
+    return test_data_csv
 
 
 @pytest.fixture(autouse=True)
@@ -128,3 +138,16 @@ def testGetDataset_UrlParamMissing(client: FlaskClient):
     response = client.get('/dataset?random_param=stuff')
     assert response.status_code == 400
     assert b'Request missing required url param \'name\'' in response.data
+
+
+@mock.patch('data_server.gcs_utils.download_blob_as_bytes',
+            side_effect=get_test_data_csv)
+def testGetDataset_csvType(mock_func: mock.MagicMock, client: FlaskClient):
+    response = client.get('/dataset?name=test_dataset.csv')
+    mock_func.assert_called_once_with('test', 'test_dataset.csv')
+    assert response.status_code == 200
+    assert response.mimetype == 'text/csv'
+    assert (response.headers.get('Content-Disposition') ==
+           'attachment; filename=test_dataset.csv')
+    # Make sure that the response hasn't changed
+    assert response.data == test_data_csv


### PR DESCRIPTION
Unlike json, csv files should be served without any format changes. 