### PR TITLE
Load ACS2010 from /data 

### DIFF
--- a/python/datasources/acs_2010_population.py
+++ b/python/datasources/acs_2010_population.py
@@ -42,8 +42,8 @@ class ACS2010Population(DataSource):
 
         for f in files:
             # Explicitly specify county_fips is a string.
-            df = gcs_to_bq_util.load_json_as_dataframe(
-                gcs_bucket, f, dtype={'state_fips': str})
+            df = gcs_to_bq_util.load_json_as_df_from_data_dir(
+                "acs_2010", f, dtype={'state_fips': str})
 
             total_val = (
                 Race.TOTAL.value if get_breakdown_col(df) == std_col.RACE_CATEGORY_ID_COL else std_col.TOTAL_VALUE)
@@ -65,6 +65,7 @@ class ACS2010Population(DataSource):
             self.clean_frame_column_names(df)
 
             table_name = f.replace('.json', '')  # Table name is file name
-            table_name = table_name.replace('acs_2010_population-', '')  # Dont need this
-            gcs_to_bq_util.add_dataframe_to_bq(
+            table_name = table_name.replace(
+                'acs_2010_population-', '')  # Dont need this
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types)

--- a/python/datasources/acs_health_insurance.py
+++ b/python/datasources/acs_health_insurance.py
@@ -74,7 +74,8 @@ class AcsHealhInsuranceRaceIngestor:
             metadata, HEALTH_INSURANCE_BY_RACE_GROUP_PREFIXES.keys()
         )
         self.metadata = parseMetadata(
-            metadata, [MetadataKey.AGE, MetadataKey.RACE], self.metadataInitializer
+            metadata, [MetadataKey.AGE,
+                       MetadataKey.RACE], self.metadataInitializer
         )
         for k, v in self.metadata.items():
             if MetadataKey.POPULATION not in v:
@@ -166,7 +167,7 @@ class AcsHealhInsuranceRaceIngestor:
             column_types[WITHOUT_HEALTH_INSURANCE_COL] = "INT64"
             column_types[TOTAL_HEALTH_INSURANCE_COL] = "INT64"
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types
             )
 
