### PR TITLE
better fix for grid layout bug on WIHE page

### DIFF
--- a/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
@@ -398,22 +398,23 @@ function EquityTab() {
         </Grid>
         <Grid
           container
+          item
+          xs={12}
+          className={styles.FaqRow}
+          alignItems="center"
+          justify="center"
+        >
+          <Grid sm={12} md={10}>
+            <FaqSection />
+          </Grid>
+        </Grid>
+        <Grid
+          container
           className={styles.JoinTheEffortRow}
+          direction="column"
           justify="center"
           alignItems="center"
         >
-          <Grid
-            container
-            item
-            xs={12}
-            className={styles.FaqRow}
-            alignItems="center"
-            justify="center"
-          >
-            <Grid sm={12} md={10}>
-              <FaqSection />
-            </Grid>
-          </Grid>
           <Grid
             item
             className={styles.JoinTheEffortHeaderRow}


### PR DESCRIPTION
The FAQ sub Grid was in the wrong position in the nested Grids, moving it into proper location in nesting fixed the weird layout issue that in a previous PR I had hack-fixed by removing a direction:column attribute. This branch replaces the column attribute and Properly Fixes #1014