### PR TITLE
re-enable SVG

### DIFF
--- a/frontend/src/cards/ui/HighestLowestList.module.scss
+++ b/frontend/src/cards/ui/HighestLowestList.module.scss
@@ -2,7 +2,7 @@
 
 .ListBox {
   margin-top: 15px;
-  background: #f1f3f4;
+  background: $listbox-color;
   border-radius: 8px;
   size: 14px;
   line-height: 20px;

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -71,7 +71,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
   const [shouldRenderMap, setShouldRenderMap] = useState(false);
 
   const [ref, width] = useResponsiveWidth(
-    100 /* default width during intialization */
+    100 /* default width during initialization */
   );
 
   // Initial spec state is set in useEffect
@@ -287,6 +287,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
 
     setSpec({
       $schema: "https://vega.github.io/schema/vega/v5.json",
+      background: "white",
       description: props.legendTitle,
       data: [
         {
@@ -387,7 +388,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
           // custom 3-dot options for states, hidden on territories
           actions={
             !props.hideActions && {
-              export: { png: true, svg: false },
+              export: { png: true, svg: true },
               source: false,
               compiled: false,
               editor: false,

--- a/frontend/src/charts/DisparityBarChart.tsx
+++ b/frontend/src/charts/DisparityBarChart.tsx
@@ -301,7 +301,7 @@ export function DisparityBarChart(props: DisparityBarChartProps) {
       <Vega
         // custom 3-dot options for states, hidden on territories
         actions={{
-          export: { png: true, svg: false },
+          export: { png: true, svg: true },
           source: false,
           compiled: false,
           editor: false,

--- a/frontend/src/charts/SimpleHorizontalBarChart.tsx
+++ b/frontend/src/charts/SimpleHorizontalBarChart.tsx
@@ -228,7 +228,7 @@ export function SimpleHorizontalBarChart(props: SimpleHorizontalBarChartProps) {
           props.hideActions
             ? false
             : {
-                export: { png: true, svg: false },
+                export: { png: true, svg: true },
                 source: false,
                 compiled: false,
                 editor: false,

--- a/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
@@ -328,9 +328,10 @@ function FaqTab() {
                 <div className={styles.FaqAnswer}>
                   <p>
                     Next to each visualization, there is a circle-shaped button
-                    with three dots in it. Click on this button and select "Save
-                    as PNG". Please note; due to technical limitations,
-                    territories are not currently exported on the national map.
+                    with three dots in it. Click on this button and save as PNG
+                    or SVG (SVG provides a higher-quality, scalable image). Due
+                    to technical limitations, territories are not currently
+                    exported on the national map.
                   </p>
                 </div>
               </Grid>

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -2,17 +2,18 @@
 $grey-dark: #222;
 $white: #fff;
 $bg-color: #e2e2e2;
-
-// default settings
-$footer-size: 490px;
 $footer-color: #edf3f0;
+$listbox-color: #f1f3f4;
 $blue: #07538f;
 $green: #228b7e;
-$max-width: 800px;
 $alt-green: #0b5240;
 $alt-black: #383838;
 $alt-dark: #5f6368;
 $alt-grey: #bdbdbd;
+
+// default settings
+$footer-size: 490px;
+$max-width: 800px;
 
 // default material breakpoints
 $sm: 600px;


### PR DESCRIPTION
adds white bg color to exported maps making images readable; re-enables SVG as PNG was exported at unusably low low resolution. small css tweaks