### PR TITLE
maps listen for full click rather than just mousedown. 

### DIFF
--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -341,7 +341,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
         {
           name: "click",
           value: 0,
-          on: [{ events: "*:mousedown", update: "datum" }],
+          on: [{ events: "click", update: "datum" }],
         },
       ],
     });


### PR DESCRIPTION
allows right clicking on maps to provide OS context menu with img save, inspect element, etc.
full click behavior is more expected rather than just mousedown 

fixes #1033