@@ -280,7 +281,8 @@ class AcsHealhInsuranceRaceIngestor:
 
             if county_fip is None:
                 state_race_data.append(
-                    [state_fip, self.state_fips[state_fip], age, race, whi, wohi, total]
+                    [state_fip, self.state_fips[state_fip],
+                        age, race, whi, wohi, total]
                 )
             else:
                 county_race_data.append(
@@ -341,7 +343,8 @@ class AcsHealhInsuranceSexIngestor:
     def __init__(self, base_url):
         self.base_url = base_url
         metadata = fetch_acs_metadata(self.base_url)["variables"]
-        metadata = trimMetadata(metadata, [HEALTH_INSURANCE_BY_SEX_GROUPS_PREFIX])
+        metadata = trimMetadata(
+            metadata, [HEALTH_INSURANCE_BY_SEX_GROUPS_PREFIX])
         self.metadata = parseMetadata(
             metadata, [MetadataKey.AGE, MetadataKey.SEX], lambda key: dict()
         )
@@ -394,7 +397,8 @@ class AcsHealhInsuranceSexIngestor:
     def upload_to_gcs(self, bucket):
         file_diff = False
         for is_county in [True, False]:
-            params = get_params(HEALTH_INSURANCE_BY_SEX_GROUPS_PREFIX, is_county)
+            params = get_params(
+                HEALTH_INSURANCE_BY_SEX_GROUPS_PREFIX, is_county)
 
             file_diff = (
                 url_file_to_gcs.url_file_to_gcs(
@@ -420,7 +424,7 @@ class AcsHealhInsuranceSexIngestor:
             column_types[WITHOUT_HEALTH_INSURANCE_COL] = "INT64"
             column_types[TOTAL_HEALTH_INSURANCE_COL] = "INT64"
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types
             )
 
@@ -534,7 +538,8 @@ class AcsHealhInsuranceSexIngestor:
             if county_fip is None:
 
                 state_sex_data.append(
-                    [state_fip, self.state_fips[state_fip], age, sex, whi, wohi, total]
+                    [state_fip, self.state_fips[state_fip],
+                        age, sex, whi, wohi, total]
                 )
 
             else:

--- a/python/datasources/acs_household_income.py
+++ b/python/datasources/acs_household_income.py
@@ -97,7 +97,7 @@ class AcsHouseholdIncomeIngestor:
 
             column_types[POPULATION_COL] = "INT64"
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types
             )
 

--- a/python/datasources/acs_poverty.py
+++ b/python/datasources/acs_poverty.py
@@ -82,9 +82,11 @@ def determine_new_age_bucket(ageStr):
         elif bucket["min"] > age["max"] or bucket["max"] < age["min"]:
             pass
         elif bucket["min"] <= age["min"] and age["max"] >= bucket["min"]:
-            raise Exception(f"Invalid Grouping [1] for age {age} for bucket {bucket}")
+            raise Exception(
+                f"Invalid Grouping [1] for age {age} for bucket {bucket}")
         elif bucket["max"] >= age["max"] and age["min"] <= bucket["min"]:
-            raise Exception(f"Invalid Grouping [2] for age {age} for bucket {bucket}")
+            raise Exception(
+                f"Invalid Grouping [2] for age {age} for bucket {bucket}")
 
     return ageStr
 
@@ -100,7 +102,8 @@ def get_race_from_key(key):
 # Standardized way of getting filename by group
 def get_filename(grp_code, is_county):
     geo = "COUNTY" if is_county else "STATE"
-    grp_name = POVERTY_BY_RACE_SEX_AGE_GROUPS[grp_code].replace(" ", "_").upper()
+    grp_name = POVERTY_BY_RACE_SEX_AGE_GROUPS[grp_code].replace(
+        " ", "_").upper()
     return f"ACS_POVERTY_BY_AGE_RACE_{geo}_{grp_name}"
 
     # Helper method from grabbing a tuple in data.  If the
@@ -125,7 +128,8 @@ class AcsPovertyIngestor:
     def __init__(self, base_url):
         self.base_url = base_url
         metadata = fetch_acs_metadata(self.base_url)["variables"]
-        metadata = trimMetadata(metadata, POVERTY_BY_RACE_SEX_AGE_GROUPS.keys())
+        metadata = trimMetadata(
+            metadata, POVERTY_BY_RACE_SEX_AGE_GROUPS.keys())
         self.metadata = parseMetadata(
             metadata,
             [MetadataKey.AGE, MetadataKey.SEX, MetadataKey.RACE],
@@ -156,7 +160,7 @@ class AcsPovertyIngestor:
             column_types[BELOW_POVERTY_COL] = "INT64"
             column_types[ABOVE_POVERTY_COL] = "INT64"
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types
             )
 

--- a/python/datasources/age_adjust_cdc_restricted.py
+++ b/python/datasources/age_adjust_cdc_restricted.py
@@ -33,14 +33,15 @@ class AgeAdjustCDCRestricted(DataSource):
 
         for geo in ['state', 'national']:
             with_race_age = 'by_race_age_state'
-            with_race_age_df = gcs_to_bq_util.load_dataframe_from_bigquery(
-                    'cdc_restricted_data', with_race_age, dtype={'state_fips': str})
+            with_race_age_df = gcs_to_bq_util.load_df_from_bigquery(
+                'cdc_restricted_data', with_race_age, dtype={'state_fips': str})
 
-            pop_df = gcs_to_bq_util.load_dataframe_from_bigquery(
-                    'census_pop_estimates', 'race_and_ethnicity', dtype={'state_fips': str})
+            pop_df = gcs_to_bq_util.load_df_from_bigquery(
+                'census_pop_estimates', 'race_and_ethnicity', dtype={'state_fips': str})
 
             # Only get the covid data from states we have population data for
-            states_with_pop = set(pop_df[std_col.STATE_FIPS_COL].drop_duplicates().to_list())
+            states_with_pop = set(
+                pop_df[std_col.STATE_FIPS_COL].drop_duplicates().to_list())
             with_race_age_df = with_race_age_df.loc[
                 with_race_age_df[std_col.STATE_FIPS_COL].isin(states_with_pop)
             ].reset_index(drop=True)
@@ -48,19 +49,25 @@ class AgeAdjustCDCRestricted(DataSource):
             pop_df_death, pop_df_hosp = pop_df, pop_df
 
             if geo == 'national':
-                with_race_age_df_death = with_race_age_df.loc[~with_race_age_df[std_col.COVID_DEATH_Y].isna()]
+                with_race_age_df_death = with_race_age_df.loc[~with_race_age_df[std_col.COVID_DEATH_Y].isna(
+                )]
                 states_to_include_death = set(
                     with_race_age_df_death[std_col.STATE_FIPS_COL].drop_duplicates().to_list())
 
-                pop_df_death = census_pop_estimates.generate_national_pop_data(pop_df, states_to_include_death)
+                pop_df_death = census_pop_estimates.generate_national_pop_data(
+                    pop_df, states_to_include_death)
 
-                with_race_age_df_hosp = with_race_age_df.loc[~with_race_age_df[std_col.COVID_HOSP_Y].isna()]
-                states_to_include_hosp = set(with_race_age_df_hosp[std_col.STATE_FIPS_COL].drop_duplicates().to_list())
+                with_race_age_df_hosp = with_race_age_df.loc[~with_race_age_df[std_col.COVID_HOSP_Y].isna(
+                )]
+                states_to_include_hosp = set(
+                    with_race_age_df_hosp[std_col.STATE_FIPS_COL].drop_duplicates().to_list())
 
-                pop_df_hosp = census_pop_estimates.generate_national_pop_data(pop_df, states_to_include_hosp)
+                pop_df_hosp = census_pop_estimates.generate_national_pop_data(
+                    pop_df, states_to_include_hosp)
 
                 groupby_cols = list(std_col.RACE_COLUMNS) + [std_col.AGE_COL]
-                with_race_age_df = cdc_restricted_local.generate_national_dataset(with_race_age_df, groupby_cols)
+                with_race_age_df = cdc_restricted_local.generate_national_dataset(
+                    with_race_age_df, groupby_cols)
 
             # Clean with race age df
             with_race_age_df = with_race_age_df.loc[
@@ -68,7 +75,8 @@ class AgeAdjustCDCRestricted(DataSource):
             ].reset_index(drop=True)
 
             with_race_age_df = with_race_age_df.loc[
-                with_race_age_df[std_col.RACE_CATEGORY_ID_COL].isin(AGE_ADJUST_RACES)
+                with_race_age_df[std_col.RACE_CATEGORY_ID_COL].isin(
+                    AGE_ADJUST_RACES)
             ].reset_index(drop=True)
 
             df = get_expected_deaths(with_race_age_df, pop_df_death)
@@ -80,8 +88,10 @@ class AgeAdjustCDCRestricted(DataSource):
 
             # TODO: Get rid of this when we do all national calculations on the backend
             if geo == 'state':
-                only_race_df = gcs_to_bq_util.load_dataframe_from_bigquery('cdc_restricted_data', only_race)
-                table_names_to_dfs[table_name] = merge_age_adjusted(only_race_df, age_adjusted_df)
+                only_race_df = gcs_to_bq_util.load_df_from_bigquery(
+                    'cdc_restricted_data', only_race)
+                table_names_to_dfs[table_name] = merge_age_adjusted(
+                    only_race_df, age_adjusted_df)
             else:
                 table_names_to_dfs[table_name] = age_adjusted_df
 
@@ -105,7 +115,7 @@ class AgeAdjustCDCRestricted(DataSource):
             # Clean up column names.
             self.clean_frame_column_names(df)
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types)
 
 
@@ -136,24 +146,28 @@ def get_expected_hosps(race_and_age_df, population_df):
 
     def get_expected_hosp_rate(row):
         this_pop_size = float(population_df.loc[
-                (population_df[std_col.RACE_CATEGORY_ID_COL] == row[std_col.RACE_CATEGORY_ID_COL]) &
-                (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
-                (population_df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.POPULATION_COL].values[0])
+            (population_df[std_col.RACE_CATEGORY_ID_COL] == row[std_col.RACE_CATEGORY_ID_COL]) &
+            (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
+            (population_df[std_col.STATE_FIPS_COL]
+             == row[std_col.STATE_FIPS_COL])
+        ][std_col.POPULATION_COL].values[0])
 
         if not this_pop_size:
-            raise ValueError('Population size for %s demographic is 0 or nil' % row[std_col.RACE_CATEGORY_ID_COL])
+            raise ValueError('Population size for %s demographic is 0 or nil' %
+                             row[std_col.RACE_CATEGORY_ID_COL])
 
         true_hosp_rate = float(row[std_col.COVID_HOSP_Y]) / this_pop_size
 
         ref_pop_size = float(population_df.loc[
-                (population_df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
-                (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
-                (population_df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.POPULATION_COL].values[0])
+            (population_df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+            (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
+            (population_df[std_col.STATE_FIPS_COL]
+             == row[std_col.STATE_FIPS_COL])
+        ][std_col.POPULATION_COL].values[0])
 
         if not ref_pop_size:
-            raise ValueError('Population size for %s demographic is 0 or nil' % REFERENCE_POPULATION)
+            raise ValueError(
+                'Population size for %s demographic is 0 or nil' % REFERENCE_POPULATION)
 
         if not row[std_col.COVID_HOSP_Y]:
             return None
@@ -178,24 +192,28 @@ def get_expected_deaths(race_and_age_df, population_df):
 
     def get_expected_death_rate(row):
         this_pop_size = float(population_df.loc[
-                (population_df[std_col.RACE_CATEGORY_ID_COL] == row[std_col.RACE_CATEGORY_ID_COL]) &
-                (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
-                (population_df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.POPULATION_COL].values[0])
+            (population_df[std_col.RACE_CATEGORY_ID_COL] == row[std_col.RACE_CATEGORY_ID_COL]) &
+            (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
+            (population_df[std_col.STATE_FIPS_COL]
+             == row[std_col.STATE_FIPS_COL])
+        ][std_col.POPULATION_COL].values[0])
 
         if not this_pop_size:
-            raise ValueError('Population size for %s demographic is 0 or nil' % row[std_col.RACE_CATEGORY_ID_COL])
+            raise ValueError('Population size for %s demographic is 0 or nil' %
+                             row[std_col.RACE_CATEGORY_ID_COL])
 
         true_death_rate = float(row[std_col.COVID_DEATH_Y]) / this_pop_size
 
         ref_pop_size = float(population_df.loc[
-                (population_df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
-                (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
-                (population_df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.POPULATION_COL].values[0])
+            (population_df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+            (population_df[std_col.AGE_COL] == row[std_col.AGE_COL]) &
+            (population_df[std_col.STATE_FIPS_COL]
+             == row[std_col.STATE_FIPS_COL])
+        ][std_col.POPULATION_COL].values[0])
 
         if not ref_pop_size:
-            raise ValueError('Population size for %s demographic is 0 or nil' % REFERENCE_POPULATION)
+            raise ValueError(
+                'Population size for %s demographic is 0 or nil' % REFERENCE_POPULATION)
 
         if not row[std_col.COVID_DEATH_Y]:
             return None
@@ -218,9 +236,9 @@ def age_adjust_from_expected(df):
 
     def get_age_adjusted_death_rate(row):
         ref_pop_expected_deaths = df.loc[
-                (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
-                (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.COVID_DEATH_Y].values[0]
+            (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+            (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
+        ][std_col.COVID_DEATH_Y].values[0]
 
         if not ref_pop_expected_deaths:
             return None
@@ -229,9 +247,9 @@ def age_adjust_from_expected(df):
 
     def get_age_adjusted_hosp_rate(row):
         ref_pop_expected_hosp = df.loc[
-                (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
-                (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.COVID_HOSP_Y].values[0]
+            (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+            (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
+        ][std_col.COVID_HOSP_Y].values[0]
 
         if not ref_pop_expected_hosp:
             return None
@@ -244,10 +262,13 @@ def age_adjust_from_expected(df):
     grouped = df.groupby(groupby_cols)
     df = grouped.sum().reset_index()
 
-    df[std_col.COVID_DEATH_RATIO_AGE_ADJUSTED] = df.apply(get_age_adjusted_death_rate, axis=1)
-    df[std_col.COVID_HOSP_RATIO_AGE_ADJUSTED] = df.apply(get_age_adjusted_hosp_rate, axis=1)
+    df[std_col.COVID_DEATH_RATIO_AGE_ADJUSTED] = df.apply(
+        get_age_adjusted_death_rate, axis=1)
+    df[std_col.COVID_HOSP_RATIO_AGE_ADJUSTED] = df.apply(
+        get_age_adjusted_hosp_rate, axis=1)
 
     needed_cols = groupby_cols
-    needed_cols.extend([std_col.COVID_DEATH_RATIO_AGE_ADJUSTED, std_col.COVID_HOSP_RATIO_AGE_ADJUSTED])
+    needed_cols.extend([std_col.COVID_DEATH_RATIO_AGE_ADJUSTED,
+                       std_col.COVID_HOSP_RATIO_AGE_ADJUSTED])
 
     return df[needed_cols]

--- a/python/datasources/cdc_restricted.py
+++ b/python/datasources/cdc_restricted.py
@@ -38,7 +38,7 @@ class CDCRestrictedData(DataSource):
                     std_col.COVID_DEATH_UNKNOWN]
         for f in files:
             # Explicitly specify county_fips is a string.
-            df = gcs_to_bq_util.load_csv_as_dataframe(
+            df = gcs_to_bq_util.load_csv_as_df(
                 gcs_bucket, f, dtype={'county_fips': str})
 
             # All columns are str, except outcome columns.
@@ -53,5 +53,5 @@ class CDCRestrictedData(DataSource):
             self.clean_frame_column_names(df)
 
             table_name = f.replace('.csv', '')  # Table name is file name
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 df, dataset, table_name, column_types=column_types)

--- a/python/datasources/cdc_vaccination_county.py
+++ b/python/datasources/cdc_vaccination_county.py
@@ -30,7 +30,8 @@ class CDCVaccinationCounty(DataSource):
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
         params = {"$limit": FILE_SIZE_LIMIT}
-        df = gcs_to_bq_util.load_csv_as_dataframe_from_web(BASE_CDC_URL, dtype={COUNTY_FIPS_COL: str}, params=params)
+        df = gcs_to_bq_util.load_csv_as_df_from_web(
+            BASE_CDC_URL, dtype={COUNTY_FIPS_COL: str}, params=params)
 
         latest_date = df['date'].max()
         df = df.loc[df['date'] == latest_date]
@@ -48,7 +49,7 @@ class CDCVaccinationCounty(DataSource):
         if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
             column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
 
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             df, dataset, "race_and_ethnicity", column_types=column_types)
 
     def generate_for_bq(self, df):

--- a/python/datasources/cdc_vaccination_national.py
+++ b/python/datasources/cdc_vaccination_national.py
@@ -100,7 +100,7 @@ class CDCVaccinationNational(DataSource):
             if std_col.RACE_INCLUDES_HISPANIC_COL in breakdown_df.columns:
                 column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 breakdown_df, dataset, breakdown, column_types=column_types)
 
     def generate_breakdown(self, breakdown, df):
@@ -133,8 +133,10 @@ class CDCVaccinationNational(DataSource):
                 output_row[breakdown] = standard_group
 
             row = df.loc[df['demographic_category'] == cdc_group]
-            output_row[std_col.VACCINATED_FIRST_DOSE] = int(row['administered_dose1'].values[0])
-            output_row[std_col.VACCINATED_PER_100K] = calc_per_100k(row['administered_dose1_pct'].values[0])
+            output_row[std_col.VACCINATED_FIRST_DOSE] = int(
+                row['administered_dose1'].values[0])
+            output_row[std_col.VACCINATED_PER_100K] = calc_per_100k(
+                row['administered_dose1_pct'].values[0])
 
             # We want the Total number of unknowns, not the unknowns of what is known
             if standard_group == "Unknown" or standard_group == Race.UNKNOWN.value:

--- a/python/datasources/census_pop_estimates.py
+++ b/python/datasources/census_pop_estimates.py
@@ -41,8 +41,8 @@ class CensusPopEstimates(DataSource):
             'upload_to_gcs should not be called for CensusPopEstimates')
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
-        df = gcs_to_bq_util.load_csv_as_dataframe_from_web(
-                BASE_POPULATION_URL, dtype={'STATE': str, 'COUNTY': str}, encoding="ISO-8859-1")
+        df = gcs_to_bq_util.load_csv_as_df_from_web(
+            BASE_POPULATION_URL, dtype={'STATE': str, 'COUNTY': str}, encoding="ISO-8859-1")
 
         state_df = generate_state_pop_data(df)
 
@@ -51,7 +51,7 @@ class CensusPopEstimates(DataSource):
         if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
             column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
 
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             state_df, dataset, "race_and_ethnicity", column_types=column_types)
 
 
@@ -84,20 +84,23 @@ def generate_state_pop_data(df):
         age_df[std_col.AGE_COL] = std_age
 
         for state_fips in age_df['STATE'].drop_duplicates().to_list():
-            state_name = age_df.loc[age_df['STATE'] == state_fips]['STNAME'].drop_duplicates().to_list()[0]
+            state_name = age_df.loc[age_df['STATE'] == state_fips]['STNAME'].drop_duplicates().to_list()[
+                0]
 
             for race in RACES_MAP.values():
                 pop_row = {}
                 pop_row[std_col.STATE_FIPS_COL] = state_fips
                 pop_row[std_col.STATE_NAME_COL] = state_name
                 pop_row[std_col.AGE_COL] = std_age
-                pop_row[std_col.POPULATION_COL] = age_df.loc[age_df['STATE'] == state_fips][race].values[0]
+                pop_row[std_col.POPULATION_COL] = age_df.loc[age_df['STATE']
+                                                             == state_fips][race].values[0]
                 pop_row[std_col.RACE_CATEGORY_ID_COL] = race
 
                 new_df.append(pop_row)
 
     new_df = pd.DataFrame(new_df)
-    new_df = new_df.sort_values([std_col.STATE_NAME_COL, std_col.AGE_COL]).reset_index(drop=True)
+    new_df = new_df.sort_values(
+        [std_col.STATE_NAME_COL, std_col.AGE_COL]).reset_index(drop=True)
     std_col.add_race_columns_from_category_id(new_df)
 
     return new_df
@@ -121,7 +124,8 @@ def generate_national_pop_data(state_df, states_to_include):
     df[std_col.STATE_FIPS_COL] = constants.US_FIPS
     df[std_col.STATE_NAME_COL] = constants.US_NAME
 
-    needed_cols = [std_col.STATE_FIPS_COL, std_col.STATE_NAME_COL, std_col.POPULATION_COL]
+    needed_cols = [std_col.STATE_FIPS_COL,
+                   std_col.STATE_NAME_COL, std_col.POPULATION_COL]
     needed_cols.extend(groupby_cols)
     df[std_col.STATE_FIPS_COL] = df[std_col.STATE_FIPS_COL].astype(str)
     return df[needed_cols].sort_values([std_col.AGE_COL, std_col.RACE_CATEGORY_ID_COL]).reset_index(drop=True)

--- a/python/datasources/county_adjacency.py
+++ b/python/datasources/county_adjacency.py
@@ -23,7 +23,7 @@ class CountyAdjacency(DataSource):
         table_name: The name of the biquery table to write to
         gcs_bucket: The name of the gcs bucket to read the data from
         filename: The name of the file in the gcs bucket to read from"""
-        frame = gcs_to_bq_util.load_csv_as_dataframe(gcs_bucket, filename, dtype={
+        frame = gcs_to_bq_util.load_csv_as_df(gcs_bucket, filename, dtype={
             'fipscounty': 'string',
             'fipsneighbor': 'string'
         })
@@ -39,6 +39,6 @@ class CountyAdjacency(DataSource):
             'neighbor_geoids': 'STRING'
         }
         col_modes = {'neighbor_geoids': 'REPEATED'}
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             frame, dataset, self.get_table_name(), column_types=column_types,
             col_modes=col_modes)

--- a/python/datasources/county_names.py
+++ b/python/datasources/county_names.py
@@ -32,7 +32,8 @@ class CountyNames(DataSource):
         gcs_bucket: The name of the gcs bucket to read the data from
         filename: The name of the file in the gcs bucket to read from"""
         try:
-            frame = gcs_to_bq_util.load_values_as_dataframe(gcs_bucket, filename)
+            frame = gcs_to_bq_util.load_values_as_df(
+                gcs_bucket, filename)
             frame = frame.rename(columns={
                 'NAME': 'county_name',
                 'state': 'state_fips_code',
@@ -43,8 +44,8 @@ class CountyNames(DataSource):
                 'state_fips_code': 'STRING',
                 'county_fips_code': 'STRING'
             }
-            gcs_to_bq_util.add_dataframe_to_bq(frame, dataset, self.get_table_name(),
-                                               column_types=column_types)
+            gcs_to_bq_util.add_df_to_bq(frame, dataset, self.get_table_name(),
+                                        column_types=column_types)
         except json.JSONDecodeError as err:
             logging.error(
                 'Unable to write to BigQuery due to improperly formatted data: %s', err)

--- a/python/datasources/covid_tracking_project_metadata.py
+++ b/python/datasources/covid_tracking_project_metadata.py
@@ -15,16 +15,17 @@ class CtpMetadata(DataSource):
         return "covid_tracking_project_metadata"
 
     def upload_to_gcs(self, _, **attrs):
-        raise NotImplementedError("upload_to_gcs should not be called for CtpMetadata")
+        raise NotImplementedError(
+            "upload_to_gcs should not be called for CtpMetadata")
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
         gcs_file = self.get_attr(attrs, "filename")
 
         # Download the raw data
-        df = gcs_to_bq_util.load_csv_as_dataframe(gcs_bucket, gcs_file)
+        df = gcs_to_bq_util.load_csv_as_df(gcs_bucket, gcs_file)
         df = self.standardize(df)
         # Write to BQ
-        gcs_to_bq_util.add_dataframe_to_bq(df, dataset, self.get_table_name())
+        gcs_to_bq_util.add_df_to_bq(df, dataset, self.get_table_name())
 
     def standardize(self, df: pd.DataFrame) -> pd.DataFrame:
         """Reformats the metadata into the standard format."""
@@ -52,7 +53,8 @@ class CtpMetadata(DataSource):
         ]
         df = df[keep_cols]
         df = df.melt(id_vars=["state_postal_abbreviation"])
-        df[["col_name", "variable_type"]] = df.variable.str.rsplit("_", 1, expand=True)
+        df[["col_name", "variable_type"]] = df.variable.str.rsplit(
+            "_", 1, expand=True)
         df.drop("variable", axis=1, inplace=True)
         df = df.pivot(
             index=["state_postal_abbreviation", "variable_type"],

--- a/python/datasources/data_source.py
+++ b/python/datasources/data_source.py
@@ -71,7 +71,7 @@ class DataSource(ABC):
         gcs_bucket: The name of the gcs bucket to read the data from
         filename: The name of the file in the gcs bucket to read from
         table_name: The name of the BigQuery table to write to"""
-        chunked_frame = gcs_to_bq_util.load_csv_as_dataframe(
+        chunked_frame = gcs_to_bq_util.load_csv_as_df(
             gcs_bucket, filename, chunksize=1000)
 
         # For the very first chunk, we set the mode to overwrite to clear the
@@ -79,7 +79,7 @@ class DataSource(ABC):
         overwrite = True
         for chunk in chunked_frame:
             self.clean_frame_column_names(chunk)
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 chunk, dataset, table_name, project=project,
                 overwrite=overwrite)
             overwrite = False

--- a/python/datasources/household_income.py
+++ b/python/datasources/household_income.py
@@ -70,12 +70,12 @@ class HouseholdIncome(DataSource):
 
         frames = []
         for blob in saipe_blobs:
-            frame = gcs_to_bq_util.load_values_blob_as_dataframe(blob)
+            frame = gcs_to_bq_util.load_values_blob_as_df(blob)
             frames.append(frame)
 
         concat = pandas.concat(frames, ignore_index=True)
         # The SAIPE API includes the query predicate columns, which are duplicates of their
         # ALL_CAPS counterparts. Toss 'em.
         concat.drop(columns=['state', 'county', 'time'], inplace=True)
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             concat, dataset, self.get_table_name())

--- a/python/datasources/kff_vaccination.py
+++ b/python/datasources/kff_vaccination.py
@@ -68,7 +68,8 @@ def get_data_url(data_type):
         'pct_share': 'COVID19 Vaccinations by RE',
         'pct_population': 'Distribution of Vaccinations, Cases, Deaths',
     }
-    df = gcs_to_bq_util.load_json_as_df_from_web_based_on_key(BASE_GITHUB_API_URL, "tree")
+    df = gcs_to_bq_util.load_json_as_df_from_web_based_on_key(
+        BASE_GITHUB_API_URL, "tree")
     df = df.loc[df['path'].str.contains(data_types_to_strings[data_type])]
     urls = df.loc[df['path'] == df['path'].max()].url
 
@@ -126,12 +127,15 @@ def generate_output_row(state_row_pct_share, state_row_pct_total, state_row_pct_
 
     output_row = {}
     output_row[std_col.STATE_NAME_COL] = state
-    output_row[std_col.VACCINATED_PCT_SHARE] = str(state_row_pct_share[generate_pct_share_key(race)].values[0])
+    output_row[std_col.VACCINATED_PCT_SHARE] = str(
+        state_row_pct_share[generate_pct_share_key(race)].values[0])
 
     if race in KFF_RACES_PCT_TOTAL:
-        output_row[std_col.VACCINATED_PCT] = str(state_row_pct_total[generate_total_pct_key(race)].values[0])
+        output_row[std_col.VACCINATED_PCT] = str(
+            state_row_pct_total[generate_total_pct_key(race)].values[0])
         output_row[std_col.POPULATION_PCT_COL] = str(
-            state_row_pct_population[generate_pct_of_population_key(race)].values[0]
+            state_row_pct_population[generate_pct_of_population_key(
+                race)].values[0]
         )
 
     if race == "Asian" and state in AAPI_STATES:
@@ -152,9 +156,12 @@ def generate_total_row(state_row_totals, state):
     output_row[std_col.STATE_NAME_COL] = state
     output_row[std_col.RACE_CATEGORY_ID_COL] = Race.TOTAL.value
 
-    state_row_totals = state_row_totals.loc[~state_row_totals['one_dose'].isnull()]
-    latest_row = state_row_totals.loc[state_row_totals['date'] == state_row_totals['date'].max()]
-    output_row[std_col.VACCINATED_FIRST_DOSE] = str(latest_row[TOTAL_KEY].values[0])
+    state_row_totals = state_row_totals.loc[~state_row_totals['one_dose'].isnull(
+    )]
+    latest_row = state_row_totals.loc[state_row_totals['date']
+                                      == state_row_totals['date'].max()]
+    output_row[std_col.VACCINATED_FIRST_DOSE] = str(
+        latest_row[TOTAL_KEY].values[0])
     output_row[std_col.POPULATION_PCT_COL] = "1.0"
     return output_row
 
@@ -175,15 +182,18 @@ class KFFVaccination(DataSource):
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
         percentage_of_total_url = get_data_url('pct_total')
-        percentage_of_total_df = github_util.decode_json_from_url_into_df(percentage_of_total_url)
+        percentage_of_total_df = github_util.decode_json_from_url_into_df(
+            percentage_of_total_url)
 
         pct_share_url = get_data_url('pct_share')
         pct_share_df = github_util.decode_json_from_url_into_df(pct_share_url)
 
         pct_population_url = get_data_url('pct_population')
-        pct_population_df = github_util.decode_json_from_url_into_df(pct_population_url)
+        pct_population_df = github_util.decode_json_from_url_into_df(
+            pct_population_url)
 
-        total_df = gcs_to_bq_util.load_csv_as_dataframe_from_web(BASE_KFF_URL_TOTALS_STATE, dtype={TOTAL_KEY: str})
+        total_df = gcs_to_bq_util.load_csv_as_df_from_web(
+            BASE_KFF_URL_TOTALS_STATE, dtype={TOTAL_KEY: str})
 
         output = []
         columns = [
@@ -229,5 +239,5 @@ class KFFVaccination(DataSource):
         column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
         column_types[std_col.VACCINATED_FIRST_DOSE] = 'INT64'
 
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             output_df, dataset, std_col.RACE_OR_HISPANIC_COL, column_types=column_types)

--- a/python/datasources/manual_uploads.py
+++ b/python/datasources/manual_uploads.py
@@ -21,7 +21,7 @@ class ManualUploads(DataSource):
         bucket_files = gcs_to_bq_util.list_bucket_files(gcs_bucket)
         for file_name in bucket_files:
             table_name = file_name.split('.')[0]
-            chunked_frame = gcs_to_bq_util.load_csv_as_dataframe(
+            chunked_frame = gcs_to_bq_util.load_csv_as_df(
                 gcs_bucket, file_name, chunksize=1000)
 
             # For the very first chunk, we set the mode to overwrite to clear
@@ -29,7 +29,7 @@ class ManualUploads(DataSource):
             overwrite = True
             for chunk in chunked_frame:
                 super().clean_frame_column_names(chunk)
-                gcs_to_bq_util.add_dataframe_to_bq_as_str_values(
+                gcs_to_bq_util.add_df_to_bq_as_str_values(
                     chunk, dataset, table_name, project=manual_uploads_project,
                     overwrite=overwrite)
                 overwrite = False

--- a/python/datasources/primary_care_access.py
+++ b/python/datasources/primary_care_access.py
@@ -74,7 +74,7 @@ class PrimaryCareAccess(DataSource):
                 'county_name',
                 'num_primary_care_physicians',
                 'primary_care_physicians_rate')
-            )
+        )
         column_types = {
             'county_fips_code': 'INT64',
             'state_name': 'STRING',
@@ -82,5 +82,5 @@ class PrimaryCareAccess(DataSource):
             'num_primary_care_physicians': 'FLOAT64',
             'primary_care_physicians_rate': 'FLOAT64',
         }
-        gcs_to_bq_util.add_dataframe_to_bq(
+        gcs_to_bq_util.add_df_to_bq(
             new_dataframe, dataset, self.get_table_name(), column_types=column_types)

--- a/python/datasources/state_names.py
+++ b/python/datasources/state_names.py
@@ -32,13 +32,15 @@ class StateNames(DataSource):
         gcs_bucket: The name of the gcs bucket to read the data from
         filename: The name of the file in the gcs bucket to read from"""
         try:
-            frame = gcs_to_bq_util.load_values_as_dataframe(gcs_bucket, filename)
+            frame = gcs_to_bq_util.load_values_as_df(
+                gcs_bucket, filename)
             frame = frame.rename(columns={
                 'state': 'state_fips_code',
                 'NAME': 'state_name'
             })
-            column_types = {'state_fips_code': 'STRING', 'state_name': 'STRING'}
-            gcs_to_bq_util.add_dataframe_to_bq(
+            column_types = {'state_fips_code': 'STRING',
+                            'state_name': 'STRING'}
+            gcs_to_bq_util.add_df_to_bq(
                 frame, dataset, self.get_table_name(), column_types=column_types)
         except json.JSONDecodeError as err:
             logging.error(

--- a/python/datasources/uhc.py
+++ b/python/datasources/uhc.py
@@ -144,7 +144,7 @@ class UHCData(DataSource):
             'upload_to_gcs should not be called for UHCData')
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
-        df = gcs_to_bq_util.load_csv_as_dataframe_from_web(BASE_UHC_URL)
+        df = gcs_to_bq_util.load_csv_as_df_from_web(BASE_UHC_URL)
 
         for breakdown in [std_col.RACE_OR_HISPANIC_COL,
                           std_col.AGE_COL,
@@ -158,7 +158,7 @@ class UHCData(DataSource):
             if std_col.RACE_INCLUDES_HISPANIC_COL in breakdown_df.columns:
                 column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 breakdown_df, dataset, breakdown, column_types=column_types)
 
     def generate_breakdown(self, breakdown, df):

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -1,9 +1,9 @@
 from datetime import datetime
 from datetime import timezone
+import pathlib
 import requests
 import json
 import os
-from pathlib import Path
 import pandas as pd
 from google.cloud import bigquery, storage
 
@@ -240,8 +240,7 @@ def load_csv_as_df_from_data_dir(directory, filename, dtype=None):
     directory: directory within data to load from
     filename: file to load the csv file from"""
 
-    home = str(Path.home())
-    file_path = os.path.join(home, "data", directory, filename)
+    file_path = os.path.join("data", directory, filename)
 
     return pd.read_csv(file_path, dtype=dtype)
 
@@ -254,8 +253,15 @@ def load_json_as_df_from_data_dir(directory, filename, dtype=None):
     directory: directory within data to load from
     filename: file to load the json file from"""
 
-    home = str(Path.home())
-    file_path = os.path.join(home, "data", directory, filename)
+    #  go up a level
+    path_parent = os.path.dirname(os.getcwd())
+    os.chdir(path_parent)
+
+    # go into /data
+    os.chdir("data")
+
+    # combine sub-dir and filename
+    file_path = os.path.join(directory, filename)
 
     return pd.read_json(file_path, dtype=dtype)
 

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -150,7 +150,7 @@ def load_values_as_df(gcs_bucket, filename):
     return load_values_blob_as_df(blob)
 
 
-def values_json_to_dataframe(json_string, dtype=None):
+def values_json_to_df(json_string, dtype=None):
     frame = pd.read_json(json_string, orient='values', dtype=dtype)
     frame.rename(columns=frame.iloc[0], inplace=True)
     frame.drop([0], inplace=True)
@@ -164,7 +164,7 @@ def load_values_blob_as_df(blob):
 
        blob: google.cloud.storage.blob.Blob object"""
     json_string = blob.download_as_string()
-    return values_json_to_dataframe(json_string)
+    return values_json_to_df(json_string)
 
 
 def load_csv_as_df(gcs_bucket, filename, dtype=None, chunksize=None,
@@ -288,7 +288,7 @@ def load_public_dataset_from_bigquery_as_df(dataset, table_name, dtype=None):
     return client.list_rows(table_id).to_dataframe(dtypes=dtype)
 
 
-def load_dataframe_from_bigquery(dataset, table_name, dtype=None):
+def load_df_from_bigquery(dataset, table_name, dtype=None):
     """Loads data from a big query table into a dataframe.
 
        dataset: The BigQuery dataset to write to.

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -7,6 +7,9 @@ import pandas as pd
 from google.cloud import bigquery, storage
 
 
+DATA_DIR = os.path.join(os.sep, 'app', 'data')
+
+
 def __convert_frame_to_json(frame):
     """Returns the serialized version of the given dataframe in json."""
     # Repeated fields are not supported with bigquery.Client.load_table_from_dataframe()
@@ -238,9 +241,7 @@ def load_csv_as_df_from_data_dir(directory, filename, dtype=None):
 
     directory: directory within data to load from
     filename: file to load the csv file from"""
-
-    file_path = os.path.join("data", directory, filename)
-
+    file_path = os.path.join(DATA_DIR, directory, filename)
     return pd.read_csv(file_path, dtype=dtype)
 
 
@@ -251,17 +252,7 @@ def load_json_as_df_from_data_dir(directory, filename, dtype=None):
 
     directory: directory within data to load from
     filename: file to load the json file from"""
-
-    #  go up a level
-    path_parent = os.path.dirname(os.getcwd())
-    os.chdir(path_parent)
-
-    # go into /data
-    os.chdir("data")
-
-    # combine sub-dir and filename
-    file_path = os.path.join(directory, filename)
-
+    file_path = os.path.join(DATA_DIR, directory, filename)
     return pd.read_json(file_path, dtype=dtype)
 
 

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from datetime import timezone
-import pathlib
 import requests
 import json
 import os

--- a/python/tests/datasources/test_acs_population.py
+++ b/python/tests/datasources/test_acs_population.py
@@ -22,7 +22,8 @@ GOLDEN_DATA_SEX = os.path.join(TEST_DIR, 'table_by_sex.csv')
 
 GOLDEN_DATA_SEX_NATIONAL = os.path.join(TEST_DIR, 'table_by_sex_national.csv')
 GOLDEN_DATA_AGE_NATIONAL = os.path.join(TEST_DIR, 'table_by_age_national.csv')
-GOLDEN_DATA_RACE_NATIONAL = os.path.join(TEST_DIR, 'table_by_race_national.csv')
+GOLDEN_DATA_RACE_NATIONAL = os.path.join(
+    TEST_DIR, 'table_by_race_national.csv')
 
 GOLDEN_DATA_AGE_COUNTY = os.path.join(TEST_DIR, 'table_by_age_county.csv')
 
@@ -33,7 +34,7 @@ def get_acs_metadata_as_json():
 
 
 def get_hispanic_or_latino_values_by_race_state_as_df():
-    return gcs_to_bq_util.values_json_to_dataframe(
+    return gcs_to_bq_util.values_json_to_df(
         os.path.join(
             TEST_DIR,
             'HISPANIC_OR_LATINO_ORIGIN_BY_RACE_state.json'
@@ -41,38 +42,43 @@ def get_hispanic_or_latino_values_by_race_state_as_df():
 
 
 def get_hispanic_or_latino_values_by_race_county_as_df():
-    return gcs_to_bq_util.values_json_to_dataframe(
+    return gcs_to_bq_util.values_json_to_df(
         os.path.join(
             TEST_DIR,
             'HISPANIC_OR_LATINO_ORIGIN_BY_RACE_county.json'
-            ), dtype={'state_fips': str}).reset_index(drop=True)
+        ), dtype={'state_fips': str}).reset_index(drop=True)
 
 
 def get_sex_by_age_value_as_df(concept):
     filename = '%s_state.json' % concept.replace(' ', '_')
-    return gcs_to_bq_util.values_json_to_dataframe(
+    return gcs_to_bq_util.values_json_to_df(
         os.path.join(TEST_DIR, filename), dtype={'state_fips': str}).reset_index(drop=True)
 
 
 def get_sex_by_age_county_value_as_df(concept):
     filename = '%s_county.json' % concept.replace(' ', '_')
-    return gcs_to_bq_util.values_json_to_dataframe(
+    return gcs_to_bq_util.values_json_to_df(
         os.path.join(TEST_DIR, filename), dtype={'county_fips': str}).reset_index(drop=True)
 
 
 # We export this function for use in other packages so it needs its own tests
 def testGenerateNationalDatasetRace():
-    state_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'state_by_race.csv'), dtype={'state_fips': str})
-    expected_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'national_by_race.csv'), dtype={'state_fips': str})
+    state_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'state_by_race.csv'), dtype={'state_fips': str})
+    expected_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'national_by_race.csv'), dtype={'state_fips': str})
     states_to_include = {'01', '06'}
 
-    national_df = generate_national_dataset(state_df, states_to_include, 'race')
+    national_df = generate_national_dataset(
+        state_df, states_to_include, 'race')
     assert_frame_equal(national_df, expected_df, check_like=True)
 
 
 def testGenerateNationalDatasetSex():
-    state_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'state_by_sex.csv'), dtype={'state_fips': str})
-    expected_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'national_by_sex.csv'), dtype={'state_fips': str})
+    state_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'state_by_sex.csv'), dtype={'state_fips': str})
+    expected_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'national_by_sex.csv'), dtype={'state_fips': str})
     states_to_include = {'01', '06'}
 
     national_df = generate_national_dataset(state_df, states_to_include, 'sex')
