### PR TITLE
Capitalize 'poverty' to match other data in mad libs

### DIFF
--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -71,7 +71,7 @@ const DROPDOWN_VAR: Record<DropdownVarId, string> = {
   //  asthma: "[coming soon] asthma",
   copd: "COPD",
   health_insurance: "Uninsured People",
-  poverty: "poverty",
+  poverty: "Poverty",
 };
 
 const MADLIB_LIST: MadLib[] = [


### PR DESCRIPTION
Looks like this got reverted accidentally somehow