### PR TITLE
Addz "run dev" script for convenience / common practice

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
     "start:development": "env-cmd -f .env.development npm run start",
+    "dev": "env-cmd -f .env.development npm run start",
     "storybook:development": "env-cmd -f .env.development npm run storybook",
     "build:staging": "env-cmd -f .env.staging npm run build",
     "build:prod": "env-cmd -f .env.prod npm run build",


### PR DESCRIPTION
Most npm repos I've worked on include `npm run dev` as a quick way to start the dev server, so I just added this script to match the existing `npm run start:development` which is longer to type and harder to remember