### PR TITLE
Split ctp data into separate tables

### DIFF
--- a/python/datasources/covid_tracking_project.py
+++ b/python/datasources/covid_tracking_project.py
@@ -75,9 +75,16 @@ class CovidTrackingProject(DataSource):
 
         merged.drop(columns=['reports_api', 'reports_ind'], inplace=True)
 
-        # Write to BQ
-        gcs_to_bq_util.append_dataframe_to_bq(
-            merged, dataset, self.get_table_name())
+        # Split into separate tables by variable type
+        for variable_type in ['cases', 'deaths', 'tests', 'hosp']:
+            result = merged.copy()
+            result = result.loc[result['variable_type'] == variable_type]
+            result.rename(columns={'value': variable_type}, inplace=True)
+            result.drop('variable_type', axis='columns', inplace=True)
+            # Write to BQ
+            gcs_to_bq_util.append_dataframe_to_bq(
+                result, dataset, self.get_table_name() + '_' + variable_type)
+
 
     @staticmethod
     def _download_metadata(dataset: str) -> pd.DataFrame:

--- a/python/datasources/covid_tracking_project.py
+++ b/python/datasources/covid_tracking_project.py
@@ -85,7 +85,6 @@ class CovidTrackingProject(DataSource):
             gcs_to_bq_util.append_dataframe_to_bq(
                 result, dataset, self.get_table_name() + '_' + variable_type)
 
-
     @staticmethod
     def _download_metadata(dataset: str) -> pd.DataFrame:
         """Downloads the metadata table from BigQuery by executing a query.


### PR DESCRIPTION
This change splits CTP data into a separate table for each of cases, deaths, hospitalizations, and tests. This is to help make it easier to use the metadata without having to encode data type in each metadata column name. 

A few weeks ago the CTP data was not parsing (from the March 2 update), but the newest (and final) version parses fine.

#308 