### PR TITLE
[DRAFT/PROOF OF CONCEPT] Create generalized variable provider that covers most of our use cases

### DIFF
--- a/frontend/src/data/config/FakeDatasetMetadata.ts
+++ b/frontend/src/data/config/FakeDatasetMetadata.ts
@@ -3,12 +3,12 @@ import { DataSourceMetadataMap } from "./MetadataMap";
 
 const datasetMetadataList: DatasetMetadata[] = [
   {
-    id: "acs_population-by_race_county_std",
+    id: "acs_population-by_race_county",
     name: "Population by Race and County",
     update_time: "2019",
   },
   {
-    id: "acs_population-by_race_state_std",
+    id: "acs_population-by_race_state",
     name: "Population by Race and State",
     update_time: "2019",
   },

--- a/frontend/src/data/config/MetadataMap.ts
+++ b/frontend/src/data/config/MetadataMap.ts
@@ -15,8 +15,8 @@ const dataSourceMetadataList: DataSourceMetadata[] = [
     description:
       "Population percentages broken down by self-reported race/ethnicity, age, and sex at the U.S. and state levels.",
     dataset_ids: [
-      "acs_population-by_race_county_std",
-      "acs_population-by_race_state_std",
+      "acs_population-by_race_county",
+      "acs_population-by_race_state",
       "acs_population-by_age_state",
       "acs_population-by_age_county",
       "acs_population-by_sex_state",

--- a/frontend/src/data/loading/DataFetcher.ts
+++ b/frontend/src/data/loading/DataFetcher.ts
@@ -74,8 +74,18 @@ export class ApiDataFetcher implements DataFetcher {
 
   // TODO build in retries, timeout before showing error to user.
   async loadDataset(datasetId: string): Promise<Row[]> {
+    // TODO drop this once datasets are renamed on the backend.
+    let realDatasetId = datasetId;
+    if (
+      ["acs_population-by_race_state", "acs_population-by_race_state"].includes(
+        datasetId
+      )
+    ) {
+      realDatasetId = datasetId + "_std";
+    }
+
     // TODO handle server returning a dataset not found error.
-    let result = await this.fetchDataset(datasetId);
+    let result = await this.fetchDataset(realDatasetId);
 
     // TODO remove these once we figure out how to make BQ export integers as
     // integers

--- a/frontend/src/data/query/Breakdowns.ts
+++ b/frontend/src/data/query/Breakdowns.ts
@@ -30,6 +30,14 @@ export const BREAKDOWN_VAR_DISPLAY_NAMES: Record<BreakdownVar, string> = {
   fips: "FIPS Code",
 };
 
+const ORDERED_BREAKDOWNS: BreakdownVar[] = [
+  "sex",
+  "age",
+  "race_and_ethnicity",
+  "date",
+  "fips",
+];
+
 export const BREAKDOWN_VAR_DISPLAY_NAMES_LOWER_CASE: Record<
   BreakdownVar,
   string
@@ -267,18 +275,20 @@ export class Breakdowns {
     return this;
   }
 
-  getJoinColumns(): BreakdownVar[] {
-    const joinCols: BreakdownVar[] = ["fips"];
+  getOrderedBreakdowns(): BreakdownVar[] {
+    const activeBreakdowns: BreakdownVar[] = ["fips"];
     Object.entries(this.demographicBreakdowns).forEach(
       ([key, demographicBreakdown]) => {
         if (demographicBreakdown.enabled) {
-          joinCols.push(demographicBreakdown.columnName);
+          activeBreakdowns.push(demographicBreakdown.columnName);
         }
       }
     );
     if (this.time) {
-      joinCols.push("date");
+      activeBreakdowns.push("date");
     }
-    return joinCols.sort();
+    return ORDERED_BREAKDOWNS.filter((breakdown) =>
+      activeBreakdowns.includes(breakdown)
+    );
   }
 }

--- a/frontend/src/data/query/queryutils.ts
+++ b/frontend/src/data/query/queryutils.ts
@@ -1,0 +1,42 @@
+import { DataFrame } from "data-forge";
+import {
+  joinOnCols,
+  JoinType,
+  maybeApplyRowReorder,
+} from "../utils/datasetutils";
+import { Breakdowns } from "./Breakdowns";
+import { MetricQueryResponse } from "./MetricQuery";
+
+export function joinResponses(
+  left: MetricQueryResponse,
+  right: MetricQueryResponse,
+  breakdowns: Breakdowns,
+  joinType: JoinType
+): MetricQueryResponse {
+  if (left.dataIsMissing()) {
+    return left;
+  }
+
+  if (right.dataIsMissing()) {
+    return right;
+  }
+
+  const leftData = new DataFrame(left.data);
+  const rightData = new DataFrame(right.data);
+
+  const joined = joinOnCols(
+    leftData,
+    rightData,
+    breakdowns.getOrderedBreakdowns(),
+    joinType
+  );
+
+  const consumedDatasetIds = left.consumedDatasetIds.concat(
+    right.consumedDatasetIds
+  );
+  const uniqueConsumedDatasetIds = Array.from(new Set(consumedDatasetIds));
+  return new MetricQueryResponse(
+    maybeApplyRowReorder(joined.toArray(), breakdowns),
+    uniqueConsumedDatasetIds
+  );
+}

--- a/frontend/src/data/utils/datasetutils.ts
+++ b/frontend/src/data/utils/datasetutils.ts
@@ -1,4 +1,4 @@
-import { IDataFrame } from "data-forge";
+import { IDataFrame, ISeries } from "data-forge";
 import { Row } from "../utils/DatasetTypes";
 import { ALL, UNKNOWN, UNKNOWN_HL } from "../utils/Constants";
 import { Breakdowns } from "../query/Breakdowns";
@@ -206,6 +206,8 @@ function sortAlphabeticallyByField(rows: Row[], fieldName: string) {
   return finalRows;
 }
 
+// TODO: move this and other functions that require knowledge of how we process
+// the data (vs just general utilities) to data/query/queryutils.ts.
 export function maybeApplyRowReorder(rows: Row[], breakdowns: Breakdowns) {
   let finalRows: Row[] = Object.assign(rows, []);
   const reorderingColumn = breakdowns.getSoleDemographicBreakdown().columnName;
@@ -222,4 +224,8 @@ export function maybeApplyRowReorder(rows: Row[], breakdowns: Breakdowns) {
     );
   }
   return finalRows;
+}
+
+export function sumSeries(series: ISeries): number {
+  return series.where((val) => val != null && !isNaN(val)).sum();
 }

--- a/frontend/src/data/variables/BrfssProvider.ts
+++ b/frontend/src/data/variables/BrfssProvider.ts
@@ -7,16 +7,15 @@ import {
 } from "../utils/datasetutils";
 import { USA_FIPS } from "../utils/Fips";
 import VariableProvider from "./VariableProvider";
-import AcsPopulationProvider from "./AcsPopulationProvider";
 import { MetricQuery, MetricQueryResponse } from "../query/MetricQuery";
 import { getDataManager } from "../../utils/globals";
 import { NON_HISPANIC } from "../utils/Constants";
 import { exclude } from "../query/BreakdownFilter";
 
 class BrfssProvider extends VariableProvider {
-  private acsProvider: AcsPopulationProvider;
+  private acsProvider: VariableProvider;
 
-  constructor(acsProvider: AcsPopulationProvider) {
+  constructor(acsProvider: VariableProvider) {
     super("brfss_provider", [
       "brfss_population_pct",
       "copd_pct",

--- a/frontend/src/data/variables/CdcCovidProvider.ts
+++ b/frontend/src/data/variables/CdcCovidProvider.ts
@@ -2,7 +2,6 @@ import { DataFrame } from "data-forge";
 import { Breakdowns } from "../query/Breakdowns";
 import VariableProvider from "./VariableProvider";
 import { USA_FIPS, USA_DISPLAY_NAME } from "../utils/Fips";
-import AcsPopulationProvider from "./AcsPopulationProvider";
 import {
   joinOnCols,
   per100k,
@@ -13,9 +12,9 @@ import { getDataManager } from "../../utils/globals";
 import { MetricId } from "../config/MetricConfig";
 
 class CdcCovidProvider extends VariableProvider {
-  private acsProvider: AcsPopulationProvider;
+  private acsProvider: VariableProvider;
 
-  constructor(acsProvider: AcsPopulationProvider) {
+  constructor(acsProvider: VariableProvider) {
     super("cdc_covid_provider", [
       "covid_cases",
       "covid_deaths",

--- a/frontend/src/data/variables/StandardVariableProvider.ts
+++ b/frontend/src/data/variables/StandardVariableProvider.ts
@@ -1,0 +1,259 @@
+import { IDataFrame } from "data-forge";
+import { Breakdowns } from "../query/Breakdowns";
+import VariableProvider from "./VariableProvider";
+import { MetricQuery, MetricQueryResponse } from "../query/MetricQuery";
+import { getDataManager } from "../../utils/globals";
+import { applyToGroups, maybeApplyRowReorder } from "../utils/datasetutils";
+import { ProviderId } from "../loading/VariableProviderMap";
+import { MetricId } from "../config/MetricConfig";
+import { Preprocessor } from "./preprocessors";
+import { OneDimensionalGroupModifier, RowModifier } from "./modifiers";
+
+// XXX open questions/todo list:
+// - look into caching after pre-processing step, or move pre-processors after
+//   geographic filter? Not sure if this is a performance problem.
+// - automate DataSourceMetadata dataset_ids by using getDatasetId and
+//   allowsBreakdowns.
+// - one thing I don't love about the modifier API is the fact that the provider
+//   is mutable and whether it fulfils the "providesMetrics" list properly
+//   depends on what modifiers are added. Could address with a builder, or pass
+//   all in the constructor (though there were issues with this because the
+//   modifiers weren't one interface). At first I had exposed Operation
+//   directly, which would be _fine_ but I wanted to attempt to be more
+//   restrictive of what specific datasets can do to avoid brittle behavior
+//   caused by arbitrary logic (which probably belongs on the backend).
+// - Spekaing of being restrictive, should the RowModifier not allow arbitrary
+//   row modifications? Could change to just have it return the new columns so
+//   that it can only be used for that purpose.
+// - Lots of test coverage lol
+
+export type StandardVariableProviderOptions = {
+  // If true, this provider uses a state-level dataset and automatically
+  // aggregates to the national level. This does not support non-breakdown,
+  // non-summable columns like a percentage. In that case, a national-level
+  // dataset must be provided on the backend.
+  autoGenerateNational?: boolean;
+
+  // If a provider is passed in, this provider will automatically left-join on
+  // the appropriate demographic and geographic breakdown columns.
+  autoJoinWithPopulation?: VariableProvider;
+};
+
+// TODO: migrate all providers to use this class.
+
+/**
+ * The StandardVariableProvider class automates most aspects of data-processing
+ * for a dataset and allows customization via options and extensible
+ * preprocessors and modifiers.
+ *
+ * This class imposes some restrictions on datasets:
+ * 1) With the exception of national-level, server-side datasets must already be
+ *    aggregated to the appropriate geographic level. For simple datasets where
+ *    all values are either breakdowns or counts that can be summed,
+ *    national-level aggregation can be done automatically from state-level data
+ *    via the autoGenerateNational param.
+ * 2) Popuation joins can only be done at the same geographic level requested.
+ *    For example, if the population join needs to be done at the state level
+ *    and then aggregated to the national level, this must be done server-side.
+ * 3) Server datasets must be named as such:
+ *        {sourceId}-{underscore_separated_demographic_breakdowns}_{geography}
+ *    Example:
+ *        acs_population-by_race_state
+ *    This class doesn't currently support multiple demographic breakdowns, but
+ *    if/when it does, the naming should order breakdowns like:
+ *        sex > age > race > time > geography
+ *    Eg:
+ *        acs_population-by_sex_age_race_county
+ * 4) This class does not currently support multiple demographic breakdowns. We
+ *    may extend the functionality in the future, but we will need to audit the
+ *    behaviors because some things aren't well-defined or tested for multiple
+ *    demographics, like state->national aggregation and calculations like
+ *    percent share.
+ * 5) A "Total" row must be included for every combination of demographic
+ *    breakdowns.
+ * 6) Every combination of geography and demographic breakdown must be
+ *    supported: {national|state|county} x {sex|age|race}.
+ *    However, this requirement can be dropped by subclassing and overriding
+ *    allowsBreakdowns.
+ *
+ * Most of these requirements can be worked around using a Preprocessor. These
+ * are run before doing most data processing, so you can do one-off changes as
+ * if it were already done that way on the server.
+ *
+ * Modifiers are run near the end of data processing, right before applying
+ * demographic filters, removing unnecessary columns, and sorting. These are
+ * best for adding derived columns like percent share.
+ */
+export default class StandardVariableProvider extends VariableProvider {
+  readonly sourceId: string;
+  readonly autoGenerateNational: boolean;
+  readonly populationProvider: VariableProvider | undefined;
+  readonly preprocessors: Preprocessor[];
+  readonly operations: Operation[];
+
+  constructor(
+    sourceId: string,
+    providerId: ProviderId,
+    providesMetrics: MetricId[],
+    {
+      autoGenerateNational = false,
+      autoJoinWithPopulation = undefined,
+    }: StandardVariableProviderOptions = {}
+  ) {
+    super(providerId, providesMetrics);
+    this.sourceId = sourceId;
+    this.autoGenerateNational = autoGenerateNational;
+    this.populationProvider = autoJoinWithPopulation;
+    this.preprocessors = [];
+    this.operations = [];
+  }
+
+  addPreprocessor(preprocessor: Preprocessor): StandardVariableProvider {
+    this.preprocessors.push(preprocessor);
+    return this;
+  }
+
+  addRowModifier(rowModifier: RowModifier): StandardVariableProvider {
+    this.operations.push(new RowOperation(rowModifier));
+    return this;
+  }
+
+  addOneDimensionalGroupModifier(
+    groupModifier: OneDimensionalGroupModifier
+  ): StandardVariableProvider {
+    this.operations.push(new OneDimensionalGroupOperation(groupModifier));
+    return this;
+  }
+
+  private shouldAutoGenerateNational(breakdowns: Breakdowns): boolean {
+    return this.autoGenerateNational && breakdowns.geography === "national";
+  }
+
+  // ALERT! KEEP IN SYNC! Make sure you update DataSourceMetadata if you update dataset IDs
+  getDatasetId(breakdowns: Breakdowns): string {
+    const breakdownStrings = breakdowns.getOrderedBreakdowns().map((b) => {
+      if (b === "race_and_ethnicity") {
+        return "race";
+      }
+      if (b === "fips") {
+        // If auto-generating national data, request state-level data because
+        // it will be automatically aggregated to the national level.
+        return this.shouldAutoGenerateNational(breakdowns)
+          ? "state"
+          : breakdowns.geography;
+      }
+      return b;
+    });
+    const res = this.sourceId + "-by_" + breakdownStrings.join("_");
+    return res;
+  }
+
+  async getDataInternal(
+    metricQuery: MetricQuery
+  ): Promise<MetricQueryResponse> {
+    const breakdowns = metricQuery.breakdowns;
+    const datasetId = this.getDatasetId(breakdowns);
+    let consumedDatasetIds = [datasetId];
+
+    const dataset = await getDataManager().loadDataset(datasetId);
+    let df = dataset.toDataFrame();
+
+    this.preprocessors.forEach((preprocessor) => {
+      df = preprocessor.apply(df, metricQuery);
+    });
+
+    // If requested, filter geography by state or county level
+    // We apply the geo filter right away to reduce subsequent calculation times
+    df = this.filterByGeo(df, breakdowns);
+    if (df.count() === 0) {
+      return new MetricQueryResponse([], [datasetId]);
+    }
+
+    df = this.renameGeoColumns(df, breakdowns);
+
+    if (this.shouldAutoGenerateNational(breakdowns)) {
+      df = this.sumStateToNational(df, breakdowns);
+    }
+
+    // Calculate population_pct based on total for breakdown
+    // Exactly one breakdown should be enabled per allowsBreakdowns()
+    const breakdownColumnName = breakdowns.getSoleDemographicBreakdown()
+      .columnName;
+
+    df = this.renameTotalToAll(df, breakdownColumnName);
+
+    if (this.populationProvider) {
+      const [data, updatedConsumedIds] = await this.joinWithPopulation(
+        df,
+        breakdowns,
+        consumedDatasetIds,
+        this.populationProvider
+      );
+      df = data;
+      consumedDatasetIds = updatedConsumedIds;
+    }
+
+    this.operations.forEach((operation) => {
+      df = operation.apply(df, metricQuery);
+    });
+
+    df = this.applyDemographicBreakdownFilters(df, breakdowns);
+    df = this.removeUnrequestedColumns(df, metricQuery);
+    return new MetricQueryResponse(
+      maybeApplyRowReorder(df.toArray(), breakdowns),
+      consumedDatasetIds
+    );
+  }
+
+  allowsBreakdowns(breakdowns: Breakdowns): boolean {
+    return !breakdowns.time && breakdowns.hasExactlyOneDemographic();
+  }
+}
+
+/**
+ * Interface for applying an operation to a DataFrame based on the given query.
+ * This interface and its implementations are intentionally not exposed beyond
+ * this file because the interface is extremely general and we want to restrict
+ * what kind of operations are supported.
+ *
+ * To add support for new types of
+ * modifiers, create an interface for the new modifier and add an Operation
+ * implementation that adapts the new modifier.
+ */
+interface Operation {
+  apply(df: IDataFrame, metricQuery: MetricQuery): IDataFrame;
+}
+
+class RowOperation implements Operation {
+  readonly rowModifier: RowModifier;
+
+  constructor(rowModifier: RowModifier) {
+    this.rowModifier = rowModifier;
+  }
+
+  apply(df: IDataFrame, metricQuery: MetricQuery): IDataFrame {
+    return df.select((row) => this.rowModifier.apply(row)).resetIndex();
+  }
+}
+
+class OneDimensionalGroupOperation implements Operation {
+  readonly groupModifier: OneDimensionalGroupModifier;
+
+  constructor(groupModifier: OneDimensionalGroupModifier) {
+    this.groupModifier = groupModifier;
+  }
+
+  apply(df: IDataFrame, metricQuery: MetricQuery): IDataFrame {
+    const result = applyToGroups(df, ["fips"], (group) =>
+      this.groupModifier.apply(group, metricQuery)
+    );
+
+    if (df.count() !== result.count()) {
+      throw new Error(
+        "Group modifier should not change the number of rows per group."
+      );
+    }
+
+    return result;
+  }
+}

--- a/frontend/src/data/variables/modifiers.ts
+++ b/frontend/src/data/variables/modifiers.ts
@@ -1,0 +1,114 @@
+import { IDataFrame } from "data-forge";
+import { MetricQuery } from "../query/MetricQuery";
+import { percent, sumSeries } from "../utils/datasetutils";
+import { ALL, UNKNOWN, UNKNOWN_HL, UNKNOWN_RACE } from "../utils/Constants";
+import { Row } from "../utils/DatasetTypes";
+
+/**
+ * The apply function is called once per row, with the new row returned. This is
+ * generally used to add new columns.
+ */
+export interface RowModifier {
+  apply(row: Row): Row;
+}
+
+/**
+ * The apply function is called once per group, where a group is defined by one
+ * group per geographic region. This is generally used to add new columns.
+ *
+ * This may not be used to add or remove rows, because that can cause brittle
+ * behavior. For example, adding a derived column and then adding rows will
+ * result in the added rows not having the derived column, while adding rows and
+ * then a derived column can result in accidentally calculating the derived
+ * column incorrectly due to the additional rows.
+ *
+ * Adding rows should be done in the preprocesor step (or we could add a
+ * separate mechanism for this).
+ */
+export interface OneDimensionalGroupModifier {
+  apply(group: IDataFrame, metricQuery: MetricQuery): IDataFrame;
+}
+
+export class RowDerivedColumn implements RowModifier {
+  readonly newColName: string;
+  readonly newColumnFn: (row: Row) => any;
+
+  constructor(newColName: string, newColumnFn: (row: Row) => any) {
+    this.newColName = newColName;
+    this.newColumnFn = newColumnFn;
+  }
+
+  apply(row: Row): Row {
+    return { ...row, [this.newColName]: this.newColumnFn(row) };
+  }
+}
+
+export class PctShareDerivedColumn implements OneDimensionalGroupModifier {
+  readonly rawCountCol: string;
+  readonly pctShareCol: string;
+  readonly skipValues: string[];
+
+  constructor(
+    rawCountCol: string,
+    pctShareSuffix: string,
+    skipValues?: string[]
+  ) {
+    this.rawCountCol = rawCountCol;
+    this.pctShareCol = rawCountCol + pctShareSuffix;
+    this.skipValues = skipValues || [];
+  }
+
+  protected getDenominator(
+    group: IDataFrame,
+    metricQuery: MetricQuery
+  ): number {
+    const breakdownColumnName = metricQuery.breakdowns.getSoleDemographicBreakdown()
+      .columnName;
+    const totalRow = group.where((r) => r[breakdownColumnName] === ALL);
+    if (totalRow.count() === 0) {
+      throw new Error("No Total value for group");
+    }
+
+    return totalRow.first()[this.rawCountCol];
+  }
+
+  apply(group: IDataFrame, metricQuery: MetricQuery): IDataFrame {
+    const breakdownColumnName = metricQuery.breakdowns.getSoleDemographicBreakdown()
+      .columnName;
+    const denominator = this.getDenominator(group, metricQuery);
+    return group
+      .generateSeries({
+        [this.pctShareCol]: (row) => {
+          return this.skipValues.includes(breakdownColumnName)
+            ? null
+            : percent(row[this.rawCountCol], denominator);
+        },
+      })
+      .resetIndex();
+  }
+}
+
+export class PctShareOfKnownDerivedColumn extends PctShareDerivedColumn {
+  static DEFAULT_SKIP_VALUES = [ALL, UNKNOWN, UNKNOWN_RACE, UNKNOWN_HL];
+
+  constructor(rawCountCol: string, pctShareSuffix: string) {
+    super(
+      rawCountCol,
+      pctShareSuffix,
+      PctShareOfKnownDerivedColumn.DEFAULT_SKIP_VALUES
+    );
+  }
+
+  protected getDenominator(
+    group: IDataFrame,
+    metricQuery: MetricQuery
+  ): number {
+    const breakdownColumnName = metricQuery.breakdowns.getSoleDemographicBreakdown()
+      .columnName;
+    const counts = group
+      .where((row) => this.skipValues.includes(row[breakdownColumnName]))
+      .getSeries(this.rawCountCol);
+
+    return sumSeries(counts);
+  }
+}

--- a/frontend/src/data/variables/preprocessors.ts
+++ b/frontend/src/data/variables/preprocessors.ts
@@ -1,0 +1,36 @@
+import { IDataFrame } from "data-forge";
+import { MetricQuery } from "../query/MetricQuery";
+
+/**
+ * Preprocessors are called by the StandardVariableProvider immediately after
+ * fetching the dataset from the server. They are extremely flexible, allowing
+ * any modifications to the dataset. The main use cases are:
+ * 1) Temporarily support backwards compatibility for backend dataset changes.
+ * 2) Support experimentation and rapid iteration by not requiring backend
+ *    changes for minor things like renaming columns or converting NaN to null.
+ *
+ * Preprocessors are run across the whole dataset and don't currently benefit
+ * from caching. Also due to their flexibility it is easier to break the
+ * provider. Therefore, they should be used sparingly - prefer to make such
+ * changes on the backend.
+ */
+export interface Preprocessor {
+  apply(df: IDataFrame, metricQuery: MetricQuery): IDataFrame;
+}
+
+/**
+ * A basic implementation of Preprocessor that takes in a function and calls it.
+ * This is really just so you don't have to define a new class whenever you want
+ * to do a one-off preprocesing step.
+ */
+export class FunctionPreprocessor implements Preprocessor {
+  readonly fn: (df: IDataFrame, metricQuery: MetricQuery) => IDataFrame;
+
+  constructor(fn: (df: IDataFrame, metricQuery: MetricQuery) => IDataFrame) {
+    this.fn = fn;
+  }
+
+  apply(df: IDataFrame, metricQuery: MetricQuery): IDataFrame {
+    return this.fn(df, metricQuery);
+  }
+}


### PR DESCRIPTION
This is just a proof of concept. Looking for high-level feedback before fleshing out some of the details a bit more, splitting into smaller chunks, and adding test coverage.

Rationale for this approach:
- automate some of the more common behaviors like basic aggregating to national level and basic joining with population, but don't provide too much customization options to avoid needing to consider complex interactions between all of them
- impose requirements on datasets that reduce the need for one-off logic per dataset. I tried to balance not making it so restrictive that it's a burden to change stuff, but not so open that we have to support really complicated use cases.
- provide lightweight interfaces for plugin-style behaviors. I initially made the plugin super generic (takes in a dataframe and returns the new dataframe) but then moved to restrict the plugin behaviors to make it more predictable and avoid edge cases caused by interacting plugins. The plugin APIs mirror the more common types of behaviors we tend to do.

There's almost certainly room for improvement here, feedback welcome :)