### PR TITLE
Align cards in comparison views

### DIFF
--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -77,6 +77,24 @@ export function formatFieldValue(metricType: MetricType, value: any): string {
   return `${formattedValue}${suffix}`;
 }
 
+export function getTableFields(variableConfig: VariableConfig): MetricConfig[] {
+  let tableFields: MetricConfig[] = [];
+  if (variableConfig) {
+    if (variableConfig.metrics["per100k"]) {
+      tableFields.push(variableConfig.metrics["per100k"]);
+    }
+    if (variableConfig.metrics["pct_share"]) {
+      tableFields.push(variableConfig.metrics["pct_share"]);
+      if (variableConfig.metrics["pct_share"].populationComparisonMetric) {
+        tableFields.push(
+          variableConfig.metrics["pct_share"].populationComparisonMetric
+        );
+      }
+    }
+  }
+  return tableFields;
+}
+
 // TODO - strongly type key
 // TODO - count and pct_share metric types should require populationComparisonMetric
 

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -77,7 +77,9 @@ export function formatFieldValue(metricType: MetricType, value: any): string {
   return `${formattedValue}${suffix}`;
 }
 
-export function getTableFields(variableConfig: VariableConfig): MetricConfig[] {
+export function getPer100kAndPctShareMetrics(
+  variableConfig: VariableConfig
+): MetricConfig[] {
   let tableFields: MetricConfig[] = [];
   if (variableConfig) {
     if (variableConfig.metrics["per100k"]) {

--- a/frontend/src/data/query/Breakdowns.ts
+++ b/frontend/src/data/query/Breakdowns.ts
@@ -15,7 +15,12 @@ export type BreakdownVar =
   | "date"
   | "fips";
 
-export type DemographicBreakdownKey = "race_and_ethnicity" | "sex" | "age";
+export const DEMOGRAPHIC_BREAKDOWNS = [
+  "race_and_ethnicity",
+  "sex",
+  "age",
+] as const;
+export type DemographicBreakdownKey = typeof DEMOGRAPHIC_BREAKDOWNS[number]; // union type of array
 
 export const BREAKDOWN_VAR_DISPLAY_NAMES: Record<BreakdownVar, string> = {
   race_and_ethnicity: "Race and Ethnicity",

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import { Grid } from "@material-ui/core";
 import { VariableDisparityReport } from "./VariableDisparityReport";
 import TwoVariableReport from "./TwoVariableReport";
 import {
@@ -45,52 +44,56 @@ function ReportProvider(props: { madLib: MadLib; setMadLib: Function }) {
           />
         );
       case "comparegeos":
-        const compareDisparityVariable = getPhraseValue(props.madLib, 1);
+        const compareDisparityVariable = getPhraseValue(
+          props.madLib,
+          1
+        ) as DropdownVarId;
         const fipsCode1 = getPhraseValue(props.madLib, 3);
         const fipsCode2 = getPhraseValue(props.madLib, 5);
         return (
-          <Grid container spacing={1} alignItems="flex-start">
-            <Grid item xs={6}>
-              <VariableDisparityReport
-                key={compareDisparityVariable + fipsCode1}
-                dropdownVarId={compareDisparityVariable as DropdownVarId}
-                fips={new Fips(fipsCode1)}
-                updateFipsCallback={(fips: Fips) =>
-                  props.setMadLib(
-                    getMadLibWithUpdatedValue(props.madLib, 3, fips.code)
-                  )
-                }
-                vertical={true}
-              />
-            </Grid>
-            <Grid item xs={6}>
-              <VariableDisparityReport
-                key={compareDisparityVariable + fipsCode2}
-                dropdownVarId={compareDisparityVariable as DropdownVarId}
-                fips={new Fips(fipsCode2)}
-                updateFipsCallback={(fips: Fips) =>
-                  props.setMadLib(
-                    getMadLibWithUpdatedValue(props.madLib, 5, fips.code)
-                  )
-                }
-                vertical={true}
-              />
-            </Grid>
-          </Grid>
+          <TwoVariableReport
+            key={compareDisparityVariable + fipsCode1 + fipsCode2}
+            dropdownVarId1={compareDisparityVariable}
+            dropdownVarId2={compareDisparityVariable}
+            fips1={new Fips(fipsCode1)}
+            fips2={new Fips(fipsCode2)}
+            updateFips1Callback={(fips: Fips) =>
+              props.setMadLib(
+                getMadLibWithUpdatedValue(props.madLib, 3, fips.code)
+              )
+            }
+            updateFips2Callback={(fips: Fips) =>
+              props.setMadLib(
+                getMadLibWithUpdatedValue(props.madLib, 5, fips.code)
+              )
+            }
+          />
         );
       case "comparevars":
-        const compareDisparityVariable1 = getPhraseValue(props.madLib, 1);
-        const compareDisparityVariable2 = getPhraseValue(props.madLib, 3);
+        const compareDisparityVariable1 = getPhraseValue(
+          props.madLib,
+          1
+        ) as DropdownVarId;
+        const compareDisparityVariable2 = getPhraseValue(
+          props.madLib,
+          3
+        ) as DropdownVarId;
         const fipsCode = getPhraseValue(props.madLib, 5);
         return (
           <TwoVariableReport
             key={
               compareDisparityVariable1 + +compareDisparityVariable2 + fipsCode
             }
-            dropdownVarId1={compareDisparityVariable1 as DropdownVarId}
-            dropdownVarId2={compareDisparityVariable2 as DropdownVarId}
-            fips={new Fips(fipsCode)}
-            updateFipsCallback={(fips: Fips) =>
+            dropdownVarId1={compareDisparityVariable1}
+            dropdownVarId2={compareDisparityVariable2}
+            fips1={new Fips(fipsCode)}
+            fips2={new Fips(fipsCode)}
+            updateFips1Callback={(fips: Fips) =>
+              props.setMadLib(
+                getMadLibWithUpdatedValue(props.madLib, 5, fips.code)
+              )
+            }
+            updateFips2Callback={(fips: Fips) =>
               props.setMadLib(
                 getMadLibWithUpdatedValue(props.madLib, 5, fips.code)
               )

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -44,17 +44,14 @@ function ReportProvider(props: { madLib: MadLib; setMadLib: Function }) {
           />
         );
       case "comparegeos":
-        const compareDisparityVariable = getPhraseValue(
-          props.madLib,
-          1
-        ) as DropdownVarId;
+        const compareDisparityVariable = getPhraseValue(props.madLib, 1);
         const fipsCode1 = getPhraseValue(props.madLib, 3);
         const fipsCode2 = getPhraseValue(props.madLib, 5);
         return (
           <TwoVariableReport
             key={compareDisparityVariable + fipsCode1 + fipsCode2}
-            dropdownVarId1={compareDisparityVariable}
-            dropdownVarId2={compareDisparityVariable}
+            dropdownVarId1={compareDisparityVariable as DropdownVarId}
+            dropdownVarId2={compareDisparityVariable as DropdownVarId}
             fips1={new Fips(fipsCode1)}
             fips2={new Fips(fipsCode2)}
             updateFips1Callback={(fips: Fips) =>
@@ -70,22 +67,16 @@ function ReportProvider(props: { madLib: MadLib; setMadLib: Function }) {
           />
         );
       case "comparevars":
-        const compareDisparityVariable1 = getPhraseValue(
-          props.madLib,
-          1
-        ) as DropdownVarId;
-        const compareDisparityVariable2 = getPhraseValue(
-          props.madLib,
-          3
-        ) as DropdownVarId;
+        const compareDisparityVariable1 = getPhraseValue(props.madLib, 1);
+        const compareDisparityVariable2 = getPhraseValue(props.madLib, 3);
         const fipsCode = getPhraseValue(props.madLib, 5);
         return (
           <TwoVariableReport
             key={
               compareDisparityVariable1 + +compareDisparityVariable2 + fipsCode
             }
-            dropdownVarId1={compareDisparityVariable1}
-            dropdownVarId2={compareDisparityVariable2}
+            dropdownVarId1={compareDisparityVariable1 as DropdownVarId}
+            dropdownVarId2={compareDisparityVariable2 as DropdownVarId}
             fips1={new Fips(fipsCode)}
             fips2={new Fips(fipsCode)}
             updateFips1Callback={(fips: Fips) =>

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -11,11 +11,13 @@ import { Fips } from "../data/utils/Fips";
 import {
   METRIC_CONFIG,
   VariableConfig,
-  getTableFields,
+  getPer100kAndPctShareMetrics,
 } from "../data/config/MetricConfig";
 import ReportToggleControls from "./ui/ReportToggleControls";
 import NoDataAlert from "./ui/NoDataAlert";
 
+/* Takes dropdownVar and fips inputs for each side-by-side column.
+Input values for each column can be the same. */
 function TwoVariableReport(props: {
   key: string;
   dropdownVarId1: DropdownVarId;
@@ -120,14 +122,14 @@ function TwoVariableReport(props: {
             <Grid item xs={6}>
               <TableCard
                 fips={props.fips1}
-                metrics={getTableFields(variableConfig1)}
+                metrics={getPer100kAndPctShareMetrics(variableConfig1)}
                 breakdownVar={breakdownVar}
               />
             </Grid>
             <Grid item xs={6}>
               <TableCard
                 fips={props.fips2}
-                metrics={getTableFields(variableConfig2)}
+                metrics={getPer100kAndPctShareMetrics(variableConfig2)}
                 breakdownVar={breakdownVar}
               />
             </Grid>

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -1,43 +1,181 @@
-import React from "react";
+import React, { useState } from "react";
 import { Grid } from "@material-ui/core";
+import { BreakdownVar, DEMOGRAPHIC_BREAKDOWNS } from "../data/query/Breakdowns";
+import { MapCard } from "../cards/MapCard";
+import { PopulationCard } from "../cards/PopulationCard";
+import { TableCard } from "../cards/TableCard";
+import { DisparityBarChartCard } from "../cards/DisparityBarChartCard";
+import { SimpleBarChartCard } from "../cards/SimpleBarChartCard";
 import { DropdownVarId } from "../utils/MadLibs";
 import { Fips } from "../data/utils/Fips";
-import { PopulationCard } from "../cards/PopulationCard";
-import { VariableDisparityReport } from "./VariableDisparityReport";
+import {
+  METRIC_CONFIG,
+  VariableConfig,
+  getTableFields,
+} from "../data/config/MetricConfig";
+import ReportToggleControls from "./ui/ReportToggleControls";
+import NoDataAlert from "./ui/NoDataAlert";
 
 function TwoVariableReport(props: {
   key: string;
   dropdownVarId1: DropdownVarId;
   dropdownVarId2: DropdownVarId;
-  fips: Fips;
-  updateFipsCallback: Function;
-  hidePopulationCard?: boolean;
+  fips1: Fips;
+  fips2: Fips;
+  updateFips1Callback: Function;
+  updateFips2Callback: Function;
 }) {
+  const [currentBreakdown, setCurrentBreakdown] = useState<
+    BreakdownVar | "all"
+  >("all");
+
+  const [variableConfig1, setVariableConfig1] = useState<VariableConfig | null>(
+    Object.keys(METRIC_CONFIG).includes(props.dropdownVarId1)
+      ? METRIC_CONFIG[props.dropdownVarId1][0]
+      : null
+  );
+  const [variableConfig2, setVariableConfig2] = useState<VariableConfig | null>(
+    Object.keys(METRIC_CONFIG).includes(props.dropdownVarId2)
+      ? METRIC_CONFIG[props.dropdownVarId2][0]
+      : null
+  );
+
+  if (variableConfig1 === null) {
+    return (
+      <Grid container spacing={1} alignItems="center" justify="center">
+        <NoDataAlert dropdownVarId={props.dropdownVarId1} />
+      </Grid>
+    );
+  }
+  if (variableConfig2 === null) {
+    return (
+      <Grid container spacing={1} alignItems="center" justify="center">
+        <NoDataAlert dropdownVarId={props.dropdownVarId2} />
+      </Grid>
+    );
+  }
+
+  const breakdownIsShown = (breakdownVar: string) =>
+    currentBreakdown === "all" || currentBreakdown === breakdownVar;
+
   return (
     <Grid container spacing={1} alignItems="flex-start">
-      <Grid item xs={12}>
-        <PopulationCard fips={props.fips} />
-      </Grid>
+      {props.fips1.code === props.fips2.code ? (
+        <Grid item xs={12}>
+          <PopulationCard fips={props.fips1} />
+        </Grid>
+      ) : (
+        <>
+          <Grid item xs={6}>
+            <PopulationCard fips={props.fips1} />
+          </Grid>
+          <Grid item xs={6}>
+            <PopulationCard fips={props.fips2} />
+          </Grid>
+        </>
+      )}
+
       <Grid item xs={6}>
-        <VariableDisparityReport
-          key={props.dropdownVarId1 + props.fips.code}
+        <ReportToggleControls
           dropdownVarId={props.dropdownVarId1}
-          fips={props.fips}
-          updateFipsCallback={(fips: Fips) => props.updateFipsCallback(fips)}
-          vertical={true}
-          hidePopulationCard={true}
+          variableConfig={variableConfig1}
+          setVariableConfig={setVariableConfig1}
+          currentBreakdown={currentBreakdown}
+          setCurrentBreakdown={setCurrentBreakdown}
         />
       </Grid>
       <Grid item xs={6}>
-        <VariableDisparityReport
-          key={props.dropdownVarId2 + props.fips.code}
+        <ReportToggleControls
           dropdownVarId={props.dropdownVarId2}
-          fips={props.fips}
-          updateFipsCallback={(fips: Fips) => props.updateFipsCallback(fips)}
-          vertical={true}
-          hidePopulationCard={true}
+          variableConfig={variableConfig2}
+          setVariableConfig={setVariableConfig2}
+          currentBreakdown={currentBreakdown}
+          setCurrentBreakdown={setCurrentBreakdown}
         />
       </Grid>
+      <Grid item xs={6}>
+        <MapCard
+          metricConfig={variableConfig1.metrics["per100k"]}
+          fips={props.fips1}
+          updateFipsCallback={(fips: Fips) => {
+            props.updateFips1Callback(fips);
+          }}
+          currentBreakdown={currentBreakdown}
+        />
+      </Grid>
+      <Grid item xs={6}>
+        <MapCard
+          metricConfig={variableConfig2.metrics["per100k"]}
+          fips={props.fips2}
+          updateFipsCallback={(fips: Fips) => {
+            props.updateFips2Callback(fips);
+          }}
+          currentBreakdown={currentBreakdown}
+        />
+      </Grid>
+
+      {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) =>
+        !breakdownIsShown(breakdownVar) ? null : (
+          <>
+            <Grid item xs={6}>
+              <TableCard
+                fips={props.fips1}
+                metrics={getTableFields(variableConfig1)}
+                breakdownVar={breakdownVar}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <TableCard
+                fips={props.fips2}
+                metrics={getTableFields(variableConfig2)}
+                breakdownVar={breakdownVar}
+              />
+            </Grid>
+          </>
+        )
+      )}
+      {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) =>
+        !breakdownIsShown(breakdownVar) ? null : (
+          <>
+            {variableConfig1.metrics["pct_share"] && (
+              <Grid item xs={6}>
+                <DisparityBarChartCard
+                  metricConfig={variableConfig1.metrics["pct_share"]}
+                  breakdownVar={breakdownVar}
+                  fips={props.fips1}
+                />
+              </Grid>
+            )}
+            {variableConfig2.metrics["pct_share"] && (
+              <Grid item xs={6}>
+                <DisparityBarChartCard
+                  metricConfig={variableConfig2.metrics["pct_share"]}
+                  breakdownVar={breakdownVar}
+                  fips={props.fips2}
+                />
+              </Grid>
+            )}
+            {variableConfig1.metrics["per100k"] && (
+              <Grid item xs={6}>
+                <SimpleBarChartCard
+                  metricConfig={variableConfig1.metrics["per100k"]}
+                  breakdownVar={breakdownVar}
+                  fips={props.fips1}
+                />
+              </Grid>
+            )}
+            {variableConfig1.metrics["per100k"] && (
+              <Grid item xs={6}>
+                <SimpleBarChartCard
+                  metricConfig={variableConfig2.metrics["per100k"]}
+                  breakdownVar={breakdownVar}
+                  fips={props.fips2}
+                />
+              </Grid>
+            )}
+          </>
+        )
+      )}
     </Grid>
   );
 }

--- a/frontend/src/reports/VariableDisparityReport.tsx
+++ b/frontend/src/reports/VariableDisparityReport.tsx
@@ -1,12 +1,6 @@
 import React, { useState } from "react";
-import { Button, Grid } from "@material-ui/core";
-import Alert from "@material-ui/lab/Alert";
-import ToggleButton from "@material-ui/lab/ToggleButton";
-import ToggleButtonGroup from "@material-ui/lab/ToggleButtonGroup";
-import {
-  BreakdownVar,
-  BREAKDOWN_VAR_DISPLAY_NAMES,
-} from "../data/query/Breakdowns";
+import { Grid } from "@material-ui/core";
+import { BreakdownVar, DEMOGRAPHIC_BREAKDOWNS } from "../data/query/Breakdowns";
 import { MapCard } from "../cards/MapCard";
 import { PopulationCard } from "../cards/PopulationCard";
 import { TableCard } from "../cards/TableCard";
@@ -17,15 +11,10 @@ import { Fips } from "../data/utils/Fips";
 import {
   METRIC_CONFIG,
   VariableConfig,
-  MetricConfig,
+  getTableFields,
 } from "../data/config/MetricConfig";
-import styles from "./Report.module.scss";
-
-const SUPPORTED_BREAKDOWNS: BreakdownVar[] = [
-  "race_and_ethnicity",
-  "age",
-  "sex",
-];
+import ReportToggleControls from "./ui/ReportToggleControls";
+import NoDataAlert from "./ui/NoDataAlert";
 
 export interface VariableDisparityReportProps {
   key: string;
@@ -48,21 +37,6 @@ export function VariableDisparityReport(props: VariableDisparityReportProps) {
       : null
   );
 
-  let tableFields: MetricConfig[] = [];
-  if (variableConfig) {
-    if (variableConfig.metrics["per100k"]) {
-      tableFields.push(variableConfig.metrics["per100k"]);
-    }
-    if (variableConfig.metrics["pct_share"]) {
-      tableFields.push(variableConfig.metrics["pct_share"]);
-      if (variableConfig.metrics["pct_share"].populationComparisonMetric) {
-        tableFields.push(
-          variableConfig.metrics["pct_share"].populationComparisonMetric
-        );
-      }
-    }
-  }
-
   const breakdownIsShown = (breakdownVar: string) =>
     currentBreakdown === "all" || currentBreakdown === breakdownVar;
 
@@ -74,102 +48,18 @@ export function VariableDisparityReport(props: VariableDisparityReportProps) {
         </Grid>
       )}
 
-      {!variableConfig && (
-        <Grid item xs={5}>
-          <Alert style={{ margin: "20px" }} severity="error">
-            This data is not currently available in the Health Equity Tracker,
-            but will be coming soon.
-            <br />
-            {/* TODO - buttons should be actual working a href links and better follow UX*/}
-            <Button
-              style={{
-                padding: "0",
-                paddingLeft: "5px",
-                paddingRight: "5px",
-                background: "none",
-                textDecoration: "underline",
-              }}
-              onClick={() => alert("unimplemented")}
-            >
-              See our roadmap to learn more.
-            </Button>
-          </Alert>
-          <Alert variant="outlined" severity="info">
-            Do you have information on {props.dropdownVarId} at the state or
-            local level?
-            <Button
-              style={{
-                padding: "0",
-                paddingLeft: "5px",
-                paddingRight: "5px",
-                background: "none",
-                textDecoration: "underline",
-              }}
-              onClick={() => alert("unimplemented")}
-            >
-              We would love to hear from you.
-            </Button>
-          </Alert>
-        </Grid>
-      )}
+      {!variableConfig && <NoDataAlert dropdownVarId={props.dropdownVarId} />}
 
       {variableConfig && (
         <Grid container spacing={1} justify="center">
           <Grid container xs={12}>
-            {!!METRIC_CONFIG[props.dropdownVarId] &&
-              METRIC_CONFIG[props.dropdownVarId].length > 1 && (
-                <Grid item className={styles.ToggleBlock}>
-                  <span className={styles.ToggleLabel}>Choose Data Type</span>
-                  <ToggleButtonGroup
-                    exclusive
-                    value={variableConfig.variableId}
-                    onChange={(e, variableId) => {
-                      if (
-                        variableId !== null &&
-                        METRIC_CONFIG[props.dropdownVarId]
-                      ) {
-                        setVariableConfig(
-                          METRIC_CONFIG[props.dropdownVarId].find(
-                            (variableConfig) =>
-                              variableConfig.variableId === variableId
-                          ) as VariableConfig
-                        );
-                      }
-                    }}
-                    aria-label="text formatting"
-                  >
-                    {METRIC_CONFIG[props.dropdownVarId].map(
-                      (variable: VariableConfig, key: number) => (
-                        <ToggleButton value={variable.variableId} key={key}>
-                          {variable.variableDisplayName}
-                        </ToggleButton>
-                      )
-                    )}
-                  </ToggleButtonGroup>
-                </Grid>
-              )}
-            <Grid item className={styles.ToggleBlock}>
-              <span className={styles.ToggleLabel}>Choose Demographic</span>
-              <ToggleButtonGroup
-                exclusive
-                value={currentBreakdown}
-                onChange={(e, v) => {
-                  if (v !== null) {
-                    setCurrentBreakdown(v);
-                  }
-                }}
-                aria-label="text formatting"
-              >
-                <ToggleButton value="all" key="all">
-                  All
-                </ToggleButton>
-                {SUPPORTED_BREAKDOWNS.map((breakdownVar) => (
-                  <ToggleButton value={breakdownVar} key={breakdownVar}>
-                    {BREAKDOWN_VAR_DISPLAY_NAMES[breakdownVar]}
-                  </ToggleButton>
-                ))}
-              </ToggleButtonGroup>
-            </Grid>
+            <ReportToggleControls
+              dropdownVarId={props.dropdownVarId}
+              variableConfig={variableConfig}
+              setVariableConfig={setVariableConfig}
+              currentBreakdown={currentBreakdown}
+              setCurrentBreakdown={setCurrentBreakdown}
+            />
           </Grid>
           <Grid item xs={props.vertical ? 12 : 6}>
             <MapCard
@@ -180,12 +70,12 @@ export function VariableDisparityReport(props: VariableDisparityReportProps) {
               }}
               currentBreakdown={currentBreakdown}
             />
-            {SUPPORTED_BREAKDOWNS.map((breakdownVar) => (
+            {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
               <>
                 {breakdownIsShown(breakdownVar) && (
                   <TableCard
                     fips={props.fips}
-                    metrics={tableFields}
+                    metrics={getTableFields(variableConfig)}
                     breakdownVar={breakdownVar}
                   />
                 )}
@@ -193,7 +83,7 @@ export function VariableDisparityReport(props: VariableDisparityReportProps) {
             ))}
           </Grid>
           <Grid item xs={props.vertical ? 12 : 6}>
-            {SUPPORTED_BREAKDOWNS.map((breakdownVar) => (
+            {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
               <>
                 {breakdownIsShown(breakdownVar) &&
                   variableConfig.metrics["pct_share"] && (

--- a/frontend/src/reports/VariableDisparityReport.tsx
+++ b/frontend/src/reports/VariableDisparityReport.tsx
@@ -11,7 +11,7 @@ import { Fips } from "../data/utils/Fips";
 import {
   METRIC_CONFIG,
   VariableConfig,
-  getTableFields,
+  getPer100kAndPctShareMetrics,
 } from "../data/config/MetricConfig";
 import ReportToggleControls from "./ui/ReportToggleControls";
 import NoDataAlert from "./ui/NoDataAlert";
@@ -75,7 +75,7 @@ export function VariableDisparityReport(props: VariableDisparityReportProps) {
                 {breakdownIsShown(breakdownVar) && (
                   <TableCard
                     fips={props.fips}
-                    metrics={getTableFields(variableConfig)}
+                    metrics={getPer100kAndPctShareMetrics(variableConfig)}
                     breakdownVar={breakdownVar}
                   />
                 )}

--- a/frontend/src/reports/ui/NoDataAlert.tsx
+++ b/frontend/src/reports/ui/NoDataAlert.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import Button from "@material-ui/core/Button";
+import { Grid } from "@material-ui/core";
+import Alert from "@material-ui/lab/Alert";
+
+function NoDataAlert(props: { dropdownVarId: string }) {
+  return (
+    <Grid item xs={5}>
+      <Alert style={{ margin: "20px" }} severity="error">
+        This data is not currently available in the Health Equity Tracker, but
+        will be coming soon.
+        <br />
+        {/* TODO - buttons should be actual working a href links and better follow UX*/}
+        <Button
+          style={{
+            padding: "0",
+            paddingLeft: "5px",
+            paddingRight: "5px",
+            background: "none",
+            textDecoration: "underline",
+          }}
+          onClick={() => alert("unimplemented")}
+        >
+          See our roadmap to learn more.
+        </Button>
+      </Alert>
+      <Alert variant="outlined" severity="info">
+        Do you have information on {props.dropdownVarId} at the state or local
+        level?
+        <Button
+          style={{
+            padding: "0",
+            paddingLeft: "5px",
+            paddingRight: "5px",
+            background: "none",
+            textDecoration: "underline",
+          }}
+          onClick={() => alert("unimplemented")}
+        >
+          We would love to hear from you.
+        </Button>
+      </Alert>
+    </Grid>
+  );
+}
+
+export default NoDataAlert;

--- a/frontend/src/reports/ui/NoDataAlert.tsx
+++ b/frontend/src/reports/ui/NoDataAlert.tsx
@@ -19,6 +19,7 @@ function NoDataAlert(props: { dropdownVarId: string }) {
             background: "none",
             textDecoration: "underline",
           }}
+          /* TODO - https://github.com/SatcherInstitute/health-equity-tracker/issues/431 */
           onClick={() => alert("unimplemented")}
         >
           See our roadmap to learn more.
@@ -35,6 +36,7 @@ function NoDataAlert(props: { dropdownVarId: string }) {
             background: "none",
             textDecoration: "underline",
           }}
+          /* TODO - https://github.com/SatcherInstitute/health-equity-tracker/issues/431 */
           onClick={() => alert("unimplemented")}
         >
           We would love to hear from you.

--- a/frontend/src/reports/ui/ReportToggleControls.tsx
+++ b/frontend/src/reports/ui/ReportToggleControls.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import ToggleButton from "@material-ui/lab/ToggleButton";
+import ToggleButtonGroup from "@material-ui/lab/ToggleButtonGroup";
+import { Grid } from "@material-ui/core";
+import { DropdownVarId } from "../../utils/MadLibs";
+import { METRIC_CONFIG, VariableConfig } from "../../data/config/MetricConfig";
+import styles from "../Report.module.scss";
+import {
+  BreakdownVar,
+  DEMOGRAPHIC_BREAKDOWNS,
+  BREAKDOWN_VAR_DISPLAY_NAMES,
+} from "../../data/query/Breakdowns";
+
+interface ReportToggleControlsProps {
+  dropdownVarId: DropdownVarId;
+  variableConfig: VariableConfig;
+  setVariableConfig: (variableConfig: VariableConfig) => void;
+  currentBreakdown: BreakdownVar | "all";
+  setCurrentBreakdown: (breakdown: BreakdownVar) => void;
+}
+
+// This wrapper ensures the proper key is set to create a new instance when
+// required rather than relying on the card caller.
+export function ReportToggleControls(props: ReportToggleControlsProps) {
+  return (
+    <ReportToggleControlsWithKey
+      key={props.dropdownVarId + props.variableConfig.variableId}
+      {...props}
+    />
+  );
+}
+
+function ReportToggleControlsWithKey(props: ReportToggleControlsProps) {
+  const enableMetricToggle =
+    !!METRIC_CONFIG[props.dropdownVarId] &&
+    METRIC_CONFIG[props.dropdownVarId].length > 1;
+
+  return (
+    <Grid container>
+      {enableMetricToggle && (
+        <Grid className={styles.ToggleBlock}>
+          <span className={styles.ToggleLabel}>Choose Data Type</span>
+          <ToggleButtonGroup
+            exclusive
+            value={props.variableConfig.variableId}
+            onChange={(e, variableId) => {
+              if (variableId !== null && METRIC_CONFIG[props.dropdownVarId]) {
+                props.setVariableConfig(
+                  METRIC_CONFIG[props.dropdownVarId].find(
+                    (variableConfig) => variableConfig.variableId === variableId
+                  ) as VariableConfig
+                );
+              }
+            }}
+          >
+            {METRIC_CONFIG[props.dropdownVarId].map(
+              (variable: VariableConfig, key: number) => (
+                <ToggleButton value={variable.variableId} key={key}>
+                  {variable.variableDisplayName}
+                </ToggleButton>
+              )
+            )}
+          </ToggleButtonGroup>
+        </Grid>
+      )}
+      <Grid item className={styles.ToggleBlock}>
+        <span className={styles.ToggleLabel}>Choose Demographic</span>
+        <ToggleButtonGroup
+          exclusive
+          value={props.currentBreakdown}
+          onChange={(e, v) => {
+            if (v !== null) {
+              props.setCurrentBreakdown(v);
+            }
+          }}
+        >
+          <ToggleButton value="all" key="all">
+            All
+          </ToggleButton>
+          {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
+            <ToggleButton value={breakdownVar} key={breakdownVar}>
+              {BREAKDOWN_VAR_DISPLAY_NAMES[breakdownVar]}
+            </ToggleButton>
+          ))}
+        </ToggleButtonGroup>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default ReportToggleControls;


### PR DESCRIPTION
Restructure reports so that on two-column comparison MadLibs each card is properly aligned with its counterpart in the other column