### PR TITLE
replace deprecated methods

### DIFF
--- a/frontend/src/utils/usePrefersReducedMotion.tsx
+++ b/frontend/src/utils/usePrefersReducedMotion.tsx
@@ -15,10 +15,8 @@ export function usePrefersReducedMotion() {
     const listener = (event: { matches: any }) => {
       setPrefersReducedMotion(!event.matches);
     };
-    // mediaQueryList.addListener(listener);
     mediaQueryList.addEventListener("change", listener);
     return () => {
-      // mediaQueryList.removeListener(listener);
       mediaQueryList.removeEventListener("change", listener);
     };
   }, []);

--- a/frontend/src/utils/usePrefersReducedMotion.tsx
+++ b/frontend/src/utils/usePrefersReducedMotion.tsx
@@ -15,9 +15,11 @@ export function usePrefersReducedMotion() {
     const listener = (event: { matches: any }) => {
       setPrefersReducedMotion(!event.matches);
     };
-    mediaQueryList.addListener(listener);
+    // mediaQueryList.addListener(listener);
+    mediaQueryList.addEventListener("change", listener);
     return () => {
-      mediaQueryList.removeListener(listener);
+      // mediaQueryList.removeListener(listener);
+      mediaQueryList.removeEventListener("change", listener);
     };
   }, []);
   return prefersReducedMotion;


### PR DESCRIPTION
Quoting from the MDN docs about MediaQueryList:

MediaQueryList.addListener() Adds a listener to the MediaQueryListener that will run a custom callback function in response to the media query status changing. This is basically an alias for EventTarget.addEventListener(), for backwards compatibility purposes.

addEventListener needs an event type as the first argument, so it becomes this:

// deprecated: MediaQueryList.addListener(listener);
MediaQueryList.addEventListener('change', listener);

The same stands true for removeListener():

// deprecated: MediaQueryList.removeListener(listener);
MediaQueryList.removeEventListener('change', listener);
