### PR TITLE
Add COMPARE ACROSS small multiples link to NO DATA FOR FILTER alert

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -426,15 +426,22 @@ function MultiMapLink(props: MultiMapLinkProps) {
   const groupTerm =
     BREAKDOWN_VAR_DISPLAY_NAMES_LOWER_CASE[props.currentBreakdown];
   return (
-    <span
-      onClick={() => props.setSmallMultiplesDialogOpen(true)}
-      role="button"
-      className={styles.CompareAcrossLink}
-      aria-label={
-        "Compare " + props.currentVariable + " across " + groupTerm + " groups"
-      }
-    >
-      Compare across {groupTerm} groups
-    </span>
+    <>
+      <span
+        onClick={() => props.setSmallMultiplesDialogOpen(true)}
+        role="button"
+        className={styles.CompareAcrossLink}
+        aria-label={
+          "Compare " +
+          props.currentVariable +
+          " across " +
+          groupTerm +
+          " groups"
+        }
+      >
+        Compare across {groupTerm} groups
+      </span>
+      .
+    </>
   );
 }


### PR DESCRIPTION
- makes COMPARE ACROSS link a reuseable component
- adds to the NO DATA AVAILABLE FOR FILTER warning as small multiples is a great way for user to see which states use which race categories
![compare across on alert](https://user-images.githubusercontent.com/41567007/138323394-f4958081-488e-4449-930f-15eb47cd323b.png)

closes #1215 