### PR TITLE
Island pop backend

### DIFF
--- a/airflow/dags/acs_2010_population.py
+++ b/airflow/dags/acs_2010_population.py
@@ -1,0 +1,41 @@
+from airflow import DAG
+from airflow.models import Variable
+from airflow.utils.dates import days_ago
+
+import util
+
+_ACS_2010_POPULATION_GCS_FILENAMES = (
+    'acs_2010_population-by_race_and_ethnicity_territory.json,'
+    'acs_2010_population-by_sex_territory.json'
+)
+_ACS_2010_POPULATION_WORKFLOW_ID = 'ACS_2010_POPULATION'
+_ACS_2010_POPULATION_DATASET = 'acs_2010_population'
+
+default_args = {'start_date': days_ago(0)}
+
+data_ingestion_dag = DAG(
+    'acs_2010_population_dag',
+    default_args=default_args,
+    schedule_interval=None,
+    description='Ingestion configuration for ACS 2010 Population Data')
+
+acs_2010_bq_payload = util.generate_bq_payload(
+    _ACS_2010_POPULATION_WORKFLOW_ID,
+    _ACS_2010_POPULATION_DATASET,
+    gcs_bucket=Variable.get('GCS_MANUAL_UPLOADS_BUCKET'),
+    filename=_ACS_2010_POPULATION_GCS_FILENAMES)
+acs_2010_bq_op = util.create_bq_ingest_operator(
+    'acs_2010_gcs_to_bq', acs_2010_bq_payload, data_ingestion_dag)
+
+acs_2010_aggregator_payload = {'dataset_name': _ACS_2010_POPULATION_DATASET}
+acs_2010_aggregator_operator = util.create_aggregator_operator(
+    'acs_2010_aggregator', acs_2010_aggregator_payload,
+    data_ingestion_dag)
+
+acs_2010_exporter_payload = {'dataset_name': _ACS_2010_POPULATION_DATASET}
+acs_2010_exporter_operator = util.create_exporter_operator(
+    'acs_2010_exporter', acs_2010_exporter_payload,
+    data_ingestion_dag)
+
+# CDC Restricted Data Ingestion DAG
+acs_2010_bq_op >> acs_2010_aggregator_operator >> acs_2010_exporter_operator

--- a/airflow/dags/acs_2010_population.py
+++ b/airflow/dags/acs_2010_population.py
@@ -6,7 +6,8 @@ import util
 
 _ACS_2010_POPULATION_GCS_FILENAMES = (
     'acs_2010_population-by_race_and_ethnicity_territory.json,'
-    'acs_2010_population-by_sex_territory.json'
+    'acs_2010_population-by_sex_territory.json,'
+    'acs_2010_population-by_age_territory.json'
 )
 _ACS_2010_POPULATION_WORKFLOW_ID = 'ACS_2010_POPULATION'
 _ACS_2010_POPULATION_DATASET = 'acs_2010_population'

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -81,10 +81,15 @@ WITH
         ON a.state_postal = b.state_postal_abbreviation
     WHERE a.state_postal != "Unknown"
   ),
+  all_acs as (
+      SELECT * FROM `acs_population.by_age_state`
+    UNION ALL
+      SELECT state_fips, state_name, age, population FROM `acs_2010_population.by_age_territory`
+  ),
   joined_with_acs as (
       SELECT x.*, y.population
       FROM cdc_restricted_age_state AS x
-      LEFT JOIN `acs_population.by_age_state` AS y
+      LEFT JOIN `all_acs` AS y
           USING (state_fips, age)
   )
 SELECT * FROM joined_with_acs

--- a/config/data_sources/AGG_cdc_restricted.sql
+++ b/config/data_sources/AGG_cdc_restricted.sql
@@ -23,10 +23,15 @@ WITH
         ON a.state_postal = b.state_postal_abbreviation
     WHERE a.state_postal != "Unknown"
   ),
