### PR TITLE
Legend label improvements

### DIFF
--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -130,7 +130,6 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
                   data={unknowns}
                   showCounties={props.fips.isUsa() ? false : true}
                   fips={props.fips}
-                  numberFormat={"percentage"}
                   scaleType="quantile"
                   scaleColorScheme="greenblue"
                   hideLegend={

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -130,6 +130,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
                   data={unknowns}
                   showCounties={props.fips.isUsa() ? false : true}
                   fips={props.fips}
+                  numberFormat={"percentage"}
                   scaleType="quantile"
                   scaleColorScheme="greenblue"
                   hideLegend={

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -98,10 +98,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       ? "Sample size too small"
       : "No data";
     const geographyName = props.showCounties ? "County" : "State";
-    const tooltipDatum =
-      props.numberFormat === "percentage"
-        ? `format(datum.${props.metric.metricId}, '0.1%')`
-        : `format(datum.${props.metric.metricId}, ',')`;
+    const tooltipDatum = `format(datum.${props.metric.metricId}, ',')`;
     const tooltipValue = `{"${geographyName}": datum.properties.name, "${props.metric.shortVegaLabel}": ${tooltipDatum} }`;
     const missingDataTooltipValue = `{"${geographyName}": datum.properties.name, "${props.metric.shortVegaLabel}": "${noDataText}" }`;
 
@@ -116,10 +113,21 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       titleLimit: 0,
       font: "monospace",
       labelFont: "monospace",
+      labelOverlap: "greedy",
+      labelSeparation: 10,
       offset: 10,
+      format: "d",
     };
     if (props.numberFormat === "percentage") {
-      legend["format"] = "0.1%";
+      legend["encode"] = {
+        labels: {
+          update: {
+            text: {
+              signal: `format(datum.label, '0.1r') + '%'`,
+            },
+          },
+        },
+      };
     }
     if (!props.hideLegend) {
       legendList.push(legend);

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -6,7 +6,6 @@ import { MetricConfig } from "../data/config/MetricConfig";
 import { FieldRange } from "../data/utils/DatasetTypes";
 import { GEOGRAPHIES_DATASET_ID } from "../data/config/MetadataMap";
 
-type NumberFormat = "raw" | "percentage";
 export type ScaleType = "quantize" | "quantile";
 
 const UNKNOWN_GREY = "#BDC1C6";
@@ -35,7 +34,6 @@ export interface ChoroplethMapProps {
   legendTitle: string;
   signalListeners: any;
   fips: Fips;
-  numberFormat?: NumberFormat;
   hideLegend?: boolean;
   fieldRange?: FieldRange;
   showCounties: boolean;
@@ -118,7 +116,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       offset: 10,
       format: "d",
     };
-    if (props.numberFormat === "percentage") {
+    if (props.metric.type === "pct_share") {
       legend["encode"] = {
         labels: {
           update: {
@@ -263,7 +261,6 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     width,
     props.metric,
     props.legendTitle,
-    props.numberFormat,
     props.data,
     props.fips,
     props.hideLegend,

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -84,6 +84,7 @@ export function Legend(props: LegendProps) {
               labelOverlap: "greedy",
               symbolType: "circle",
               size: DOT_SIZE_SCALE,
+              format: "d",
             },
           ],
         },


### PR DESCRIPTION
Closes #868 

- Makes the legend labels on the unknowns map into %ages as they should be
- Adds a strategy to reduce label overlap & define overlapping as < 10 px of space between labels
- Change format of the labels for the map card & the small multiples to integer, as they are all per 100k metrics