@@ -80,8 +86,10 @@ def testGenerateNationalDatasetSex():
 
 
 def testGenerateNationalDatasetAge():
-    state_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'state_by_age.csv'), dtype={'state_fips': str})
-    expected_df = pd.read_csv(os.path.join(TEST_DIR, 'national', 'national_by_age.csv'), dtype={'state_fips': str})
+    state_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'state_by_age.csv'), dtype={'state_fips': str})
+    expected_df = pd.read_csv(os.path.join(
+        TEST_DIR, 'national', 'national_by_age.csv'), dtype={'state_fips': str})
     states_to_include = {'01', '06'}
 
     national_df = generate_national_dataset(state_df, states_to_include, 'age')
@@ -90,9 +98,9 @@ def testGenerateNationalDatasetAge():
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df',
             return_value=get_hispanic_or_latino_values_by_race_state_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqRace(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     acsPopulationIngester = ACSPopulationIngester(False, "https://SOME-URL")
@@ -111,8 +119,8 @@ def testWriteToBqRace(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_js
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqSexAgeRace(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -134,8 +142,8 @@ def testWriteToBqSexAgeRace(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, m
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqSexAge(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -157,8 +165,8 @@ def testWriteToBqSexAge(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqAge(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -181,8 +189,8 @@ def testWriteToBqAge(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_jso
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqSex(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -204,8 +212,8 @@ def testWriteToBqSex(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_jso
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqAgeNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -227,8 +235,8 @@ def testWriteToBqAgeNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, 
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqRaceNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -250,8 +258,8 @@ def testWriteToBqRaceNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock,
 
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqSexNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_state_as_df()]
@@ -274,8 +282,8 @@ def testWriteToBqSexNational(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, 
 # Do one County level test to make sure our logic there is correct
 @mock.patch('ingestion.census.fetch_acs_metadata',
             return_value=get_acs_metadata_as_json())
-@mock.patch('ingestion.gcs_to_bq_util.load_values_as_dataframe')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_values_as_df')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqAgeCounty(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock, mock_json: mock.MagicMock):
     side_effects = [get_hispanic_or_latino_values_by_race_county_as_df()]

--- a/python/tests/datasources/test_age_adjustment.py
+++ b/python/tests/datasources/test_age_adjustment.py
@@ -16,8 +16,10 @@ COVID_DATA_SIMPLE = os.path.join(TEST_DIR, 'race_age_state_simple.json')
 EXPECTED_DEATHS_JSON = os.path.join(TEST_DIR, "expected_deaths.json")
 AGE_ADJUST_JSON = os.path.join(TEST_DIR, "age_adjusted.json")
 
-GOLDEN_INTEGRATION_DATA_STATE = os.path.join(TEST_DIR, 'cdc_restricted-by_race_state-with_age_adjust.json')
-GOLDEN_INTEGRATION_DATA_NATIONAL = os.path.join(TEST_DIR, 'cdc_restricted-by_race_national-with_age_adjust.json')
+GOLDEN_INTEGRATION_DATA_STATE = os.path.join(
+    TEST_DIR, 'cdc_restricted-by_race_state-with_age_adjust.json')
+GOLDEN_INTEGRATION_DATA_NATIONAL = os.path.join(
+    TEST_DIR, 'cdc_restricted-by_race_national-with_age_adjust.json')
 
 
 def get_census_pop_estimates_as_df():
@@ -53,7 +55,8 @@ def testExpectedDeathsAndHospitalizations():
 
 
 def testAgeAdjust():
-    expected_deaths_df = pd.read_json(EXPECTED_DEATHS_JSON, dtype={'state_fips': str})
+    expected_deaths_df = pd.read_json(
+        EXPECTED_DEATHS_JSON, dtype={'state_fips': str})
 
     df = age_adjust.age_adjust_from_expected(expected_deaths_df)
     expected_df = pd.read_json(AGE_ADJUST_JSON, dtype={'state_fips': str})
@@ -62,8 +65,8 @@ def testAgeAdjust():
 
 
 # Integration tests
-@mock.patch('ingestion.gcs_to_bq_util.load_dataframe_from_bigquery')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_df_from_bigquery')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqState(mock_bq: mock.MagicMock, mock_df: mock.MagicMock):
     mock_df.side_effect = [
@@ -88,11 +91,12 @@ def testWriteToBqState(mock_bq: mock.MagicMock, mock_df: mock.MagicMock):
         'death_ratio_age_adjusted': float,
     })
 
-    assert_frame_equal(mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
+    assert_frame_equal(
+        mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_dataframe_from_bigquery')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.load_df_from_bigquery')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBqNational(mock_bq: mock.MagicMock, mock_df: mock.MagicMock):
     mock_df.side_effect = [
@@ -116,4 +120,5 @@ def testWriteToBqNational(mock_bq: mock.MagicMock, mock_df: mock.MagicMock):
         'state_fips': str,
     })
 
-    assert_frame_equal(mock_bq.call_args_list[1].args[0], expected_df, check_like=True)
+    assert_frame_equal(
+        mock_bq.call_args_list[1].args[0], expected_df, check_like=True)

--- a/python/tests/datasources/test_cdc_vaccination_county.py
+++ b/python/tests/datasources/test_cdc_vaccination_county.py
@@ -10,16 +10,17 @@ from datasources.cdc_vaccination_county import CDCVaccinationCounty
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data", "cdc_vaccination_county")
 
-GOLDEN_DATA = os.path.join(TEST_DIR, 'cdc_vaccination_county-race_and_ethnicity.csv')
+GOLDEN_DATA = os.path.join(
+    TEST_DIR, 'cdc_vaccination_county-race_and_ethnicity.csv')
 
 
 def get_total_vaccinations_as_df():
     return pd.read_csv(os.path.join(TEST_DIR, 'cdc_vaccination_county_test.csv'), dtype=str)
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe_from_web',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df_from_web',
             return_value=get_total_vaccinations_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     cdcVaccinationCounty = CDCVaccinationCounty()
@@ -36,4 +37,5 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
         'vaccinated_first_dose': str,
         'race_includes_hispanic': str,
     })
-    assert_frame_equal(mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
+    assert_frame_equal(
+        mock_bq.call_args_list[0].args[0], expected_df, check_like=True)

--- a/python/tests/datasources/test_cdc_vaccination_national.py
+++ b/python/tests/datasources/test_cdc_vaccination_national.py
@@ -8,7 +8,8 @@ from datasources.cdc_vaccination_national import CDCVaccinationNational
 
 # Current working directory.
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data", "cdc_vaccination_national")
+TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data",
+                        "cdc_vaccination_national")
 
 GOLDEN_DATA = {
     'race_and_ethnicity': os.path.join(TEST_DIR, 'cdc_vaccination_national_by_race_and_ethnicity.csv'),
@@ -26,7 +27,7 @@ def get_state_test_data_as_df():
 
 @mock.patch('ingestion.gcs_to_bq_util.load_json_as_df_from_web',
             return_value=get_state_test_data_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     cdcVaccination = CDCVaccinationNational()
@@ -52,4 +53,5 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
         print(mock_bq.call_args_list[i].args[0].columns)
         print(expected_dfs[demos[i]].columns)
 
-        assert_frame_equal(mock_bq.call_args_list[i].args[0], expected_dfs[demos[i]], check_like=True)
+        assert_frame_equal(
+            mock_bq.call_args_list[i].args[0], expected_dfs[demos[i]], check_like=True)

--- a/python/tests/datasources/test_census_pop_estimates.py
+++ b/python/tests/datasources/test_census_pop_estimates.py
@@ -12,8 +12,10 @@ import ingestion.standardized_columns as std_col
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data", "census_pop_estimates")
 
-STATE_POP_DATA = os.path.join(TEST_DIR, 'census_pop_estimates-race_ethnicity_age_state.csv')
-NATIONAL_POP_DATA = os.path.join(TEST_DIR, 'census_pop_estimates-race_ethnicity_age_national.csv')
+STATE_POP_DATA = os.path.join(
+    TEST_DIR, 'census_pop_estimates-race_ethnicity_age_state.csv')
+NATIONAL_POP_DATA = os.path.join(
+    TEST_DIR, 'census_pop_estimates-race_ethnicity_age_national.csv')
 
 
 def get_pop_estimates_as_df():
@@ -23,9 +25,9 @@ def get_pop_estimates_as_df():
     })
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe_from_web',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df_from_web',
             return_value=get_pop_estimates_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     censusPopEstimates = CensusPopEstimates()
@@ -41,7 +43,8 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
         'state_fips': str,
     })
 
-    assert_frame_equal(mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
+    assert_frame_equal(
+        mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
 
 
 def testGenerateNationalPopData():
@@ -53,7 +56,8 @@ def testGenerateNationalPopData():
         'state_fips': str,
     })
 
-    states_to_include = state_df[std_col.STATE_FIPS_COL].drop_duplicates().to_list()
+    states_to_include = state_df[std_col.STATE_FIPS_COL].drop_duplicates(
+    ).to_list()
     df = generate_national_pop_data(state_df, states_to_include)
 
     assert_frame_equal(df, national_df, check_like=True)

--- a/python/tests/datasources/test_covid_tracking_project.py
+++ b/python/tests/datasources/test_covid_tracking_project.py
@@ -56,9 +56,9 @@ def get_test_metadata_as_df():
 
 @mock.patch('datasources.covid_tracking_project.CovidTrackingProject._download_metadata',
             return_value=get_test_metadata_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df',
             return_value=get_test_data_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(mock_append_to_bq: mock.MagicMock, mock_csv: mock.MagicMock,
                   mock_download: mock.MagicMock):
@@ -147,7 +147,7 @@ def testWriteToBq_MissingAttr():
 
 @mock.patch('datasources.covid_tracking_project.CovidTrackingProject._download_metadata',
             return_value=pd.DataFrame({}))
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df',
             return_value=get_test_data_as_df())
 def testWriteToBq_MetadataMissing(mock_csv: mock.MagicMock,
                                   mock_download: mock.MagicMock):

--- a/python/tests/datasources/test_covid_tracking_project_metadata.py
+++ b/python/tests/datasources/test_covid_tracking_project_metadata.py
@@ -42,14 +42,14 @@ def generate_test_data() -> pd.DataFrame:
 
 def get_expected_data() -> pd.DataFrame:
     expected_cols = [
-         col_std.STATE_POSTAL_COL,
-         'variable_type',
-         'reports_api',
-         col_std.RACE_INCLUDES_HISPANIC_COL,
-         'race_mutually_exclusive',
-         'reports_ind',
-         'reports_race',
-         'reports_ethnicity']
+        col_std.STATE_POSTAL_COL,
+        'variable_type',
+        'reports_api',
+        col_std.RACE_INCLUDES_HISPANIC_COL,
+        'race_mutually_exclusive',
+        'reports_ind',
+        'reports_race',
+        'reports_ethnicity']
     expected_data = [
         ['AL', 'cases',  1, 1, 0, 0, 1, 1],
         ['AL', 'deaths', 1, 1, 0, 0, 1, 1],
@@ -61,9 +61,9 @@ def get_expected_data() -> pd.DataFrame:
     return pd.DataFrame(expected_data, columns=expected_cols)
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df',
             return_value=generate_test_data())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq')
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq')
 def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     ctp = CtpMetadata()
     kwargs = {'filename': 'test_file.csv', 'table_name': 'output_table'}
@@ -72,8 +72,10 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
     expected = get_expected_data()
     # Check that the contents of the dataframes are the same, ignoring column order.
     assert_frame_equal(
-        result.set_index([col_std.STATE_POSTAL_COL, 'variable_type'], drop=False),
-        expected.set_index([col_std.STATE_POSTAL_COL, 'variable_type'], drop=False),
+        result.set_index(
+            [col_std.STATE_POSTAL_COL, 'variable_type'], drop=False),
+        expected.set_index(
+            [col_std.STATE_POSTAL_COL, 'variable_type'], drop=False),
         check_like=True)
 
 

--- a/python/tests/datasources/test_kff_vaccination.py
+++ b/python/tests/datasources/test_kff_vaccination.py
@@ -11,7 +11,8 @@ from datasources.kff_vaccination import get_data_url
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data", "kff_vaccination")
 
-GOLDEN_DATA = os.path.join(TEST_DIR, 'kff_vaccination_by_race_and_ethnicity.csv')
+GOLDEN_DATA = os.path.join(
+    TEST_DIR, 'kff_vaccination_by_race_and_ethnicity.csv')
 
 
 def get_github_file_list_as_df():
@@ -47,10 +48,10 @@ def testGetDataUrlPctShare(mock_json: mock.MagicMock):
     assert get_data_url('pct_share') == "some-other-up-to-date-url"
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe_from_web',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df_from_web',
             return_value=get_state_totals_test_data_as_df())
 @mock.patch('ingestion.github_util.decode_json_from_url_into_df')
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(
         mock_bq: mock.MagicMock,
@@ -78,4 +79,5 @@ def testWriteToBq(
         'population_pct': str,
     })
 
-    assert_frame_equal(mock_bq.call_args_list[0].args[0], expected_df, check_like=True)
+    assert_frame_equal(
+        mock_bq.call_args_list[0].args[0], expected_df, check_like=True)

--- a/python/tests/datasources/test_uhc_brfss.py
+++ b/python/tests/datasources/test_uhc_brfss.py
@@ -24,9 +24,9 @@ def get_test_data_as_df():
                               })
 
 
-@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_dataframe_from_web',
+@mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df_from_web',
             return_value=get_test_data_as_df())
