### PR TITLE
fix weird non-responsive footer spacing

### DIFF
--- a/frontend/src/Footer.module.scss
+++ b/frontend/src/Footer.module.scss
@@ -6,8 +6,6 @@
   width: 100%;
   background: $footer-color;
   position: absolute;
-  bottom: 0;
-  max-height: $footer-size;
   margin: auto;
   padding: 50px 10px;
 }

--- a/frontend/src/styles/variables.scss
+++ b/frontend/src/styles/variables.scss
@@ -12,7 +12,7 @@ $alt-dark: #5f6368;
 $alt-grey: #bdbdbd;
 
 // default settings
-$footer-size: 300px;
+$footer-size: 10rem;
 $max-width: 800px;
 
 // default material breakpoints


### PR DESCRIPTION
footer background color was getting restricted to a certain size, which wasn't large enough on mobile. Setting a hard px amount larger made other problems on desktop. Fixed by using responsive units `rem` that scale with the page size

fixes #1211

![Screen Shot 2021-10-12 at 3 34 51 PM](https://user-images.githubusercontent.com/41567007/137032747-542dc9a2-2847-40ac-813a-a1e7f4892fc6.png)
![Screen Shot 2021-10-12 at 3 35 14 PM](https://user-images.githubusercontent.com/41567007/137032752-2542af00-e782-4fc7-a972-a985f0074103.png)
![Screen Shot 2021-10-12 at 3 35 21 PM](https://user-images.githubusercontent.com/41567007/137032755-91512a04-5604-4397-8b13-e365445bb7dc.png)
![Screen Shot 2021-10-12 at 3 35 30 PM](https://user-images.githubusercontent.com/41567007/137032758-bc727157-b3df-4361-a349-038218e7c99d.png)
