### PR TITLE
switch to using TOTAL as the standard population for age adjustment 

### DIFF
--- a/python/datasources/age_adjust_cdc_restricted.py
+++ b/python/datasources/age_adjust_cdc_restricted.py
@@ -9,6 +9,7 @@ from ingestion import gcs_to_bq_util
 from ingestion import dataset_utils
 
 REFERENCE_POPULATION = std_col.Race.TOTAL.value
+BASE_POPULATION = std_col.Race.WHITE_NH.value
 
 AGE_ADJUST_RACES = {std_col.Race.WHITE_NH.value, std_col.Race.BLACK_NH.value, std_col.Race.HISP.value,
                     std_col.Race.AIAN_NH.value, std_col.Race.NHPI_NH.value, std_col.Race.ASIAN_NH.value}
@@ -218,9 +219,9 @@ def age_adjust_from_expected(df):
 
     def get_age_adjusted_death_rate(row):
         ref_pop_expected_deaths = df.loc[
-                (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+                (df[std_col.RACE_CATEGORY_ID_COL] == BASE_POPULATION) &
                 (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.COVID_DEATH_Y].values[0]
+            ]['expected_deaths'].values[0]
 
         if not ref_pop_expected_deaths:
             return None
@@ -229,9 +230,9 @@ def age_adjust_from_expected(df):
 
     def get_age_adjusted_hosp_rate(row):
         ref_pop_expected_hosp = df.loc[
-                (df[std_col.RACE_CATEGORY_ID_COL] == REFERENCE_POPULATION) &
+                (df[std_col.RACE_CATEGORY_ID_COL] == BASE_POPULATION) &
                 (df[std_col.STATE_FIPS_COL] == row[std_col.STATE_FIPS_COL])
-            ][std_col.COVID_HOSP_Y].values[0]
+            ]['expected_hosps'].values[0]
 
         if not ref_pop_expected_hosp:
             return None

--- a/python/datasources/age_adjust_cdc_restricted.py
+++ b/python/datasources/age_adjust_cdc_restricted.py
@@ -8,7 +8,7 @@ from datasources.data_source import DataSource
 from ingestion import gcs_to_bq_util
 from ingestion import dataset_utils
 
-REFERENCE_POPULATION = std_col.Race.WHITE_NH.value
+REFERENCE_POPULATION = std_col.Race.TOTAL.value
 
 AGE_ADJUST_RACES = {std_col.Race.WHITE_NH.value, std_col.Race.BLACK_NH.value, std_col.Race.HISP.value,
                     std_col.Race.AIAN_NH.value, std_col.Race.NHPI_NH.value, std_col.Race.ASIAN_NH.value}

--- a/python/datasources/census_pop_estimates.py
+++ b/python/datasources/census_pop_estimates.py
@@ -88,8 +88,7 @@ def generate_state_pop_data(df):
         age_df[std_col.AGE_COL] = std_age
 
         for state_fips in age_df['STATE'].drop_duplicates().to_list():
-            state_name = age_df.loc[age_df['STATE'] == state_fips]['STNAME'].drop_duplicates().to_list()[
-                0]
+            state_name = age_df.loc[age_df['STATE'] == state_fips]['STNAME'].drop_duplicates().to_list()[0]
 
             for race in RACES_MAP.values():
                 pop_row = {}