+  all_acs as (
+      SELECT * FROM `acs_population.by_race_state_std`
+    UNION ALL
+      SELECT * FROM `acs_2010_population.by_race_and_ethnicity_territory`
+  ),
   joined_with_acs as (
       SELECT x.*, y.population
       FROM cdc_restricted_race_state AS x
-      LEFT JOIN `acs_population.by_race_state_std` AS y
+      LEFT JOIN `all_acs` AS y
           USING (state_fips, race_category_id)
   )
 SELECT * FROM joined_with_acs
@@ -47,10 +52,15 @@ WITH
         ON a.state_postal = b.state_postal_abbreviation
     WHERE a.state_postal != "Unknown"
   ),
+  all_acs as (
+      SELECT * FROM `acs_population.by_sex_state`
+    UNION ALL
+      SELECT * FROM `acs_2010_population.by_sex_territory`
+  ),
   joined_with_acs as (
       SELECT x.*, y.population
       FROM cdc_restricted_sex_state AS x
-      LEFT JOIN `acs_population.by_sex_state` AS y
+      LEFT JOIN `all_acs` AS y
           USING (state_fips, sex)
   )
 SELECT * FROM joined_with_acs

--- a/config/data_sources/acs_2010_population.tf
+++ b/config/data_sources/acs_2010_population.tf
@@ -1,0 +1,7 @@
+# Resources and routines for ACS population ingestion.
+
+# Create a BigQuery dataset for ACS population data.
+resource "google_bigquery_dataset" "bq_acs_2010_population" {
+  dataset_id = "acs_2010_population"
+  location   = "US"
+}

--- a/data/acs_2010/acs_2010_population-by_age_territory.json
+++ b/data/acs_2010/acs_2010_population-by_age_territory.json
@@ -1,61 +1,61 @@
 [
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "Total",
     "population": "159358"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "0-9",
     "population": "28273"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "10-19",
     "population": "29453"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "20-29",
     "population": "23125"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "30-39",
     "population": "21750"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "40-49",
     "population": "32822"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "50-59",
     "population": "16918"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "60-69",
     "population": "10250"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "70-79",
     "population": "5014"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "age": "80+",
     "population": "1844"
   },
@@ -121,61 +121,61 @@
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "Total",
     "population": "106405"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "0-9",
     "population": "14650"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "10-19",
     "population": "15047"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "20-29",
     "population": "11869"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "30-39",
     "population": "12813"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "40-49",
     "population": "15181"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "50-59",
     "population": "15086"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "60-69",
     "population": "13225"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "70-79",
     "population": "6043"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "age": "80+",
     "population": "2491"
   }

--- a/data/acs_2010/acs_2010_population-by_age_territory.json
+++ b/data/acs_2010/acs_2010_population-by_age_territory.json
@@ -1,0 +1,182 @@
+[
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "Total",
+    "population": "159358"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "0-9",
+    "population": "28273"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "10-19",
+    "population": "29453"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "20-29",
+    "population": "23125"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "30-39",
+    "population": "21750"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "40-49",
+    "population": "32822"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "50-59",
+    "population": "16918"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "60-69",
+    "population": "10250"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "70-79",
+    "population": "5014"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "age": "80+",
+    "population": "1844"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "Total",
+    "population": "53883"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "0-9",
+    "population": "9440"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "10-19",
+    "population": "9171"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "20-29",
+    "population": "5697"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "30-39",
+    "population": "8955"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "40-49",
+    "population": "10775"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "50-59",
+    "population": "6735"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "60-69",
+    "population": "2243"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "70-79",
+    "population": "690"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "age": "80+",
+    "population": "177"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "Total",
+    "population": "106405"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "0-9",
+    "population": "14650"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "10-19",
+    "population": "15047"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "20-29",
+    "population": "11869"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "30-39",
+    "population": "12813"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "40-49",
+    "population": "15181"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "50-59",
+    "population": "15086"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "60-69",
+    "population": "13225"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "70-79",
+    "population": "6043"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "age": "80+",
+    "population": "2491"
+  }
+]

--- a/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
+++ b/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
@@ -1,0 +1,26 @@
+[
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "population": "106405",
+    "race_category_id": "TOTAL"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "population": "18504",
+    "race_category_id": "HISP"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "population": "70379",
+    "race_category_id": "BLACK_NH"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "population": "14352",
+    "race_category_id": "WHITE_NH"
+  }
+]

