### PR TITLE
imports img for proper rendering on nested routes

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -32,6 +32,7 @@ import {
   TERMS_OF_SERVICE_PAGE_LINK,
   WHAT_IS_HEALTH_EQUITY_PAGE_LINK,
 } from "./utils/urlutils";
+import AppBarLogo from "./assets/AppbarLogo.png";
 
 // the following components make CSS modules which are imported by other components, so they must load first
 import AboutUsPage from "./pages/AboutUs/AboutUsPage";
@@ -105,7 +106,7 @@ function AppToolbar() {
     <Toolbar className={styles.AppToolbar}>
       <ReactRouterLinkButton url="/" className={styles.AppbarLogoImg}>
         <img
-          src="img/appbar/AppbarLogo.png"
+          src={AppBarLogo}
           className={styles.AppbarLogoImg}
           alt="Health Equity Tracker logo"
           role="link"


### PR DESCRIPTION
using Create React App we should probably consider importing almost all over our images from /src rather than leaving them in /public ; this this specific change to the Logo was necessary for components that render on different level routes (like the header and already done footer), which was causing the imp to break on deeper leveled routes

for instance /whatishealthequity and /whatishealthequity/blog
 