--- a/python/tests/data/age_adjustment/age_adjusted.json
+++ b/python/tests/data/age_adjustment/age_adjusted.json
@@ -16,8 +16,8 @@
     "race": "Hispanic or Latino",
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
-    "death_ratio_age_adjusted": 3.4,
-    "hosp_ratio_age_adjusted": 3.4
+    "death_ratio_age_adjusted": 3.3,
+    "hosp_ratio_age_adjusted": 3.3
   },
   {
     "state_fips": "01",

--- a/python/tests/data/age_adjustment/cdc_restricted-by_race_national-with_age_adjust.json
+++ b/python/tests/data/age_adjustment/cdc_restricted-by_race_national-with_age_adjust.json
@@ -16,7 +16,7 @@
     "race": "Hispanic or Latino",
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
-    "death_ratio_age_adjusted": 3.4,
+    "death_ratio_age_adjusted": 3.3,
     "hosp_ratio_age_adjusted": 4.4
   },
   {

--- a/python/tests/data/age_adjustment/cdc_restricted-by_race_state-with_age_adjust.json
+++ b/python/tests/data/age_adjustment/cdc_restricted-by_race_state-with_age_adjust.json
@@ -48,7 +48,7 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "Black or African American (Non-Hispanic)",
     "death_ratio_age_adjusted": null,
-    "hosp_ratio_age_adjusted": 1.0
+    "hosp_ratio_age_adjusted": 0.7
   },
   {
     "state_fips": "06",
@@ -60,7 +60,7 @@
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
     "death_ratio_age_adjusted": null,
-    "hosp_ratio_age_adjusted": 21.2
+    "hosp_ratio_age_adjusted": 13.3
   },
   {
     "state_fips": "06",

--- a/python/tests/data/age_adjustment/cdc_restricted-by_race_state-with_age_adjust.json
+++ b/python/tests/data/age_adjustment/cdc_restricted-by_race_state-with_age_adjust.json
@@ -22,8 +22,8 @@
     "race": "Hispanic or Latino",
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
-    "death_ratio_age_adjusted": 3.4,
-    "hosp_ratio_age_adjusted": 3.4
+    "death_ratio_age_adjusted": 3.3,
+    "hosp_ratio_age_adjusted": 3.3
   },
   {
     "state_fips": "01",

--- a/python/tests/data/age_adjustment/census_pop_estimates.csv
+++ b/python/tests/data/age_adjustment/census_pop_estimates.csv
@@ -2,36 +2,48 @@ state_fips,state_name,age,population,race_category_id,race,race_includes_hispani
 01,Alabama,0-29,600000,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,0-29,200000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,0-29,10000,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,0-29,810000,TOTAL,Total,,Total
 01,Alabama,30-59,800000,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,30-59,300000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,30-59,60000,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,30-59,1160000,TOTAL,Total,,Total
 01,Alabama,60+,200000,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,60+,60000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,60+,6000,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,60+,266000,TOTAL,Total,,Total
 01,Alabama,All,1600000,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,All,560000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,All,76000,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,All,2236000,TOTAL,Total,,Total
 06,California,0-29,10000,WHITE_NH,White,False,White (Non-Hispanic)
 06,California,0-29,22000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 06,California,0-29,130000,HISP,Hispanic or Latino,True,Hispanic or Latino
+06,California,0-29,162000,TOTAL,Total,,Total
 06,California,30-59,8400000,WHITE_NH,White,False,White (Non-Hispanic)
 06,California,30-59,3500000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 06,California,30-59,660000,HISP,Hispanic or Latino,True,Hispanic or Latino
+06,California,30-59,12560000,TOTAL,Total,,Total
 06,California,60+,2600000,WHITE_NH,White,False,White (Non-Hispanic)
 06,California,60+,670000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 06,California,60+,66000,HISP,Hispanic or Latino,True,Hispanic or Latino
+06,California,60+,3336000,TOTAL,Total,,Total
 06,California,All,11010000,WHITE_NH,White,False,White (Non-Hispanic)
 06,California,All,5460000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 06,California,All,7446000,HISP,Hispanic or Latino,True,Hispanic or Latino
+06,California,All,23916000,TOTAL,Total,,Total
 10,Delaware,0-29,10000,WHITE_NH,White,False,White (Non-Hispanic)
 10,Delaware,0-29,22000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 10,Delaware,0-29,130000,HISP,Hispanic or Latino,True,Hispanic or Latino
+10,Delaware,0-29,162000,TOTAL,Total,,Total
 10,Delaware,30-59,8400000,WHITE_NH,White,False,White (Non-Hispanic)
 10,Delaware,30-59,3500000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 10,Delaware,30-59,660000,HISP,Hispanic or Latino,True,Hispanic or Latino
+10,Delaware,30-59,12560000,TOTAL,Total,,Total
 10,Delaware,60+,2600000,WHITE_NH,White,False,White (Non-Hispanic)
 10,Delaware,60+,670000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 10,Delaware,60+,66000,HISP,Hispanic or Latino,True,Hispanic or Latino
+10,Delaware,60+,3336000,TOTAL,Total,,Total
 10,Delaware,All,165500000,WHITE_NH,White,False,White (Non-Hispanic)
 10,Delaware,All,5460000,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 10,Delaware,All,7446000,HISP,Hispanic or Latino,True,Hispanic or Latino
+10,Delaware,All,178406000,TOTAL,Total,,Total

--- a/python/tests/data/age_adjustment/expected_deaths.json
+++ b/python/tests/data/age_adjustment/expected_deaths.json
@@ -10,8 +10,8 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "Black or African American (Non-Hispanic)",
     "age": "0-29",
-    "expected_deaths": 60.0,
-    "expected_hosps": 60.0
+    "expected_deaths": 81.0,
+    "expected_hosps": 81.0
   },
   {
     "state_fips": "01",
@@ -24,8 +24,8 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "Black or African American (Non-Hispanic)",
     "age": "30-59",
-    "expected_deaths": 533.33,
-    "expected_hosps": 533.33
+    "expected_deaths": 773.33,
+    "expected_hosps": 773.33
   },
   {
     "state_fips": "01",
@@ -38,8 +38,8 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "Black or African American (Non-Hispanic)",
     "age": "60+",
-    "expected_deaths": 2666.67,
-    "expected_hosps": 2666.67
+    "expected_deaths": 3546.67,
+    "expected_hosps": 3546.67
   },
   {
     "state_fips": "01",
@@ -52,8 +52,8 @@
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
     "age": "0-29",
-    "expected_deaths": 600,
-    "expected_hosps": 600
+    "expected_deaths": 810,
+    "expected_hosps": 810
   },
   {
     "state_fips": "01",
@@ -66,8 +66,8 @@
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
     "age": "30-59",
-    "expected_deaths": 1333.33,
-    "expected_hosps": 1333.33
+    "expected_deaths": 1933.33,
+    "expected_hosps": 1933.33
   },
   {
     "state_fips": "01",
@@ -80,8 +80,8 @@
     "race_includes_hispanic": true,
     "race_and_ethnicity": "Hispanic or Latino",
     "age": "60+",
-    "expected_deaths": 16666.67,
-    "expected_hosps": 16666.67
+    "expected_deaths": 22166.67,
+    "expected_hosps": 22166.67
   },
   {
     "state_fips": "01",
@@ -94,8 +94,8 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "White (Non-Hispanic)",
     "age": "0-29",
-    "expected_deaths": 50,
-    "expected_hosps": 50
+    "expected_deaths": 67.5,
+    "expected_hosps": 67.5
   },
   {
     "state_fips": "01",
@@ -108,8 +108,8 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "White (Non-Hispanic)",
     "age": "30-59",
-    "expected_deaths": 500,
-    "expected_hosps": 500
+    "expected_deaths": 725,
+    "expected_hosps": 725
   },
   {
     "state_fips": "01",
@@ -122,7 +122,7 @@
     "race_includes_hispanic": false,
     "race_and_ethnicity": "White (Non-Hispanic)",
     "age": "60+",
-    "expected_deaths": 5000,
-    "expected_hosps": 5000
+    "expected_deaths": 6650,
+    "expected_hosps": 6650
   }
 ]

