### PR TITLE
Fixes issue with suppressing incorrect age buckets on non-UHC vars

### DIFF
--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -40,6 +40,7 @@ import Divider from "@material-ui/core/Divider";
 import {
   UHC_API_NH_DETERMINANTS,
   UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
+  UHC_DETERMINANTS,
   UHC_VOTER_AGE_DETERMINANTS,
 } from "../data/variables/BrfssProvider";
 import { urlMap } from "../utils/externalUrls";
@@ -68,21 +69,37 @@ export function TableCard(props: TableCardProps) {
 
   // choose demographic groups to exclude from the table
   let exclusionList = [ALL];
+
+  // across all variables
   if (props.breakdownVar === "race_and_ethnicity") {
     exclusionList.push(NON_HISPANIC);
+  }
 
-    // use either API or ASIAN + NHPI
+  // only for UHC variables
+  const ALL_UHC_DETERMINANTS = [
+    ...UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
+    ...UHC_VOTER_AGE_DETERMINANTS,
+    ...UHC_DETERMINANTS,
+  ];
+  if (
+    ALL_UHC_DETERMINANTS.includes(current100k) &&
+    props.breakdownVar === "race_and_ethnicity"
+  ) {
     UHC_API_NH_DETERMINANTS.includes(current100k)
       ? exclusionList.push(ASIAN_NH, NHPI_NH)
       : exclusionList.push(API_NH);
-  } else if (props.breakdownVar === "age") {
+  } else if (
+    ALL_UHC_DETERMINANTS.includes(current100k) &&
+    props.breakdownVar === "age"
+  ) {
     // get correct age buckets for this determinant
     let determinantBuckets: any[] = [];
     if (UHC_DECADE_PLUS_5_AGE_DETERMINANTS.includes(current100k))
       determinantBuckets.push(...DECADE_PLUS_5_AGE_BUCKETS);
     else if (UHC_VOTER_AGE_DETERMINANTS.includes(current100k))
       determinantBuckets.push(...VOTER_AGE_BUCKETS);
-    else determinantBuckets.push(...BROAD_AGE_BUCKETS);
+    else if (UHC_DETERMINANTS.includes(current100k))
+      determinantBuckets.push(...BROAD_AGE_BUCKETS);
 
     // remove all of the other age groups
     const irrelevantAgeBuckets = AGE_BUCKETS.filter(

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -135,7 +135,6 @@ export function TableChart(props: TableChartProps) {
               <Tooltip title="No data available">
                 <WarningRoundedIcon />
               </Tooltip>
-              {console.log(row)}
               <span className={styles.ScreenreaderTitleHeader}>
                 No Data Available
               </span>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1484--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>  

## Description

In creating the dynamic age-buckets for UHC vars, I accidentally used an `else` instead of `else if` which was causing non-UHC variables to use UHC age bucket logic. I fixed by only running that logic if it's currently on a  UHC variable. 


## How has this been tested?
desktop

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
