### PR TITLE
make the frontend server more powerful

### DIFF
--- a/config/run.tf
+++ b/config/run.tf
@@ -180,6 +180,14 @@ resource "google_cloud_run_service" "frontend_service" {
           name  = "DATA_SERVER_URL"
           value = google_cloud_run_service.data_server_service.status.0.url
         }
+
+        resources {
+          limits = {
+            memory = "8Gi"
+            cpu = 4
+          }
+        }
+
       }
       service_account_name = google_service_account.frontend_runner_identity.email
     }


### PR DESCRIPTION
from 1 -> 8 GB mem
from 1 -> 4 cpu

<!--- Provide a general summary of your changes in the Title above -->


## Description
<!--- Describe your changes in detail -->
Bumps the frontend server to specs mentioned above


## Motivation and Context
Was seeing slowness after we turned gzipping on, I think the server was getting a little overloaded.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested changes by hand on the dev cloud console

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

