### PR TITLE
checks in state fips file for testing

### DIFF
--- a/python/tests/data/utils/state_fips.json
+++ b/python/tests/data/utils/state_fips.json
@@ -1,0 +1,344 @@
+[
+  {
+    "state_fips_code": "01",
+    "state_postal_abbreviation": "AL",
+    "state_name": "Alabama",
+    "state_gnisid": "01779775"
+  },
+  {
+    "state_fips_code": "02",
+    "state_postal_abbreviation": "AK",
+    "state_name": "Alaska",
+    "state_gnisid": "01785533"
+  },
+  {
+    "state_fips_code": "04",
+    "state_postal_abbreviation": "AZ",
+    "state_name": "Arizona",
+    "state_gnisid": "01779777"
+  },
+  {
+    "state_fips_code": "05",
+    "state_postal_abbreviation": "AR",
+    "state_name": "Arkansas",
+    "state_gnisid": "00068085"
+  },
+  {
+    "state_fips_code": "06",
+    "state_postal_abbreviation": "CA",
+    "state_name": "California",
+    "state_gnisid": "01779778"
+  },
+  {
+    "state_fips_code": "08",
+    "state_postal_abbreviation": "CO",
+    "state_name": "Colorado",
+    "state_gnisid": "01779779"
+  },
+  {
+    "state_fips_code": "09",
+    "state_postal_abbreviation": "CT",
+    "state_name": "Connecticut",
+    "state_gnisid": "01779780"
+  },
+  {
+    "state_fips_code": "10",
+    "state_postal_abbreviation": "DE",
+    "state_name": "Delaware",
+    "state_gnisid": "01779781"
+  },
+  {
+    "state_fips_code": "11",
+    "state_postal_abbreviation": "DC",
+    "state_name": "District of Columbia",
+    "state_gnisid": "01702382"
+  },
+  {
+    "state_fips_code": "12",
+    "state_postal_abbreviation": "FL",
+    "state_name": "Florida",
+    "state_gnisid": "00294478"
+  },
+  {
+    "state_fips_code": "13",
+    "state_postal_abbreviation": "GA",
+    "state_name": "Georgia",
+    "state_gnisid": "01705317"
+  },
+  {
+    "state_fips_code": "15",
+    "state_postal_abbreviation": "HI",
+    "state_name": "Hawaii",
+    "state_gnisid": "01779782"
+  },
+  {
+    "state_fips_code": "16",
+    "state_postal_abbreviation": "ID",
+    "state_name": "Idaho",
+    "state_gnisid": "01779783"
+  },
+  {
+    "state_fips_code": "17",
+    "state_postal_abbreviation": "IL",
+    "state_name": "Illinois",
+    "state_gnisid": "01779784"
+  },
+  {
+    "state_fips_code": "18",
+    "state_postal_abbreviation": "IN",
+    "state_name": "Indiana",
+    "state_gnisid": "00448508"
+  },
+  {
+    "state_fips_code": "19",
+    "state_postal_abbreviation": "IA",
+    "state_name": "Iowa",
+    "state_gnisid": "01779785"
+  },
+  {
+    "state_fips_code": "20",
+    "state_postal_abbreviation": "KS",
+    "state_name": "Kansas",
+    "state_gnisid": "00481813"
+  },
+  {
+    "state_fips_code": "21",
+    "state_postal_abbreviation": "KY",
+    "state_name": "Kentucky",
+    "state_gnisid": "01779786"
+  },
+  {
+    "state_fips_code": "22",
+    "state_postal_abbreviation": "LA",
+    "state_name": "Louisiana",
+    "state_gnisid": "01629543"
+  },
+  {
+    "state_fips_code": "23",
+    "state_postal_abbreviation": "ME",
+    "state_name": "Maine",
+    "state_gnisid": "01779787"
+  },
+  {
+    "state_fips_code": "24",
+    "state_postal_abbreviation": "MD",
+    "state_name": "Maryland",
+    "state_gnisid": "01714934"
+  },
+  {
+    "state_fips_code": "25",
+    "state_postal_abbreviation": "MA",
+    "state_name": "Massachusetts",
+    "state_gnisid": "00606926"
+  },
+  {
+    "state_fips_code": "26",
+    "state_postal_abbreviation": "MI",
+    "state_name": "Michigan",
+    "state_gnisid": "01779789"
+  },
+  {
+    "state_fips_code": "27",
+    "state_postal_abbreviation": "MN",
+    "state_name": "Minnesota",
+    "state_gnisid": "00662849"
+  },
+  {
+    "state_fips_code": "28",
+    "state_postal_abbreviation": "MS",
+    "state_name": "Mississippi",
+    "state_gnisid": "01779790"
+  },
+  {
+    "state_fips_code": "29",
+    "state_postal_abbreviation": "MO",
+    "state_name": "Missouri",
+    "state_gnisid": "01779791"
+  },
+  {
+    "state_fips_code": "30",
+    "state_postal_abbreviation": "MT",
+    "state_name": "Montana",
+    "state_gnisid": "00767982"
+  },
+  {
+    "state_fips_code": "31",
+    "state_postal_abbreviation": "NE",
+    "state_name": "Nebraska",
+    "state_gnisid": "01779792"
+  },
+  {
+    "state_fips_code": "32",
+    "state_postal_abbreviation": "NV",
+    "state_name": "Nevada",
+    "state_gnisid": "01779793"
+  },
+  {
+    "state_fips_code": "33",
+    "state_postal_abbreviation": "NH",
+    "state_name": "New Hampshire",
+    "state_gnisid": "01779794"
+  },
+  {
+    "state_fips_code": "34",
+    "state_postal_abbreviation": "NJ",
+    "state_name": "New Jersey",
+    "state_gnisid": "01779795"
+  },
+  {
+    "state_fips_code": "35",
+    "state_postal_abbreviation": "NM",
+    "state_name": "New Mexico",
+    "state_gnisid": "00897535"
+  },
+  {
+    "state_fips_code": "36",
+    "state_postal_abbreviation": "NY",
+    "state_name": "New York",
+    "state_gnisid": "01779796"
+  },
+  {
+    "state_fips_code": "37",
+    "state_postal_abbreviation": "NC",
+    "state_name": "North Carolina",
+    "state_gnisid": "01027616"
+  },
+  {
+    "state_fips_code": "38",
+    "state_postal_abbreviation": "ND",
+    "state_name": "North Dakota",
+    "state_gnisid": "01779797"
+  },
+  {
+    "state_fips_code": "39",
+    "state_postal_abbreviation": "OH",
+    "state_name": "Ohio",
+    "state_gnisid": "01085497"
+  },
+  {
+    "state_fips_code": "40",
+    "state_postal_abbreviation": "OK",
+    "state_name": "Oklahoma",
+    "state_gnisid": "01102857"
+  },
+  {
+    "state_fips_code": "41",
+    "state_postal_abbreviation": "OR",
+    "state_name": "Oregon",
+    "state_gnisid": "01155107"
+  },
+  {
+    "state_fips_code": "42",
+    "state_postal_abbreviation": "PA",
+    "state_name": "Pennsylvania",
+    "state_gnisid": "01779798"
+  },
+  {
+    "state_fips_code": "44",
+    "state_postal_abbreviation": "RI",
+    "state_name": "Rhode Island",
+    "state_gnisid": "01219835"
+  },
+  {
+    "state_fips_code": "45",
+    "state_postal_abbreviation": "SC",
+    "state_name": "South Carolina",
+    "state_gnisid": "01779799"
+  },
+  {
+    "state_fips_code": "46",
+    "state_postal_abbreviation": "SD",
+    "state_name": "South Dakota",
+    "state_gnisid": "01785534"
+  },
+  {
+    "state_fips_code": "47",
+    "state_postal_abbreviation": "TN",
+    "state_name": "Tennessee",
+    "state_gnisid": "01325873"
+  },
+  {
+    "state_fips_code": "48",
+    "state_postal_abbreviation": "TX",
+    "state_name": "Texas",
+    "state_gnisid": "01779801"
+  },
+  {
+    "state_fips_code": "49",
+    "state_postal_abbreviation": "UT",
+    "state_name": "Utah",
+    "state_gnisid": "01455989"
+  },
+  {
+    "state_fips_code": "50",
+    "state_postal_abbreviation": "VT",
+    "state_name": "Vermont",
+    "state_gnisid": "01779802"
+  },
+  {
+    "state_fips_code": "51",
+    "state_postal_abbreviation": "VA",
+    "state_name": "Virginia",
+    "state_gnisid": "01779803"
+  },
+  {
+    "state_fips_code": "53",
+    "state_postal_abbreviation": "WA",
+    "state_name": "Washington",
+    "state_gnisid": "01779804"
+  },
+  {
+    "state_fips_code": "54",
+    "state_postal_abbreviation": "WV",
+    "state_name": "West Virginia",
+    "state_gnisid": "01779805"
+  },
+  {
+    "state_fips_code": "55",
+    "state_postal_abbreviation": "WI",
+    "state_name": "Wisconsin",
+    "state_gnisid": "01779806"
+  },
+  {
+    "state_fips_code": "56",
+    "state_postal_abbreviation": "WY",
+    "state_name": "Wyoming",
+    "state_gnisid": "01779807"
+  },
+  {
+    "state_fips_code": "60",
+    "state_postal_abbreviation": "AS",
+    "state_name": "American Samoa",
+    "state_gnisid": "01802701"
+  },
+  {
+    "state_fips_code": "66",
+    "state_postal_abbreviation": "GU",
+    "state_name": "Guam",
+    "state_gnisid": "01802705"
+  },
+  {
+    "state_fips_code": "69",
+    "state_postal_abbreviation": "MP",
+    "state_name": "Northern Mariana Islands",
+    "state_gnisid": "01779809"
+  },
+  {
+    "state_fips_code": "72",
+    "state_postal_abbreviation": "PR",
+    "state_name": "Puerto Rico",
+    "state_gnisid": "01779808"
+  },
+  {
+    "state_fips_code": "74",
+    "state_postal_abbreviation": "UM",
+    "state_name": "U.S. Minor Outlying Islands",
+    "state_gnisid": "01878752"
+  },
+  {
+    "state_fips_code": "78",
+    "state_postal_abbreviation": "VI",
+    "state_name": "U.S. Virgin Islands",
+    "state_gnisid": "01802710"
+  }
+]

--- a/python/tests/datasources/test_utils.py
+++ b/python/tests/datasources/test_utils.py
@@ -1,0 +1,10 @@
+import os
+import pandas as pd
+
+# Current working directory.
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_DIR = os.path.join(THIS_DIR, os.pardir, "data", "utils")
+
+
+def get_state_fips_codes_as_df():
+    return pd.read_json(os.path.join(TEST_DIR, 'state_fips.json'), dtype=str)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a checked in state fips file so we can mock out the call to big query to merge in state fips codes.

To use it add the following decoration ontop of every test function that merges in state fips codes using [the merge_fips_codes function](https://github.com/SatcherInstitute/health-equity-tracker/blob/3ce95d2637c56bda34c1127fd29830dbddaf08dd/python/ingestion/dataset_utils.py#L111-L126)
```
@mock.patch('ingestion.gcs_to_bq_util.load_public_dataset_from_bigquery_as_df',
            return_value=test_utils.get_state_fips_codes_as_df())
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Chore (developer productivity fix that doesn't affect the user)
