### PR TITLE
Change unknown map update into Warning

### DIFF
--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -123,7 +123,7 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
                     handleClose={() => setUnknownsMapDialogOpen(false)}
                     open={unknownsMapDialogOpen}
                   />
-                  <Alert severity="info">
+                  <Alert severity="warning">
                     {unknowns[0][props.metricConfig.metricId]}
                     {props.metricConfig.shortVegaLabel} in{" "}
                     {props.fips.getFullDisplayName} reported had an unknown


### PR DESCRIPTION
Closes #555 

Here's the UI change: 
![Screen Shot 2021-04-08 at 11 16 30 AM](https://user-images.githubusercontent.com/6402808/114076843-fd0f0d00-985b-11eb-9b73-07360066f0a7.png)

This is also updating the colors of the alert (compare to the one on the left) per the Material guidelines.