### PR TITLE
Replace all &nbsp characters with regular spaces

### DIFF
--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -159,15 +159,15 @@ function ReportProvider(props: { madLib: MadLib; setMadLib: Function }) {
           cases , hospitalizations and deaths because they have not provided
           sufficient disaggregated data to the CDC:{" "}
           <b>
-            Louisiana, Mississippi, Missouri, New Hampshire, North Dakota,{" "}
-            Texas, and Wyoming
+            Louisiana, Mississippi, Missouri, New Hampshire, North Dakota,{" "}
+            Texas, and Wyoming
           </b>
           . The following states' data for COVID-19 are included, but their data
           should be interpreted with caution since the cases reported may not be
-          representative of the population at large: 
+          representative of the population at large:{" "}
           <b>
-            Connecticut, Florida, Kentucky, Maryland, Michigan, Nebraska, New
-            Mexico, Ohio, Rhode Island, West Virginia.
+            Connecticut, Florida, Kentucky, Maryland, Michigan, Nebraska, New
+            Mexico, Ohio, Rhode Island, West Virginia.
           </b>
         </p>
         <h3>Missing Outcomes</h3>


### PR DESCRIPTION
Non-breaking spaces in the What Data Are Missing? section caused text not to wrap in the state lists on mobile. Replaces the &nbsp characters with regular spaces to allow proper text wrapping.

Before:

![Before](https://user-images.githubusercontent.com/10671916/119732705-88615380-be46-11eb-9db5-968d2f8242c3.png)

After:

<img width="261" alt="After" src="https://user-images.githubusercontent.com/10671916/119732827-b2b31100-be46-11eb-8fc4-7a683ca68694.png">