### PR TITLE
remove all instances of the pandas dataframe append function

### DIFF
--- a/python/datasources/cdc_restricted_local.py
+++ b/python/datasources/cdc_restricted_local.py
@@ -164,7 +164,8 @@ def accumulate_data(df, geo_cols, overall_df, demog_col, names_mapping):
         totals[demog_col] = std_col.Race.TOTAL.value
     else:
         totals[demog_col] = std_col.TOTAL_VALUE
-    df = df.append(totals)
+
+    df = pd.concat([df, totals])
     df = df.set_index(groupby_cols)
 
     if not overall_df.empty:

--- a/python/tests/ingestion/test_dataset_utils.py
+++ b/python/tests/ingestion/test_dataset_utils.py
@@ -1,6 +1,8 @@
 import json
 import pytest
 
+import pandas as pd
+
 from pandas.testing import assert_frame_equal
 from ingestion import gcs_to_bq_util, dataset_utils  # pylint: disable=no-name-in-module
 
@@ -118,8 +120,14 @@ def testGeneratePctShareColExtraTotalError():
     df = gcs_to_bq_util.values_json_to_dataframe(
         json.dumps(_fake_race_data)).reset_index(drop=True)
 
-    extra_row = [{'state_fips': '01', 'state_name': 'Alabama', 'race': 'TOTAL', 'population': '66'}]
-    df = df.append(extra_row, ignore_index=True)
+    extra_row = pd.DataFrame([{
+        'state_fips': '01',
+        'state_name': 'Alabama',
+        'race': 'TOTAL',
+        'population': '66',
+    }])
+
+    df = pd.concat([df, extra_row])
 
     df['population'] = df['population'].astype(int)
 


### PR DESCRIPTION
* it is depreciated and will be removed in a future version

<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
No frontend changes

## Description
<!--- Describe your changes in detail -->
Removes the pandas `.append` function and replaces it with the `.concat` function. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

Pandas has depreciated `.append` because it is not very performant and throws a very annoying error every time we use it.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Ran our unit tests which should be good.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