-@mock.patch('ingestion.gcs_to_bq_util.add_dataframe_to_bq',
+@mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq',
             return_value=None)
 def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
 
@@ -80,6 +80,6 @@ def testWriteToBq(mock_bq: mock.MagicMock, mock_csv: mock.MagicMock):
         expected_df = pd.read_json(
             GOLDEN_DATA[demographics[i]], dtype=expected_dtype)
 
-        # output created in mocked load_csv_as_dataframe_from_web() should be the same as the expected df
+        # output created in mocked load_csv_as_df_from_web() should be the same as the expected df
         assert_frame_equal(
             mock_bq.call_args_list[i].args[0], expected_df, check_like=True)

--- a/python/tests/ingestion/test_dataset_utils.py
+++ b/python/tests/ingestion/test_dataset_utils.py
@@ -81,14 +81,14 @@ def testPercentAvoidRoundingToZero():
 
 
 def testAddSumOfRows():
-    df = gcs_to_bq_util.values_json_to_dataframe(
+    df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_fake_race_data_without_totals)).reset_index(drop=True)
 
     df['population'] = df['population'].astype(int)
 
     df = dataset_utils.add_sum_of_rows(df, 'race', 'population', 'TOTAL')
 
-    expected_df = gcs_to_bq_util.values_json_to_dataframe(
+    expected_df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_expected_race_data_with_totals)).reset_index(drop=True)
 
     expected_df['population'] = expected_df['population'].astype(int)
