### PR TITLE
Add a max percentage resolution to fix the 'Other' gender issue

### DIFF
--- a/frontend/src/data/utils/DatasetCalculator.test.ts
+++ b/frontend/src/data/utils/DatasetCalculator.test.ts
@@ -1,5 +1,8 @@
 import { DataFrame, IDataFrame } from "data-forge";
-import { DatasetCalculator } from "./DatasetCalculator";
+import {
+  DatasetCalculator,
+  MAXIMUM_PERCENTAGE_RESOLUTION,
+} from "./DatasetCalculator";
 
 describe("Dataset Calculator", () => {
   let calc = new DatasetCalculator();
@@ -14,6 +17,10 @@ describe("Dataset Calculator", () => {
 
   test("Testing percent", async () => {
     expect(calc.percent(10, 20)).toEqual(50);
+  });
+
+  test("Testing percent max resolution", async () => {
+    expect(calc.percent(1, MAXIMUM_PERCENTAGE_RESOLUTION + 1)).toBeNull();
   });
 
   test("Testing percent share one race", async () => {

--- a/frontend/src/data/utils/DatasetCalculator.test.ts
+++ b/frontend/src/data/utils/DatasetCalculator.test.ts
@@ -7,8 +7,12 @@ import {
 describe("Dataset Calculator", () => {
   let calc = new DatasetCalculator();
 
-  test("Testing calculation", async () => {
+  test("Testing per 100k", async () => {
     expect(calc.per100k(100, 1000)).toEqual(10000);
+  });
+
+  test("Testing per 100k max resolution", async () => {
+    expect(calc.per100k(1, MAXIMUM_PERCENTAGE_RESOLUTION + 1)).toBeNull();
   });
 
   test("Testing total", async () => {

--- a/frontend/src/data/utils/DatasetCalculator.ts
+++ b/frontend/src/data/utils/DatasetCalculator.ts
@@ -3,6 +3,11 @@ import { BreakdownVar } from "../query/Breakdowns";
 import { ALL, UNKNOWN, UNKNOWN_RACE } from "./Constants";
 import { applyToGroups } from "./datasetutils";
 
+// The finest grain percentage resolution we support - below this resolution,
+// we treat the data as null/nonexistent. The smallest supported percentage
+// can be calculated as 1 / resolution * 100.
+export const MAXIMUM_PERCENTAGE_RESOLUTION = 100000;
+
 export class DatasetCalculator {
   /** Calculates a rate as occurrences per 100k */
   per100k(numerator: number, denominator: number): number | null {
@@ -13,7 +18,10 @@ export class DatasetCalculator {
 
   /** Calculates a rate as a percent to one decimal place. */
   percent(numerator: number, denominator: number): number | null {
-    return numerator == null || denominator == null || denominator === 0
+    return numerator == null ||
+      denominator == null ||
+      denominator === 0 ||
+      MAXIMUM_PERCENTAGE_RESOLUTION * numerator < denominator
       ? null
       : Math.round((1000 * numerator) / denominator) / 10;
   }

--- a/frontend/src/data/utils/DatasetCalculator.ts
+++ b/frontend/src/data/utils/DatasetCalculator.ts
@@ -5,13 +5,17 @@ import { applyToGroups } from "./datasetutils";
 
 // The finest grain percentage resolution we support - below this resolution,
 // we treat the data as null/nonexistent. The smallest supported percentage
-// can be calculated as 1 / resolution * 100.
+// can be calculated as 1 / resolution * 100, and the smallest supported per
+// 100k number is then 1 / resolution * 100000.
 export const MAXIMUM_PERCENTAGE_RESOLUTION = 100000;
 
 export class DatasetCalculator {
   /** Calculates a rate as occurrences per 100k */
   per100k(numerator: number, denominator: number): number | null {
-    return numerator == null || denominator == null || denominator === 0
+    return numerator == null ||
+      denominator == null ||
+      denominator === 0 ||
+      MAXIMUM_PERCENTAGE_RESOLUTION * numerator < denominator
       ? null
       : Math.round(100000 * (numerator / denominator));
   }


### PR DESCRIPTION
Makes it so that the %age of covid cases for Other becomes "no data" rather than 0%