### PR TITLE
adds grid sizing to multimap for better responsive layout

### DIFF
--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -65,7 +65,13 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
           {BREAKDOWN_VAR_DISPLAY_NAMES_LOWER_CASE[props.breakdown]} groups
         </Typography>
         <Grid container justify="space-around">
-          <Grid item className={styles.SmallMultipleLegendMap}>
+          <Grid
+            xs={12}
+            sm={6}
+            md={4}
+            item
+            className={styles.SmallMultipleLegendMap}
+          >
             <b>Legend</b>
             <div className={styles.LegendDiv}>
               <Legend
@@ -83,6 +89,9 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
             );
             return (
               <Grid
+                xs={12}
+                sm={6}
+                md={4}
                 item
                 key={`${breakdownValue}-grid-item`}
                 className={styles.SmallMultipleMap}


### PR DESCRIPTION
fixes #485 

now options are full width on XS, 2 panels per row on SM, and max of 3 panels per row on MD and up. This prevents some weirdness, and the weirdness addressed in that issue no longer exists because UNKNOWN is no longer displayed on the multipmap