### PR TITLE
Remove unknown county/state data from CDC restricted tables

### DIFF
--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -11,12 +11,13 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_race_state AS
 WITH cdc_restricted_race_state AS (
     SELECT DISTINCT
         b.state_fips_code as state_fips,
-        IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
+        b.state_name,
         a.race_and_ethnicity,
         a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
     FROM `cdc_restricted_data.cdc_restricted_by_race_state` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
         ON a.state_postal = b.state_postal_abbreviation
+    WHERE a.state_postal != "Unknown"
 )
 SELECT x.*, y.population
 FROM cdc_restricted_race_state AS x
@@ -29,12 +30,13 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_state AS
 WITH cdc_restricted_sex_state AS (
     SELECT DISTINCT
         b.state_fips_code as state_fips,
-        IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
+        b.state_name,
         a.sex,
         a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
     FROM `cdc_restricted_data.cdc_restricted_by_sex_state` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
-    ON a.state_postal = b.state_postal_abbreviation
+        ON a.state_postal = b.state_postal_abbreviation
+    WHERE a.state_postal != "Unknown"
 )
 SELECT x.*, y.population
 FROM cdc_restricted_sex_state AS x
@@ -47,12 +49,13 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_age_state AS
 WITH cdc_restricted_age_state AS (
     SELECT DISTINCT
         b.state_fips_code as state_fips,
-        IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
+        b.state_name,
         a.age,
         a.cases, a.hosp_y, a.hosp_n, a.hosp_unknown, a.death_y, a.death_n, a.death_unknown
     FROM `cdc_restricted_data.cdc_restricted_by_age_state` AS a
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_states` AS b
-    ON a.state_postal = b.state_postal_abbreviation
+        ON a.state_postal = b.state_postal_abbreviation
+    WHERE a.state_postal != "Unknown"
 )
 SELECT x.*, y.population
 FROM cdc_restricted_age_state AS x
@@ -71,7 +74,7 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_race_county AS
 WITH cdc_restricted_race_county AS (
     SELECT DISTINCT
         a.county_fips,
-        IF(a.county_fips = "", "Unknown", c.area_name) as county_name,
+        c.area_name as county_name,
         IF(a.state_postal = "Unknown", "", b.state_fips_code) as state_fips,
         IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
         a.race_and_ethnicity,
@@ -82,6 +85,7 @@ WITH cdc_restricted_race_county AS (
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_all` as c
         ON a.county_fips = c.county_fips_code AND
            c.summary_level_name = "state-county"
+    WHERE a.county_fips != ""
 )
 SELECT x.*, y.population
 FROM cdc_restricted_race_county AS x
@@ -94,7 +98,7 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_sex_county AS
 WITH cdc_restricted_sex_county AS (
     SELECT DISTINCT
         a.county_fips,
-        IF(a.county_fips = "", "Unknown", c.area_name) as county_name,
+        c.area_name as county_name,
         IF(a.state_postal = "Unknown", "", b.state_fips_code) as state_fips,
         IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
         a.sex,
@@ -105,6 +109,7 @@ WITH cdc_restricted_sex_county AS (
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_all` as c
         ON a.county_fips = c.county_fips_code AND
            c.summary_level_name = "state-county"
+    WHERE a.county_fips != ""
 )
 SELECT x.*, y.population
 FROM cdc_restricted_sex_county AS x
@@ -117,7 +122,7 @@ CREATE OR REPLACE TABLE cdc_restricted_data.by_age_county AS
 WITH cdc_restricted_age_county AS (
     SELECT DISTINCT
         a.county_fips,
-        IF(a.county_fips = "", "Unknown", c.area_name) as county_name,
+        c.area_name as county_name,
         IF(a.state_postal = "Unknown", "", b.state_fips_code) as state_fips,
         IF(a.state_postal = "Unknown", "Unknown", b.state_name) as state_name,
         a.age,
@@ -128,6 +133,7 @@ WITH cdc_restricted_age_county AS (
     LEFT JOIN `bigquery-public-data.census_utility.fips_codes_all` as c
         ON a.county_fips = c.county_fips_code AND
            c.summary_level_name = "state-county"
+    WHERE a.county_fips != ""
 )
 SELECT x.*, y.population
 FROM cdc_restricted_age_county AS x


### PR DESCRIPTION
These data are screwing up the dataframes in the FE due to the null values. They don't contain any useful info anyway, so just remove them.