### PR TITLE
For ACS health insurance, only show demographic groups we have data for

### DIFF
--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -2,13 +2,13 @@
 export type MetricId =
   | "population"
   | "population_pct"
-  | "brfss_population_pct"
   | "diabetes_count"
   | "diabetes_per_100k"
   | "diabetes_pct_share"
   | "copd_count"
   | "copd_per_100k"
   | "copd_pct_share"
+  | "brfss_population_pct"
   | "covid_cases"
   | "covid_deaths"
   | "covid_hosp"
@@ -30,6 +30,7 @@ export type MetricId =
   | "health_insurance_count"
   | "health_insurance_per_100k"
   | "health_insurance_pct_share"
+  | "health_insurance_population_pct"
   | "poverty_count"
   | "poverty_per_100k";
 
@@ -317,13 +318,6 @@ export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
       variableDisplayName: "Uninsured people",
       variableFullDisplayName: "Uninsured people",
       metrics: {
-        count: {
-          metricId: "health_insurance_count",
-          fullCardTitleName: "Uninsured individuals",
-          shortVegaLabel: "Uninsured individuals",
-          type: "count",
-          populationComparisonMetric: POPULATION_VARIABLE_CONFIG.metrics.count,
-        },
         per100k: {
           metricId: "health_insurance_per_100k",
           fullCardTitleName: "Uninsured individuals per 100,000 people",
@@ -335,8 +329,12 @@ export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
           fullCardTitleName: "Share of uninsured Americans",
           shortVegaLabel: "% of uninsured",
           type: "pct_share",
-          populationComparisonMetric:
-            POPULATION_VARIABLE_CONFIG.metrics.pct_share,
+          populationComparisonMetric: {
+            metricId: "health_insurance_population_pct",
+            fullCardTitleName: "Population Share",
+            shortVegaLabel: "% of total population",
+            type: "pct_share",
+          },
         },
       },
     },
@@ -347,13 +345,6 @@ export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
       variableDisplayName: "Poverty",
       variableFullDisplayName: "Below the poverty level",
       metrics: {
-        count: {
-          metricId: "poverty_count",
-          fullCardTitleName: "Individuals below the poverty line",
-          shortVegaLabel: "Individuals below the poverty line",
-          type: "count",
-          populationComparisonMetric: POPULATION_VARIABLE_CONFIG.metrics.count,
-        },
         per100k: {
           metricId: "poverty_per_100k",
           fullCardTitleName:

--- a/frontend/src/data/variables/AcsHealthInsuranceProvider.ts
+++ b/frontend/src/data/variables/AcsHealthInsuranceProvider.ts
@@ -13,6 +13,7 @@ class AcsHealthInsuranceProvider extends VariableProvider {
       "health_insurance_count",
       "health_insurance_per_100k",
       "health_insurance_pct_share",
+      "health_insurance_population_pct",
     ]);
   }
 
@@ -79,12 +80,11 @@ class AcsHealthInsuranceProvider extends VariableProvider {
     }
 
     //Remove white hispanic to bring inline with others
-    df = df
-      .where(
-        (row) =>
-          //We remove these races because they are subsets
-          row["race_and_ethnicity"] !== WHITE_NH
-      )
+    df = df.where(
+      (row) =>
+        //We remove these races because they are subsets
+        row["race_and_ethnicity"] !== WHITE_NH
+    );
 
     let totalPivot: { [key: string]: (series: ISeries) => any } = {
       with_health_insurance: (series: ISeries) => series.sum(),
@@ -125,6 +125,15 @@ class AcsHealthInsuranceProvider extends VariableProvider {
       breakdowns.getSoleDemographicBreakdown().columnName,
       ["fips"]
     );
+
+    df = this.calculatePctShare(
+      df,
+      "total",
+      "health_insurance_population_pct",
+      breakdowns.getSoleDemographicBreakdown().columnName,
+      ["fips"]
+    );
+
     df = this.applyDemographicBreakdownFilters(df, breakdowns);
     df = this.removeUnrequestedColumns(df, metricQuery);
 
@@ -132,10 +141,7 @@ class AcsHealthInsuranceProvider extends VariableProvider {
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {
-    return (
-      breakdowns.hasExactlyOneDemographic() &&
-      !breakdowns.time
-    );
+    return breakdowns.hasExactlyOneDemographic() && !breakdowns.time;
   }
 }
 


### PR DESCRIPTION
Same fix as Josh recently made for BRFSS data in #613. We'll have to do the same thing for ACS poverty once the pct_share calculations are added there (Seth has a PR for this in-progress).