### PR TITLE
Updating health equity page styles

### DIFF
--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.module.scss
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.module.scss
@@ -99,7 +99,7 @@
       font-size: 14px;
       font-weight: 400;
       line-height: 26px;
-      color: #5F6368;
+      color: #5f6368;
       margin: 0px;
     }
 
@@ -286,7 +286,7 @@
 
   .JoinTheEffortItemContainer {
     padding: 30px 0px 30px 0px;
-    border-top: 1px solid #5F6368;
+    border-top: 1px solid #5f6368;
     display: flex;
     align-items: center;
   }
@@ -331,42 +331,14 @@
     padding: 10px 0 10px 0;
   }
 
-  .EmailAddressForm {
-    border-radius: 40px;
-    width: 485px;
-    height: 60px;
-    background-color: white;
-    border: 1px solid #888888;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .EmailAddressFormText {
-    height: 60px;
-    background-color: transparent;
-    border: none;
-    margin-left: 20px;
-    font-size: 16px;
-
-    &:focus {
-      outline: none;
-    }
+  .EmailTextField {
+    width: 260px;
   }
 
   .EmailAddressFormSubmit {
-    height: 48px;
-    width: 150px;
-    border-radius: 40px;
-    background: $alt-green;
-    color: white;
-    border: none;
-    margin-right: 10px;
-
-    &:focus {
-      outline: 1px solid darkgreen;
-    }
+    height: 56px;
+    margin-left: 5px;
+    border-radius: 40px !important;
   }
 
   .SocialsDiv {
@@ -383,10 +355,21 @@
     font-size: 35px;
   }
 
+  .CopyIcon {
+    color: $alt-green;
+    height: 35px;
+  }
+
   .ContactUsLink {
     color: $alt-green;
     font-weight: 500;
     font-size: 26px;
     line-height: 31.47px;
+  }
+}
+
+.TextField {
+  .MuiOutlinedInput-root {
+    border-radius: 40px !important;
   }
 }

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -1,6 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "./WhatIsHealthEquityPage.module.scss";
+import Button from "@material-ui/core/Button";
+import Hidden from "@material-ui/core/Hidden";
+import IconButton from "@material-ui/core/IconButton";
+import FileCopyIcon from "@material-ui/icons/FileCopy";
 import Grid from "@material-ui/core/Grid";
+import TextField from "@material-ui/core/TextField";
 import Typography from "@material-ui/core/Typography";
 import FacebookIcon from "@material-ui/icons/Facebook";
 import TwitterIcon from "@material-ui/icons/Twitter";
@@ -11,8 +16,11 @@ import {
   ABOUT_US_PAGE_LINK,
 } from "../../utils/urlutils";
 import { ABOUT_US_CONTACT_TAB_INDEX } from "../AboutUs/AboutUsPage";
