### PR TITLE
Swap service account token for basicAuth

### DIFF
--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -81,16 +81,16 @@ app.use('/api', apiProxy);
 // auth middleware must be installed before setting up routes so it applies
 // to the whole site.
 if (!getBooleanEnvVar("DISABLE_BASIC_AUTH")) {
-    const username = assertEnvVar("BASIC_AUTH_USERNAME");
-    const password = assertEnvVar("BASIC_AUTH_PASSWORD");
-    app.use(basicAuth({
-      // Temporary values until we can use Github Secrets. Also needs to be set up
-      // so that it's disabled for production but enabled for the test site.
-      users: { [username]: password },
-      challenge: true,
-      realm: 'Health Equity Tracker',
-    }));
-  }
+  const username = assertEnvVar("BASIC_AUTH_USERNAME");
+  const password = assertEnvVar("BASIC_AUTH_PASSWORD");
+  app.use(basicAuth({
+    // Temporary values until we can use Github Secrets. Also needs to be set up
+    // so that it's disabled for production but enabled for the test site.
+    users: { [username]: password },
+    challenge: true,
+    realm: 'Health Equity Tracker',
+  }));
+}
 
 // Serve static files from the build directory.
 app.use(express.static(path.join(__dirname, 'build')));

--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -76,22 +76,24 @@ app.use('/api', apiProxy);
 // auth middleware must be installed before setting up routes so it applies
 // to the whole site except for api requests which go to the data server and use
 // service account tokens instead.
-app.use((req, res, next) => {
-  if (!req.path.startsWith('/api') && !getBooleanEnvVar("DISABLE_BASIC_AUTH")) {
-    const username = assertEnvVar("BASIC_AUTH_USERNAME");
-    const password = assertEnvVar("BASIC_AUTH_PASSWORD");       
-    basicAuth({
-      // Temporary values until we can use Github Secrets. Also needs to be set up
-      // so that it's disabled for production but enabled for the test site.
-      users: { [username]: password },
-      challenge: true,
-      realm: 'Health Equity Tracker',
-    })       
-    next();
-  } else {
-    next();
-  }
+if (!getBooleanEnvVar("DISABLE_BASIC_AUTH")) {
+  app.use((req, res, next) => {
+    if (!req.path.startsWith('/api')) {
+      const username = assertEnvVar("BASIC_AUTH_USERNAME");
+      const password = assertEnvVar("BASIC_AUTH_PASSWORD");       
+      basicAuth({
+        // Temporary values until we can use Github Secrets. Also needs to be set up
+        // so that it's disabled for production but enabled for the test site.
+        users: { [username]: password },
+        challenge: true,
+        realm: 'Health Equity Tracker',
+      })       
+      next();
+    } else {
+      next();
+    }
   });
+}
 
 // Serve static files from the build directory.
 app.use(express.static(path.join(__dirname, 'build')));


### PR DESCRIPTION
Using basicAuth overrides the service account token in the "Authorization" header. So put the service account token in a temporary header until right before the proxy request is sent. 