### PR TITLE
Adds target COVID phrases to tracker text

### DIFF
--- a/frontend/src/pages/AboutUs/TheProjectTab.tsx
+++ b/frontend/src/pages/AboutUs/TheProjectTab.tsx
@@ -168,10 +168,10 @@ function TheProjectTab() {
               </Typography>
               <Typography variant="body1" paragraph={true}>
                 The Health Equity Tracker aims to give a detailed view of health
-                outcomes by race, ethnicity, sex, socioeconomic status, and
-                other critical factors. Our hope is that it will help
-                policymakers understand what resources and support affected
-                communities need to be able to improve their outcomes.
+                outcomes by race, ethnicity, sex, and other critical factors.
+                Our hope is that it will help policymakers understand what
+                resources and support affected communities need to be able to
+                improve their outcomes.
               </Typography>
             </Grid>
 

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -389,8 +389,8 @@ function LandingPage() {
                   </h4>
                   <p className={styles.HowToStepTextSubheader}>
                     The interactive maps and graphs are a great way to
-                    investigate the data more closely. If a state or county is
-                    gray, that means there’s no data currently available.
+                    investigate the data more closely, currently reporting
+                    COVID-19 cases by race at the state and county level.
                   </p>
                 </div>
               </Grid>


### PR DESCRIPTION
## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1432--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>  

## Description

For better search engine visibility, we should highlight the following phrases (esp. given our unique availability at the county level)

- [x] Covid-19 cases by race at the state and county level

## Motivation and Context

Part of #1428 , but more to add if possible 

## How has this been tested?

Chrome MacOS

## Screenshots (if appropriate):

## Types of changes
- wording