+import { CopyToClipboard } from "react-copy-to-clipboard";
 
 function WhatIsHealthEquityPage() {
+  const [textCopied, setTextCopied] = useState(false);
+
   return (
     <div className={styles.WhatIsHealthEquityPage}>
       <Grid container className={styles.Grid}>
@@ -23,13 +31,22 @@ function WhatIsHealthEquityPage() {
           justify="center"
           alignItems="center"
         >
-          <Grid container item xs={12} sm={12} md={4} className={styles.HeaderImgItem}>
-            <img
-              src="img/pexels-marcus-aurelius-4063919 1.png"
-              className={styles.HeaderImg}
-              alt="A woman in a wheelchair relaxing with a cup of tea"
-            />
-          </Grid>
+          <Hidden smDown>
+            <Grid
+              container
+              item
+              xs={12}
+              sm={12}
+              md={4}
+              className={styles.HeaderImgItem}
+            >
+              <img
+                src="img/pexels-marcus-aurelius-4063919 1.png"
+                className={styles.HeaderImg}
+                alt="A woman in a wheelchair relaxing with a cup of tea"
+              />
+            </Grid>
+          </Hidden>
           <Grid item xs={12} sm={12} md={8} className={styles.HeaderTextItem}>
             <Typography className={styles.HeaderText}>
               What is Health Equity?
@@ -58,7 +75,13 @@ function WhatIsHealthEquityPage() {
               alignItems="flex-start"
               className={styles.DefinitionsContainer}
             >
-              <Grid item  xs={12} sm={12} md={6} className={styles.DefinitionsItem}>
+              <Grid
+                item
+                xs={12}
+                sm={12}
+                md={6}
+                className={styles.DefinitionsItem}
+              >
                 <Typography className={styles.DefinitionHeader}>
                   Political determinants of health
                 </Typography>
@@ -75,7 +98,13 @@ function WhatIsHealthEquityPage() {
                   Daniel Dawes, 2020
                 </span>
               </Grid>
-              <Grid item  xs={12} sm={12} md={6} className={styles.DefinitionsItem}>
+              <Grid
+                item
+                xs={12}
+                sm={12}
+                md={6}
+                className={styles.DefinitionsItem}
+              >
                 <Typography className={styles.DefinitionHeader}>
                   Social determinant of health
                 </Typography>
@@ -115,7 +144,7 @@ function WhatIsHealthEquityPage() {
               justify="space-around"
               xs={12}
             >
-              <Grid item  xs={12} sm={12} md={9} className={styles.ResourceItem}>
+              <Grid item xs={12} sm={12} md={9} className={styles.ResourceItem}>
                 <iframe
                   className={styles.ResourceVideoEmbed}
                   width="100%"
@@ -138,7 +167,7 @@ function WhatIsHealthEquityPage() {
                   political determinants of health
                 </p>
               </Grid>
-              <Grid item  xs={12} sm={12} md={3}>
+              <Grid item xs={12} sm={12} md={3}>
                 <Grid
                   container
                   direction="column"
@@ -210,7 +239,13 @@ function WhatIsHealthEquityPage() {
               justify="space-between"
               alignItems="flex-start"
             >
-              <Grid item  xs={12} sm={12} md={6} className={styles.NewsAndStoriesItem}>
+              <Grid
+                item
+                xs={12}
+                sm={12}
+                md={6}
+                className={styles.NewsAndStoriesItem}
+              >
                 <img
                   className={styles.NewsAndStoriesBigImg}
                   src="img/pexels-august-de-richelieu-4261261 1.png"
@@ -231,7 +266,13 @@ function WhatIsHealthEquityPage() {
                   </a>
                 </p>
               </Grid>
-              <Grid item  xs={12} sm={12} md={6} className={styles.NewsAndStoriesItem}>
+              <Grid
+                item
+                xs={12}
+                sm={6}
+                md={6}
+                className={styles.NewsAndStoriesItem}
+              >
                 <img
                   className={styles.NewsAndStoriesBigImg}
                   src="img/pexels-cottonbro-7000149 1.png"
@@ -250,7 +291,13 @@ function WhatIsHealthEquityPage() {
                   </a>
                 </p>
               </Grid>
-              <Grid item  xs={12} sm={12} md={4} className={styles.NewsAndStoriesItem}>
+              <Grid
+                item
+                xs={12}
+                sm={6}
+                md={4}
+                className={styles.NewsAndStoriesItem}
+              >
                 <img
                   className={styles.NewsAndStoriesSmallImg}
                   src="img/pexels-alex-green-5699516 1.png"
@@ -266,7 +313,13 @@ function WhatIsHealthEquityPage() {
                   </a>
                 </p>
               </Grid>
-              <Grid item  xs={12} sm={12} md={4} className={styles.NewsAndStoriesItem}>
+              <Grid
+                item
+                xs={12}
+                sm={6}
+                md={4}
+                className={styles.NewsAndStoriesItem}
+              >
                 <img
                   className={styles.NewsAndStoriesSmallImg}
                   src="img/pexels-ketut-subiyanto-4473409 2.png"
@@ -279,7 +332,13 @@ function WhatIsHealthEquityPage() {
                   <a href="/">Learn more</a>
                 </p>
               </Grid>
-              <Grid item  xs={12} sm={12} md={4} className={styles.NewsAndStoriesItem}>
+              <Grid
+                item
+                xs={12}
+                sm={6}
+                md={4}
+                className={styles.NewsAndStoriesItem}
+              >
                 <img
                   className={styles.NewsAndStoriesSmallImg}
                   src="img/Screen Shot 2021-03-01 at 5.25 1.png"
@@ -318,19 +377,26 @@ function WhatIsHealthEquityPage() {
             <br />
           </Grid>
           <Grid container className={styles.JoinTheEffortItemContainer}>
+            <Hidden smDown>
+              <Grid
+                item
+                xs={5}
+                className={styles.JoinTheEffortImgContainer}
+                style={{ backgroundColor: "#275141" }}
+              >
+                <img
+                  src="img/Dots_1@2x 4.png"
+                  alt="Decorative dots"
+                  className={styles.JoinTheEffortImg}
+                />
+              </Grid>
+            </Hidden>
             <Grid
               item
-              xs={5}
-              className={styles.JoinTheEffortImgContainer}
-              style={{ backgroundColor: "#275141" }}
+              sm={12}
+              md={7}
+              className={styles.JoinTheEffortTextContainer}
             >
-              <img
-                src="img/Dots_1@2x 4.png"
-                alt="Decorative dots"
-                className={styles.JoinTheEffortImg}
-              />
-            </Grid>
-            <Grid item xs={7} className={styles.JoinTheEffortTextContainer}>
               <Typography className={styles.JoinTheEffortStepHeaderText}>
                 Sign up for our newsletter
               </Typography>
@@ -338,39 +404,51 @@ function WhatIsHealthEquityPage() {
                 Want updates on the latest news in health equity? Sign up for
                 our Satcher Health Leadership Institute newsletter.
               </p>
-              <form className={styles.EmailAddressForm}
-                    action="https://satcherinstitute.us11.list-manage.com/subscribe?u=6a52e908d61b03e0bbbd4e790&id=3ec1ba23cd&"
-                    method="post"
-                    target="_blank">
-                <input
-                  className={styles.EmailAddressFormText}
-                  type="email"
-                  id="mce-EMAIL"
+              <form
+                action="https://satcherinstitute.us11.list-manage.com/subscribe?u=6a52e908d61b03e0bbbd4e790&id=3ec1ba23cd&"
+                method="post"
+                target="_blank"
+              >
+                <TextField
+                  id="Enter email address to sign up" // Accessibility label
                   name="MERGE0"
+                  variant="outlined"
+                  className={styles.EmailTextField}
+                  type="email"
                   placeholder="Enter email address"
                 />
-                <input
-                  className={styles.EmailAddressFormSubmit}
+                <Button
                   type="submit"
-                  value="Sign up"
-                />
+                  color="primary"
+                  variant="contained"
+                  className={styles.EmailAddressFormSubmit}
+                >
+                  Sign up
+                </Button>
               </form>
             </Grid>
           </Grid>
           <Grid container className={styles.JoinTheEffortItemContainer}>
+            <Hidden smDown>
+              <Grid
+                item
+                md={5}
+                className={styles.JoinTheEffortImgContainer}
+                style={{ backgroundColor: "#D85C47" }}
+              >
+                <img
+                  src="img/het_lines 8.png"
+                  alt="Decorative thick lines"
+                  className={styles.JoinTheEffortImg}
+                />
+              </Grid>
+            </Hidden>
             <Grid
               item
-              xs={5}
-              className={styles.JoinTheEffortImgContainer}
-              style={{ backgroundColor: "#D85C47" }}
+              sm={12}
+              md={7}
+              className={styles.JoinTheEffortTextContainer}
             >
-              <img
-                src="img/het_lines 8.png"
-                alt="Decorative thick lines"
-                className={styles.JoinTheEffortImg}
-              />
-            </Grid>
-            <Grid item xs={7} className={styles.JoinTheEffortTextContainer}>
               <Typography className={styles.JoinTheEffortStepHeaderText}>
                 Share information with your community
               </Typography>
@@ -382,49 +460,75 @@ function WhatIsHealthEquityPage() {
                 <br />
                 Share this tool with your network
               </p>
-              <form className={styles.EmailAddressForm}>
-                <input
-                  className={styles.EmailAddressFormText}
-                  type="text"
-                  value="www.healthequitytracker.org"
-                  readOnly
-                />
-              </form>
               <div className={styles.SocialsDiv}>
-                <a target="_blank"
-                   rel="noopener noreferrer"
-                   href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fhealthequitytracker.org%2F&amp;src=sdkpreparse">
+                <IconButton
+                  target="_blank"
+                  href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fhealthequitytracker.org%2F&amp;src=sdkpreparse"
+                >
                   <FacebookIcon className={styles.SocialsIcon} />
-                </a>
-                <a target="_blank"
-                   rel="noopener noreferrer"
-                   href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fhealthequitytracker.org">
+                </IconButton>
+                <IconButton
+                  target="_blank"
+                  href="https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Fhealthequitytracker.org"
+                >
                   <LinkedInIcon className={styles.SocialsIcon} />
-                </a>
-                <a target="_blank"
-                   rel="noopener noreferrer"
-                   href="https://twitter.com/share?url=https%3A%2F%2Fwww.healthequitytracker.org"
-                   className="twitter-share-button"
-                   data-url="https://www.healthequitytracker.org">
+                </IconButton>
+                <IconButton
+                  target="_blank"
+                  href="https://twitter.com/share?url=https%3A%2F%2Fwww.healthequitytracker.org"
+                >
                   <TwitterIcon className={styles.SocialsIcon} />
-                </a>
+                </IconButton>
+              </div>
+              <TextField
+                InputProps={{
+                  readOnly: true,
+                }}
+                id="www.healthequitytracker.org" // Accessibility label
+                variant="outlined"
+                defaultValue="www.healthequitytracker.org"
+                className={styles.TextField}
+              />
+              <div className={styles.SocialsDiv}>
+                <CopyToClipboard
+                  text="www.healthequitytracker.org"
+                  onCopy={() => {
+                    setTextCopied(true);
+                    setTimeout(() => setTextCopied(false), 1500);
+                  }}
+                >
+                  <Button
+                    className={styles.CopyIcon}
+                    startIcon={<FileCopyIcon />}
+                  >
+                    Copy link to clipboard
+                  </Button>
+                </CopyToClipboard>
+                {textCopied && <span>Text copied!</span>}
               </div>
             </Grid>
           </Grid>
           <Grid container className={styles.JoinTheEffortItemContainer}>
+            <Hidden smDown>
+              <Grid
+                item
+                xs={5}
+                className={styles.JoinTheEffortImgContainer}
+                style={{ backgroundColor: "#A5CDC0" }}
+              >
+                <img
+                  src="img/LINES-2@2x 3.png"
+                  alt="Decorative thin lines"
+                  className={styles.JoinTheEffortImg}
+                />
+              </Grid>
+            </Hidden>
             <Grid
               item
-              xs={5}
-              className={styles.JoinTheEffortImgContainer}
-              style={{ backgroundColor: "#A5CDC0" }}
+              sm={12}
+              md={7}
+              className={styles.JoinTheEffortTextContainer}
             >
-              <img
-                src="img/LINES-2@2x 3.png"
-                alt="Decorative thin lines"
-                className={styles.JoinTheEffortImg}
-              />
-            </Grid>
-            <Grid item xs={7} className={styles.JoinTheEffortTextContainer}>
               <Typography className={styles.JoinTheEffortStepHeaderText}>
                 Share your story
               </Typography>


### PR DESCRIPTION
Closes #570

Added a copy functionality to the link, converted text fields buttons into material components, addressed some responsiveness. See side by side changes:

![Screen Shot 2021-04-08 at 6 34 31 PM](https://user-images.githubusercontent.com/6402808/114116314-534e7100-9899-11eb-8059-9642bfb4eae6.png)
![Screen Shot 2021-04-08 at 6 34 19 PM](https://user-images.githubusercontent.com/6402808/114116330-56e1f800-9899-11eb-8120-6aa1b50906f9.png)
![Screen Shot 2021-04-08 at 6 34 06 PM](https://user-images.githubusercontent.com/6402808/114116340-5ba6ac00-9899-11eb-8054-daaf88de2a08.png)
![Screen Shot 2021-04-08 at 6 33 40 PM](https://user-images.githubusercontent.com/6402808/114116344-5e090600-9899-11eb-882a-231e82215b3c.png)
![Screen Shot 2021-04-08 at 6 33 19 PM](https://user-images.githubusercontent.com/6402808/114116346-606b6000-9899-11eb-9868-ba4f4c4b15d9.png)
![Screen Shot 2021-04-08 at 6 33 08 PM](https://user-images.githubusercontent.com/6402808/114116352-62352380-9899-11eb-85fb-1eebcab445f5.png)
![Screen Shot 2021-04-08 at 6 32 53 PM](https://user-images.githubusercontent.com/6402808/114116355-63fee700-9899-11eb-8340-654bd698a9ae.png)
![Screen Shot 2021-04-08 at 6 32 26 PM](https://user-images.githubusercontent.com/6402808/114116361-65c8aa80-9899-11eb-889a-70b7c3f22ab7.png)
