### PR TITLE
Remove highlighting behavior for top x feature

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -284,11 +284,7 @@ function MapCardWithKey(props: MapCardProps) {
                   signalListeners={signalListeners}
                   metric={metricConfig}
                   legendTitle={metricConfig.fullCardTitleName}
-                  data={
-                    listExpanded
-                      ? highestRatesList.concat(lowestRatesList)
-                      : dataForActiveBreakdownFilter
-                  }
+                  data={dataForActiveBreakdownFilter}
                   legendData={dataForActiveBreakdownFilter}
                   hideLegend={
                     queryResponse.dataIsMissing() ||


### PR DESCRIPTION
Removes map highlighting for now as the behavior currently is too jumpy. Krista, if you know of an easy way to stop the map reload / jumpiness, lemme know and we can get that in instead.. otherwise we think it makes sense to just disable this for now as the code freeze is next Wednesday