### PR TITLE
Friendly tab routes, with back button support

### DIFF
--- a/frontend/src/pages/AboutUs/AboutUsPage.tsx
+++ b/frontend/src/pages/AboutUs/AboutUsPage.tsx
@@ -13,9 +13,9 @@ import {
 import { useHistory } from "react-router-dom";
 import { friendlyTabNamesAboutUs } from "../../utils/urlutils";
 
-export const ABOUT_US_PROJECT_TAB_INDEX = 0;
-export const ABOUT_US_TEAM_TAB_INDEX = 1;
-export const ABOUT_US_CONTACT_TAB_INDEX = 2;
+// export const ABOUT_US_PROJECT_TAB_INDEX = 0;
+// export const ABOUT_US_TEAM_TAB_INDEX = 1;
+export const ABOUT_US_CONTACT_TAB_INDEX = "contact";
 
 export function AboutUsPage() {
   const history = useHistory();

--- a/frontend/src/pages/AboutUs/AboutUsPage.tsx
+++ b/frontend/src/pages/AboutUs/AboutUsPage.tsx
@@ -11,6 +11,7 @@ import {
   useSearchParams,
 } from "../../utils/urlutils";
 import { useHistory } from "react-router-dom";
+import { friendlyTabNamesAboutUs } from "../../utils/urlutils";
 
 export const ABOUT_US_PROJECT_TAB_INDEX = 0;
 export const ABOUT_US_TEAM_TAB_INDEX = 1;
@@ -21,7 +22,9 @@ export function AboutUsPage() {
   const params = useSearchParams();
 
   const [tabIndex, setTabIndex] = React.useState(
-    params[TAB_PARAM] ? Number(params[TAB_PARAM]) : 0
+    params[TAB_PARAM]
+      ? Number(friendlyTabNamesAboutUs.indexOf(params[TAB_PARAM]))
+      : 0
   );
 
   const [locationKeys, setLocationKeys] = React.useState<
@@ -29,7 +32,9 @@ export function AboutUsPage() {
   >([]);
 
   useEffect(() => {
-    history.push(`${ABOUT_US_PAGE_LINK}?${TAB_PARAM}=${tabIndex}`);
+    history.push(
+      `${ABOUT_US_PAGE_LINK}?${TAB_PARAM}=${friendlyTabNamesAboutUs[tabIndex]}`
+    );
   }, [history, tabIndex]);
 
   useEffect(() => {
@@ -38,12 +43,12 @@ export function AboutUsPage() {
         if (locationKeys[1] === location.key) {
           // Handle forward event
           setLocationKeys(([_, ...keys]) => keys);
-          window.location.reload();
         } else {
           // Handle back event
           setLocationKeys((keys) => [location.key, ...keys]);
-          window.location.reload();
         }
+
+        window.location.reload();
       }
     });
   }, [history, locationKeys]);

--- a/frontend/src/pages/AboutUs/AboutUsPage.tsx
+++ b/frontend/src/pages/AboutUs/AboutUsPage.tsx
@@ -1,22 +1,52 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import styles from "./AboutUsPage.module.scss";
 import TheProjectTab from "./TheProjectTab";
 import OurTeamTab from "./OurTeamTab";
 import ContactUsTab from "./ContactUsTab";
-import { TAB_PARAM, useSearchParams } from "../../utils/urlutils";
+import {
+  ABOUT_US_PAGE_LINK,
+  TAB_PARAM,
+  useSearchParams,
+} from "../../utils/urlutils";
+import { useHistory } from "react-router-dom";
 
 export const ABOUT_US_PROJECT_TAB_INDEX = 0;
 export const ABOUT_US_TEAM_TAB_INDEX = 1;
 export const ABOUT_US_CONTACT_TAB_INDEX = 2;
 
 export function AboutUsPage() {
+  const history = useHistory();
   const params = useSearchParams();
 
   const [tabIndex, setTabIndex] = React.useState(
     params[TAB_PARAM] ? Number(params[TAB_PARAM]) : 0
   );
+
+  const [locationKeys, setLocationKeys] = React.useState<
+    (string | undefined)[]
+  >([]);
+
+  useEffect(() => {
+    history.push(`${ABOUT_US_PAGE_LINK}?${TAB_PARAM}=${tabIndex}`);
+  }, [history, tabIndex]);
+
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "POP") {
+        if (locationKeys[1] === location.key) {
+          // Handle forward event
+          setLocationKeys(([_, ...keys]) => keys);
+          window.location.reload();
+        } else {
+          // Handle back event
+          setLocationKeys((keys) => [location.key, ...keys]);
+          window.location.reload();
+        }
+      }
+    });
+  }, [history, locationKeys]);
 
   const handleChange = (event: React.ChangeEvent<{}>, newTabIndex: number) => {
     setTabIndex(newTabIndex);

--- a/frontend/src/pages/AboutUs/OurTeamTab.tsx
+++ b/frontend/src/pages/AboutUs/OurTeamTab.tsx
@@ -292,6 +292,7 @@ function OurTeamTab() {
               {LEADERSHIP_TEAM.map((leader) => {
                 return (
                   <Grid
+                    key={leader.name}
                     item
                     xs={12}
                     sm={6}
@@ -323,7 +324,7 @@ function OurTeamTab() {
             <Grid container className={styles.GridSubRow}>
               {GOOGLE_FELLOWS.map((fellow) => {
                 return fellow.link == null ? (
-                  <Grid item className={styles.TextProfile}>
+                  <Grid item className={styles.TextProfile} key={fellow.name}>
                     <span style={{ fontSize: "16px", fontWeight: 500 }}>
                       {fellow.name}
                     </span>
@@ -333,7 +334,7 @@ function OurTeamTab() {
                     </span>
                   </Grid>
                 ) : (
-                  <Grid item className={styles.TextProfile}>
+                  <Grid item className={styles.TextProfile} key={fellow.name}>
                     <a
                       href={fellow.link}
                       style={{ fontSize: "16px", fontWeight: 500 }}
@@ -365,7 +366,7 @@ function OurTeamTab() {
           <Grid item xs={12}>
             <Grid container className={styles.GridSubRow}>
               {HE_TASKFORCE.map((name) => (
-                <Grid item className={styles.TextProfile}>
+                <Grid item className={styles.TextProfile} key={name}>
                   <span style={{ fontSize: "16px", fontWeight: 500 }}>
                     {name}
                   </span>
@@ -384,7 +385,7 @@ function OurTeamTab() {
 
           <Grid item xs={12}>
             {PARTNERS.map((partner) => (
-              <a href={partner.url}>
+              <a href={partner.url} key={partner.url}>
                 <img
                   src={partner.imageUrl}
                   alt={partner.alt}

--- a/frontend/src/pages/WhatIsHealthEquity/ResourcesTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/ResourcesTab.tsx
@@ -18,7 +18,8 @@ const RESOURCES = [
   },
   {
     name: "Teaching the Difference Between Equality, Equity, and Justice",
-    url: "https://www.paperpinecone.com/blog/teaching-difference-between-equality-equity-and-justice-preschool",
+    url:
+      "https://www.paperpinecone.com/blog/teaching-difference-between-equality-equity-and-justice-preschool",
   },
   {
     name: "Equity vs. Equality: What's the Difference?",
@@ -26,7 +27,8 @@ const RESOURCES = [
   },
   {
     name: "Social determinants of health -WHO",
-    url: "https://www.who.int/health-topics/social-determinants-of-health#tab=tab_1",
+    url:
+      "https://www.who.int/health-topics/social-determinants-of-health#tab=tab_1",
   },
   {
     name: "Equity- WHO",
@@ -34,7 +36,8 @@ const RESOURCES = [
   },
   {
     name: "Intro to Health Equity and Social Determinants of Health",
-    url: "https://www.ncbi.nlm.nih.gov/books/NBK540766/#:~:text=Health%20equity%2C%20as%20defined%20by,of%20health%20for%20all%20people.",
+    url:
+      "https://www.ncbi.nlm.nih.gov/books/NBK540766/#:~:text=Health%20equity%2C%20as%20defined%20by,of%20health%20for%20all%20people.",
   },
   {
     name: "Health Disparities and Health Equity: The Issue Is Justice",
@@ -50,11 +53,13 @@ const RESOURCES = [
   },
   {
     name: "Health Equity: Why It Matters, and How To Take Action - RWJF",
-    url: "https://www.rwjf.org/en/library/features/achieving-health-equity.html",
+    url:
+      "https://www.rwjf.org/en/library/features/achieving-health-equity.html",
   },
   {
     name: "Health Equity and Prevention Primer",
-    url: "https://www.preventioninstitute.org/tools/tools-general/health-equity-toolkit#:~:text=The%20Health%20Equity%20and%20Prevention%20Primer%20(HEPP)%20is%20a%20web,%2C%20and%20multi%2Dsector%20engagement.",
+    url:
+      "https://www.preventioninstitute.org/tools/tools-general/health-equity-toolkit#:~:text=The%20Health%20Equity%20and%20Prevention%20Primer%20(HEPP)%20is%20a%20web,%2C%20and%20multi%2Dsector%20engagement.",
   },
   {
     name: "APIAHF: Health Equity",
@@ -62,7 +67,8 @@ const RESOURCES = [
   },
   {
     name: "UCLA HEALTH: COVID-19 exposes how Native Hawaiians and Pacific...",
-    url: "https://www.uclahealth.org/covid19-exposes-how-native-hawaiians-and-pacific-islanders-face-stark-health-care-disparities",
+    url:
+      "https://www.uclahealth.org/covid19-exposes-how-native-hawaiians-and-pacific-islanders-face-stark-health-care-disparities",
   },
   {
     name: "Health Equity Matters for Asian Americans, Native Hawaiians...",
@@ -78,27 +84,33 @@ const RESOURCES = [
   },
   {
     name: "Racialization as a Barrier to Achieving Health Equity for Native...",
-    url: "https://journalofethics.ama-assn.org/article/racialization-barrier-achieving-health-equity-native-americans/2020-10",
+    url:
+      "https://journalofethics.ama-assn.org/article/racialization-barrier-achieving-health-equity-native-americans/2020-10",
   },
   {
     name: "The Impact of Historical Trauma on American Indian Health Equity",
-    url: "https://www.medicalnewstoday.com/articles/the-impact-of-historical-trauma-on-american-indian-health-equity",
+    url:
+      "https://www.medicalnewstoday.com/articles/the-impact-of-historical-trauma-on-american-indian-health-equity",
   },
   {
     name: "COVID-19 and Equity*- APHA",
-    url: "https://www.apha.org/topics-and-issues/communicable-disease/coronavirus/equity",
+    url:
+      "https://www.apha.org/topics-and-issues/communicable-disease/coronavirus/equity",
   },
   {
     name: "COVID-19 and Health Equity: A Policy Platform and Voices",
-    url: "https://www.apha.org/events-and-meetings/apha-calendar/webinar-events/2020/covid-19-and-health-equity",
+    url:
+      "https://www.apha.org/events-and-meetings/apha-calendar/webinar-events/2020/covid-19-and-health-equity",
   },
   {
     name: "Investing in Latino Leadership for Health Equity and Justice...",
-    url: "https://www.gih.org/publication/investing-in-latino-leadership-for-health-equity-and-justice/",
+    url:
+      "https://www.gih.org/publication/investing-in-latino-leadership-for-health-equity-and-justice/",
   },
   {
     name: "Tackling Health disparities among latinos in the US",
-    url: "https://nimhd.blogs.govdelivery.com/2018/10/11/tackling-health-disparities-among-latinos-in-the-united-states/",
+    url:
+      "https://nimhd.blogs.govdelivery.com/2018/10/11/tackling-health-disparities-among-latinos-in-the-united-states/",
   },
   {
     name: "Hispanic/Lainto- Minority Health",
@@ -110,10 +122,12 @@ const RESOURCES = [
   },
   {
     name: "The Economic Case for Health Equity - ASTHO",
-    url: "https://www.astho.org/Programs/Health-Equity/Economic-Case-Issue-Brief/",
+    url:
+      "https://www.astho.org/Programs/Health-Equity/Economic-Case-Issue-Brief/",
   },
   {
-    name: "Estimating the economic burden of racial health inequalities in the United States",
+    name:
+      "Estimating the economic burden of racial health inequalities in the United States",
     url: "https://pubmed.ncbi.nlm.nih.gov/21563622/",
   },
   {
@@ -121,20 +135,25 @@ const RESOURCES = [
     url: "http://www.rootsofhealthinequity.org/",
   },
   {
-    name: "Health equity and social justice 101 series: Part I The Politics of Health Inequity",
+    name:
+      "Health equity and social justice 101 series: Part I The Politics of Health Inequity",
     url: "https://www.youtube.com/watch?v=2k5XPbEB4H0",
   },
   {
     name: "NACCHO Health Equity and Social Justice Resources and Trainings",
-    url: "https://www.naccho.org/programs/public-health-infrastructure/health-equity",
+    url:
+      "https://www.naccho.org/programs/public-health-infrastructure/health-equity",
   },
   {
-    name: "How to use data to inform community health assessment and planning: NACCHO's Mobiling for Action through Planning and Partnerships (MAPP) framework",
-    url: "https://www.naccho.org/programs/public-health-infrastructure/performance-improvement/community-health-assessment/mapp",
+    name:
+      "How to use data to inform community health assessment and planning: NACCHO's Mobiling for Action through Planning and Partnerships (MAPP) framework",
+    url:
+      "https://www.naccho.org/programs/public-health-infrastructure/performance-improvement/community-health-assessment/mapp",
   },
   {
     name: "UIHI Best Practices",
-    url: "https://www.uihi.org/resources/best-practices-for-american-indian-and-alaska-native-data-collection/",
+    url:
+      "https://www.uihi.org/resources/best-practices-for-american-indian-and-alaska-native-data-collection/",
   },
   {
     name: "Racial Equity Index",
@@ -162,7 +181,8 @@ const RESOURCES = [
   },
   {
     name: "Bloomberg: COVID-19 Global Vaccine Tracker",
-    url: "https://www.bloomberg.com/graphics/covid-vaccine-tracker-global-distribution/us-vaccine-demographics.html",
+    url:
+      "https://www.bloomberg.com/graphics/covid-vaccine-tracker-global-distribution/us-vaccine-demographics.html",
   },
   {
     name: "APM Research: COVID-19 Vaccine Progress",
@@ -174,7 +194,8 @@ const RESOURCES = [
   },
   {
     name: "New York Times: Real-Time, Interactive COVID-19 Tracker",
-    url: "https://www.nytimes.com/interactive/2020/us/coronavirus-us-cases.html",
+    url:
+      "https://www.nytimes.com/interactive/2020/us/coronavirus-us-cases.html",
   },
   {
     name: "California COVID-19 Health Equity Site",
@@ -185,81 +206,90 @@ const RESOURCES = [
     url: "https://www.apmresearchlab.org/",
   },
   {
-    name: "Building Trust and Access to the COVID-19 Vaccine in Communities of Color and Tribal Nations",
-    url: "https://www.tfah.org/report-details/trust-and-access-to-covid-19-vaccine-within-communities-of-color/",
+    name:
+      "Building Trust and Access to the COVID-19 Vaccine in Communities of Color and Tribal Nations",
+    url:
+      "https://www.tfah.org/report-details/trust-and-access-to-covid-19-vaccine-within-communities-of-color/",
   },
   {
-    name: "Advancing Health Equity: What we learned from Community-based Health Equity Initiatives",
+    name:
+      "Advancing Health Equity: What we learned from Community-based Health Equity Initiatives",
     url: "https://www.tfah.org/initiatives/health-equity/",
   },
   {
     name: "TFAH Health Equity Webinar Series",
-    url: "https://www.tfah.org/article/tfah-webinar-series-on-achieving-health-equity-through-collaborations-innovative-funding-and-leadership/",
+    url:
+      "https://www.tfah.org/article/tfah-webinar-series-on-achieving-health-equity-through-collaborations-innovative-funding-and-leadership/",
   },
   {
-    name: "CDC - Johnson & Johnson’s Janssen COVID-19 Vaccine Overview and Safety",
-    url: "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/janssen.html",
+    name:
+      "CDC - Johnson & Johnson’s Janssen COVID-19 Vaccine Overview and Safety",
+    url:
+      "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/janssen.html",
   },
   {
     name: "CDC - Pfizer-BioNTech COVID-19 Vaccine Overview and Safety",
-    url: "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Pfizer-BioNTech.html",
+    url:
+      "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Pfizer-BioNTech.html",
   },
   {
     name: "CDC - Moderna COVID-19 Vaccine Overview and Safety",
-    url: "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Moderna.html",
+    url:
+      "https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Moderna.html",
   },
   {
     name: "Medical Justice In Advocacy Fellowship",
-    url: "https://www.ama-assn.org/delivering-care/health-equity/medical-justice-advocacy-fellowship",
+    url:
+      "https://www.ama-assn.org/delivering-care/health-equity/medical-justice-advocacy-fellowship",
   },
   {
     name: "THE ECONOMIC BURDEN OF HEALTH INEQUALITIES IN THE UNITED STATES",
-    url: "https://hsrc.himmelfarb.gwu.edu/cgi/viewcontent.cgi?article=1224&context=sphhs_policy_facpubs",
+    url:
+      "https://hsrc.himmelfarb.gwu.edu/cgi/viewcontent.cgi?article=1224&context=sphhs_policy_facpubs",
   },
   {
     name: "Satcher Health Leadership Institute",
     url: "https://satcherinstitute.org/",
   },
-]
+];
 
 function ResourcesTab() {
   return (
-      <>
-        <title>
-          Health Equity Resources - What Is Health Equity? -
-          Health Equity Tracker
-        </title>
-        <h1 className={styles.ScreenreaderTitleHeader}>
-          Health Equity Resources
-        </h1>
-        <Grid container className={styles.Grid}>
-          <Grid container className={styles.ResourcesSection}>
-            <Grid item xs={12} sm={12} md={3}>
-              <Typography
-                  id="main"
-                  tabIndex={-1}
-                  className={styles.ResourcesHeaderText}
-                  variant="h2"
-              >
-                Resources
-              </Typography>
-            </Grid>
-            <Grid item xs={12} sm={12} md={9}>
-              <Grid container>
-                <Grid item>
-                  <ul className={styles.ResourcesList}>
-                    {RESOURCES.map((resource) => (
-                        <li className={styles.ResourcesListItem}>
-                          <a href={resource.url}>{resource.name}</a>
-                        </li>
-                    ))}
-                  </ul>
-                </Grid>
+    <>
+      <title>
+        Health Equity Resources - What Is Health Equity? - Health Equity Tracker
+      </title>
+      <h1 className={styles.ScreenreaderTitleHeader}>
+        Health Equity Resources
+      </h1>
+      <Grid container className={styles.Grid}>
+        <Grid container className={styles.ResourcesSection}>
+          <Grid item xs={12} sm={12} md={3}>
+            <Typography
+              id="main"
+              tabIndex={-1}
+              className={styles.ResourcesHeaderText}
+              variant="h2"
+            >
+              Resources
+            </Typography>
+          </Grid>
+          <Grid item xs={12} sm={12} md={9}>
+            <Grid container>
+              <Grid item>
+                <ul className={styles.ResourcesList}>
+                  {RESOURCES.map((resource) => (
+                    <li className={styles.ResourcesListItem} key={resource.url}>
+                      <a href={resource.url}>{resource.name}</a>
+                    </li>
+                  ))}
+                </ul>
               </Grid>
             </Grid>
           </Grid>
         </Grid>
-      </>
+      </Grid>
+    </>
   );
 }
 

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -4,19 +4,59 @@ import Tab from "@material-ui/core/Tab";
 import styles from "./WhatIsHealthEquityPage.module.scss";
 import EquityTab from "./EquityTab";
 import FaqTab from "./FaqTab";
-import { TAB_PARAM, useSearchParams } from "../../utils/urlutils";
-import ResourcesTab from './ResourcesTab';
+import {
+  TAB_PARAM,
+  useSearchParams,
+  WHAT_IS_HEALTH_EQUITY_PAGE_LINK,
+} from "../../utils/urlutils";
+import ResourcesTab from "./ResourcesTab";
+import { useEffect } from "react";
+import { useHistory, useLocation } from "react-router-dom";
 
 export const WIHE_HEALTH_EQUITY_TAB_INDEX = 0;
 export const WIHE_FAQ_TAB_INDEX = 1;
 export const WIHE_JOIN_THE_EFFORT_SECTION_ID = "join";
 
 export function WhatIsHealthEquityPage() {
+  const history = useHistory();
   const params = useSearchParams();
+  const location = useLocation();
 
   const [tabIndex, setTabIndex] = React.useState(
     params[TAB_PARAM] ? Number(params[TAB_PARAM]) : 0
   );
+
+  useEffect(() => {
+    history.push(`${WHAT_IS_HEALTH_EQUITY_PAGE_LINK}?${TAB_PARAM}=${tabIndex}`);
+  }, [history, tabIndex]);
+
+  const [locationKeys, setLocationKeys] = React.useState<
+    (string | undefined)[]
+  >([]);
+
+  useEffect(() => {
+    return history.listen((location) => {
+      if (history.action === "PUSH") {
+        if (location.key) setLocationKeys([location.key]);
+      }
+
+      if (history.action === "POP") {
+        if (locationKeys[1] === location.key) {
+          setLocationKeys(([_, ...keys]) => keys);
+
+          // Handle forward event
+          console.log("forward button");
+        } else {
+          setLocationKeys((keys) => [location.key, ...keys]);
+
+          // Handle back event
+          console.log("back button");
+          // window.location.reload();
+        }
+        window.location.reload();
+      }
+    });
+  }, [history, locationKeys]);
 
   const handleChange = (event: React.ChangeEvent<{}>, newTabIndex: number) => {
     setTabIndex(newTabIndex);
@@ -41,8 +81,8 @@ export function WhatIsHealthEquityPage() {
           label="Frequently Asked Questions"
         />
         <Tab
-            className={styles.WhatIsHealthEquityTab}
-            label="Health Equity Resources"
+          className={styles.WhatIsHealthEquityTab}
+          label="Health Equity Resources"
         />
       </Tabs>
       {tabIndex === 0 && <EquityTab />}

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "../../utils/urlutils";
 import ResourcesTab from "./ResourcesTab";
 import { useEffect } from "react";
-import { useHistory, useLocation } from "react-router-dom";
+import { useHistory } from "react-router-dom";
 
 export const WIHE_HEALTH_EQUITY_TAB_INDEX = 0;
 export const WIHE_FAQ_TAB_INDEX = 1;
@@ -20,19 +20,17 @@ export const WIHE_JOIN_THE_EFFORT_SECTION_ID = "join";
 export function WhatIsHealthEquityPage() {
   const history = useHistory();
   const params = useSearchParams();
-  const location = useLocation();
 
   const [tabIndex, setTabIndex] = React.useState(
     params[TAB_PARAM] ? Number(params[TAB_PARAM]) : 0
   );
+  const [locationKeys, setLocationKeys] = React.useState<
+    (string | undefined)[]
+  >([]);
 
   useEffect(() => {
     history.push(`${WHAT_IS_HEALTH_EQUITY_PAGE_LINK}?${TAB_PARAM}=${tabIndex}`);
   }, [history, tabIndex]);
-
-  const [locationKeys, setLocationKeys] = React.useState<
-    (string | undefined)[]
-  >([]);
 
   useEffect(() => {
     return history.listen((location) => {
@@ -42,18 +40,14 @@ export function WhatIsHealthEquityPage() {
 
       if (history.action === "POP") {
         if (locationKeys[1] === location.key) {
-          setLocationKeys(([_, ...keys]) => keys);
-
           // Handle forward event
-          console.log("forward button");
+          setLocationKeys(([_, ...keys]) => keys);
+          window.location.reload();
         } else {
-          setLocationKeys((keys) => [location.key, ...keys]);
-
           // Handle back event
-          console.log("back button");
-          // window.location.reload();
+          setLocationKeys((keys) => [location.key, ...keys]);
+          window.location.reload();
         }
-        window.location.reload();
       }
     });
   }, [history, locationKeys]);

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -14,8 +14,8 @@ import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
 import { friendlyTabNamesWIHE } from "../../utils/urlutils";
 
-export const WIHE_HEALTH_EQUITY_TAB_INDEX = 0;
-export const WIHE_FAQ_TAB_INDEX = 1;
+export const WIHE_HEALTH_EQUITY_TAB_INDEX = "equity";
+export const WIHE_FAQ_TAB_INDEX = "faq";
 export const WIHE_JOIN_THE_EFFORT_SECTION_ID = "join";
 
 export function WhatIsHealthEquityPage() {

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -12,6 +12,7 @@ import {
 import ResourcesTab from "./ResourcesTab";
 import { useEffect } from "react";
 import { useHistory } from "react-router-dom";
+import { friendlyTabNamesWIHE } from "../../utils/urlutils";
 
 export const WIHE_HEALTH_EQUITY_TAB_INDEX = 0;
 export const WIHE_FAQ_TAB_INDEX = 1;
@@ -22,14 +23,18 @@ export function WhatIsHealthEquityPage() {
   const params = useSearchParams();
 
   const [tabIndex, setTabIndex] = React.useState(
-    params[TAB_PARAM] ? Number(params[TAB_PARAM]) : 0
+    params[TAB_PARAM]
+      ? Number(friendlyTabNamesWIHE.indexOf(params[TAB_PARAM]))
+      : 0
   );
   const [locationKeys, setLocationKeys] = React.useState<
     (string | undefined)[]
   >([]);
 
   useEffect(() => {
-    history.push(`${WHAT_IS_HEALTH_EQUITY_PAGE_LINK}?${TAB_PARAM}=${tabIndex}`);
+    history.push(
+      `${WHAT_IS_HEALTH_EQUITY_PAGE_LINK}?${TAB_PARAM}=${friendlyTabNamesWIHE[tabIndex]}`
+    );
   }, [history, tabIndex]);
 
   useEffect(() => {
@@ -40,7 +45,7 @@ export function WhatIsHealthEquityPage() {
 
       if (history.action === "POP") {
         if (locationKeys[1] === location.key) {
-          // Handle forward event
+          // Handle forward event.
           setLocationKeys(([_, ...keys]) => keys);
           window.location.reload();
         } else {

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -35,6 +35,10 @@ export const DEMOGRAPHIC_PARAM = "demo";
 export const DATA_TYPE_1_PARAM = "dt1";
 export const DATA_TYPE_2_PARAM = "dt2";
 
+// define friendly tab names for query param routing on pages with sub-tab pages
+export const friendlyTabNamesWIHE = ["equity", "faq", "resources"];
+export const friendlyTabNamesAboutUs = ["project", "team", "contact"];
+
 export function LinkWithStickyParams(props: {
   to: string;
   target?: string;


### PR DESCRIPTION
Fixes #717

- Loading any tab populates a query param in the address bar, yielding a unique link for every sub tab (for sharing and external linking)
- query param displays user friendly word rather than numerical tab index
- manually intercepts back button and force refreshes the page; this hack to compensate for react router not recognizing changes in params as actual page changes. 
- adds keys to mapped arrays to fix react warnings