--- a/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
+++ b/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
@@ -1,25 +1,25 @@
 [
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "population": "106405",
     "race_category_id": "TOTAL"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "population": "18504",
     "race_category_id": "HISP"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "population": "70379",
     "race_category_id": "BLACK_NH"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "population": "14352",
     "race_category_id": "WHITE_NH"
   },
@@ -73,49 +73,49 @@
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "159358",
     "race_category_id": "TOTAL"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "51381",
     "race_category_id": "ASIAN_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "1540",
     "race_category_id": "BLACK_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "78582",
     "race_category_id": "NHPI_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "11321",
     "race_category_id": "WHITE_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "14929",
     "race_category_id": "MULTI_OR_OTHER_STANDARD_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "404",
     "race_category_id": "OTHER_STANDARD_NH"
   },
   {
     "state_fips": "66",
-    "state_name": "GUAM",
+    "state_name": "Guam",
     "population": "1201",
     "race_category_id": "HISP"
   }

--- a/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
+++ b/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
@@ -24,6 +24,54 @@
     "race_category_id": "WHITE_NH"
   },
   {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "53883",
+    "race_category_id": "TOTAL"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "26908",
+    "race_category_id": "ASIAN_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "55",
+    "race_category_id": "BLACK_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "18800",
+    "race_category_id": "NHPI_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "1117",
+    "race_category_id": "WHITE_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "6832",
+    "race_category_id": "MULTI_OR_OTHER_STANDARD_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "117",
+    "race_category_id": "OTHER_STANDARD_NH"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "population": "54",
+    "race_category_id": "HISP"
+  },
+  {
     "state_fips": "66",
     "state_name": "GUAM",
     "population": "159358",

--- a/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
+++ b/data/acs_2010/acs_2010_population-by_race_and_ethnicity_territory.json
@@ -22,5 +22,53 @@
     "state_name": "Virgin Islands",
     "population": "14352",
     "race_category_id": "WHITE_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "159358",
+    "race_category_id": "TOTAL"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "51381",
+    "race_category_id": "ASIAN_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "1540",
+    "race_category_id": "BLACK_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "78582",
+    "race_category_id": "NHPI_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "11321",
+    "race_category_id": "WHITE_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "14929",
+    "race_category_id": "MULTI_OR_OTHER_STANDARD_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "404",
+    "race_category_id": "OTHER_STANDARD_NH"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "GUAM",
+    "population": "1201",
+    "race_category_id": "HISP"
   }
 ]

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -34,5 +34,23 @@
     "state_name": "Virgin Islands",
     "sex": "Female",
     "population": "55538"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "sex": "Total",
+    "population": "53883"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "sex": "Male",
+    "population": "27746"
+  },
+  {
+    "state_fips": "69",
+    "state_name": "Northern Mariana Islands",
+    "sex": "Female",
+    "population": "26137"
   }
 ]

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -19,19 +19,19 @@
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "sex": "Total",
     "population": "106405"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "sex": "Male",
     "population": "50867"
   },
   {
     "state_fips": "78",
-    "state_name": "Virgin Islands",
+    "state_name": "U.S. Virgin Islands",
     "sex": "Female",
     "population": "55538"
   },

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -1,0 +1,38 @@
+[
+  {
+    "state_fips": "66",
+    "state_name": "Guam",
+    "sex": "Total",
+    "population": "168783"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "Guam",
+    "sex": "Male",
+    "population": "85140"
+  },
+  {
+    "state_fips": "66",
+    "state_name": "Guam",
+    "sex": "Female",
+    "population": "83643"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "sex": "Total",
+    "population": "106405"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "sex": "Male",
+    "population": "50867"
+  },
+  {
+    "state_fips": "78",
+    "state_name": "Virgin Islands",
+    "sex": "Female",
+    "population": "55538"
+  }
+]

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -3,19 +3,19 @@
     "state_fips": "66",
     "state_name": "Guam",
     "sex": "Total",
