### PR TITLE
Retain Tracker Settings

### DIFF
--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -1,5 +1,9 @@
 import { FIPS_MAP, USA_FIPS } from "../data/utils/Fips";
 
+const CACHE_KEY_DISPARITY = "disparity";
+const CACHE_KEY_COMPAREGEOS = "comparegeos";
+const CACHE_KEY_COMPAREVARS = "comparevars";
+
 // Map of phrase segment index to its selected value
 export type PhraseSelections = Record<number, string>;
 
@@ -52,6 +56,13 @@ export function getMadLibWithUpdatedValue(
     ...originalMadLib.activeSelections,
   };
   updatePhraseSelections[phraseSegementIndex] = newValue;
+
+  // cache the new tracker settings for retrieval if user navigates off and back onto the tracker
+  localStorage.setItem(
+    originalMadLib.id,
+    JSON.stringify(updatePhraseSelections)
+  );
+
   return {
     ...originalMadLib,
     activeSelections: updatePhraseSelections,
@@ -97,12 +108,29 @@ const CATEGORIES_LIST: Category[] = [
   },
 ];
 
+// default settings if user hasn't selected anything and nothing is cached
+const GEORGIA_FIPS = "13";
+const freshDisparitySettings = { 1: "covid", 3: USA_FIPS };
+const freshCompareGeosSettings = { 1: "covid", 3: GEORGIA_FIPS, 5: USA_FIPS };
+const freshCompareVarsSettings = { 1: "diabetes", 3: "covid", 5: USA_FIPS };
+
+// if settings are cached, use them; otherwise use fresh settings
+const disparitySettings = localStorage.getItem(CACHE_KEY_DISPARITY)
+  ? JSON.parse(localStorage.getItem(CACHE_KEY_DISPARITY) as string)
+  : freshDisparitySettings;
+const compareGeosSettings = localStorage.getItem(CACHE_KEY_COMPAREGEOS)
+  ? JSON.parse(localStorage.getItem(CACHE_KEY_COMPAREGEOS) as string)
+  : freshCompareGeosSettings;
+const compareVarsSettings = localStorage.getItem(CACHE_KEY_COMPAREVARS)
+  ? JSON.parse(localStorage.getItem(CACHE_KEY_COMPAREVARS) as string)
+  : freshCompareVarsSettings;
+
 const MADLIB_LIST: MadLib[] = [
   {
     id: "disparity",
     phrase: ["Investigate rates of", DROPDOWN_VAR, "in", FIPS_MAP],
-    defaultSelections: { 1: "covid", 3: USA_FIPS },
-    activeSelections: { 1: "covid", 3: USA_FIPS },
+    defaultSelections: disparitySettings,
+    activeSelections: disparitySettings,
   },
   {
     id: "comparegeos",
@@ -114,8 +142,8 @@ const MADLIB_LIST: MadLib[] = [
       " and ",
       FIPS_MAP,
     ],
-    defaultSelections: { 1: "covid", 3: "13", 5: USA_FIPS }, // 13 is Georgia
-    activeSelections: { 1: "covid", 3: "13", 5: USA_FIPS }, // 13 is Georgia
+    defaultSelections: compareGeosSettings,
+    activeSelections: compareGeosSettings,
   },
   {
     id: "comparevars",
@@ -127,8 +155,8 @@ const MADLIB_LIST: MadLib[] = [
       " in ",
       FIPS_MAP,
     ],
-    defaultSelections: { 1: "diabetes", 3: "covid", 5: USA_FIPS }, // 13 is Georgia
-    activeSelections: { 1: "diabetes", 3: "covid", 5: USA_FIPS }, // 13 is Georgia
+    defaultSelections: compareVarsSettings,
+    activeSelections: compareVarsSettings,
   },
 ];
 

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -114,7 +114,7 @@ const freshDisparitySettings = { 1: "covid", 3: USA_FIPS };
 const freshCompareGeosSettings = { 1: "covid", 3: GEORGIA_FIPS, 5: USA_FIPS };
 const freshCompareVarsSettings = { 1: "diabetes", 3: "covid", 5: USA_FIPS };
 
-// if settings are cached, use them; otherwise use fresh settings
+// if variable/geo settings are cached, use them; otherwise use fresh settings
 const disparitySettings = sessionStorage.getItem(CACHE_KEY_DISPARITY)
   ? JSON.parse(sessionStorage.getItem(CACHE_KEY_DISPARITY) as string)
   : freshDisparitySettings;

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -58,7 +58,7 @@ export function getMadLibWithUpdatedValue(
   updatePhraseSelections[phraseSegementIndex] = newValue;
 
   // cache the new tracker settings for retrieval if user navigates off and back onto the tracker
-  localStorage.setItem(
+  sessionStorage.setItem(
     originalMadLib.id,
     JSON.stringify(updatePhraseSelections)
   );
@@ -115,14 +115,14 @@ const freshCompareGeosSettings = { 1: "covid", 3: GEORGIA_FIPS, 5: USA_FIPS };
 const freshCompareVarsSettings = { 1: "diabetes", 3: "covid", 5: USA_FIPS };
 
 // if settings are cached, use them; otherwise use fresh settings
-const disparitySettings = localStorage.getItem(CACHE_KEY_DISPARITY)
-  ? JSON.parse(localStorage.getItem(CACHE_KEY_DISPARITY) as string)
+const disparitySettings = sessionStorage.getItem(CACHE_KEY_DISPARITY)
+  ? JSON.parse(sessionStorage.getItem(CACHE_KEY_DISPARITY) as string)
   : freshDisparitySettings;
-const compareGeosSettings = localStorage.getItem(CACHE_KEY_COMPAREGEOS)
-  ? JSON.parse(localStorage.getItem(CACHE_KEY_COMPAREGEOS) as string)
+const compareGeosSettings = sessionStorage.getItem(CACHE_KEY_COMPAREGEOS)
+  ? JSON.parse(sessionStorage.getItem(CACHE_KEY_COMPAREGEOS) as string)
   : freshCompareGeosSettings;
-const compareVarsSettings = localStorage.getItem(CACHE_KEY_COMPAREVARS)
-  ? JSON.parse(localStorage.getItem(CACHE_KEY_COMPAREVARS) as string)
+const compareVarsSettings = sessionStorage.getItem(CACHE_KEY_COMPAREVARS)
+  ? JSON.parse(sessionStorage.getItem(CACHE_KEY_COMPAREVARS) as string)
   : freshCompareVarsSettings;
 
 const MADLIB_LIST: MadLib[] = [


### PR DESCRIPTION
Problem: when a user has made detailed selections including multiple variables or geo locations, it can be frustrating for them to click on another page (eg "Methodology" for an explanation) and then click back to the tracker and realize that they have to input all of their selections again. 

Solution: use sessionStorage (similar to a cookie that gets erased whenever a user closes their browser window) to memorize 
- the carousel setting (eg "Investigate", "Explore Relationships")
- the condition and geographic settings for each carousel setting (eg "COPD" in "California")

Additionally: This PR removes some code that wasn't accomplishing anything, and also triggers the population of URL params (eg `?mls=1.covid-3.00&mlp=disparity` at the end of the address bar) which was missing in some instances

Considerations: 
- There is no longer a way to "reset" the tracker to the default settings, short of closing the window and reopening. This doesn't really seem like a problem for users, and only a potential annoyance for us in development.
- We have the option to use `localStorage` instead of `sessionStorage` which will remember the settings across the closing and reopening of windows. We need to discuss if this would be helpful or annoying for users.

Fixes #1197