### PR TITLE
Removes feedback box from tracker tab

### DIFF
--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -25,7 +25,6 @@ import {
   VariableConfig,
 } from "../data/config/MetricConfig";
 import { Link } from "react-router-dom";
-import FeedbackBox from "../pages/ui/FeedbackBox";
 import ShareButtons from "./ui/ShareButtons";
 import { Helmet } from "react-helmet-async";
 import { urlMap } from "../utils/externalUrls";
@@ -313,8 +312,6 @@ function ReportProvider(props: ReportProviderProps) {
           </div>
         </aside>
       </div>
-
-      <FeedbackBox />
     </>
   );
 }


### PR DESCRIPTION
## Description

As the Feedback Box hasn't been used at all, we need to consider the balance of possibility of user feedback VS usability for everyone. There is so much happening on the tracker page that it makes sense to remove the hover box and take one more distraction away from the user. 

We should consider #1395 as most people will use the contact page to get in touch and the form might be quicker/better for them than emailing. This may allow us to consider removing the feedback from other pages entirely. 
