### PR TITLE
Smoothly scrolls user to top of page on changes to tracker settings

### DIFF
--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -92,6 +92,11 @@ function ExploreDataPage() {
     };
   }, []);
 
+  /* scroll to top on any changes to the madlib settings */
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [madLib]);
+
   const setMadLibWithParam = (ml: MadLib) => {
     setParameter(MADLIB_SELECTIONS_PARAM, stringifyMls(ml.activeSelections));
     setMadLib(ml);


### PR DESCRIPTION
 fixes #1195

## Issue: 
When the user adjusts the madlib settings (condition, geo, or carousel setting) the page appears to jump around at times. This is because the browser is attempting to maintain position, but some cards are expanding / contracting and that causes the "same" scroll position to look different (and often random). 

## Solution: 
Whenever the user selects a new setting (condition, geo, or carousel setting), smoothly scroll them back to the top of the page. This reinforces to the user that they are seeing an entirely new report as well as prevents the "random" jumping of scroll position that happens when some charts/maps/alerts appear and disappear

## Future Idea: #1383
We have discussed a feature that has a hover box on the side of the tracker to outline all cards available, and showing the user where they are and what other cards (off screen) are available. This would be the ideal behavioral, and this would track which specific card was "in view" and re-scroll the user to the equivalent scroll position with new tracker position. 

 
[
smooth scroll to top if user adjusts madlib vars, geos or tracker mode](https://user-images.githubusercontent.com/41567007/147702288-81537d85-dec1-41f4-99cc-81387c5fa4d2.mp4
)