@@ -97,24 +97,25 @@ def testAddSumOfRows():
 
 
 def testGeneratePctShareCol():
-    df = gcs_to_bq_util.values_json_to_dataframe(
+    df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_fake_race_data)).reset_index(drop=True)
 
     df['population'] = df['population'].astype(int)
 
-    expected_df = gcs_to_bq_util.values_json_to_dataframe(
+    expected_df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_expected_pct_share_data)).reset_index(drop=True)
 
     expected_df['population'] = expected_df['population'].astype(int)
     expected_df['pct_share'] = expected_df['pct_share'].astype(float)
 
-    df = dataset_utils.generate_pct_share_col(df, 'population', 'pct_share', 'race', 'TOTAL')
+    df = dataset_utils.generate_pct_share_col(
+        df, 'population', 'pct_share', 'race', 'TOTAL')
 
     assert_frame_equal(expected_df, df)
 
 
 def testGeneratePctShareColNoTotalError():
-    df = gcs_to_bq_util.values_json_to_dataframe(
+    df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_fake_race_data)).reset_index(drop=True)
 
     df = df.loc[df['race'] != 'TOTAL']
@@ -123,11 +124,12 @@ def testGeneratePctShareColNoTotalError():
 
     expected_error = r"There is no TOTAL value for this chunk of data"
     with pytest.raises(ValueError, match=expected_error):
