### PR TITLE
Tweaks to Covid Tracking Project ingestion

### DIFF
--- a/python/datasources/covid_tracking_project.py
+++ b/python/datasources/covid_tracking_project.py
@@ -55,6 +55,7 @@ class CovidTrackingProject(DataSource):
         df.rename(columns={'state': 'state_postal_abbreviation'}, inplace=True)
         df.replace({col_std.RACE_COL: self.get_standard_columns()},
                    inplace=True)
+        df['date'] = df['date'].map(lambda ts: ts.strftime("%Y-%m-%d"))
 
         # Get the metadata table
         metadata = self._download_metadata(dataset)

--- a/python/datasources/covid_tracking_project_metadata.py
+++ b/python/datasources/covid_tracking_project_metadata.py
@@ -43,6 +43,7 @@ class CtpMetadata(DataSource):
         df = df.pivot(
             index=['state_postal_abbreviation', 'variable_type'],
             columns='col_name', values='value').reset_index()
+        df.replace({'variable_type': {'death': 'deaths'}}, inplace=True)
         df.rename_axis(None, inplace=True)
         df.rename(columns=self._metadata_columns_map(), inplace=True)
 

--- a/python/tests/datasources/test_covid_tracking_project.py
+++ b/python/tests/datasources/test_covid_tracking_project.py
@@ -71,7 +71,6 @@ def testWriteToBq(mock_append_to_bq: mock.MagicMock, mock_csv: mock.MagicMock,
     assert len(result.loc[
         result['race'] == col_std.Race.API.value].index) == 6
     expected_dtypes = {col: np.object for col in result.columns}
-    expected_dtypes['date'] = np.dtype('datetime64[ns]')
     expected_dtypes['value'] = np.float64
     for col in result.columns:
         assert result[col].dtype == expected_dtypes[col]

--- a/python/tests/datasources/test_covid_tracking_project_metadata.py
+++ b/python/tests/datasources/test_covid_tracking_project_metadata.py
@@ -43,9 +43,7 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     # We should have a record for each state/variable_type (e.g. cases, death)
     # combo
     assert len(result.index) == 3 * 2
-    print(result.index)
-    with pd.option_context('display.max_rows', None, 'display.max_columns', None):
-        print(result)
     assert result.loc[result['state_postal_abbreviation'] == 'AL'].all().all()
     assert not result.loc[result['state_postal_abbreviation'] == 'PA', 'reports_api':].any().any()
     assert result.loc[result['state_postal_abbreviation'] == 'GA'].all().all()
+    assert result['variable_type'].isin(['cases', 'deaths']).all()


### PR DESCRIPTION
- Rename "death" to "deaths" in CTP metadata to match CTP data
- Format "date" column as string to be autodetected by BQ
#116 