### PR TITLE
Add aggregation for CDC restricted data

### DIFF
--- a/airflow/dags/cdc_restricted.py
+++ b/airflow/dags/cdc_restricted.py
@@ -27,11 +27,19 @@ cdc_bq_payload = util.generate_bq_payload(
     _CDC_RESTRICTED_WORKFLOW_ID,
     _CDC_RESTRICTED_DATASET,
     gcs_bucket=Variable.get('GCS_MANUAL_UPLOADS_BUCKET'),
-    filename=_CDC_RESTRICTED_GCS_FILENAMES
-)
+    filename=_CDC_RESTRICTED_GCS_FILENAMES)
 cdc_restricted_bq_op = util.create_bq_ingest_operator(
-    'cdc_restricted_data', cdc_bq_payload, data_ingestion_dag
-)
+    'cdc_restricted_data', cdc_bq_payload, data_ingestion_dag)
+
+cdc_restricted_aggregator_payload = {'dataset_name': _CDC_RESTRICTED_DATASET}
+cdc_restricted_aggregator_operator = util.create_aggregator_operator(
+    'cdc_restricted_aggregator', cdc_restricted_aggregator_payload,
+    data_ingestion_dag)
+
+cdc_restricted_exporter_payload = {'dataset_name': _CDC_RESTRICTED_DATASET}
+cdc_restricted_exporter_operator = util.create_exporter_operator(
+    'cdc_restricted_exporter', cdc_restricted_exporter_payload,
+    data_ingestion_dag)
 
 # CDC Restricted Data Ingestion DAG
-cdc_restricted_bq_op
+cdc_restricted_bq_op >> cdc_restricted_aggregator_operator >> cdc_restricted_exporter_operator