-        df = dataset_utils.generate_pct_share_col(df, 'population', 'pct_share', 'race', 'TOTAL')
+        df = dataset_utils.generate_pct_share_col(
+            df, 'population', 'pct_share', 'race', 'TOTAL')
 
 
 def testGeneratePctShareColExtraTotalError():
-    df = gcs_to_bq_util.values_json_to_dataframe(
+    df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_fake_race_data)).reset_index(drop=True)
 
     extra_row = pd.DataFrame([{
@@ -143,4 +145,5 @@ def testGeneratePctShareColExtraTotalError():
 
     expected_error = r"There are multiple TOTAL values for this chunk of data, there should only be one"
     with pytest.raises(ValueError, match=expected_error):
-        df = dataset_utils.generate_pct_share_col(df, 'population', 'pct_share', 'race', 'TOTAL')
+        df = dataset_utils.generate_pct_share_col(
+            df, 'population', 'pct_share', 'race', 'TOTAL')

--- a/python/tests/ingestion/test_dataset_utils.py
+++ b/python/tests/ingestion/test_dataset_utils.py
@@ -96,7 +96,7 @@ _expected_merged_fips = [
 
 
 def _get_fips_codes_as_df():
-    return gcs_to_bq_util.values_json_to_dataframe(
+    return gcs_to_bq_util.values_json_to_df(
         json.dumps(_fips_codes_from_bq), dtype=str).reset_index(drop=True)
 
 
@@ -182,9 +182,9 @@ def testGeneratePctShareColExtraTotalError():
 @mock.patch('ingestion.gcs_to_bq_util.load_public_dataset_from_bigquery_as_df',
             return_value=_get_fips_codes_as_df())
 def testMergeFipsCodes(mock_bq: mock.MagicMock):
-    df = gcs_to_bq_util.values_json_to_dataframe(
+    df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_data_without_fips_codes), dtype=str).reset_index(drop=True)
-    expected_df = gcs_to_bq_util.values_json_to_dataframe(
+    expected_df = gcs_to_bq_util.values_json_to_df(
         json.dumps(_expected_merged_fips), dtype=str).reset_index(drop=True)
 
     df = dataset_utils.merge_fips_codes(df)

--- a/python/tests/test_census.py
+++ b/python/tests/test_census.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 from pandas.testing import assert_frame_equal
+# pylint: disable=no-name-in-module
 from ingestion import census, gcs_to_bq_util
 
 

--- a/python/tests/test_census.py
+++ b/python/tests/test_census.py
@@ -1,6 +1,5 @@
 import unittest
 import json
-from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 from ingestion import census, gcs_to_bq_util
 
@@ -129,7 +128,7 @@ class GcsToBqTest(unittest.TestCase):
             "B02001_008E": ["Two or more races"]
         }, group_vars)
 
-    def testStandarizeFrameOneDim(self):
+    def testStandardizeFrameOneDim(self):
         """Tests standardizing an ACS DataFrame"""
         metadata = census.parse_acs_metadata(
             self._fake_metadata, ["B02001", "B01001"])
@@ -143,7 +142,7 @@ class GcsToBqTest(unittest.TestCase):
             json.dumps(self._expected_race_data)).reset_index(drop=True)
         assert_frame_equal(expected_df, df)
 
-    def testStandarizeFrameTwoDims(self):
+    def testStandardizeFrameTwoDims(self):
         """Tests standardizing an ACS DataFrame"""
         metadata = census.parse_acs_metadata(
             self._fake_metadata, ["B02001", "B01001"])

--- a/python/tests/test_census.py
+++ b/python/tests/test_census.py
@@ -58,46 +58,47 @@ class GcsToBqTest(unittest.TestCase):
     }
 
     _fake_sex_by_age_data = [
-        ["NAME","B01001_011E","B01001_012E","B01001_042E","B01001_041E","state"],
-        ["Alabama","20","15","42","70","01"],
-        ["Alaska","5","8","19","100","02"],
-        ["Arizona","26","200","83","123","04"],
+        ["NAME", "B01001_011E", "B01001_012E",
+            "B01001_042E", "B01001_041E", "state"],
+        ["Alabama", "20", "15", "42", "70", "01"],
+        ["Alaska", "5", "8", "19", "100", "02"],
+        ["Arizona", "26", "200", "83", "123", "04"],
     ]
 
     _expected_sex_by_age_data = [
-        ["state_fips","state_name","sex","age","population"],
-        ["01","Alabama","Male","25 to 29 years","20"],
-        ["01","Alabama","Male","30 to 34 years","15"],
-        ["01","Alabama","Female","55 to 59 years","70"],
-        ["01","Alabama","Female","60 and 61 years","42"],
-        ["02","Alaska","Male","25 to 29 years","5"],
-        ["02","Alaska","Male","30 to 34 years","8"],
-        ["02","Alaska","Female","55 to 59 years","100"],
-        ["02","Alaska","Female","60 and 61 years","19"],
-        ["04","Arizona","Male","25 to 29 years","26"],
-        ["04","Arizona","Male","30 to 34 years","200"],
-        ["04","Arizona","Female","55 to 59 years","123"],
-        ["04","Arizona","Female","60 and 61 years","83"],
+        ["state_fips", "state_name", "sex", "age", "population"],
+        ["01", "Alabama", "Male", "25 to 29 years", "20"],
+        ["01", "Alabama", "Male", "30 to 34 years", "15"],
+        ["01", "Alabama", "Female", "55 to 59 years", "70"],
+        ["01", "Alabama", "Female", "60 and 61 years", "42"],
+        ["02", "Alaska", "Male", "25 to 29 years", "5"],
+        ["02", "Alaska", "Male", "30 to 34 years", "8"],
+        ["02", "Alaska", "Female", "55 to 59 years", "100"],
+        ["02", "Alaska", "Female", "60 and 61 years", "19"],
+        ["04", "Arizona", "Male", "25 to 29 years", "26"],
+        ["04", "Arizona", "Male", "30 to 34 years", "200"],
+        ["04", "Arizona", "Female", "55 to 59 years", "123"],
+        ["04", "Arizona", "Female", "60 and 61 years", "83"],
     ]
 
     _fake_race_data = [
-        ["NAME","B02001_005E","B02001_007E","B02001_008E","state"],
-        ["Alabama","66","70","92","01"],
-        ["Alaska","45","11","60","02"],
-        ["Arizona","23","46","26","04"],
+        ["NAME", "B02001_005E", "B02001_007E", "B02001_008E", "state"],
+        ["Alabama", "66", "70", "92", "01"],
+        ["Alaska", "45", "11", "60", "02"],
+        ["Arizona", "23", "46", "26", "04"],
     ]
 
     _expected_race_data = [
-        ["state_fips","state_name","race","population"],
-        ["01","Alabama","Asian alone","66"],
-        ["01","Alabama","Some other race alone","70"],
-        ["01","Alabama","Two or more races","92"],
-        ["02","Alaska","Asian alone","45"],
-        ["02","Alaska","Some other race alone","11"],
-        ["02","Alaska","Two or more races","60"],
-        ["04","Arizona","Asian alone","23"],
-        ["04","Arizona","Some other race alone","46"],
-        ["04","Arizona","Two or more races","26"],
+        ["state_fips", "state_name", "race", "population"],
+        ["01", "Alabama", "Asian alone", "66"],
+        ["01", "Alabama", "Some other race alone", "70"],
+        ["01", "Alabama", "Two or more races", "92"],
+        ["02", "Alaska", "Asian alone", "45"],
+        ["02", "Alaska", "Some other race alone", "11"],
+        ["02", "Alaska", "Two or more races", "60"],
+        ["04", "Arizona", "Asian alone", "23"],
+        ["04", "Arizona", "Some other race alone", "46"],
+        ["04", "Arizona", "Two or more races", "26"],
     ]
 
     def testAcsMetadata(self):
@@ -134,11 +135,11 @@ class GcsToBqTest(unittest.TestCase):
             self._fake_metadata, ["B02001", "B01001"])
         group_vars = census.get_vars_for_group("RACE", metadata, 1)
 
