### PR TITLE
fix react warning on FAQs; make PSHandler logs development only

### DIFF
--- a/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
@@ -57,7 +57,7 @@ In this tracker, we are using many sources, including <a href="https://www.censu
   <li>comprehensive race and ethnicity breakdowns</li>
   <li>comprehensive sex and age breakdowns</li>
 </ul>
-<span className={styles.FaqSubheaderText}>
+<span class={styles.FaqSubheaderText}>
   Known limitations in the data
 </span>
 <ul>

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -1,6 +1,7 @@
 import Button from "@material-ui/core/Button";
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
+import { getLogger } from "./globals";
 import { MadLibId, PhraseSelections } from "./MadLibs";
 
 export const STICKY_VERSION_PARAM = "sv";
@@ -212,7 +213,7 @@ export const psSubscribe = (
   keyPrefix = "unk"
 ): { unsubscribe: () => void } => {
   const key = keyPrefix + "_" + psCount;
-  console.log("Adding PSHandler: " + key);
+  getLogger().debugLog("Adding PSHandler: " + key);
   psSubscriptions[key] = handler;
   psCount++;
   return {
@@ -223,7 +224,7 @@ export const psSubscribe = (
 };
 
 export const psUnsubscribe = (k: string) => {
-  console.log("Removing PSHandler: " + k);
+  getLogger().debugLog("Removing PSHandler: " + k);
   delete psSubscriptions[k];
 };
 
@@ -231,7 +232,7 @@ window.onpopstate = () => {
   Object.keys(psSubscriptions).forEach((key) => {
     const handler = psSubscriptions[key];
     if (handler) {
-      console.log("Firing PSHandler: " + key);
+      getLogger().debugLog("Firing PSHandler: " + key);
       handler();
     }
   });


### PR DESCRIPTION
the `parse()` command is interpreting a string into HTML; only JSX needs `className` ; using `class` fixed that warning

also, the `PShandler` logs were going into the console in production which doesn't seem like great practice. 