### PR TITLE
Hide legend for MapCard when one result

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -250,7 +250,7 @@ function MapCardWithKey(props: MapCardProps) {
                   data={dataForActiveBreakdownFilter}
                   hideLegend={
                     queryResponse.dataIsMissing() ||
-                    dataForActiveBreakdownFilter.length === 0
+                    dataForActiveBreakdownFilter.length <= 1
                   }
                   showCounties={props.fips.isUsa() ? false : true}
                   fips={props.fips}


### PR DESCRIPTION
Closes #545

Legends just act weird when there is only one line in the dataset (for instance looking at values for one county). This just hides the legend in those circumstances since it's pointless. See comparison: 

![Screen Shot 2021-04-08 at 2 48 41 PM](https://user-images.githubusercontent.com/6402808/114100804-b29c8900-9879-11eb-9f93-c7642b201796.png)

Notice hover is still working.