--- a/python/tests/data/census_pop_estimates/census_pop_estimates-race_ethnicity_age_national.csv
+++ b/python/tests/data/census_pop_estimates/census_pop_estimates-race_ethnicity_age_national.csv
@@ -4,58 +4,68 @@ state_fips,state_name,age,population,race_category_id,race,race_includes_hispani
 00,United States,0-9,2842,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,0-9,654,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,0-9,12,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,0-9,14263,TOTAL,Total,,Total
 00,United States,0-9,9868,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,10-19,44,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,10-19,154,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,10-19,3347,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,10-19,661,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,10-19,18,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,10-19,15770,TOTAL,Total,,Total
 00,United States,10-19,11079,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,20-29,71,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,20-29,175,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,20-29,3218,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,20-29,521,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,20-29,4,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,20-29,14622,TOTAL,Total,,Total
 00,United States,20-29,10348,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,30-39,65,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,30-39,259,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,30-39,3191,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,30-39,609,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,30-39,12,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,30-39,15327,TOTAL,Total,,Total
 00,United States,30-39,11003,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,40-49,69,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,40-49,264,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,40-49,3144,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,40-49,508,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,40-49,17,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,40-49,15717,TOTAL,Total,,Total
 00,United States,40-49,11561,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,50-59,102,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,50-59,159,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,50-59,2704,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,50-59,327,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,50-59,12,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,50-59,16322,TOTAL,Total,,Total
 00,United States,50-59,12912,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,60-69,79,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,60-69,130,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,60-69,2267,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,60-69,163,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,60-69,4,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,60-69,13183,TOTAL,Total,,Total
 00,United States,60-69,10436,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,70-79,76,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,70-79,59,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,70-79,1016,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,70-79,108,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,70-79,0,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,70-79,8833,TOTAL,Total,,Total
 00,United States,70-79,7512,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,80+,25,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,80+,37,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,80+,512,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,80+,76,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,80+,2,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,80+,4628,TOTAL,Total,,Total
 00,United States,80+,3947,WHITE_NH,White,FALSE,White (Non-Hispanic)
 00,United States,All,593,AIAN_NH,American Indian and Alaska Native,FALSE,American Indian and Alaska Native (Non-Hispanic)
 00,United States,All,1405,ASIAN_NH,Asian,FALSE,Asian (Non-Hispanic)
 00,United States,All,22241,BLACK_NH,Black or African American,FALSE,Black or African American (Non-Hispanic)
 00,United States,All,3627,HISP,Hispanic or Latino,TRUE,Hispanic or Latino
 00,United States,All,81,NHPI_NH,Native Hawaiian and Pacific Islander,FALSE,Native Hawaiian and Pacific Islander (Non-Hispanic)
