### PR TITLE
adds commas w oxfords and "AND" between multiple cited data sources

### DIFF
--- a/frontend/src/cards/ui/Sources.tsx
+++ b/frontend/src/cards/ui/Sources.tsx
@@ -8,6 +8,17 @@ import {
 import { DataSourceMetadataMap } from "../../data/config/MetadataMap";
 import { MetricQueryResponse } from "../../data/query/MetricQuery";
 
+function addPunctuation(idx: number, numSources: number) {
+  let punctuation = "";
+  // ADD COMMAS (INCL OXFORDS) FOR THREE OR MORE SOURCES
+  if (numSources > 2 && idx < numSources - 1) punctuation += ", ";
+  // ADD " AND " BETWEEN LAST TWO SOURCES
+  if (numSources > 1 && idx === numSources - 2) punctuation += " and ";
+  // ADD FINAL PERIOD
+  if (idx === numSources - 1) punctuation += ".";
+  return punctuation;
+}
+
 type DataSourceInfo = {
   name: string;
   updateTimes: Set<string>;
@@ -80,16 +91,7 @@ export function Sources(props: {
               {Array.from(dataSourceMap[dataSourceId].updateTimes).join(", ")})
             </>
           )}
-          {/* ADD COMMAS INCL OXFORDS AND OR SPACES FOR THREE OR MORE SOURCES */}
-          {Object.keys(dataSourceMap).length > 2 &&
-          idx < Object.keys(dataSourceMap).length - 1
-            ? ", "
-            : " "}
-          {/* ADD "AND" BETWEEN LAST TWO SOURCES */}
-          {Object.keys(dataSourceMap).length > 1 &&
-          idx === Object.keys(dataSourceMap).length - 2
-            ? "and "
-            : ""}
+          {addPunctuation(idx, Object.keys(dataSourceMap).length)}
         </Fragment>
       ))}
     </>

--- a/frontend/src/cards/ui/Sources.tsx
+++ b/frontend/src/cards/ui/Sources.tsx
@@ -74,7 +74,6 @@ export function Sources(props: {
   return (
     <>
       {Object.keys(dataSourceMap).length > 0 && <>Sources: </>}
-      {/* TODO- add commas and "and" between the data sources */}
       {Object.keys(dataSourceMap).map((dataSourceId, idx) => (
         <Fragment key={dataSourceId}>
           <LinkWithStickyParams

--- a/frontend/src/cards/ui/Sources.tsx
+++ b/frontend/src/cards/ui/Sources.tsx
@@ -64,7 +64,7 @@ export function Sources(props: {
     <>
       {Object.keys(dataSourceMap).length > 0 && <>Sources: </>}
       {/* TODO- add commas and "and" between the data sources */}
-      {Object.keys(dataSourceMap).map((dataSourceId) => (
+      {Object.keys(dataSourceMap).map((dataSourceId, idx) => (
         <Fragment key={dataSourceId}>
           <LinkWithStickyParams
             target="_blank"
@@ -77,9 +77,19 @@ export function Sources(props: {
           ) : (
             <>
               (updated{" "}
-              {Array.from(dataSourceMap[dataSourceId].updateTimes).join(", ")}){" "}
+              {Array.from(dataSourceMap[dataSourceId].updateTimes).join(", ")})
             </>
           )}
+          {/* ADD COMMAS INCL OXFORDS AND OR SPACES FOR THREE OR MORE SOURCES */}
+          {Object.keys(dataSourceMap).length > 2 &&
+          idx < Object.keys(dataSourceMap).length - 1
+            ? ", "
+            : " "}
+          {/* ADD "AND" BETWEEN LAST TWO SOURCES */}
+          {Object.keys(dataSourceMap).length > 1 &&
+          idx === Object.keys(dataSourceMap).length - 2
+            ? "and "
+            : ""}
         </Fragment>
       ))}
     </>

--- a/frontend/src/cards/ui/Sources.tsx
+++ b/frontend/src/cards/ui/Sources.tsx
@@ -8,7 +8,7 @@ import {
 import { DataSourceMetadataMap } from "../../data/config/MetadataMap";
 import { MetricQueryResponse } from "../../data/query/MetricQuery";
 
-function addPunctuation(idx: number, numSources: number) {
+function insertPunctuation(idx: number, numSources: number) {
   let punctuation = "";
   // ADD COMMAS (INCL OXFORDS) FOR THREE OR MORE SOURCES
   if (numSources > 2 && idx < numSources - 1) punctuation += ", ";
@@ -90,7 +90,7 @@ export function Sources(props: {
               {Array.from(dataSourceMap[dataSourceId].updateTimes).join(", ")})
             </>
           )}
-          {addPunctuation(idx, Object.keys(dataSourceMap).length)}
+          {insertPunctuation(idx, Object.keys(dataSourceMap).length)}
         </Fragment>
       ))}
     </>


### PR DESCRIPTION
closes #972 

Does not add a period at the end of the citation; is that wanted as we are using periods at the ends of our alerts? Not sure standard practice for data citations.