### PR TITLE
Blog fix

### DIFF
--- a/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
@@ -22,18 +22,6 @@ import { Link } from "react-router-dom";
 export const ARTICLES_TERM = "Articles";
 const NUM_OF_LOADING_SKELETONS = 6;
 
-// hide selected posts on production but not dev so authors can use dev for a preview
-/* 
-function hidePostsOnProd(articles: Article[]) {
-  if (window.location.hostname === "healthequitytracker.org")
-    return (articles = articles.filter(
-      (article) => article.acf.hide_on_production !== true
-    ));
-
-  return articles;
-} 
-*/
-
 /*
 displays several loading indicator elements while blog content is fetched
 */
@@ -150,11 +138,9 @@ function AllPosts() {
         );
       }
     } else {
-      // const visibleArticles = hidePostsOnProd(data?.data);
-      const visibleArticles = data?.data;
-      if (visibleArticles?.length > 0)
+      if (data?.data?.length > 0)
         setFilteredArticles(
-          visibleArticles.filter((article: Article) => !article.sticky)
+          data.data.filter((article: Article) => !article.sticky)
         );
       setSelectedCategory("");
     }
@@ -179,11 +165,9 @@ function AllPosts() {
         );
       }
     } else {
-      // const visibleArticles = hidePostsOnProd(data?.data);
-      const visibleArticles = data?.data;
-      if (visibleArticles?.length > 0)
+      if (data?.data?.length > 0)
         setFilteredArticles(
-          visibleArticles.filter((article: Article) => !article.sticky)
+          data.data.filter((article: Article) => !article.sticky)
         );
       setSelectedAuthor("");
     }

--- a/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
@@ -23,6 +23,7 @@ export const ARTICLES_TERM = "Articles";
 const NUM_OF_LOADING_SKELETONS = 6;
 
 // hide selected posts on production but not dev so authors can use dev for a preview
+/* 
 function hidePostsOnProd(articles: Article[]) {
   if (window.location.hostname === "healthequitytracker.org")
     return (articles = articles.filter(
@@ -30,7 +31,8 @@ function hidePostsOnProd(articles: Article[]) {
     ));
 
   return articles;
-}
+} 
+*/
 
 /*
 displays several loading indicator elements while blog content is fetched

--- a/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
@@ -148,7 +148,8 @@ function AllPosts() {
         );
       }
     } else {
-      const visibleArticles = hidePostsOnProd(data?.data);
+      // const visibleArticles = hidePostsOnProd(data?.data);
+      const visibleArticles = data?.data;
       if (visibleArticles?.length > 0)
         setFilteredArticles(
           visibleArticles.filter((article: Article) => !article.sticky)
@@ -176,7 +177,8 @@ function AllPosts() {
         );
       }
     } else {
-      const visibleArticles = hidePostsOnProd(data?.data);
+      // const visibleArticles = hidePostsOnProd(data?.data);
+      const visibleArticles = data?.data;
       if (visibleArticles?.length > 0)
         setFilteredArticles(
           visibleArticles.filter((article: Article) => !article.sticky)

--- a/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
@@ -336,10 +336,10 @@ function AllPosts() {
               )}
               {error && !isLoading && (
                 <>
-                  <ArticlesSkeleton doPulse={false} />
                   <Box mt={5}>
                     <i>Problem updating articles.</i>
                   </Box>
+                  <ArticlesSkeleton doPulse={false} />
                 </>
               )}
             </Grid>

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -62,12 +62,12 @@ export default function WhatIsHealthEquityPage() {
             component={Link}
             to={FAQ_TAB_LINK}
           />
-          <Tab
+          {/* <Tab
             value={NEWS_TAB_LINK}
             label="News"
             component={Link}
             to={NEWS_TAB_LINK}
-          />
+          /> */}
           <Tab
             value={RESOURCES_TAB_LINK}
             label="Resources"

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -201,7 +201,7 @@ export function setParameters(paramMap: ParamKeyValue[]) {
 }
 
 const defaultHandler = <T extends unknown>(inp: string | null): T => {
-  return (inp as unknown) as T;
+  return inp as unknown as T;
 };
 
 export function removeParamAndReturnValue<T1>(


### PR DESCRIPTION
- remove potentially broken hiding preview posts on prod feature (filed as new idea #1445)
- hide link to /news so we can confirm it is fully working on prod without potentially serving a broken feature
 