+00,United States,All,118665,TOTAL,Total,,Total
 00,United States,All,88666,WHITE_NH,White,FALSE,White (Non-Hispanic)

--- a/python/tests/data/census_pop_estimates/census_pop_estimates-race_ethnicity_age_state.csv
+++ b/python/tests/data/census_pop_estimates/census_pop_estimates-race_ethnicity_age_state.csv
@@ -5,117 +5,137 @@ state_fips,state_name,age,population,race_category_id,race,race_includes_hispani
 01,Alabama,0-9,166,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,0-9,12,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,0-9,608,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,0-9,13484,TOTAL,Total,,Total
 01,Alabama,10-19,10420,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,10-19,3340,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,10-19,32,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,10-19,150,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,10-19,18,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,10-19,620,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,10-19,15020,TOTAL,Total,,Total
 01,Alabama,20-29,9770,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,20-29,3210,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,20-29,58,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,20-29,172,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,20-29,4,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,20-29,474,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,20-29,13954,TOTAL,Total,,Total
 01,Alabama,30-39,10192,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,30-39,3182,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,30-39,50,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,30-39,210,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,30-39,12,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,30-39,566,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,30-39,14388,TOTAL,Total,,Total
 01,Alabama,40-49,10892,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,40-49,3136,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,40-49,48,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,40-49,260,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,40-49,16,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,40-49,466,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,40-49,14962,TOTAL,Total,,Total
 01,Alabama,50-59,11996,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,50-59,2696,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,50-59,90,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,50-59,156,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,50-59,12,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,50-59,296,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,50-59,15342,TOTAL,Total,,Total
 01,Alabama,60-69,9456,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,60-69,2262,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,60-69,66,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,60-69,84,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,60-69,4,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,60-69,142,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,60-69,12106,TOTAL,Total,,Total
 01,Alabama,70-79,6950,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,70-79,1016,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,70-79,72,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,70-79,58,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,70-79,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,70-79,100,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,70-79,8252,TOTAL,Total,,Total
 01,Alabama,80+,3562,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,80+,512,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,80+,22,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,80+,36,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,80+,2,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,80+,70,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,80+,4230,TOTAL,Total,,Total
 01,Alabama,All,82430,WHITE_NH,White,False,White (Non-Hispanic)
 01,Alabama,All,22196,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 01,Alabama,All,486,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 01,Alabama,All,1292,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 01,Alabama,All,80,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 01,Alabama,All,3342,HISP,Hispanic or Latino,True,Hispanic or Latino
