### PR TITLE
Fix download column names and value escaping

### DIFF
--- a/frontend/src/data/utils/DatasetTypes.ts
+++ b/frontend/src/data/utils/DatasetTypes.ts
@@ -40,6 +40,15 @@ export interface FieldRange {
 // TODO: make typedef for valid data types instead of any.
 export type Row = Readonly<Record<string, any>>;
 
+// Note: we currently don't support both commas and quotes together, which
+// requires escaping the quotes with another quote.
+function convertSpecialCharactersForCsv(val: any) {
+  if (typeof val === "string" && val.includes(",")) {
+    return `"${val}"`;
+  }
+  return val;
+}
+
 export class Dataset {
   readonly rows: Readonly<Row[]>;
   readonly metadata: Readonly<DatasetMetadata>;
@@ -54,15 +63,17 @@ export class Dataset {
   }
 
   toCsvString() {
-    const headers = this.metadata.fields.map((f) => f.name);
-    const stringFields = this.metadata.fields
-      .filter((f) => f.data_type === "string")
-      .map((f) => f.name);
-    const addQuotes = (val: string) => `"${val}"`;
+    // Assume the columns are the same as the keys of the first row. This is
+    // okay since every row has the same keys. However, we could improve this by
+    // sending column names as structured data from the server.
+    const fields = Object.keys(this.rows[0]);
+
     const df = this.toDataFrame().transformSeries(
-      Object.fromEntries(stringFields.map((name) => [name, addQuotes]))
+      Object.fromEntries(
+        fields.map((name) => [name, convertSpecialCharactersForCsv])
+      )
     );
-    return [headers]
+    return [fields]
       .concat(df.toRows())
       .map((row) => row.join(","))
       .join("\n");


### PR DESCRIPTION
I looked into migrating to server-side downloads (#234) and there were a few issues, including the download spinner didn't track download progress and errors weren't handled well (they resulted in the browser navigating to the dataset url). So I think we should keep the client-side downloads.

I fixed it to auto-detect the column names and escape the values properly. For performance, I think we shouldn't be too concerned because I tested on the ACS gender/race/age/count one and it still worked. Also any dataset that is large enough to cause a problem with downloads will likely also cause a problem with the explore data site and we'll have to address it by chunking the dataset anyway.