### PR TITLE
Better UI for opening Highest/Lowest

### DIFF
--- a/frontend/src/cards/ui/HighestLowestList.module.scss
+++ b/frontend/src/cards/ui/HighestLowestList.module.scss
@@ -22,6 +22,7 @@
   size: 14px;
   text-align: left;
   margin-right: 50px;
+  cursor: pointer;
 }
 
 .ListBoxTitle {

--- a/frontend/src/cards/ui/HighestLowestList.tsx
+++ b/frontend/src/cards/ui/HighestLowestList.tsx
@@ -56,6 +56,7 @@ export function HighestLowestList(props: HighestLowestListProps) {
         </IconButton>
       </div>
       <div
+        onClick={() => props.setListExpanded(!props.listExpanded)}
         aria-hidden={true}
         className={
           props.listExpanded ? styles.ListBoxTitleExpanded : styles.ListBoxTitle


### PR DESCRIPTION
makes highest/lowest collapsed box clickable to expand, rather than just the tiny dropdown arrow. more like a real dropdown


https://user-images.githubusercontent.com/41567007/142059557-4fb2c76f-d446-4217-a27c-0773f37d684c.mov

fixes #1300 