-        df = gcs_to_bq_util.values_json_to_dataframe(
+        df = gcs_to_bq_util.values_json_to_df(
             json.dumps(self._fake_race_data))
         df = census.standardize_frame(
             df, group_vars, ["race"], False, "population")
-        expected_df = gcs_to_bq_util.values_json_to_dataframe(
+        expected_df = gcs_to_bq_util.values_json_to_df(
             json.dumps(self._expected_race_data)).reset_index(drop=True)
         assert_frame_equal(expected_df, df)
 
@@ -148,11 +149,11 @@ class GcsToBqTest(unittest.TestCase):
             self._fake_metadata, ["B02001", "B01001"])
         group_vars = census.get_vars_for_group("SEX BY AGE", metadata, 2)
 
-        df = gcs_to_bq_util.values_json_to_dataframe(
+        df = gcs_to_bq_util.values_json_to_df(
             json.dumps(self._fake_sex_by_age_data))
         df = census.standardize_frame(
             df, group_vars, ["sex", "age"], False, "population")
-        expected_df = gcs_to_bq_util.values_json_to_dataframe(
+        expected_df = gcs_to_bq_util.values_json_to_df(
             json.dumps(self._expected_sex_by_age_data)).reset_index(drop=True)
         assert_frame_equal(expected_df, df)
 

--- a/python/tests/test_gcs_to_bq.py
+++ b/python/tests/test_gcs_to_bq.py
@@ -24,7 +24,7 @@ class GcsToBqTest(TestCase):
         mock_attrs = {
             'download_as_string.return_value': json.dumps(self._test_data)}
         mock_blob = Mock(**mock_attrs)
-        frame = gcs_to_bq_util.load_values_blob_as_dataframe(mock_blob)
+        frame = gcs_to_bq_util.load_values_blob_as_df(mock_blob)
 
         self.assertListEqual(list(frame.columns.array),
                              ["label1", "label2", "label3"])
@@ -36,7 +36,7 @@ class GcsToBqTest(TestCase):
     @freeze_time("2020-01-01")
     def testAddDataframeToBq_AutoSchema(self):
         """Tests that autodetect is used when no column_types are provided to
-           add_dataframe_to_bq."""
+           add_df_to_bq."""
         test_frame = DataFrame(
             data=self._test_data[1:], columns=self._test_data[0], index=[1, 2])
 
@@ -47,7 +47,7 @@ class GcsToBqTest(TestCase):
             mock_instance.dataset.return_value = mock_table
             mock_table.table.return_value = 'test-project.test-dataset.table'
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 test_frame.copy(deep=True), "test-dataset", "table")
 
             mock_instance.load_table_from_json.assert_called()
@@ -63,7 +63,7 @@ class GcsToBqTest(TestCase):
     @freeze_time("2020-01-01")
     def testAddDataframeToBq_IgnoreColModes(self):
         """Tests that col_modes is ignored when no column_types are provided
-           to add_dataframe_to_bq."""
+           to add_df_to_bq."""
         test_frame = DataFrame(
             data=self._test_data[1:], columns=self._test_data[0], index=[1, 2])
 
@@ -74,7 +74,7 @@ class GcsToBqTest(TestCase):
             mock_instance.dataset.return_value = mock_table
             mock_table.table.return_value = 'test-project.test-dataset.table'
 
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 test_frame.copy(deep=True), "test-dataset", "table",
                 col_modes={'label1': 'REPEATED', 'label2': 'REQUIRED'})
 
@@ -91,7 +91,7 @@ class GcsToBqTest(TestCase):
     @freeze_time("2020-01-01")
     def testAddDataframeToBq_SpecifySchema(self):
         """Tests that the BigQuery schema is properly defined when column_types
-           are provided to add_dataframe_to_bq."""
+           are provided to add_df_to_bq."""
         test_frame = DataFrame(
             data=self._test_data[1:], columns=self._test_data[0], index=[1, 2])
 
@@ -105,7 +105,7 @@ class GcsToBqTest(TestCase):
             column_types = {label: 'STRING' for label in test_frame.columns}
             col_modes = {'label1': 'REPEATED',
                          'label2': 'REQUIRED'}
-            gcs_to_bq_util.add_dataframe_to_bq(
+            gcs_to_bq_util.add_df_to_bq(
                 test_frame.copy(deep=True), 'test-dataset', 'table',
                 column_types=column_types, col_modes=col_modes)
 
@@ -143,7 +143,7 @@ class GcsToBqTest(TestCase):
         with open(test_file_path, 'w') as f:
             f.write(test_data)
 
-        df = gcs_to_bq_util.load_csv_as_dataframe(
+        df = gcs_to_bq_util.load_csv_as_df(
             'gcs_bucket', 'test_file.csv', parse_dates=['col1'], thousands=',')
         # With parse_dates, col1 should be interpreted as numpy datetime. With
         # thousands=',', numeric columns should be interpreted correctly even if
@@ -154,10 +154,10 @@ class GcsToBqTest(TestCase):
         for col in df.columns:
             self.assertEqual(df[col].dtype, expected_types[col])
 
-        # Re-write the test data since load_csv_as_dataframe removes the file.
+        # Re-write the test data since load_csv_as_df removes the file.
         with open(test_file_path, 'w') as f:
             f.write(test_data)
-        df = gcs_to_bq_util.load_csv_as_dataframe('gcs_bucket', 'test_file.csv')
+        df = gcs_to_bq_util.load_csv_as_df('gcs_bucket', 'test_file.csv')
         # Without the additional read_csv args, the data are inferred to the
         # default np.object type.
         expected_types = {'col1': np.int64, 'col2': np.object,

--- a/run_gcs_to_bq/Dockerfile
+++ b/run_gcs_to_bq/Dockerfile
@@ -11,6 +11,7 @@ ENV APP_HOME /app
 WORKDIR $APP_HOME
 COPY ./run_gcs_to_bq ./run_gcs_to_bq
 COPY ./python ./python
+COPY ./data ./data
 
 # Install production dependencies.
 RUN python -m pip install --upgrade pip


### PR DESCRIPTION
- rather than needing to manually upload acs2010 files, this adds new functions that allow reading directly from the `/data` directory which are then pushed to BigQuery
- brings all functions in line to use `df` instead of some being `dataframe`
- use convention of `pd` for pandas