### PR TITLE
fix bug with `covid_vaccinations`

### DIFF
--- a/frontend/public/sitemap.txt
+++ b/frontend/public/sitemap.txt
@@ -4,7 +4,7 @@ https://healthequitytracker.org/faqs
 https://healthequitytracker.org/resources
 https://healthequitytracker.org/exploredata
 https://healthequitytracker.org/exploredata?mls=1.covid-3.00-5.13&amp;mlp=comparegeos
-https://healthequitytracker.org/exploredata?mls=1.covid-3.vaccinations-5.00&amp;mlp=comparevars
+https://healthequitytracker.org/exploredata?mls=1.covid-3.covid_vaccinations-5.00&amp;mlp=comparevars
 https://healthequitytracker.org/exploredata?mls=1.covid-3.06037-5.36061&amp;mlp=comparegeos
 https://healthequitytracker.org/exploredata?mls=1.depression-3.06075&amp;mlp=disparity
 https://healthequitytracker.org/exploredata?mls=1.excessive_drinking-3.26&amp;mlp=disparity

--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -59,7 +59,7 @@ export interface TableCardProps {
 // We need to get this property, but we want to show it as
 // part of the "population_pct" column, and not as its own column
 export const NEVER_SHOW_PROPERTIES = [
-  METRIC_CONFIG.vaccinations[0]?.metrics?.pct_share
+  METRIC_CONFIG.covid_vaccinations[0]?.metrics?.pct_share
     ?.secondaryPopulationComparisonMetric,
 ];
 

--- a/frontend/src/cards/storybook/MapCard.stories.tsx
+++ b/frontend/src/cards/storybook/MapCard.stories.tsx
@@ -35,7 +35,7 @@ CovidPer100kMap.args = {
 
 export const VaccinesPer100kMap = Template.bind({});
 VaccinesPer100kMap.args = {
-  variableConfig: METRIC_CONFIG["vaccinations"][0],
+  variableConfig: METRIC_CONFIG["covid_vaccinations"][0],
   currentBreakdown: RACE,
 };
 

--- a/frontend/src/cards/storybook/UnknownsMapCard.stories.tsx
+++ b/frontend/src/cards/storybook/UnknownsMapCard.stories.tsx
@@ -37,6 +37,6 @@ CovidPercentShareMap.args = {
 
 export const VaccinePercentShareMap = Template.bind({});
 VaccinePercentShareMap.args = {
-  variableConfig: METRIC_CONFIG["vaccinations"][0],
+  variableConfig: METRIC_CONFIG["covid_vaccinations"][0],
   currentBreakdown: RACE,
 };

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -5,7 +5,7 @@ export type DropdownVarId =
   | "copd"
   | "health_insurance"
   | "poverty"
-  | "vaccinations"
+  | "covid_vaccinations"
   | "depression"
   | "suicide"
   | "substance"
@@ -28,12 +28,10 @@ export type VariableId =
   | "covid_hospitalizations"
   | "non_medical_drug_use"
   | "non_medical_rx_opioid_use"
-  | "illicit_opioid_use"
-  | "covid_vaccinations";
+  | "illicit_opioid_use";
 
 // consts for simpler code
-export const VAXX: DropdownVarId = "vaccinations";
-export const COVID_VAXX: VariableId = "covid_vaccinations";
+export const COVID_VAXX: DropdownVarId = "covid_vaccinations";
 
 export type MetricId =
   | "acs_vaccine_population_pct"
@@ -235,7 +233,7 @@ export function getPer100kAndPctShareMetrics(
 // Note: metrics must be declared in a consistent order because the UI relies
 // on this to build toggles.
 // TODO: make the UI consistent regardless of metric config order.
-export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
+export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
   covid: [
     {
       variableId: "covid_cases",
@@ -374,9 +372,9 @@ export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
     },
   ],
 
-  vaccinations: [
+  covid_vaccinations: [
     {
-      variableId: "vaccinations",
+      variableId: "covid_vaccinations",
       variableDisplayName: "Vaccinations",
       variableFullDisplayName: "COVID-19 Vaccinations",
       variableDefinition: `For the national level and most states this indicates people who have received at least one dose of a COVID-19 vaccine.`,
@@ -402,7 +400,7 @@ export const METRIC_CONFIG: Record<string, VariableConfig[]> = {
           knownBreakdownComparisonMetric: {
             metricId: "vaccinated_share_of_known",
             fullCardTitleName: "Share Of Total COVID-19 Vaccinations",
-            shortLabel: "% of COVID-19 vaccinations",
+            shortLabel: "% of vaccinations",
             type: "pct_share",
           },
           secondaryPopulationComparisonMetric: {

--- a/frontend/src/pages/AboutUs/TheProjectTab.tsx
+++ b/frontend/src/pages/AboutUs/TheProjectTab.tsx
@@ -20,7 +20,7 @@ import { usePrefersReducedMotion } from "../../utils/usePrefersReducedMotion";
 import { Helmet } from "react-helmet-async";
 import LazyLoad from "react-lazyload";
 import { DataSourceMetadataMap } from "../../data/config/MetadataMap";
-import { METRIC_CONFIG } from "../../data/config/MetricConfig";
+import { DropdownVarId, METRIC_CONFIG } from "../../data/config/MetricConfig";
 import FeedbackBox from "../ui/FeedbackBox";
 import { DEMOGRAPHIC_BREAKDOWNS } from "../../data/query/Breakdowns";
 
@@ -73,7 +73,8 @@ function TheProjectTab() {
   // tally number of conditions (including sub-conditions like COVID) x # demographic options
   const numVariables =
     Object.keys(METRIC_CONFIG).reduce(
-      (tally, conditionKey) => (tally += METRIC_CONFIG[conditionKey].length),
+      (tally, conditionKey) =>
+        (tally += METRIC_CONFIG[conditionKey as DropdownVarId].length),
       0
     ) * DEMOGRAPHIC_BREAKDOWNS.length;
 

--- a/frontend/src/reports/OneVariableReport.tsx
+++ b/frontend/src/reports/OneVariableReport.tsx
@@ -12,7 +12,7 @@ import {
   DropdownVarId,
   METRIC_CONFIG,
   VariableConfig,
-  VAXX,
+  COVID_VAXX,
 } from "../data/config/MetricConfig";
 import { BreakdownVar, DEMOGRAPHIC_BREAKDOWNS } from "../data/query/Breakdowns";
 import { RACE } from "../data/utils/Constants";
@@ -172,7 +172,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
       {variableConfig && (
         <Grid container spacing={1} justifyContent="center">
           {/* DEMOGRAPHIC / DATA TYPE TOGGLE(S) */}
-          {!(props.dropdownVarId === VAXX && props.fips.isCounty()) && (
+          {!(props.dropdownVarId === COVID_VAXX && props.fips.isCounty()) && (
             <Grid item container xs={12} md={SINGLE_COLUMN_WIDTH}>
               <ReportToggleControls
                 dropdownVarId={props.dropdownVarId}

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -12,7 +12,7 @@ import {
   METRIC_CONFIG,
   VariableConfig,
   VariableId,
-  VAXX,
+  COVID_VAXX,
 } from "../data/config/MetricConfig";
 import { BreakdownVar, DEMOGRAPHIC_BREAKDOWNS } from "../data/query/Breakdowns";
 import { RACE } from "../data/utils/Constants";
@@ -138,7 +138,9 @@ function TwoVariableReport(props: {
 
           {/* 2 SETS OF DEMOGRAPHIC AND DATA TYPE TOGGLES */}
           <Grid container>
-            {!(props.dropdownVarId1 === VAXX && props.fips1.isCounty()) && (
+            {!(
+              props.dropdownVarId1 === COVID_VAXX && props.fips1.isCounty()
+            ) && (
               <Grid item xs={12} sm={6}>
                 <ReportToggleControls
                   dropdownVarId={props.dropdownVarId1}
@@ -149,7 +151,9 @@ function TwoVariableReport(props: {
                 />
               </Grid>
             )}
-            {!(props.dropdownVarId2 === VAXX && props.fips2.isCounty()) && (
+            {!(
+              props.dropdownVarId2 === COVID_VAXX && props.fips2.isCounty()
+            ) && (
               <Grid item xs={12} sm={6}>
                 <ReportToggleControls
                   dropdownVarId={props.dropdownVarId2}
@@ -167,7 +171,9 @@ function TwoVariableReport(props: {
           <Grid item xs={12} sm={6} id="populationCard">
             {/* FIRST POPULATION CARD FOR COMPARE RATES REPORT */}
             <PopulationCard jumpToData={props.jumpToData} fips={props.fips1} />
-            {!(props.dropdownVarId1 === VAXX && props.fips1.isCounty()) && (
+            {!(
+              props.dropdownVarId1 === COVID_VAXX && props.fips1.isCounty()
+            ) && (
               /* FIRST TOGGLE(S) FOR COMPARE RATES REPORT */
               <ReportToggleControls
                 dropdownVarId={props.dropdownVarId1}
@@ -181,7 +187,9 @@ function TwoVariableReport(props: {
           <Grid item xs={12} sm={6}>
             {/* SECOND POPULATION CARD FOR COMPARE RATES REPORT */}
             <PopulationCard jumpToData={props.jumpToData} fips={props.fips2} />
-            {!(props.dropdownVarId2 === VAXX && props.fips2.isCounty()) && (
+            {!(
+              props.dropdownVarId2 === COVID_VAXX && props.fips2.isCounty()
+            ) && (
               /* SECOND TOGGLE(S) FOR COMPARE RATES REPORT */
               <ReportToggleControls
                 dropdownVarId={props.dropdownVarId2}

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -76,10 +76,12 @@ If a condition contains multiple data types, they are
 treated as individual items  */
 export function getSelectedConditions(madLib: MadLib) {
   const condition1array: VariableConfig[] =
-    METRIC_CONFIG[getPhraseValue(madLib, 1)];
+    METRIC_CONFIG[getPhraseValue(madLib, 1) as DropdownVarId];
   // get 2nd condition if in compare var mode
   const condition2array: VariableConfig[] =
-    madLib.id === "comparevars" ? METRIC_CONFIG[getPhraseValue(madLib, 3)] : [];
+    madLib.id === "comparevars"
+      ? METRIC_CONFIG[getPhraseValue(madLib, 3) as DropdownVarId]
+      : [];
 
   // make a list of conditions and sub-conditions, including #2 if it's unique
   return condition2array.length && condition2array !== condition1array
@@ -93,7 +95,7 @@ const DROPDOWN_VAR: Record<DropdownVarId, string> = {
   copd: "COPD",
   health_insurance: "Uninsured Individuals",
   poverty: "Poverty",
-  vaccinations: "COVID-19 Vaccinations",
+  covid_vaccinations: "COVID-19 Vaccinations",
   depression: "Depression",
   suicide: "Suicide",
   substance: "Opioid and Other Substance Misuse",
@@ -117,7 +119,7 @@ const CATEGORIES_LIST: Category[] = [
   {
     title: "COVID-19",
     definition: "",
-    options: ["covid", "vaccinations"],
+    options: ["covid", "covid_vaccinations"],
   },
   {
     title: "Political Determinants of Health",

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -33,7 +33,7 @@ export const NEWS_TAB_LINK = "/news";
 // TRACKER SETTINGS
 export const COVID_HOSP_NY_COUNTY_SETTING =
   "?dt1=hospitalizations&mls=1.covid-3.36061";
-export const COVID_VAX_US_SETTING = "?mls=1.vaccinations-3.00";
+export const COVID_VAX_US_SETTING = "?mls=1.covid_vaccinations-3.00";
 export const COPD_US_SETTING = "?mls=1.copd-3.00";
 export const DIABETES_US_SETTING = "?mls=1.diabetes-3.00";
 export const UNINSURANCE_US_SETTING = "?mls=1.health_insurance-3.00";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1532--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.covid_vaccinations-5.00&mlp=comparevars" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

There was a bug where going into compare view for two conditions including covid vaccinations would crash the page. This is because the code logic was looking at the VariableConfig's name which was `vaccinations` but I had updated the rest of the code to use unique and more explicit VariableIds including `covid_vaccinations`.


## Solution

- Updated this particular config to use a consistent name of `covid_vaccinations`
- added stronger typing so that the name of a metric config item needs to be a `DropdownVarId` and not just a string. If this typing was in place we could have avoided this error



## How has this been tested?
manually. We need to implement e2e testing to at least check each carousel mode and a handful of UI settings


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

