### PR TITLE
Improves URL tests with User Agent

### DIFF
--- a/frontend/src/utils/externalUrls.test.ts
+++ b/frontend/src/utils/externalUrls.test.ts
@@ -10,16 +10,10 @@ export const WAIT_FOR_URL_STATUSES = 5 * 60 * 1000;
 export const SUCCESS_CODE = 200;
 
 // skip some URLs (like linkedin) that block traffic / error out
-export const UNTESTABLE_URLS = [
-  urlMap.shliLinkedIn,
-  "https://www.bloomberg.com/graphics/covid-vaccine-tracker-global-distribution/us-vaccine-demographics.html",
-];
+export const UNTESTABLE_URLS = [urlMap.shliLinkedIn, urlMap.shliTwitter];
 
 // skip some URLs we know don't provide HTTPS
-export const KNOWN_INSECURE_URLS = [
-  "http://www.rootsofhealthinequity.org/",
-  "https://www.press.jhu.edu/newsroom/political-determinants-health", // Remove this when they fix their cert chain
-];
+export const KNOWN_INSECURE_URLS = ["http://www.rootsofhealthinequity.org/"];
 
 // accepts an array of urls found on the site, filters out known untestable or insecure sites
 export function getTestableUrls(allUrls: string[]): string[] {
@@ -32,7 +26,12 @@ export function getTestableUrls(allUrls: string[]): string[] {
 // accepts a url string and returns an awaited status code
 export async function getStatus(url: string): Promise<number> {
   try {
-    const response = await axios.get(url);
+    const response = await axios.get(url, {
+      headers: {
+        "User-Agent":
+          "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:15.0) Gecko/20100101 Firefox/15.0.1",
+      },
+    });
     return response.status;
   } catch (error) {
     console.error(url, "Error getting response code");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Our external URL tests were flaky; sending a user agent header will prevent some of the blocking/erroring we were getting and improves test reliability

## Motivation and Context
closes #1376 

## How has this been tested?

removed some URLs from known error lists and frontend tests are passing locally

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