+01,Alabama,All,111738,TOTAL,Total,,Total
 56,Wyoming,0-9,676,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,0-9,0,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,0-9,14,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,0-9,2,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,0-9,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,0-9,46,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,0-9,779,TOTAL,Total,,Total
 56,Wyoming,10-19,659,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,10-19,7,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,10-19,12,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,10-19,4,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,10-19,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,10-19,41,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,10-19,750,TOTAL,Total,,Total
 56,Wyoming,20-29,578,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,20-29,8,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,20-29,13,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,20-29,3,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,20-29,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,20-29,47,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,20-29,668,TOTAL,Total,,Total
 56,Wyoming,30-39,811,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,30-39,9,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,30-39,15,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,30-39,49,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,30-39,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,30-39,43,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,30-39,939,TOTAL,Total,,Total
 56,Wyoming,40-49,669,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,40-49,8,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,40-49,21,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,40-49,4,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,40-49,1,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,40-49,42,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,40-49,755,TOTAL,Total,,Total
 56,Wyoming,50-59,916,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,50-59,8,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,50-59,12,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,50-59,3,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,50-59,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,50-59,31,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,50-59,980,TOTAL,Total,,Total
 56,Wyoming,60-69,980,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,60-69,5,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,60-69,13,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,60-69,46,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,60-69,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,60-69,21,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,60-69,1077,TOTAL,Total,,Total
 56,Wyoming,70-79,562,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,70-79,0,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,70-79,4,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,70-79,1,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,70-79,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,70-79,8,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,70-79,581,TOTAL,Total,,Total
 56,Wyoming,80+,385,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,80+,0,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,80+,3,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,80+,1,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,80+,0,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,80+,6,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,80+,398,TOTAL,Total,,Total
 56,Wyoming,All,6236,WHITE_NH,White,False,White (Non-Hispanic)
 56,Wyoming,All,45,BLACK_NH,Black or African American,False,Black or African American (Non-Hispanic)
 56,Wyoming,All,107,AIAN_NH,American Indian and Alaska Native,False,American Indian and Alaska Native (Non-Hispanic)
 56,Wyoming,All,113,ASIAN_NH,Asian,False,Asian (Non-Hispanic)
 56,Wyoming,All,1,NHPI_NH,Native Hawaiian and Pacific Islander,False,Native Hawaiian and Pacific Islander (Non-Hispanic)
 56,Wyoming,All,285,HISP,Hispanic or Latino,True,Hispanic or Latino
+56,Wyoming,All,6927,TOTAL,Total,,Total


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Uses the Total population breakdown of each state as the standard population for age adjustment.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
For #966, and in response to expert feedback we had on using `White (Non-Hispanic)` as the standard population.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Yes, testes were updated. 


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- New feature (non-breaking change which adds functionality)
