### PR TITLE
adds merge_pop_numbers function

### DIFF
--- a/python/ingestion/dataset_utils.py
+++ b/python/ingestion/dataset_utils.py
@@ -124,3 +124,30 @@ def merge_fips_codes(df):
     df = df.rename(columns={'state_fips_code': std_col.STATE_FIPS_COL}).reset_index(drop=True)
 
     return df
+
+
+def merge_pop_numbers(df, demo, loc):
+    """Merges the corresponding `population` and `population_pct` column into the given df
+
+      df: a pandas with demogrpahic and a `state_fips` column
+      demo: the demographic in the df, either `age`, `race`, or `sex`
+      loc: the location level for the df, either `state` or `national`"""
+
+    on_col_map = {
+        'age': std_col.AGE_COL,
+        'race': std_col.RACE_CATEGORY_ID_COL,
+        'sex': std_col.SEX_COL,
+    }
+
+    if demo not in on_col_map:
+        raise ValueError('%s not a demographic option, must be one of: %s' % (demo, on_col_map.keys()))
+
+    pop_table_name = 'by_%s_%s' % (demo, loc)
+    if demo == 'race' and loc == 'state':
+        pop_table_name += '_std'
+
+    pop_df = gcs_to_bq_util.load_df_from_bigquery('acs_population', pop_table_name, dtype={'state_fips': str})
+    pop_df = pop_df[[std_col.STATE_FIPS_COL, on_col_map[demo], std_col.POPULATION_COL, std_col.POPULATION_PCT_COL]]
+
+    df = pd.merge(df, pop_df, how='left', on=[std_col.STATE_FIPS_COL, on_col_map[demo]])
+    return df.reset_index(drop=True)

--- a/python/ingestion/dataset_utils.py
+++ b/python/ingestion/dataset_utils.py
@@ -129,7 +129,7 @@ def merge_fips_codes(df):
 def merge_pop_numbers(df, demo, loc):
     """Merges the corresponding `population` and `population_pct` column into the given df
 
-      df: a pandas with demogrpahic and a `state_fips` column
+      df: a pandas df with demographic (race, sex, or age) and a `state_fips` column
       demo: the demographic in the df, either `age`, `race`, or `sex`
       loc: the location level for the df, either `state` or `national`"""
 

--- a/python/tests/ingestion/test_dataset_utils.py
+++ b/python/tests/ingestion/test_dataset_utils.py
@@ -71,7 +71,6 @@ _expected_race_data_with_totals = [
     ['04', 'Arizona', 'TOTAL', '95'],
 ]
 
-
 _data_without_fips_codes = [
     ['state_name', 'other_col'],
     ['United States', 'something_cool'],
@@ -79,13 +78,11 @@ _data_without_fips_codes = [
     ['Georgia', 'something_else'],
 ]
 
-
 _fips_codes_from_bq = [
     ['state_fips_code', 'state_postal_abbreviation', 'state_name', 'state_gnisid'],
     ['06', 'CA', 'California', '01779778'],
     ['13', 'GA', 'Georgia', '01705317'],
 ]
-
 
 _expected_merged_fips = [
     ['state_name', 'other_col', 'state_fips'],
@@ -94,10 +91,37 @@ _expected_merged_fips = [
     ['Georgia', 'something_else', '13'],
 ]
 
+_data_without_pop_numbers = [
+    ['state_fips', 'race_category_id', 'other_col'],
+    ['01', 'BLACK_NH', 'something_cool'],
+    ['01', 'WHITE_NH', 'something_else_cool'],
+    ['02', 'BLACK_NH', 'something_cooler'],
+]
+
+_pop_data = [
+    ['state_fips', 'race_category_id', 'population', 'population_pct'],
+    ['01', 'BLACK_NH', '100', '25'],
+    ['01', 'WHITE_NH', '300', '75'],
+    ['02', 'BLACK_NH', '100', '50'],
+    ['100', 'BLACK_NH', '100', '50'],
+]
+
+_expected_merged_with_pop_numnbers = [
+    ['state_fips', 'race_category_id', 'population', 'population_pct', 'other_col'],
+    ['01', 'BLACK_NH', '100', '25', 'something_cool'],
+    ['01', 'WHITE_NH', '300', '75', 'something_else_cool'],
+    ['02', 'BLACK_NH', '100', '50', 'something_cooler'],
+]
+
 
 def _get_fips_codes_as_df():
     return gcs_to_bq_util.values_json_to_df(
         json.dumps(_fips_codes_from_bq), dtype=str).reset_index(drop=True)
+
+
+def _get_pop_data_as_df():
+    return gcs_to_bq_util.values_json_to_df(
+        json.dumps(_pop_data), dtype=str).reset_index(drop=True)
 
 
 def testRatioRoundToNone():
@@ -188,6 +212,21 @@ def testMergeFipsCodes(mock_bq: mock.MagicMock):
         json.dumps(_expected_merged_fips), dtype=str).reset_index(drop=True)
 
     df = dataset_utils.merge_fips_codes(df)
+
+    assert mock_bq.call_count == 1
+    assert_frame_equal(df, expected_df, check_like=True)
+
+
+@mock.patch('ingestion.gcs_to_bq_util.load_df_from_bigquery',
+            return_value=_get_pop_data_as_df())
+def testMergePopNumbers(mock_bq: mock.MagicMock):
+    df = gcs_to_bq_util.values_json_to_df(
+        json.dumps(_data_without_pop_numbers), dtype=str).reset_index(drop=True)
+
+    expected_df = gcs_to_bq_util.values_json_to_df(
+        json.dumps(_expected_merged_with_pop_numnbers), dtype=str).reset_index(drop=True)
+
+    df = dataset_utils.merge_pop_numbers(df, 'race', 'state')
 
     assert mock_bq.call_count == 1
     assert_frame_equal(df, expected_df, check_like=True)


### PR DESCRIPTION
* merges `population` and `population_pct` columns into an existing df
* for #1474 issues

<!--- Provide a general summary of your changes in the Title above -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
So we can have a consistent function to easily merge in population numbers.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Yes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- New feature (non-breaking change which adds functionality)

