### PR TITLE
remove the word Fake from actual dataset meta data to avoid confusion

### DIFF
--- a/frontend/src/data/config/DatasetMetadata.ts
+++ b/frontend/src/data/config/DatasetMetadata.ts
@@ -174,7 +174,7 @@ const datasetMetadataList: DatasetMetadata[] = [
   },
 ];
 
-export const FakeDatasetMetadataMap: Record<
+export const DatasetMetadataMap: Record<
   string,
   DatasetMetadata
 > = Object.fromEntries(

--- a/frontend/src/data/config/MetadataMap.ts
+++ b/frontend/src/data/config/MetadataMap.ts
@@ -2,8 +2,8 @@ import { DataSourceMetadata } from "../utils/DatasetTypes";
 
 export const GEOGRAPHIES_DATASET_ID = "geographies";
 
-// ALERT!!! Keep this file in sync with FakeDatasetMetadata while it is present
-// All dataset IDs should be in the FakeDatasetMetadata
+// ALERT!!! Keep this file in sync with DatasetMetadata while it is present
+// All dataset IDs should be in the DatasetMetadata
 
 const dataSourceMetadataList: DataSourceMetadata[] = [
   {

--- a/frontend/src/data/loading/DataFetcher.ts
+++ b/frontend/src/data/loading/DataFetcher.ts
@@ -3,7 +3,7 @@
 // establish the API types.
 
 import { MapOfDatasetMetadata, Row } from "../utils/DatasetTypes";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { Environment } from "../../utils/Environment";
 import { DataFrame } from "data-forge";
 import { GEOGRAPHIES_DATASET_ID } from "../config/MetadataMap";
@@ -149,6 +149,6 @@ export class ApiDataFetcher implements DataFetcher {
 
   async getMetadata(): Promise<MapOfDatasetMetadata> {
     // TODO replace with real API call.
-    return FakeDatasetMetadataMap;
+    return DatasetMetadataMap;
   }
 }

--- a/frontend/src/data/react/WithLoadingOrErrorUI.test.tsx
+++ b/frontend/src/data/react/WithLoadingOrErrorUI.test.tsx
@@ -4,7 +4,7 @@ import { DatasetMetadata, Row } from "../utils/DatasetTypes";
 import { act } from "react-dom/test-utils";
 import { MetricQuery } from "../query/MetricQuery";
 import { Breakdowns } from "../query/Breakdowns";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { WithMetrics } from "./WithLoadingOrErrorUI";
 import {
   autoInitGlobals,
@@ -17,7 +17,7 @@ import { excludeAll } from "../query/BreakdownFilter";
 const STATE_NAMES_ID = "state_names";
 const ANOTHER_FAKE_DATASET_ID = "fake_dataset_2";
 const fakeMetadata = {
-  ...FakeDatasetMetadataMap,
+  ...DatasetMetadataMap,
   [STATE_NAMES_ID]: {} as DatasetMetadata,
   [ANOTHER_FAKE_DATASET_ID]: {} as DatasetMetadata,
 };

--- a/frontend/src/data/variables/Acs2010PopulationProvider.test.ts
+++ b/frontend/src/data/variables/Acs2010PopulationProvider.test.ts
@@ -4,7 +4,7 @@ import {
   getDataFetcher,
   resetCacheDebug,
 } from "../../utils/globals";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { Breakdowns } from "../query/Breakdowns";
 import { createMissingDataResponse, MetricQuery } from "../query/MetricQuery";
 import {
@@ -73,7 +73,7 @@ describe("Acs2010PopulationProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("Invalid Breakdown", async () => {

--- a/frontend/src/data/variables/AcsHealthInsuranceProvider.test.ts
+++ b/frontend/src/data/variables/AcsHealthInsuranceProvider.test.ts
@@ -1,6 +1,6 @@
 import { Breakdowns } from "../query/Breakdowns";
 import { Fips } from "../utils/Fips";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import {
   autoInitGlobals,
   getDataFetcher,
@@ -122,7 +122,7 @@ describe("AcsHealthInsuranceProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("State and Race Breakdown", async () => {

--- a/frontend/src/data/variables/AcsPopulationProvider.test.ts
+++ b/frontend/src/data/variables/AcsPopulationProvider.test.ts
@@ -4,7 +4,7 @@ import {
   getDataFetcher,
   resetCacheDebug,
 } from "../../utils/globals";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { onlyIncludeStandardRaces } from "../query/BreakdownFilter";
 import { Breakdowns } from "../query/Breakdowns";
 import {
@@ -121,7 +121,7 @@ describe("AcsPopulationProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("Invalid Breakdown", async () => {

--- a/frontend/src/data/variables/AcsPovertyProvider.test.ts
+++ b/frontend/src/data/variables/AcsPovertyProvider.test.ts
@@ -1,6 +1,6 @@
 import { Breakdowns } from "../query/Breakdowns";
 import { Fips } from "../utils/Fips";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import {
   autoInitGlobals,
   getDataFetcher,
@@ -117,7 +117,7 @@ describe("AcsPovertyProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("testing state aggregate by race alone", async () => {

--- a/frontend/src/data/variables/BrfssProvider.test.ts
+++ b/frontend/src/data/variables/BrfssProvider.test.ts
@@ -3,7 +3,7 @@ import AcsPopulationProvider from "./AcsPopulationProvider";
 import { Breakdowns, BreakdownVar } from "../query/Breakdowns";
 import { MetricQuery, MetricQueryResponse } from "../query/MetricQuery";
 import { Fips } from "../utils/Fips";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { excludeAll } from "../query/BreakdownFilter";
 import {
   autoInitGlobals,
@@ -111,7 +111,7 @@ describe("BrfssProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("State and Race Breakdown", async () => {

--- a/frontend/src/data/variables/CdcCovidProvider.test.ts
+++ b/frontend/src/data/variables/CdcCovidProvider.test.ts
@@ -3,7 +3,7 @@ import AcsPopulationProvider from "./AcsPopulationProvider";
 import { Breakdowns, BreakdownVar } from "../query/Breakdowns";
 import { MetricQuery, MetricQueryResponse } from "../query/MetricQuery";
 import { Fips } from "../utils/Fips";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import {
   autoInitGlobals,
   getDataFetcher,
@@ -82,7 +82,7 @@ describe("cdcCovidProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("County and Race Breakdown", async () => {

--- a/frontend/src/data/variables/VaccineProvider.test.ts
+++ b/frontend/src/data/variables/VaccineProvider.test.ts
@@ -3,7 +3,7 @@ import AcsPopulationProvider from "./AcsPopulationProvider";
 import { Breakdowns, BreakdownVar } from "../query/Breakdowns";
 import { MetricQuery, MetricQueryResponse } from "../query/MetricQuery";
 import { Fips } from "../utils/Fips";
-import { FakeDatasetMetadataMap } from "../config/FakeDatasetMetadata";
+import { DatasetMetadataMap } from "../config/DatasetMetadata";
 import { excludeAll } from "../query/BreakdownFilter";
 import {
   autoInitGlobals,
@@ -150,7 +150,7 @@ describe("VaccineProvider", () => {
   beforeEach(() => {
     resetCacheDebug();
     dataFetcher.resetState();
-    dataFetcher.setFakeMetadataLoaded(FakeDatasetMetadataMap);
+    dataFetcher.setFakeMetadataLoaded(DatasetMetadataMap);
   });
 
   test("State and Race Breakdown", async () => {


### PR DESCRIPTION
Eventually we plan to grab this metadata via an API endpoint, but for now it's loaded through a hard coded file. The file was originally named with the word "Fake" as it was intended for mocking/testing. 

Until we make the intended endpoint change, we should avoid using the word Fake as it is confusing and makes the data seem like it's not being used by the production app.
