### PR TITLE
Fix DOESN'T ADD UP message

### DIFF
--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -20,6 +20,7 @@ import {
   UNKNOWN,
   UNKNOWN_RACE,
   UNKNOWN_ETHNICITY,
+  HISPANIC,
 } from "../data/utils/Constants";
 import { Row } from "../data/utils/DatasetTypes";
 import UnknownsAlert from "./ui/UnknownsAlert";
@@ -106,25 +107,35 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
               row[props.breakdownVar] !== UNKNOWN_ETHNICITY
           );
 
-        let shouldShowDoesntAddUpMessage = false;
-        if (
+        // include a note about percents adding to over 100%
+        // if race options include hispanic  twice (eg "White" and "Hispanic" can both include Hispanic people)
+        // also require at least some data to be available to avoid showing info on suppressed/undefined states
+        const shouldShowDoesntAddUpMessage =
           props.breakdownVar === "race_and_ethnicity" &&
-          queryResponse.data.length > 0
-        ) {
-          shouldShowDoesntAddUpMessage = true;
-          queryResponse.data.forEach((elem) => {
-            if (elem[props.breakdownVar].includes("(Non-Hispanic)")) {
-              shouldShowDoesntAddUpMessage = false;
-            }
-          });
-        }
+          queryResponse.data.length > 0 &&
+          queryResponse.data.every(
+            (row) =>
+              !row[props.breakdownVar].includes("(Non-Hispanic)") ||
+              row[props.breakdownVar] === HISPANIC
+          ) &&
+          queryResponse.data.some((row) => row[metricConfig.metricId]);
 
         const dataAvailable = !queryResponse.shouldShowMissingDataMessage([
           metricConfig.metricId,
         ]);
         return (
           <>
-            {!dataAvailable && (
+            {/* Display either UnknownsAlert OR MissingDataAlert */}
+            {dataAvailable ? (
+              <UnknownsAlert
+                metricConfig={metricConfig}
+                queryResponse={queryResponse}
+                breakdownVar={props.breakdownVar}
+                displayType="chart"
+                known={true}
+                overrideAndWithOr={props.breakdownVar === "race_and_ethnicity"}
+              />
+            ) : (
               <CardContent className={styles.Breadcrumbs}>
                 <MissingDataAlert
                   dataName={metricConfig.fullCardTitleName}
@@ -139,16 +150,6 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
                   }
                 />
               </CardContent>
-            )}
-            {dataAvailable && (
-              <UnknownsAlert
-                metricConfig={metricConfig}
-                queryResponse={queryResponse}
-                breakdownVar={props.breakdownVar}
-                displayType="chart"
-                known={true}
-                overrideAndWithOr={props.breakdownVar === "race_and_ethnicity"}
-              />
             )}
             {dataAvailable && dataWithoutUnknowns.length !== 0 && (
               <CardContent className={styles.Breadcrumbs}>
@@ -167,10 +168,11 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
             )}
             {shouldShowDoesntAddUpMessage && (
               <Alert severity="info">
-                Population percentages on this graph add up to over 100% because
-                the racial categories reported for{" "}
-                {metricConfig.fullCardTitleName} include Hispanic individuals in
-                each racial category. As a result, Hispanic individuals are
+                Population percentages on this graph may add up to over 100%
+                because the racial categories reported for{" "}
+                {metricConfig.fullCardTitleName} in{" "}
+                {props.fips.getFullDisplayName()} include Hispanic individuals
+                in each racial category. As a result, Hispanic individuals are
                 counted twice.
               </Alert>
             )}

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -168,8 +168,8 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
             )}
             {shouldShowDoesntAddUpMessage && (
               <Alert severity="info">
-                Population percentages on this graph may add up to over 100%
-                because the racial categories reported for{" "}
+                Population percentages on this graph add up to over 100% because
+                the racial categories reported for{" "}
                 {metricConfig.fullCardTitleName} in{" "}
                 {props.fips.getFullDisplayName()} include Hispanic individuals
                 in each racial category. As a result, Hispanic individuals are

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -108,11 +108,10 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
           );
 
         // include a note about percents adding to over 100%
-        // if race options include hispanic  twice (eg "White" and "Hispanic" can both include Hispanic people)
+        // if race options include hispanic twice (eg "White" and "Hispanic" can both include Hispanic people)
         // also require at least some data to be available to avoid showing info on suppressed/undefined states
         const shouldShowDoesntAddUpMessage =
           props.breakdownVar === "race_and_ethnicity" &&
-          queryResponse.data.length > 0 &&
           queryResponse.data.every(
             (row) =>
               !row[props.breakdownVar].includes("(Non-Hispanic)") ||


### PR DESCRIPTION
fixes #1377 where `Doesnt Add Up` alert was appearing on suppressed states. Also simplifies the logic and adds the geo name to the alert for user clarity