### PR TITLE
Preserves determinant/geo when switching carousel mode

### DIFF
--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -151,42 +151,40 @@ function ExploreDataPage() {
   const handleCarouselChange = (index: number) => {
     // Extract values from the CURRENT madlib
     const var1 = madLib.activeSelections[1];
-    let currentVar2, currentGeo1, currentGeo2;
+    let geo1;
 
     switch (madLib.id) {
       case "disparity":
-        currentGeo1 = madLib.activeSelections[3];
+        geo1 = madLib.activeSelections[3];
         break;
 
       case "comparegeos":
-        currentGeo1 = madLib.activeSelections[3];
-        currentGeo2 = madLib.activeSelections[5];
+        geo1 = madLib.activeSelections[3];
+        // currentGeo2 = madLib.activeSelections[5];
         break;
 
       case "comparevars":
-        currentVar2 = madLib.activeSelections[3];
-        currentGeo1 = madLib.activeSelections[5];
+        // currentVar2 = madLib.activeSelections[3];
+        geo1 = madLib.activeSelections[5];
     }
 
-    // retain current  or use defaults / alternate defaults (to avoid duplicate selections)
+    // default settings
     let updatedMadLib;
-    const updatedGeo1 = currentGeo1;
-    const updatedVar2 =
-      currentVar2 || var1 === "covid" ? "vaccinations" : "covid";
-    const updatedGeo2 = currentGeo2 || currentGeo1 === "13" ? "00" : "13";
+    const var2 = var1 === "covid" ? "vaccinations" : "covid";
+    const geo2 = geo1 === "00" ? "13" : "00"; // default to US or Georgia
 
-    // Construct updated madlib based on the future carousel setting
+    // Construct UPDATED madlib based on the future carousel Madlib shape
     switch (MADLIB_LIST[index].id) {
       case "disparity":
-        updatedMadLib = { 1: var1, 3: updatedGeo1 };
+        updatedMadLib = { 1: var1, 3: geo1 };
         break;
 
       case "comparegeos":
-        updatedMadLib = { 1: var1, 3: updatedGeo1, 5: updatedGeo2 };
+        updatedMadLib = { 1: var1, 3: geo1, 5: geo2 };
         break;
 
       case "comparevars":
-        updatedMadLib = { 1: var1, 3: updatedVar2, 5: updatedGeo1 };
+        updatedMadLib = { 1: var1, 3: var2, 5: geo1 };
     }
 
     setMadLib({

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -147,26 +147,14 @@ function ExploreDataPage() {
   const theme = useTheme();
   const pageIsWide = useMediaQuery(theme.breakpoints.up("sm"));
 
-  // switch between madlib carousel modes (disparity, comparevars, compare geos)
+  // madlib carousel position changes (disparity, comparevars, compare geos)
   const handleCarouselChange = (index: number) => {
     // Extract values from the CURRENT madlib
     const var1 = madLib.activeSelections[1];
-    let geo1;
-
-    switch (madLib.id) {
-      case "disparity":
-        geo1 = madLib.activeSelections[3];
-        break;
-
-      case "comparegeos":
-        geo1 = madLib.activeSelections[3];
-        // currentGeo2 = madLib.activeSelections[5];
-        break;
-
-      case "comparevars":
-        // currentVar2 = madLib.activeSelections[3];
-        geo1 = madLib.activeSelections[5];
-    }
+    const geo1 =
+      madLib.id === "comparevars"
+        ? madLib.activeSelections[5]
+        : madLib.activeSelections[3];
 
     // default settings
     let updatedMadLib;

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -147,6 +147,64 @@ function ExploreDataPage() {
   const theme = useTheme();
   const pageIsWide = useMediaQuery(theme.breakpoints.up("sm"));
 
+  // switch between madlib carousel modes (disparity, comparevars, compare geos)
+  const handleCarouselChange = (index: number) => {
+    // Extract values from the CURRENT madlib
+    const var1 = madLib.activeSelections[1];
+    let currentVar2, currentGeo1, currentGeo2;
+
+    switch (madLib.id) {
+      case "disparity":
+        currentGeo1 = madLib.activeSelections[3];
+        break;
+
+      case "comparegeos":
+        currentGeo1 = madLib.activeSelections[3];
+        currentGeo2 = madLib.activeSelections[5];
+        break;
+
+      case "comparevars":
+        currentVar2 = madLib.activeSelections[3];
+        currentGeo1 = madLib.activeSelections[5];
+    }
+
+    // retain current  or use defaults / alternate defaults (to avoid duplicate selections)
+    let updatedMadLib;
+    const updatedGeo1 = currentGeo1;
+    const updatedVar2 =
+      currentVar2 || var1 === "covid" ? "vaccinations" : "covid";
+    const updatedGeo2 = currentGeo2 || currentGeo1 === "13" ? "00" : "13";
+
+    // Construct updated madlib based on the future carousel setting
+    switch (MADLIB_LIST[index].id) {
+      case "disparity":
+        updatedMadLib = { 1: var1, 3: updatedGeo1 };
+        break;
+
+      case "comparegeos":
+        updatedMadLib = { 1: var1, 3: updatedGeo1, 5: updatedGeo2 };
+        break;
+
+      case "comparevars":
+        updatedMadLib = { 1: var1, 3: updatedVar2, 5: updatedGeo1 };
+    }
+
+    setMadLib({
+      ...MADLIB_LIST[index],
+      activeSelections: updatedMadLib,
+    });
+    setParameters([
+      {
+        name: MADLIB_SELECTIONS_PARAM,
+        value: stringifyMls(updatedMadLib),
+      },
+      {
+        name: MADLIB_PHRASE_PARAM,
+        value: MADLIB_LIST[index].id,
+      },
+    ]);
+  };
+
   return (
     <>
       <Onboarding
@@ -169,24 +227,9 @@ function ExploreDataPage() {
             animation="slide"
             navButtonsAlwaysVisible={true}
             index={initialIndex}
-            onChange={(index: number) => {
-              let newState = {
-                ...MADLIB_LIST[index],
-                activeSelections: {
-                  ...MADLIB_LIST[index].defaultSelections,
-                },
-              };
-              setMadLib(newState);
-              setParameters([
-                {
-                  name: MADLIB_SELECTIONS_PARAM,
-                  value: stringifyMls(newState.activeSelections),
-                },
-                { name: MADLIB_PHRASE_PARAM, value: MADLIB_LIST[index].id },
-              ]);
-            }}
+            onChange={handleCarouselChange}
           >
-            {MADLIB_LIST.map((madlib: MadLib, i) => (
+            {MADLIB_LIST.map((_madlib: MadLib, i) => (
               <CarouselMadLib
                 madLib={madLib}
                 setMadLib={setMadLibWithParam}

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -227,11 +227,12 @@ function ExploreDataPage() {
             index={initialIndex}
             onChange={handleCarouselChange}
           >
-            {MADLIB_LIST.map((_madlib: MadLib, i) => (
+            {/* carousel settings same length as MADLIB_LIST, but fill each with madlib constructed earlier */}
+            {MADLIB_LIST.map((_, i) => (
               <CarouselMadLib
                 madLib={madLib}
                 setMadLib={setMadLibWithParam}
-                key={i}
+                key={`carousel_setting_${i}`}
               />
             ))}
           </Carousel>

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -228,11 +228,11 @@ function ExploreDataPage() {
             onChange={handleCarouselChange}
           >
             {/* carousel settings same length as MADLIB_LIST, but fill each with madlib constructed earlier */}
-            {MADLIB_LIST.map((_, i) => (
+            {MADLIB_LIST.map((madLibShape) => (
               <CarouselMadLib
                 madLib={madLib}
                 setMadLib={setMadLibWithParam}
-                key={`carousel_setting_${i}`}
+                key={madLibShape.id}
               />
             ))}
           </Carousel>

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -11,6 +11,7 @@ import {
   MadLib,
   MADLIB_LIST,
   PhraseSegment,
+  PhraseSelections,
 } from "../../utils/MadLibs";
 import {
   getParameter,
@@ -148,7 +149,7 @@ function ExploreDataPage() {
   const pageIsWide = useMediaQuery(theme.breakpoints.up("sm"));
 
   // madlib carousel position changes (disparity, comparevars, compare geos)
-  const handleCarouselChange = (index: number) => {
+  const handleCarouselChange = (carouselIndex: number) => {
     // Extract values from the CURRENT madlib
     const var1 = madLib.activeSelections[1];
     const geo1 =
@@ -157,26 +158,16 @@ function ExploreDataPage() {
         : madLib.activeSelections[3];
 
     // default settings
-    let updatedMadLib;
     const var2 = var1 === "covid" ? "vaccinations" : "covid";
     const geo2 = geo1 === "00" ? "13" : "00"; // default to US or Georgia
 
     // Construct UPDATED madlib based on the future carousel Madlib shape
-    switch (MADLIB_LIST[index].id) {
-      case "disparity":
-        updatedMadLib = { 1: var1, 3: geo1 };
-        break;
-
-      case "comparegeos":
-        updatedMadLib = { 1: var1, 3: geo1, 5: geo2 };
-        break;
-
-      case "comparevars":
-        updatedMadLib = { 1: var1, 3: var2, 5: geo1 };
-    }
+    let updatedMadLib: PhraseSelections = { 1: var1, 3: geo1 }; // disparity "Investigate Rates"
+    if (carouselIndex === 1) updatedMadLib = { 1: var1, 3: geo1, 5: geo2 }; // comparegeos "Compare Rates"
+    if (carouselIndex === 2) updatedMadLib = { 1: var1, 3: var2, 5: geo1 }; // comparevars "Explore Relationships"
 
     setMadLib({
-      ...MADLIB_LIST[index],
+      ...MADLIB_LIST[carouselIndex],
       activeSelections: updatedMadLib,
     });
     setParameters([
@@ -186,7 +177,7 @@ function ExploreDataPage() {
       },
       {
         name: MADLIB_PHRASE_PARAM,
-        value: MADLIB_LIST[index].id,
+        value: MADLIB_LIST[carouselIndex].id,
       },
     ]);
   };

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -148,8 +148,7 @@ function ExploreDataPage() {
   const theme = useTheme();
   const pageIsWide = useMediaQuery(theme.breakpoints.up("sm"));
 
-  // madlib carousel position changes (disparity, comparevars, compare geos)
-  const handleCarouselChange = (carouselIndex: number) => {
+  const handleCarouselChange = (carouselMode: number) => {
     // Extract values from the CURRENT madlib
     const var1 = madLib.activeSelections[1];
     const geo1 =
@@ -157,17 +156,17 @@ function ExploreDataPage() {
         ? madLib.activeSelections[5]
         : madLib.activeSelections[3];
 
-    // default settings
+    // default non-duplicate settings for compare modes
     const var2 = var1 === "covid" ? "vaccinations" : "covid";
     const geo2 = geo1 === "00" ? "13" : "00"; // default to US or Georgia
 
     // Construct UPDATED madlib based on the future carousel Madlib shape
     let updatedMadLib: PhraseSelections = { 1: var1, 3: geo1 }; // disparity "Investigate Rates"
-    if (carouselIndex === 1) updatedMadLib = { 1: var1, 3: geo1, 5: geo2 }; // comparegeos "Compare Rates"
-    if (carouselIndex === 2) updatedMadLib = { 1: var1, 3: var2, 5: geo1 }; // comparevars "Explore Relationships"
+    if (carouselMode === 1) updatedMadLib = { 1: var1, 3: geo1, 5: geo2 }; // comparegeos "Compare Rates"
+    if (carouselMode === 2) updatedMadLib = { 1: var1, 3: var2, 5: geo1 }; // comparevars "Explore Relationships"
 
     setMadLib({
-      ...MADLIB_LIST[carouselIndex],
+      ...MADLIB_LIST[carouselMode],
       activeSelections: updatedMadLib,
     });
     setParameters([
@@ -177,7 +176,7 @@ function ExploreDataPage() {
       },
       {
         name: MADLIB_PHRASE_PARAM,
-        value: MADLIB_LIST[carouselIndex].id,
+        value: MADLIB_LIST[carouselMode].id,
       },
     ]);
   };


### PR DESCRIPTION
Fixes #1197 

### PROBLEM: 

Currently, every change in carousel setting resets the madlibs to the default settings. So when the user selects a condition and geography on the "Investigate" setting of the carousel, when they click on a new setting (eg either of the compare reports) their previously selected settings are abandoned and it defaults to covid.diabetes and USA/Georgia. 

### PROPOSED:

Improve the UX by retaining the decisions the user has already made (eg selecting particular condition(s) and geographies). Currently, this will only preserve the CURRENT options that can fit in the NEW options, meaning if the user is on a 1 CONDITION 1 GEO report and goes to a 2 CONDITION 1 GEO report, the 2nd condition will have to be a default (covid, or covid vaccinations if covid is the first selection)

In the future, it might be nice to use localstorage to remember the last setting the user has made for all 4 potential slots `Condition1 Condition2 Geo1 Geo2` but that adds complexity and should be handled independently
