### PR TITLE
Remove max percent resolution

### DIFF
--- a/frontend/src/data/utils/DatasetCalculator.test.ts
+++ b/frontend/src/data/utils/DatasetCalculator.test.ts
@@ -1,8 +1,5 @@
 import { DataFrame, IDataFrame } from "data-forge";
-import {
-  DatasetCalculator,
-  MAXIMUM_PERCENTAGE_RESOLUTION,
-} from "./DatasetCalculator";
+import { DatasetCalculator } from "./DatasetCalculator";
 
 describe("Dataset Calculator", () => {
   let calc = new DatasetCalculator();
@@ -11,20 +8,12 @@ describe("Dataset Calculator", () => {
     expect(calc.per100k(100, 1000)).toEqual(10000);
   });
 
-  test("Testing per 100k max resolution", async () => {
-    expect(calc.per100k(1, MAXIMUM_PERCENTAGE_RESOLUTION + 1)).toBeNull();
-  });
-
   test("Testing total", async () => {
     expect(calc.estimateTotal(10, 20)).toEqual(2);
   });
 
   test("Testing percent", async () => {
     expect(calc.percent(10, 20)).toEqual(50);
-  });
-
-  test("Testing percent max resolution", async () => {
-    expect(calc.percent(1, MAXIMUM_PERCENTAGE_RESOLUTION + 1)).toBeNull();
   });
 
   test("Testing percent share one race", async () => {

--- a/frontend/src/data/utils/DatasetCalculator.ts
+++ b/frontend/src/data/utils/DatasetCalculator.ts
@@ -7,7 +7,7 @@ import { applyToGroups } from "./datasetutils";
 // we treat the data as null/nonexistent. The smallest supported percentage
 // can be calculated as 1 / resolution * 100, and the smallest supported per
 // 100k number is then 1 / resolution * 100000.
-export const MAXIMUM_PERCENTAGE_RESOLUTION = 100000;
+export const MAXIMUM_PERCENTAGE_RESOLUTION = 200000;
 
 export class DatasetCalculator {
   /** Calculates a rate as occurrences per 100k */

--- a/frontend/src/data/utils/DatasetCalculator.ts
+++ b/frontend/src/data/utils/DatasetCalculator.ts
@@ -3,29 +3,17 @@ import { BreakdownVar } from "../query/Breakdowns";
 import { ALL, UNKNOWN, UNKNOWN_RACE } from "./Constants";
 import { applyToGroups } from "./datasetutils";
 
-// The finest grain percentage resolution we support - below this resolution,
-// we treat the data as null/nonexistent. The smallest supported percentage
-// can be calculated as 1 / resolution * 100, and the smallest supported per
-// 100k number is then 1 / resolution * 100000.
-export const MAXIMUM_PERCENTAGE_RESOLUTION = 200000;
-
 export class DatasetCalculator {
   /** Calculates a rate as occurrences per 100k */
   per100k(numerator: number, denominator: number): number | null {
-    return numerator == null ||
-      denominator == null ||
-      denominator === 0 ||
-      MAXIMUM_PERCENTAGE_RESOLUTION * numerator < denominator
+    return numerator == null || denominator == null || denominator === 0
       ? null
       : Math.round(100000 * (numerator / denominator));
   }
 
   /** Calculates a rate as a percent to one decimal place. */
   percent(numerator: number, denominator: number): number | null {
-    return numerator == null ||
-      denominator == null ||
-      denominator === 0 ||
-      MAXIMUM_PERCENTAGE_RESOLUTION * numerator < denominator
+    return numerator == null || denominator == null || denominator === 0
       ? null
       : Math.round((1000 * numerator) / denominator) / 10;
   }


### PR DESCRIPTION
Upon further thought, I don't think it's the right thing to do to have a max percent resolution. There are cases such as 0 deaths per100k for age 0-9 in Alaska, which I think we should indeed show as 0 per100k rather than saying "no data." Basically, I don't think it makes sense to suppress a data point if it's < 1 per100k and instead we should just show the 0 - "no data" has a specific meaning in the tracker (no underlying reported data) and being < 1 per100k doesn't fit that meaning.

Note that the upshot is that we will see 0% share of cases for gender "Other" in the US; IMO it's better to launch with this minor weirdness and think through the proper way to fix this post-launch.