--- a/airflow/dags/cdc_restricted.py
+++ b/airflow/dags/cdc_restricted.py
@@ -29,7 +29,7 @@ cdc_bq_payload = util.generate_bq_payload(
     gcs_bucket=Variable.get('GCS_MANUAL_UPLOADS_BUCKET'),
     filename=_CDC_RESTRICTED_GCS_FILENAMES)
 cdc_restricted_bq_op = util.create_bq_ingest_operator(
-    'cdc_restricted_data', cdc_bq_payload, data_ingestion_dag)
+    'cdc_restricted_gcs_to_bq', cdc_bq_payload, data_ingestion_dag)
 
 cdc_restricted_aggregator_payload = {'dataset_name': _CDC_RESTRICTED_DATASET}
 cdc_restricted_aggregator_operator = util.create_aggregator_operator(

--- a/config/data_sources/AGG_acs_population.sql
+++ b/config/data_sources/AGG_acs_population.sql
@@ -37,14 +37,14 @@ CREATE TEMP FUNCTION getStaggeredDecadeAgeBuckets(x ANY TYPE) AS (
 -- been deduped and only include the latest rows.
 CREATE OR REPLACE TABLE acs_population.by_sex_age_state AS
 SELECT state_fips, state_name, sex, getDecadeAgeBucket(age) AS age, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std`
+FROM `acs_population.by_sex_age_race_state_std_staging`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, state_name, sex, age
 ORDER BY state_fips, state_name, sex, age;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_age_county AS
 SELECT state_fips, county_fips, county_name, sex, getDecadeAgeBucket(age) AS age, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std`
+FROM `acs_population.by_sex_age_race_county_std_staging`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, county_fips, county_name, sex, age
 ORDER BY state_fips, county_fips, county_name, sex, age;
@@ -68,13 +68,13 @@ ORDER BY state_fips, county_fips, county_name, age;
 -- age bucket availability.
 CREATE OR REPLACE TABLE acs_population.by_sex_age_race_state_staggered_buckets AS
 SELECT state_fips, state_name, sex, getStaggeredDecadeAgeBuckets(age) AS age, race_and_ethnicity, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std`
+FROM `acs_population.by_sex_age_race_state_std_staging`
 GROUP BY state_fips, state_name, sex, age, race_and_ethnicity
 ORDER BY state_fips, state_name, sex, age, race_and_ethnicity;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_age_race_county_staggered_buckets AS
 SELECT state_fips, county_fips, county_name, sex, getStaggeredDecadeAgeBuckets(age) AS age, race_and_ethnicity, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std`
+FROM `acs_population.by_sex_age_race_county_std_staging`
 GROUP BY state_fips, county_fips, county_name, sex, age, race_and_ethnicity
 ORDER BY state_fips, county_fips, county_name, sex, age, race_and_ethnicity;
 
@@ -94,14 +94,14 @@ ORDER BY state_fips, county_fips, county_name, age, race_and_ethnicity;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_state AS
 SELECT state_fips, state_name, sex, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std`
+FROM `acs_population.by_sex_age_race_state_std_staging`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, state_name, sex
 ORDER BY state_fips, state_name, sex;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_county AS
 SELECT state_fips, county_fips, county_name, sex, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std`
+FROM `acs_population.by_sex_age_race_county_std_staging`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, county_fips, county_name, sex
 ORDER BY state_fips, county_fips, county_name, sex;

--- a/config/data_sources/AGG_acs_population.sql
+++ b/config/data_sources/AGG_acs_population.sql
@@ -37,14 +37,14 @@ CREATE TEMP FUNCTION getStaggeredDecadeAgeBuckets(x ANY TYPE) AS (
 -- been deduped and only include the latest rows.
 CREATE OR REPLACE TABLE acs_population.by_sex_age_state AS
 SELECT state_fips, state_name, sex, getDecadeAgeBucket(age) AS age, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std_staging`
+FROM `acs_population.by_sex_age_race_state_std`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, state_name, sex, age
 ORDER BY state_fips, state_name, sex, age;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_age_county AS
 SELECT state_fips, county_fips, county_name, sex, getDecadeAgeBucket(age) AS age, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std_staging`
+FROM `acs_population.by_sex_age_race_county_std`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, county_fips, county_name, sex, age
 ORDER BY state_fips, county_fips, county_name, sex, age;
@@ -68,13 +68,13 @@ ORDER BY state_fips, county_fips, county_name, age;
 -- age bucket availability.
 CREATE OR REPLACE TABLE acs_population.by_sex_age_race_state_staggered_buckets AS
 SELECT state_fips, state_name, sex, getStaggeredDecadeAgeBuckets(age) AS age, race_and_ethnicity, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std_staging`
+FROM `acs_population.by_sex_age_race_state_std`
 GROUP BY state_fips, state_name, sex, age, race_and_ethnicity
 ORDER BY state_fips, state_name, sex, age, race_and_ethnicity;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_age_race_county_staggered_buckets AS
 SELECT state_fips, county_fips, county_name, sex, getStaggeredDecadeAgeBuckets(age) AS age, race_and_ethnicity, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std_staging`
+FROM `acs_population.by_sex_age_race_county_std`
 GROUP BY state_fips, county_fips, county_name, sex, age, race_and_ethnicity
 ORDER BY state_fips, county_fips, county_name, sex, age, race_and_ethnicity;
 
@@ -94,14 +94,14 @@ ORDER BY state_fips, county_fips, county_name, age, race_and_ethnicity;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_state AS
 SELECT state_fips, state_name, sex, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_state_std_staging`
+FROM `acs_population.by_sex_age_race_state_std`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, state_name, sex
 ORDER BY state_fips, state_name, sex;
 
 CREATE OR REPLACE TABLE acs_population.by_sex_county AS
 SELECT state_fips, county_fips, county_name, sex, SUM(population) AS population
-FROM `acs_population.by_sex_age_race_county_std_staging`
+FROM `acs_population.by_sex_age_race_county_std`
 WHERE race_and_ethnicity = "Total"
 GROUP BY state_fips, county_fips, county_name, sex
 ORDER BY state_fips, county_fips, county_name, sex;

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -1,0 +1,127 @@
+-- Ignore all ingestion timestamps. These queries assume that the dataset has
+-- already been deduped and only include the latest rows.
+
+-- State-level joins with ACS population tables. First, we join with a public
+-- state fips codes dataset so we can convert from two-leter state postal
+-- abbreivation to state fips and full state name (eg AL -> 01 and "Alabama").
+CREATE OR REPLACE TABLE cdc_restricted_data.by_race_state AS
+WITH cdc_restricted_race_state AS (
+    SELECT
+        b.state_fips_code as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.race_and_ethnicity,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_race_state` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+    ON a.state_name = b.state_postal_abbreviation
+)
+SELECT
+    x.state_fips, x.state_name,
+    x.race_and_ethnicity,
+    x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
+    y.population
+FROM cdc_restricted_race_state AS x
+LEFT JOIN `acs_population.by_race_state_std_staging` AS y ON
+  x.state_fips = y.state_fips AND
+  x.race_and_ethnicity = y.race_and_ethnicity
+;
+
+CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_state AS
+WITH cdc_restricted_sex_state AS (
+    SELECT
+        b.state_fips_code as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.sex,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_sex_state` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+    ON a.state_name = b.state_postal_abbreviation
+)
+SELECT
+    x.state_fips, x.state_name,
+    x.sex,
+    x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
+    y.population
+FROM cdc_restricted_sex_state AS x
+LEFT JOIN `acs_population.by_sex_state` AS y ON
+  x.state_fips = y.state_fips AND
+  x.sex = y.sex
+;
+
+CREATE OR REPLACE TABLE cdc_restricted_data.by_age_state AS
+WITH cdc_restricted_age_state AS (
+    SELECT
+        b.state_fips_code as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.age,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_age_state` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+    ON a.state_name = b.state_postal_abbreviation
+)
+SELECT
+    x.state_fips, x.state_name,
+    x.age,
+    x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
+    y.population
+FROM cdc_restricted_age_state AS x
+LEFT JOIN `acs_population.by_age_state` AS y ON
+  x.state_fips = y.state_fips AND
+  x.age = y.age
+;
+
+
+-- County-level joins with ACS population tables. We do the same join as in the
+-- state case first to get state fips codes.
+CREATE OR REPLACE TABLE cdc_restricted_data.by_race_county AS
+WITH cdc_restricted_race_county AS (
+    SELECT
+        a.county_fips, a.county_name,
+        b.state_fips_code as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.race_and_ethnicity,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_race_state` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+    ON a.state_name = b.state_postal_abbreviation
+)
+SELECT
+    x.county_fips, y.county_name, y.state_fips, x.state_name,
+    x.race_and_ethnicity,
+    x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
+    y.population
+FROM cdc_restricted_race_county AS x
+LEFT JOIN `acs_population.by_race_county_std_staging` AS y ON
+  x.county_fips = CAST(y.county_fips as INT64) AND
+  x.race_and_ethnicity = y.race_and_ethnicity
+;
+
+CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_county AS
+SELECT
+    x.county_fips, y.county_name, y.state_fips, x.state_name,
+    x.sex,
+    SUM(x.cases) as cases,
+    SUM(x.hosp_y) as hosp_y, SUM(x.hosp_n) as hosp_n, SUM(x.hosp_unknown) as hosp_unknown,
+    SUM(x.death_y) as death_y, SUM(x.death_n)as death_n, SUM(x.death_unknown) as death_unknown,
+    SUM(y.population) as population
+FROM `cdc_restricted_data.cdc_restricted_by_sex_county` AS x
+LEFT JOIN `acs_population.by_sex_county` AS y ON
+  x.county_fips = CAST(y.county_fips as INT64) AND
+  x.sex = y.sex
+GROUP BY 1, 2, 3, 4, 5
+;
+
+CREATE OR REPLACE TABLE cdc_restricted_data.by_age_county AS
+SELECT
+    x.county_fips, y.county_name, y.state_fips, x.state_name,
+    x.age,
+    SUM(x.cases) as cases,
+    SUM(x.hosp_y) as hosp_y, SUM(x.hosp_n) as hosp_n, SUM(x.hosp_unknown) as hosp_unknown,
+    SUM(x.death_y) as death_y, SUM(x.death_n)as death_n, SUM(x.death_unknown) as death_unknown,
+    SUM(y.population) as population
+FROM `cdc_restricted_data.cdc_restricted_by_age_county` AS x
+LEFT JOIN `acs_population.by_age_county` AS y ON
+  x.county_fips = CAST(y.county_fips as INT64) AND
+  x.age = y.age
+GROUP BY 1, 2, 3, 4, 5
+;

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -4,16 +4,17 @@
 -- State-level joins with ACS population tables. First, we join with a public
 -- state fips codes dataset so we can convert from two-leter state postal
 -- abbreivation to state fips and full state name (eg AL -> 01 and "Alabama").
+-- Then we join with ACS on state x {race, sex, age}.
 CREATE OR REPLACE TABLE cdc_restricted_data.by_race_state AS
 WITH cdc_restricted_race_state AS (
-    SELECT
+    SELECT DISTINCT
         b.state_fips_code as state_fips,
         IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
         a.race_and_ethnicity,
         a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
     FROM `cdc_restricted_data.cdc_restricted_by_race_state` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
-    ON a.state_name = b.state_postal_abbreviation
+        ON a.state_name = b.state_postal_abbreviation
 )
 SELECT
     x.state_fips, x.state_name,
@@ -28,7 +29,7 @@ LEFT JOIN `acs_population.by_race_state_std_staging` AS y ON
 
 CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_state AS
 WITH cdc_restricted_sex_state AS (
-    SELECT
+    SELECT DISTINCT
         b.state_fips_code as state_fips,
         IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
         a.sex,
@@ -50,7 +51,7 @@ LEFT JOIN `acs_population.by_sex_state` AS y ON
 
 CREATE OR REPLACE TABLE cdc_restricted_data.by_age_state AS
 WITH cdc_restricted_age_state AS (
-    SELECT
+    SELECT DISTINCT
         b.state_fips_code as state_fips,
         IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
         a.age,
@@ -71,57 +72,75 @@ LEFT JOIN `acs_population.by_age_state` AS y ON
 ;
 
 
--- County-level joins with ACS population tables. We do the same join as in the
--- state case first to get state fips codes.
+-- County-level joins with ACS population tables. We first do the same join as
+-- in the state case to get state fips codes and use ACS state & county names,
+-- but also join with the ACS population table to get ACS county names. We then
+-- join again with ACS, this time to get county x {race, sex, age} data.
 CREATE OR REPLACE TABLE cdc_restricted_data.by_race_county AS
 WITH cdc_restricted_race_county AS (
-    SELECT
-        a.county_fips, a.county_name,
-        b.state_fips_code as state_fips,
+    SELECT DISTINCT
+        a.county_fips,
+        IF(a.county_fips = "", "Unknown", c.county_name) as county_name,
+        IF(a.state_name = "Unknown", "", b.state_fips_code) as state_fips,
         IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
         a.race_and_ethnicity,
         a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
-    FROM `cdc_restricted_data.cdc_restricted_by_race_state` AS a
+    FROM `cdc_restricted_data.cdc_restricted_by_race_county` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
-    ON a.state_name = b.state_postal_abbreviation
+        ON a.state_name = b.state_postal_abbreviation
+    LEFT JOIN `acs_population.by_race_county_std_staging` as c
+        ON a.county_fips = c.county_fips
 )
 SELECT
-    x.county_fips, y.county_name, y.state_fips, x.state_name,
-    x.race_and_ethnicity,
-    x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
-    y.population
+    x.*, y.population
 FROM cdc_restricted_race_county AS x
 LEFT JOIN `acs_population.by_race_county_std_staging` AS y ON
-  x.county_fips = CAST(y.county_fips as INT64) AND
-  x.race_and_ethnicity = y.race_and_ethnicity
+    x.county_fips = y.county_fips AND
+    x.race_and_ethnicity = y.race_and_ethnicity
 ;
 
 CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_county AS
+WITH cdc_restricted_sex_county AS (
+    SELECT DISTINCT
+        a.county_fips,
+        IF(a.county_fips = "", "Unknown", c.county_name) as county_name,
+        IF(a.state_name = "Unknown", "", b.state_fips_code) as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.sex,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_sex_county` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+        ON a.state_name = b.state_postal_abbreviation
+    LEFT JOIN `acs_population.by_sex_county` as c
+        ON a.county_fips = c.county_fips
+)
 SELECT
-    x.county_fips, y.county_name, y.state_fips, x.state_name,
-    x.sex,
-    SUM(x.cases) as cases,
-    SUM(x.hosp_y) as hosp_y, SUM(x.hosp_n) as hosp_n, SUM(x.hosp_unknown) as hosp_unknown,
-    SUM(x.death_y) as death_y, SUM(x.death_n)as death_n, SUM(x.death_unknown) as death_unknown,
-    SUM(y.population) as population
-FROM `cdc_restricted_data.cdc_restricted_by_sex_county` AS x
+    x.*, y.population
+FROM cdc_restricted_sex_county AS x
 LEFT JOIN `acs_population.by_sex_county` AS y ON
-  x.county_fips = CAST(y.county_fips as INT64) AND
-  x.sex = y.sex
-GROUP BY 1, 2, 3, 4, 5
+    x.county_fips = y.county_fips AND
+    x.sex = y.sex
 ;
 
 CREATE OR REPLACE TABLE cdc_restricted_data.by_age_county AS
+WITH cdc_restricted_age_county AS (
+    SELECT DISTINCT
+        a.county_fips,
+        IF(a.county_fips = "", "Unknown", c.county_name) as county_name,
+        IF(a.state_name = "Unknown", "", b.state_fips_code) as state_fips,
+        IF(a.state_name = "Unknown", "Unknown", b.state_name) as state_name,
+        a.age,
+        a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
+    FROM `cdc_restricted_data.cdc_restricted_by_age_county` AS a
+    LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
+        ON a.state_name = b.state_postal_abbreviation
+    LEFT JOIN `acs_population.by_age_county` as c
+        ON a.county_fips = c.county_fips
+)
 SELECT
-    x.county_fips, y.county_name, y.state_fips, x.state_name,
-    x.age,
-    SUM(x.cases) as cases,
-    SUM(x.hosp_y) as hosp_y, SUM(x.hosp_n) as hosp_n, SUM(x.hosp_unknown) as hosp_unknown,
-    SUM(x.death_y) as death_y, SUM(x.death_n)as death_n, SUM(x.death_unknown) as death_unknown,
-    SUM(y.population) as population
-FROM `cdc_restricted_data.cdc_restricted_by_age_county` AS x
+    x.*, y.population
+FROM cdc_restricted_age_county AS x
 LEFT JOIN `acs_population.by_age_county` AS y ON
-  x.county_fips = CAST(y.county_fips as INT64) AND
-  x.age = y.age
-GROUP BY 1, 2, 3, 4, 5
+    x.county_fips = y.county_fips AND
+    x.age = y.age
 ;

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -96,6 +96,7 @@ SELECT
 FROM cdc_restricted_race_county AS x
 LEFT JOIN `acs_population.by_race_county_std_staging` AS y ON
     x.county_fips = y.county_fips AND
+    x.state_fips = y.state_fips AND
     x.race_and_ethnicity = y.race_and_ethnicity
 ;
 
@@ -119,6 +120,7 @@ SELECT
 FROM cdc_restricted_sex_county AS x
 LEFT JOIN `acs_population.by_sex_county` AS y ON
     x.county_fips = y.county_fips AND
+    x.state_fips = y.state_fips AND
     x.sex = y.sex
 ;
 
@@ -142,5 +144,6 @@ SELECT
 FROM cdc_restricted_age_county AS x
 LEFT JOIN `acs_population.by_age_county` AS y ON
     x.county_fips = y.county_fips AND
+    x.state_fips = y.state_fips AND
     x.age = y.age
 ;

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -22,7 +22,7 @@ SELECT
     x.cases, x.hosp_y, x.hosp_n, x.hosp_unknown, x.death_y, x.death_n, x.death_unknown,
     y.population
 FROM cdc_restricted_race_state AS x
-LEFT JOIN `acs_population.by_race_state_std_staging` AS y ON
+LEFT JOIN `acs_population.by_race_state_std` AS y ON
   x.state_fips = y.state_fips AND
   x.race_and_ethnicity = y.race_and_ethnicity
 ;
@@ -88,13 +88,13 @@ WITH cdc_restricted_race_county AS (
     FROM `cdc_restricted_data.cdc_restricted_by_race_county` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
         ON a.state_name = b.state_postal_abbreviation
-    LEFT JOIN `acs_population.by_race_county_std_staging` as c
+    LEFT JOIN `acs_population.by_race_county_std` as c
         ON a.county_fips = c.county_fips
 )
 SELECT
     x.*, y.population
 FROM cdc_restricted_race_county AS x
-LEFT JOIN `acs_population.by_race_county_std_staging` AS y ON
+LEFT JOIN `acs_population.by_race_county_std` AS y ON
     x.county_fips = y.county_fips AND
     x.state_fips = y.state_fips AND
     x.race_and_ethnicity = y.race_and_ethnicity

--- a/config/data_sources/cdc_restricted.tf
+++ b/config/data_sources/cdc_restricted.tf
@@ -6,10 +6,10 @@ resource "google_bigquery_dataset" "bq_cdc_restricted" {
   location   = "US"
 }
 
-resource "google_bigquery_routine" "bq_agg_acs_population" {
+resource "google_bigquery_routine" "bq_agg_cdc_restricted" {
   dataset_id = google_bigquery_dataset.bq_cdc_restricted.dataset_id
-  routine_id = "AGG_acs_population"
+  routine_id = "AGG_cdc_restricted"
   routine_type = "PROCEDURE"
   language = "SQL"
-  definition_body = file("${path.module}/AGG_acs_population.sql")
+  definition_body = file("${path.module}/AGG_cdc_restricted.sql")
 }

--- a/config/data_sources/cdc_restricted.tf
+++ b/config/data_sources/cdc_restricted.tf
@@ -5,3 +5,11 @@ resource "google_bigquery_dataset" "bq_cdc_restricted" {
   dataset_id = "cdc_restricted_data"
   location   = "US"
 }
+
+resource "google_bigquery_routine" "bq_agg_acs_population" {
+  dataset_id = google_bigquery_dataset.bq_cdc_restricted.dataset_id
+  routine_id = "AGG_acs_population"
+  routine_type = "PROCEDURE"
+  language = "SQL"
+  definition_body = file("${path.module}/AGG_acs_population.sql")
+}

--- a/python/datasources/acs_population.py
+++ b/python/datasources/acs_population.py
@@ -210,9 +210,9 @@ class ACSPopulationIngester():
             sex_by_age_frames[concept] = sex_by_age_frame
 
         frames = {
-            self.get_staging_table_name_by_race(): self.get_all_races_frame(
+            self.table_name_by_race(): self.get_all_races_frame(
                 race_and_hispanic_frame, total_frame),
-            self.get_staging_table_name_by_sex_age_race(): self.get_sex_by_age_and_race(
+            self.table_name_by_sex_age_race(): self.get_sex_by_age_and_race(
                 var_map, sex_by_age_frames)
         }
 

--- a/python/datasources/cdc_restricted_local.py
+++ b/python/datasources/cdc_restricted_local.py
@@ -45,7 +45,7 @@ COL_NAME_MAPPING = {
 
 # Mapping for county_fips, county, and state unknown values to "Unknown".
 COUNTY_FIPS_NAMES_MAPPING = {"NA": "-1"}  # Has to be str for later ingestion.
-COUNTY_NAMES_MAPPING = {"MISSING": "Unknown", "NA": "Unknown"}
+COUNTY_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
 STATE_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
 
 # Mappings for race, sex, and age values in the data to a standardized forms.

--- a/python/datasources/cdc_restricted_local.py
+++ b/python/datasources/cdc_restricted_local.py
@@ -44,7 +44,7 @@ COL_NAME_MAPPING = {
 }
 
 # Mapping for county_fips, county, and state unknown values to "Unknown".
-COUNTY_FIPS_NAMES_MAPPING = {"NA": "-1"}  # Has to be str for later ingestion.
+COUNTY_FIPS_NAMES_MAPPING = {"NA": ""}
 COUNTY_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
 STATE_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
 
@@ -213,6 +213,11 @@ def main():
             def _clean_str(x):
                 return x.replace('"', '').strip() if isinstance(x, str) else x
             df = df.applymap(_clean_str)
+
+            # For county fips, we make sure they are strings of length 5 as per
+            # our standardization (ignoring empty values).
+            df[COUNTY_FIPS_COL] = df[COUNTY_FIPS_COL].map(
+                lambda x: x.zfill(5) if len(x) > 0 else x)
 
             # For each of ({state, county} x {race, sex, age}), we slice the
             # data to focus on that dimension and aggregate.

--- a/python/datasources/cdc_restricted_local.py
+++ b/python/datasources/cdc_restricted_local.py
@@ -43,10 +43,75 @@ COL_NAME_MAPPING = {
     AGE_COL: std_col.AGE_COL,
 }
 
-# Mapping for county_fips, county, and state unknown values to "Unknown".
+# Mapping for county_fips and county unknown values to "Unknown".
 COUNTY_FIPS_NAMES_MAPPING = {"NA": "-1"}  # Has to be str for later ingestion.
 COUNTY_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
-STATE_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
+
+# Mapping for state 2-letter abbreviations to full name and for unknowns. This
+# is copied from https://pe.usps.com/text/pub28/28apb.htm.
+STATE_NAMES_MAPPING = {
+    "AL": "Alabama",
+    "AK": "Alaska",
+    "AS": "American Samoa",
+    "AZ": "Arizona",
+    "AR": "Arkansas",
+    "CA": "California",
+    "CO": "Colorado",
+    "CT": "Connecticut",
+    "DE": "Delaware",
+    "DC": "District of Columbia",
+    "FM": "Federated States of Micronesia",
+    "FL": "Florida",
+    "GA": "Georgia",
+    "GU": "Guam",
+    "HI": "Hawaii",
+    "ID": "Idaho",
+    "IL": "Illinois",
+    "IN": "Indiana",
+    "IA": "Iowa",
+    "KS": "Kansas",
+    "KY": "Kentucky",
+    "LA": "Louisiana",
+    "ME": "Maine",
+    "MH": "Marshall Islands",
+    "MD": "Maryland",
+    "MA": "Massachusetts",
+    "MI": "Michigan",
+    "MN": "Minnesota",
+    "MS": "Mississippi",
+    "MO": "Missouri",
+    "MT": "Montana",
+    "NE": "Nebraska",
+    "NV": "Nevada",
+    "NH": "New Hampshire",
+    "NJ": "New Jersey",
+    "NM": "New Mexico",
+    "NY": "New York",
+    "NC": "North Carolina",
+    "ND": "North Dakota",
+    "MP": "Northern Mariana Islands",
+    "OH": "Ohio",
+    "OK": "Oklahoma",
+    "OR": "Oregon",
+    "PW": "Palau",
+    "PA": "Pennsylvania",
+    "PR": "Puerto Rico",
+    "RI": "Rhode Island",
+    "SC": "South Carolina",
+    "SD": "South Dakota",
+    "TN": "Tennessee",
+    "TX": "Texas",
+    "UT": "Utah",
+    "VT": "Vermont",
+    "VI": "Virgin Islands",
+    "VA": "Virginia",
+    "WA": "Washington",
+    "WV": "West Virginia",
+    "WI": "Wisconsin",
+    "WY": "Wyoming",
+    "Missing": "Unknown",
+    "NA": "Unknown"
+}
 
 # Mappings for race, sex, and age values in the data to a standardized forms.
 # Note that these mappings cover the possible values in the data as of 3/1/21.

--- a/python/datasources/cdc_restricted_local.py
+++ b/python/datasources/cdc_restricted_local.py
@@ -43,75 +43,10 @@ COL_NAME_MAPPING = {
     AGE_COL: std_col.AGE_COL,
 }
 
-# Mapping for county_fips and county unknown values to "Unknown".
+# Mapping for county_fips, county, and state unknown values to "Unknown".
 COUNTY_FIPS_NAMES_MAPPING = {"NA": "-1"}  # Has to be str for later ingestion.
-COUNTY_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
-
-# Mapping for state 2-letter abbreviations to full name and for unknowns. This
-# is copied from https://pe.usps.com/text/pub28/28apb.htm.
-STATE_NAMES_MAPPING = {
-    "AL": "Alabama",
-    "AK": "Alaska",
-    "AS": "American Samoa",
-    "AZ": "Arizona",
-    "AR": "Arkansas",
-    "CA": "California",
-    "CO": "Colorado",
-    "CT": "Connecticut",
-    "DE": "Delaware",
-    "DC": "District of Columbia",
-    "FM": "Federated States of Micronesia",
-    "FL": "Florida",
-    "GA": "Georgia",
-    "GU": "Guam",
-    "HI": "Hawaii",
-    "ID": "Idaho",
-    "IL": "Illinois",
-    "IN": "Indiana",
-    "IA": "Iowa",
-    "KS": "Kansas",
-    "KY": "Kentucky",
-    "LA": "Louisiana",
-    "ME": "Maine",
-    "MH": "Marshall Islands",
-    "MD": "Maryland",
-    "MA": "Massachusetts",
-    "MI": "Michigan",
-    "MN": "Minnesota",
-    "MS": "Mississippi",
-    "MO": "Missouri",
-    "MT": "Montana",
-    "NE": "Nebraska",
-    "NV": "Nevada",
-    "NH": "New Hampshire",
-    "NJ": "New Jersey",
-    "NM": "New Mexico",
-    "NY": "New York",
-    "NC": "North Carolina",
-    "ND": "North Dakota",
-    "MP": "Northern Mariana Islands",
-    "OH": "Ohio",
-    "OK": "Oklahoma",
-    "OR": "Oregon",
-    "PW": "Palau",
-    "PA": "Pennsylvania",
-    "PR": "Puerto Rico",
-    "RI": "Rhode Island",
-    "SC": "South Carolina",
-    "SD": "South Dakota",
-    "TN": "Tennessee",
-    "TX": "Texas",
-    "UT": "Utah",
-    "VT": "Vermont",
-    "VI": "Virgin Islands",
-    "VA": "Virginia",
-    "WA": "Washington",
-    "WV": "West Virginia",
-    "WI": "Wisconsin",
-    "WY": "Wyoming",
-    "Missing": "Unknown",
-    "NA": "Unknown"
-}
+COUNTY_NAMES_MAPPING = {"MISSING": "Unknown", "NA": "Unknown"}
+STATE_NAMES_MAPPING = {"Missing": "Unknown", "NA": "Unknown"}
 
 # Mappings for race, sex, and age values in the data to a standardized forms.
 # Note that these mappings cover the possible values in the data as of 3/1/21.


### PR DESCRIPTION
Add aggregation logic for joining CDC restricted data with the public state_fips dataset & the ACS population tables. Also fix a standardization issue in the cdc_restricted local script to make county_fips a string.

Note this also updates/uses the "_staging" tables, which is a change that will have to be updated to use "_latest" once dedupe work is complete