### PR TITLE
adds rename Total to All function back into the BrfssProvider

### DIFF
--- a/frontend/src/data/variables/BrfssProvider.ts
+++ b/frontend/src/data/variables/BrfssProvider.ts
@@ -98,6 +98,7 @@ class BrfssProvider extends VariableProvider {
 
     df = this.filterByGeo(df, breakdowns);
 
+    df = this.renameTotalToAll(df, breakdownColumnName);
     df = this.renameGeoColumns(df, breakdowns);
 
     let acsBreakdowns = breakdowns.copy();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1537--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>   <-- Update this link once you have PR# 

## Description
<!--- Describe your changes in detail -->
* Right now it will do nothing because the UHC backend is currently
  sending All
* In #1520 I will need to switch back to using total to properly merge
  the UHC data with the population
* Then I will change Total to All on the backend all at once and remove
  the `renameTotalToAll` function everywhere

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Manually 
