### PR TITLE
Madlib tabs

### DIFF
--- a/frontend/src/pages/ExploreData/ExploreDataPage.module.scss
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.module.scss
@@ -20,11 +20,11 @@
   background: white;
   padding-bottom: 20px;
   padding-top: 20px;
-  font-size: 20pt;
-  line-height: 20pt;
   box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3),
     0px 1px 3px 1px rgba(60, 64, 67, 0.15);
   transition: padding-top 0.2s, padding-bottom 0.2s;
+  font-size: 20pt;
+  line-height: 20pt;
 }
 
 .Carousel {

--- a/frontend/src/pages/ExploreData/ExploreDataPage.module.scss
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.module.scss
@@ -69,6 +69,22 @@
   }
 }
 
+.TabBar {
+  background-color: white !important;
+  padding: 6px 12px;
+  overflow: hidden;
+  position: relative;
+  font-size: 0.875rem;
+  min-height: 48px;
+  text-align: center;
+  font-family: "DM Sans", sans-serif !important;
+  font-weight: 500;
+  line-height: 1.75;
+  white-space: normal;
+  letter-spacing: 0.02857em;
+  text-transform: none;
+}
+
 // override the joyride component to allow different color for "back" text and "next" background
 button[data-action="back"] {
   color: #fff !important;

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -192,31 +192,50 @@ function ExploreDataPage() {
         <Route
           path="/"
           render={(history) => (
-            <Tabs
-              indicatorColor="primary"
-              textColor="primary"
-              centered
-              value={history.location.pathname}
-            >
-              <Tab
-                value={`/exploredata/`}
-                label="Investigate"
-                component={Link}
-                to={`/exploredata/`}
-              />
-              <Tab
-                value={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
-                label="Compare Locations"
-                component={Link}
-                to={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
-              />
-              <Tab
-                value={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
-                label="Compare Conditions"
-                component={Link}
-                to={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
-              />
-            </Tabs>
+            <div className={styles.TabBar}>
+              <Tabs
+                indicatorColor="primary"
+                textColor="primary"
+                centered
+                value={history.location.pathname}
+                onChange={(e) => {
+                  console.log(e.nativeEvent);
+                  let newState = {
+                    ...MADLIB_LIST[2],
+                    activeSelections: {
+                      ...MADLIB_LIST[2].defaultSelections,
+                    },
+                  };
+                  setMadLib(newState);
+                  setParameters([
+                    {
+                      name: MADLIB_SELECTIONS_PARAM,
+                      value: stringifyMls(newState.activeSelections),
+                    },
+                    { name: MADLIB_PHRASE_PARAM, value: MADLIB_LIST[2].id },
+                  ]);
+                }}
+              >
+                <Tab
+                  value={`/exploredata/`}
+                  label="Investigate"
+                  component={Link}
+                  to={`/exploredata/`}
+                />
+                <Tab
+                  value={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
+                  label="Compare Locations"
+                  component={Link}
+                  to={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
+                />
+                <Tab
+                  value={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+                  label="Compare Conditions"
+                  component={Link}
+                  to={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+                />
+              </Tabs>
+            </div>
           )}
         />
 
@@ -238,13 +257,13 @@ function ExploreDataPage() {
               />
             </div>
           </Route>
-          <Route path={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}>
+          <Route path={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00/`}>
             <div
               className={styles.CarouselContainer}
               id="onboarding-start-your-search"
             >
               <CarouselMadLib
-                madLib={MADLIB_LIST[2]}
+                madLib={MADLIB_LIST[1]}
                 setMadLib={setMadLibWithParam}
               />
             </div>
@@ -256,7 +275,7 @@ function ExploreDataPage() {
             </div>
           </Route>
           <Route
-            path={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+            path={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00/`}
           >
             <div
               className={styles.CarouselContainer}

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,4 +1,4 @@
-import { Grid } from "@material-ui/core";
+import { Grid, Tab, Tabs } from "@material-ui/core";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
 import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
@@ -28,6 +28,7 @@ import styles from "./ExploreDataPage.module.scss";
 import { Onboarding } from "./Onboarding";
 import OptionsSelector from "./OptionsSelector";
 import { Helmet } from "react-helmet";
+import { Link, Route, Switch } from "react-router-dom";
 
 const EXPLORE_DATA_ID = "main";
 
@@ -149,7 +150,7 @@ function ExploreDataPage() {
       </Helmet>
       <h1 className={styles.ScreenreaderTitleHeader}>Explore the Data</h1>
       <div id={EXPLORE_DATA_ID} tabIndex={-1} className={styles.ExploreData}>
-        <div
+        {/* <div
           className={styles.CarouselContainer}
           id="onboarding-start-your-search"
         >
@@ -187,10 +188,93 @@ function ExploreDataPage() {
               />
             ))}
           </Carousel>
-        </div>
-        <div className={styles.ReportContainer}>
-          <ReportProvider madLib={madLib} setMadLib={setMadLibWithParam} />
-        </div>
+            </div> */}
+        <Route
+          path="/"
+          render={(history) => (
+            <Tabs
+              indicatorColor="primary"
+              textColor="primary"
+              centered
+              value={history.location.pathname}
+            >
+              <Tab
+                value={`/exploredata/`}
+                label="Investigate"
+                component={Link}
+                to={`/exploredata/`}
+              />
+              <Tab
+                value={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
+                label="Compare Locations"
+                component={Link}
+                to={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}
+              />
+              <Tab
+                value={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+                label="Compare Conditions"
+                component={Link}
+                to={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+              />
+            </Tabs>
+          )}
+        />
+
+        <Switch>
+          <Route path={`/exploredata/`}>
+            <div
+              className={styles.CarouselContainer}
+              id="onboarding-start-your-search"
+            >
+              <CarouselMadLib
+                madLib={MADLIB_LIST[0]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+            <div className={styles.ReportContainer}>
+              <ReportProvider
+                madLib={MADLIB_LIST[0]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+          </Route>
+          <Route path={`/exploredata?mlp=comparegeos&mls=1.covid-3.13-5.00`}>
+            <div
+              className={styles.CarouselContainer}
+              id="onboarding-start-your-search"
+            >
+              <CarouselMadLib
+                madLib={MADLIB_LIST[2]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+            <div className={styles.ReportContainer}>
+              <ReportProvider
+                madLib={MADLIB_LIST[1]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+          </Route>
+          <Route
+            path={`/exploredata?mlp=comparevars&mls=1.diabetes-3.covid-5.00`}
+          >
+            <div
+              className={styles.CarouselContainer}
+              id="onboarding-start-your-search"
+            >
+              <CarouselMadLib
+                madLib={MADLIB_LIST[2]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+            <div className={styles.ReportContainer}>
+              <ReportProvider
+                madLib={MADLIB_LIST[2]}
+                setMadLib={setMadLibWithParam}
+              />
+            </div>
+          </Route>
+        </Switch>
       </div>
     </>
   );

--- a/frontend/src/pages/ExploreData/OptionsSelector.module.scss
+++ b/frontend/src/pages/ExploreData/OptionsSelector.module.scss
@@ -33,7 +33,15 @@
 }
 
 .MadLibButton {
-  font-size: 25px !important;
+  @media only screen and (max-width: $sm) {
+    font-size: 12pt !important;
+    line-height: 100% !important;
+  }
+  @media only screen and (min-width: $sm) {
+    font-size: 25px !important;
+    line-height: 25px !important;
+  }
+  // font-size: 25px !important;
   font-weight: normal !important;
   text-decoration: underline !important;
   text-underline-offset: 3px !important;


### PR DESCRIPTION
Mock up of using material tabs to select the various tracker modes instead of the carousel.

PROs: 
- same sub-page navigation as is used on other pages like ABOUT US and WHAT IS HEALTH EQUITY
- the tab title provides indication to user what other settings will be, as opposed to the anonymous carousel dots
- far better A11y and overall understanding of UI by users. Carousels are generally frowned upon for this type of UI

CONs: 
- User might disregard the tabs thinking they are part of the overall site navigation, rather than options of the tracker (possibly move tabs lower on the screen? inside the grey tracker box?)

![madlib tabs](https://user-images.githubusercontent.com/41567007/136806088-bfecfe43-0a0e-455b-b61d-f602dd74ae85.png)
