### PR TITLE
Add missing google-auth requirement

### DIFF
--- a/e2e_tests/requirements.txt
+++ b/e2e_tests/requirements.txt
@@ -1,1 +1,2 @@
 requests
+google-auth


### PR DESCRIPTION
It was already installed in the virtual env I was testing in, so I forgot to add it here.