### PR TITLE
reduced, consistent white space at bottom of tracker page

### DIFF
--- a/frontend/src/reports/Report.module.scss
+++ b/frontend/src/reports/Report.module.scss
@@ -49,3 +49,7 @@
 .FootnoteLargeHeading {
   font-size: 2rem;
 }
+
+.FootnoteLargeHeading:first-of-type {
+  margin-block-start: 0px;
+}

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -12,7 +12,7 @@ $alt-dark: #5f6368;
 $alt-grey: #bdbdbd;
 
 // default settings
-$footer-size: 490px;
+$footer-size: 300px;
 $max-width: 800px;
 
 // default material breakpoints


### PR DESCRIPTION
smaller and consistent white space around the MISSING DATA / DEFINITION block between the tracker and the footer

<img width="1788" alt="whitespace bottom" src="https://user-images.githubusercontent.com/41567007/136590329-ec4ab713-cf05-415c-accd-7861b135e442.png">
<img width="1788" alt="whitespace top" src="https://user-images.githubusercontent.com/41567007/136590335-abefca1c-4bc9-422b-83a2-31d1d7412784.png">
