### PR TITLE
loads header first

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -173,12 +173,11 @@ function App() {
           <CssBaseline />
           <div className={styles.App}>
             <div className={styles.Content}>
+              <a className={styles.SkipMainLink} href="#main">
+                Skip to main content
+              </a>
               <Router>
                 <header>
-                  <a className={styles.SkipMainLink} href="#main">
-                    Skip to main content
-                  </a>
-
                   <AppBar position="static" elevation={0}>
                     {width > MOBILE_BREAKPOINT ? (
                       <AppToolbar />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -174,11 +174,11 @@ function App() {
           <div className={styles.App}>
             <div className={styles.Content}>
               <Router>
-                <Suspense fallback={<i></i>}>
+                <header>
                   <a className={styles.SkipMainLink} href="#main">
                     Skip to main content
                   </a>
-                  <ScrollToTop />
+
                   <AppBar position="static" elevation={0}>
                     {width > MOBILE_BREAKPOINT ? (
                       <AppToolbar />
@@ -186,6 +186,9 @@ function App() {
                       <MobileAppToolbar />
                     )}
                   </AppBar>
+                </header>
+                <ScrollToTop />
+                <Suspense fallback={<></>}>
                   <main>
                     <Switch>
                       <Route


### PR DESCRIPTION
as the page loads, currently it flashes the footer in the middle of the screen, and then fills in the rest of the page. this is mainly noticeable on the `explore data` page.

This PR makes it so the header nav bar displays first, and then the rest of the page follows. This is a more expected behavior and yields a better experience for the user