### PR TITLE
clarify that we currently only suppress pop from states that dont report cases

### DIFF
--- a/frontend/src/pages/DataCatalog/MethodologyTab.tsx
+++ b/frontend/src/pages/DataCatalog/MethodologyTab.tsx
@@ -86,10 +86,11 @@ function MethodologyTab() {
                     incomplete and potentially skewed.
                   </li>
                   <li>
-                    When calculating national-level per100k COVID-19 rates, we
-                    do not include the population of states whose data are
-                    suppressed as part of the total population. See the 'What
-                    data are missing' section for further details.
+                    When calculating national-level per100k COVID-19 rates for
+                    cases, deaths, and hospitalizations, we only include the
+                    population of states that do not have a suppressed case
+                    count as part of the total population. See the 'What data
+                    are missing' section for further details.
                   </li>
                   <li>
                     To protect the privacy of affected individuals, COVID-19


### PR DESCRIPTION
- we should consider changing this: see #1471

<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1472--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>   <-- Update this link once you have PR# 

## Description
<!--- Describe your changes in detail -->
Add a more clear description of how we calculate national population numbers

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
The current explanation is confusing and doesn't exactly describe how we calculate national population numbers

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

