### PR TITLE
Replaces No Data messages with "Insufficient Data"

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -329,10 +329,6 @@ function MapCardWithKey(props: MapCardProps) {
             {metricConfig && dataForActiveBreakdownFilter.length ? (
               <CardContent>
                 <ChoroplethMap
-                  useSmallSampleMessage={
-                    !mapQueryResponse.dataIsMissing() &&
-                    (props.variableConfig.surveyCollectedData || false)
-                  }
                   signalListeners={signalListeners}
                   metric={metricConfig}
                   legendTitle={metricConfig.shortVegaLabel}
@@ -371,11 +367,6 @@ function MapCardWithKey(props: MapCardProps) {
                       return (
                         <div className={styles.TerritoryCircle} key={code}>
                           <ChoroplethMap
-                            useSmallSampleMessage={
-                              !mapQueryResponse.dataIsMissing() &&
-                              (props.variableConfig.surveyCollectedData ||
-                                false)
-                            }
                             signalListeners={signalListeners}
                             metric={metricConfig}
                             legendTitle={metricConfig.fullCardTitleName}

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -314,8 +314,8 @@ function MapCardWithKey(props: MapCardProps) {
               activeBreakdownFilter !== "All" && (
                 <CardContent>
                   <Alert severity="warning" role="note">
-                    No data available for filter: <b>{activeBreakdownFilter}</b>
-                    .{" "}
+                    Insufficient data available for filter:{" "}
+                    <b>{activeBreakdownFilter}</b>.{" "}
                     <MultiMapLink
                       setSmallMultiplesDialogOpen={setSmallMultiplesDialogOpen}
                       currentBreakdown={props.currentBreakdown}

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -219,10 +219,6 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             {showingVisualization && (
               <CardContent>
                 <ChoroplethMap
-                  useSmallSampleMessage={
-                    !mapQueryResponse.dataIsMissing() &&
-                    (props.variableConfig.surveyCollectedData || false)
-                  }
                   isUnknownsMap={true}
                   signalListeners={signalListeners}
                   metric={metricConfig}
@@ -246,11 +242,6 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
                         <div key={code} className={styles.TerritoryCircle}>
                           <ChoroplethMap
                             isUnknownsMap={true}
-                            useSmallSampleMessage={
-                              !mapQueryResponse.dataIsMissing() &&
-                              (props.variableConfig.surveyCollectedData ||
-                                false)
-                            }
                             signalListeners={signalListeners}
                             metric={metricConfig}
                             legendTitle={metricConfig.fullCardTitleName}

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -194,9 +194,9 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
               <Box my={3}>
                 <Alert severity="warning">
                   <p className={styles.NoDataWarning}>
-                    No {props.metricConfig.shortVegaLabel} data reported at the{" "}
-                    {props.fips.getChildFipsTypeDisplayName()} level for the
-                    following groups:{" "}
+                    Insufficient {props.metricConfig.shortVegaLabel} data
+                    reported at the {props.fips.getChildFipsTypeDisplayName()}{" "}
+                    level for the following groups:{" "}
                     {props.breakdownValuesNoData.map((group, i) => (
                       <span key={group}>
                         <b>{group}</b>

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -104,7 +104,6 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     key={breakdownValue}
                     signalListeners={{ click: (...args: any) => {} }}
                     metric={props.metricConfig}
-                    useSmallSampleMessage={props.useSmallSampleMessage}
                     legendTitle={props.metricConfig.fullCardTitleName}
                     legendData={props.data}
                     data={dataForValue}
@@ -134,7 +133,6 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                         <ChoroplethMap
                           signalListeners={{ click: (...args: any) => {} }}
                           metric={props.metricConfig}
-                          useSmallSampleMessage={props.useSmallSampleMessage}
                           legendTitle={props.metricConfig.fullCardTitleName}
                           legendData={props.data}
                           data={dataForValue}

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -70,8 +70,6 @@ export interface ChoroplethMapProps {
   scaleColorScheme?: string;
   // If true, the geography will be rendered as a circle. Used to display territories at national level.
   overrideShapeWithCircle?: boolean;
-  // Instead of missing data saying "no data" use a "sample size too small" message. Used for surveyed data.
-  useSmallSampleMessage: boolean;
   // Do not show a tooltip when there is no data.
   hideMissingDataTooltip?: boolean;
   // Callbacks set up so map interactions can update the React UI
@@ -151,9 +149,6 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     }
 
     /* SET UP TOOLTIP */
-    const noDataText = props.useSmallSampleMessage
-      ? "Sample size too small"
-      : NO_DATA_MESSAGE;
 
     /* PROPERLY LABEL THE HOVERED GEO REGION IF TERRITORY */
     const countyOrEquivalent =
@@ -173,7 +168,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
         ? props.metric.unknownsVegaLabel
         : props.metric.shortVegaLabel;
     const tooltipValue = `{"${geographyName}": datum.properties.name, "${tooltipLabel}": ${tooltipDatum} }`;
-    const missingDataTooltipValue = `{"${geographyName}": datum.properties.name, "${tooltipLabel}": "${noDataText}" }`;
+    const missingDataTooltipValue = `{"${geographyName}": datum.properties.name, "${tooltipLabel}": "${NO_DATA_MESSAGE}" }`;
 
     /* SET UP LEGEND */
     let legendList = [];
@@ -484,7 +479,6 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     props.fieldRange,
     props.scaleType,
     props.scaleColorScheme,
-    props.useSmallSampleMessage,
     props.hideMissingDataTooltip,
     props.overrideShapeWithCircle,
     props.geoData,

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -89,7 +89,7 @@ export function Legend(props: LegendProps) {
         },
         {
           name: MISSING_PLACEHOLDER_VALUES,
-          values: [{ missing: "No data" }],
+          values: [{ missing: "Insufficient data" }],
         },
       ],
       layout: { padding: 20, bounds: "full", align: "each" },

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -16,7 +16,7 @@ const DATASET_VALUES = "dataset_values";
 export const MISSING_PLACEHOLDER_VALUES = "missing_data";
 export const LEGEND_SYMBOL_TYPE = "square";
 export const LEGEND_TEXT_FONT = "inter";
-export const NO_DATA_MESSAGE = "No data";
+export const NO_DATA_MESSAGE = "Insufficient data";
 
 export const EQUAL_DOT_SIZE = 200;
 export const LEGEND_COLOR_COUNT = 7;

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -132,11 +132,11 @@ export function TableChart(props: TableChartProps) {
               {...cell.getCellProps()}
               style={row.index % 2 === 0 ? cellStyle : altCellStyle}
             >
-              <Tooltip title="No data available">
+              <Tooltip title="Insufficient Data">
                 <WarningRoundedIcon />
               </Tooltip>
               <span className={styles.ScreenreaderTitleHeader}>
-                No Data Available
+                Insufficient Data
               </span>
             </TableCell>
           ) : (
@@ -160,7 +160,7 @@ export function TableChart(props: TableChartProps) {
   return (
     <>
       {props.data.length <= 0 || props.metrics.length <= 0 ? (
-        <h1>No Data provided</h1>
+        <h1>Insufficient Data</h1>
       ) : (
         <TableContainer component={Paper} style={{ maxHeight: "100%" }}>
           <Table stickyHeader {...getTableProps()}>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1502--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>  

## Description

In many cases the tracker cannot display data due to a range of concerns including small sample/population sizes, data integrity issues, and many more. Previously most of our messaging used the phrase `No Data` but this isn't always the most accurate, as we (or our data source) has chosen to suppress the data for the previously mentioned concerns. In these cases it is more accurate to use the phrase `Insufficient data`. 

We also went to some lengths to use the phrase `Sample Size Too Small` for maps generated from survey data, however to simplify our messaging and our codebase, I have removed that logic and stick with the new `Insufficient Data` for these survey cases. 

- use `Insufficient Data` instead of `No Data` on map legends and hover tooltips
- use `Insufficient Data` instead of `No Data`  on table `!` icon hover tooltip
- use `Insufficient Data` instead of `Sample Size Too Small` for maps generated from survey data

## Motivation and Context
#1499 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="678" alt="Screen Shot 2022-03-03 at 10 23 03 AM" src="https://user-images.githubusercontent.com/41567007/156619531-c4e28909-e618-46db-8382-f1c974b4e107.png">
<img width="692" alt="Screen Shot 2022-03-03 at 10 23 39 AM" src="https://user-images.githubusercontent.com/41567007/156619535-da0b9913-daef-431f-a9fb-928300d99edf.png">
<img width="622" alt="Screen Shot 2022-03-03 at 10 26 55 AM" src="https://user-images.githubusercontent.com/41567007/156619536-342f7f83-3d83-439a-9afc-24ac06658176.png">
<img width="690" alt="Screen Shot 2022-03-03 at 10 28 04 AM" src="https://user-images.githubusercontent.com/41567007/156619539-fce9dbbd-94d0-460d-b8e6-826a977a60aa.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- New feature (non-breaking change which adds functionality)
- Refactor (code improvement that doesn't affect UI)