-    "population": "168783"
+    "population": "159358"
   },
   {
     "state_fips": "66",
     "state_name": "Guam",
     "sex": "Male",
-    "population": "85140"
+    "population": "81568"
   },
   {
     "state_fips": "66",
     "state_name": "Guam",
     "sex": "Female",
-    "population": "83643"
+    "population": "77790"
   },
   {
     "state_fips": "78",

--- a/python/datasources/acs_2010_population.py
+++ b/python/datasources/acs_2010_population.py
@@ -1,0 +1,47 @@
+import ingestion.standardized_columns as std_col
+
+from datasources.data_source import DataSource
+from ingestion import gcs_to_bq_util
+
+
+class ACS2010Population(DataSource):
+
+    @staticmethod
+    def get_id():
+        return 'ACS_2010_POPULATION'
+
+    @staticmethod
+    def get_table_name():
+        return 'acs_2010_population'
+
+    def upload_to_gcs(self, _, **attrs):
+        raise NotImplementedError(
+            'upload_to_gcs should not be called for ACS2010Population')
+
+    def write_to_bq(self, dataset, gcs_bucket, **attrs):
+        gcs_files = self.get_attr(attrs, 'filename')
+
+        # In this instance, we expect filename to be a string with
+        # comma-separated CSV filenames.
+        if ',' not in gcs_files:
+            raise ValueError('filename passed to write_to_bq is not a '
+                             'comma-separated list of files')
+        files = gcs_files.split(',')
+        print("Files that will be written to BQ:", files)
+
+        for f in files:
+            # Explicitly specify county_fips is a string.
+            df = gcs_to_bq_util.load_json_as_dataframe(
+                gcs_bucket, f, dtype={'state_fips': str})
+
+            # All columns are str, except outcome columns.
+            column_types = {c: 'STRING' for c in df.columns}
+            if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
+                column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
+
+            # Clean up column names.
+            self.clean_frame_column_names(df)
+
+            table_name = f.replace('.csv', '')  # Table name is file name
+            gcs_to_bq_util.add_dataframe_to_bq(
+                df, dataset, table_name, column_types=column_types)

--- a/python/datasources/acs_2010_population.py
+++ b/python/datasources/acs_2010_population.py
@@ -34,14 +34,26 @@ class ACS2010Population(DataSource):
             df = gcs_to_bq_util.load_json_as_dataframe(
                 gcs_bucket, f, dtype={'state_fips': str})
 
+            if std_col.RACE_CATEGORY_ID_COL in df.columns:
+                std_col.add_race_columns_from_category_id(df)
+
             # All columns are str, except outcome columns.
             column_types = {c: 'STRING' for c in df.columns}
+            column_types[std_col.POPULATION_COL] = 'INT64'
             if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
                 column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
 
             # Clean up column names.
             self.clean_frame_column_names(df)
 
-            table_name = f.replace('.csv', '')  # Table name is file name
+            table_name = f.replace('.json', '')  # Table name is file name
+            table_name = table_name.replace('acs_2010_population-', '')  # Dont need this
             gcs_to_bq_util.add_dataframe_to_bq(
                 df, dataset, table_name, column_types=column_types)
+
+def reorder_columns(df, col_order):
+    """Reorders colums based on col_order
+
+    df: dataframe to reorder
+    col_order: Desired column order"""
+    return df[col_order]

--- a/python/datasources/data_sources.py
+++ b/python/datasources/data_sources.py
@@ -1,4 +1,5 @@
 from datasources.acs_population import ACSPopulation
+from datasources.acs_2010_population import ACS2010Population
 from datasources.cdc_covid_deaths import CDCCovidDeaths
 from datasources.cdc_restricted import CDCRestrictedData
 from datasources.county_adjacency import CountyAdjacency
@@ -19,6 +20,7 @@ from datasources.uhc import UHCData
 # that data source.
 DATA_SOURCES_DICT = {
     ACSPopulation.get_id(): ACSPopulation(),
+    ACS2010Population.get_id(): ACS2010Population(),
     CDCCovidDeaths.get_id(): CDCCovidDeaths(),
     CDCRestrictedData.get_id(): CDCRestrictedData(),
     CountyAdjacency.get_id(): CountyAdjacency(),

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -193,6 +193,35 @@ def load_csv_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
     os.remove(local_path)
     return frame
 
+def load_json_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
+                          parse_dates=False, thousands=None):
+    """Loads json data from the provided gcs_bucket and filename to a DataFrame.
+       Expects the data to be in csv format, with the first row as the column
+       names.
+
+       gcs_bucket: The name of the gcs bucket to read the data from
+       filename: The name of the file in the gcs bucket to read from
+       dtype: An optional dictionary of column names to column types, as
+              specified by the pandas API. Not all column types need to be
+              specified; column type is auto-detected. This is useful, for
+              example, to force integer-like ids to be treated as strings
+       parse_dates: Column(s) that should be parsed and interpreted as dates.
+       thousands: str to be used as a thousands separator for parsing numbers"""
+    client = storage.Client()
+    bucket = client.get_bucket(gcs_bucket)
+    blob = bucket.blob(filename)
+    local_path = local_file_path(filename)
+    blob.download_to_filename(local_path)
+    frame = pandas.read_json(local_path, dtype=dtype, chunksize=chunksize,
+                            parse_dates=parse_dates, thousands=thousands)
+
+    # Warning: os.remove() will remove the directory entry but will not release
+    # the file's storage until the file is no longer being used by |frame|.
+    # Double warning: This will cause an exception on Windows. See
+    # https://docs.python.org/3/library/os.html#os.remove for details.
+    os.remove(local_path)
+    return frame
+
 
 def load_csv_as_dataframe_from_web(url, dtype=None):
     """Loads csv data from the provided url to a DataFrame.

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -193,8 +193,7 @@ def load_csv_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
     os.remove(local_path)
     return frame
 
-def load_json_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
-                          parse_dates=False, thousands=None):
+def load_json_as_dataframe(gcs_bucket, filename, dtype=None):
     """Loads json data from the provided gcs_bucket and filename to a DataFrame.
        Expects the data to be in csv format, with the first row as the column
        names.
@@ -204,16 +203,13 @@ def load_json_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
        dtype: An optional dictionary of column names to column types, as
               specified by the pandas API. Not all column types need to be
               specified; column type is auto-detected. This is useful, for
-              example, to force integer-like ids to be treated as strings
-       parse_dates: Column(s) that should be parsed and interpreted as dates.
-       thousands: str to be used as a thousands separator for parsing numbers"""
+              example, to force integer-like ids to be treated as strings"""
     client = storage.Client()
     bucket = client.get_bucket(gcs_bucket)
     blob = bucket.blob(filename)
     local_path = local_file_path(filename)
     blob.download_to_filename(local_path)
-    frame = pandas.read_json(local_path, dtype=dtype, chunksize=chunksize,
-                            parse_dates=parse_dates, thousands=thousands)
+    frame = pandas.read_json(local_path, dtype=dtype)
 
     # Warning: os.remove() will remove the directory entry but will not release
     # the file's storage until the file is no longer being used by |frame|.

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -193,6 +193,7 @@ def load_csv_as_dataframe(gcs_bucket, filename, dtype=None, chunksize=None,
     os.remove(local_path)
     return frame
 
+
 def load_json_as_dataframe(gcs_bucket, filename, dtype=None):
     """Loads json data from the provided gcs_bucket and filename to a DataFrame.
        Expects the data to be in csv format, with the first row as the column


### PR DESCRIPTION
Resolves #986

* Sources the population data from the ACS 2010 survey for
   * Guam
   * Northern Mariana Islands
   * US Virgin Islands
  
* Fixes a bug where we incorrectly calculated the national COVID per 100k metric
    * We were adding in the COVID numbers from the three territories in the numerator for the COVID numbers, but did NOT have the population numbers in the denominator.
    * Thus, we were marginally over estimating the number of COVID cases per 100k. 
    * It had a marginal impact on all races expect for Native Hawaiian / Pacific Islander which dropped by about 1500 per 100k. 