### PR TITLE
Manually revert scroll-to-id

### DIFF
--- a/frontend/src/cards/ui/MissingDataAlert.tsx
+++ b/frontend/src/cards/ui/MissingDataAlert.tsx
@@ -85,7 +85,7 @@ function AltDataTypesMessage(props: AltDataTypesMessageProps) {
             <a
               href={`${EXPLORE_DATA_PAGE_LINK}${
                 dataTypeLinkMap[dataType.variableId as AgeAdjustedVariableId]
-              }#${AGE_ADJ}`}
+              }`}
             >
               {dataType.variableFullDisplayName}
             </a>

--- a/frontend/src/cards/ui/MissingDataAlert.tsx
+++ b/frontend/src/cards/ui/MissingDataAlert.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Alert } from "@material-ui/lab";
 import {
-  AGE_ADJ,
   EXPLORE_DATA_PAGE_LINK,
   LinkWithStickyParams,
   WHAT_IS_HEALTH_EQUITY_PAGE_LINK,

--- a/frontend/src/pages/DataCatalog/AgeAdjustmentTab.tsx
+++ b/frontend/src/pages/DataCatalog/AgeAdjustmentTab.tsx
@@ -3,7 +3,6 @@ import Grid from "@material-ui/core/Grid";
 import styles from "./DataCatalogPage.module.scss";
 import { Helmet } from "react-helmet-async";
 import {
-  AGE_ADJ,
   COVID_DEATHS_US_SETTING,
   COVID_HOSP_US_SETTING,
   EXPLORE_DATA_PAGE_LINK,
@@ -41,25 +40,11 @@ function AgeAdjustmentTab() {
                 order to show a more accurate and equitable view of the impact
                 on non-white communities in the United States. Currently, we are
                 able to calculate these age-adjusted ratios for{" "}
-                <Link
-                  to={
-                    EXPLORE_DATA_PAGE_LINK +
-                    COVID_DEATHS_US_SETTING +
-                    "#" +
-                    AGE_ADJ
-                  }
-                >
+                <Link to={EXPLORE_DATA_PAGE_LINK + COVID_DEATHS_US_SETTING}>
                   COVID-19 deaths
                 </Link>
                 {" and "}
-                <Link
-                  to={
-                    EXPLORE_DATA_PAGE_LINK +
-                    COVID_HOSP_US_SETTING +
-                    "#" +
-                    AGE_ADJ
-                  }
-                >
+                <Link to={EXPLORE_DATA_PAGE_LINK + COVID_HOSP_US_SETTING}>
                   hospitalizations
                 </Link>
                 , and we present the findings in a distinct, age-adjusted table.
@@ -453,11 +438,9 @@ function AgeAdjustmentTab() {
             variant="contained"
             color="primary"
             className={styles.PrimaryButton}
-            href={
-              EXPLORE_DATA_PAGE_LINK + COVID_DEATHS_US_SETTING + "#" + AGE_ADJ
-            }
+            href={EXPLORE_DATA_PAGE_LINK + COVID_DEATHS_US_SETTING}
           >
-            Explore the age-adjusted data
+            Explore the data
           </Button>
         </Grid>
       </Grid>

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -18,7 +18,6 @@ import {
 } from "../../utils/MadLibs";
 import {
   getParameter,
-  HIGHLIGHT_CANCEL_DELAY,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
   parseMls,
@@ -46,17 +45,12 @@ function ExploreDataPage() {
   const doScrollToData: boolean =
     location?.hash === `#${WHAT_DATA_ARE_MISSING_ID}`;
 
-  const [scrollToRef, setScrollToRef] = useState<string | undefined>(
-    location?.hash
-  );
-
   const [showStickyLifeline, setShowStickyLifeline] = useState(false);
 
   // Set up initial mad lib values based on defaults and query params
   const params = useSearchParams();
 
   // swap out old variable ids for backwards compatibility of outside links
-
   const foundIndex = MADLIB_LIST.findIndex(
     (madlib) => madlib.id === params[MADLIB_PHRASE_PARAM]
   );
@@ -212,9 +206,6 @@ function ExploreDataPage() {
       )
     );
 
-    // after delay, un-highlight any single card that was linked
-    scrollToRef &&
-      window.setTimeout(() => setScrollToRef(""), HIGHLIGHT_CANCEL_DELAY);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [madLib]);
 
@@ -283,7 +274,6 @@ function ExploreDataPage() {
             showLifeLineAlert={showStickyLifeline}
             setMadLib={setMadLibWithParam}
             doScrollToData={doScrollToData}
-            scrollToRef={scrollToRef}
           />
         </div>
       </div>

--- a/frontend/src/reports/OneVariableReport.tsx
+++ b/frontend/src/reports/OneVariableReport.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import { Grid } from "@material-ui/core";
-import React, { useEffect, useState, Fragment, useRef } from "react";
+import React, { useEffect, useState, Fragment } from "react";
 import LazyLoad from "react-lazyload";
 import { DisparityBarChartCard } from "../cards/DisparityBarChartCard";
 import { MapCard } from "../cards/MapCard";
@@ -23,7 +23,6 @@ import {
   DATA_TYPE_2_PARAM,
   DEMOGRAPHIC_PARAM,
   getParameter,
-  HIGHLIGHT_SCROLL_DELAY,
   psSubscribe,
   setParameter,
   setParameters,
@@ -32,15 +31,6 @@ import {
 import { SINGLE_COLUMN_WIDTH } from "./ReportProvider";
 import NoDataAlert from "./ui/NoDataAlert";
 import ReportToggleControls from "./ui/ReportToggleControls";
-import styles from "./Report.module.scss";
-
-function jumpToCard(ref: any): void {
-  if (ref?.current) {
-    ref.current.scrollIntoView({ block: "center", behavior: "smooth" });
-    ref.current = null;
-    ref = null;
-  }
-}
 
 export interface OneVariableReportProps {
   key: string;
@@ -50,60 +40,9 @@ export interface OneVariableReportProps {
   hidePopulationCard?: boolean;
   jumpToDefinitions: Function;
   jumpToData: Function;
-  scrollToRef?: string;
 }
 
 export function OneVariableReport(props: OneVariableReportProps) {
-  function highlightMatch(id: string) {
-    return props.scrollToRef === id
-      ? { className: styles.HighlightedCard }
-      : {};
-  }
-
-  const mapRef = useRef<HTMLInputElement>(null);
-  const barRef = useRef<HTMLInputElement>(null);
-  const unknownsRef = useRef<HTMLInputElement>(null);
-  const disparityRef = useRef<HTMLInputElement>(null);
-  const tableRef = useRef<HTMLInputElement>(null);
-  const ageAdjRef = useRef<HTMLInputElement>(null);
-
-  let target: any = null;
-
-  // handle incoming #hash link request
-  useEffect(() => {
-    switch (props.scrollToRef) {
-      case "#map":
-        target = mapRef;
-        break;
-      case "#bar":
-        target = barRef;
-        break;
-      case "#unknowns":
-        target = unknownsRef;
-        break;
-      case "#disparity":
-        target = disparityRef;
-        break;
-      case "#table":
-        target = tableRef;
-        break;
-      case "#age-adjusted":
-        target = ageAdjRef;
-        break;
-    }
-
-    window.setTimeout(() => {
-      jumpToCard(target);
-    }, HIGHLIGHT_SCROLL_DELAY);
-    // remove hash from URL
-    // eslint-disable-next-line no-restricted-globals
-    history.pushState(
-      "",
-      document.title,
-      window.location.pathname + window.location.search
-    );
-  }, [props.scrollToRef]);
-
   const [currentBreakdown, setCurrentBreakdown] = useState<BreakdownVar>(
     getParameter(DEMOGRAPHIC_PARAM, RACE)
   );
@@ -192,13 +131,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           )}
 
           {/* 100k MAP CARD */}
-          <Grid
-            item
-            xs={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={mapRef}
-            {...highlightMatch("#map")}
-          >
+          <Grid item xs={12} md={SINGLE_COLUMN_WIDTH}>
             <MapCard
               variableConfig={variableConfig}
               fips={props.fips}
@@ -212,14 +145,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* 100K BAR CHART CARD */}
-          <Grid
-            item
-            xs={12}
-            sm={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={barRef}
-            {...highlightMatch("#bar")}
-          >
+          <Grid item xs={12} sm={12} md={SINGLE_COLUMN_WIDTH}>
             <LazyLoad offset={600} height={750} once>
               {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
                 <Fragment key={breakdownVar}>
@@ -237,14 +163,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* UNKNOWNS MAP CARD */}
-          <Grid
-            item
-            xs={12}
-            sm={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={unknownsRef}
-            {...highlightMatch("#unknowns")}
-          >
+          <Grid item xs={12} sm={12} md={SINGLE_COLUMN_WIDTH}>
             <LazyLoad offset={800} height={750} once>
               {variableConfig.metrics["pct_share"] && (
                 <UnknownsMapCard
@@ -261,14 +180,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* DISPARITY BAR CHART COMPARE VS POPULATION */}
-          <Grid
-            item
-            xs={12}
-            sm={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={disparityRef}
-            {...highlightMatch("#disparity")}
-          >
+          <Grid item xs={12} sm={12} md={SINGLE_COLUMN_WIDTH}>
             <LazyLoad offset={800} height={750} once>
               {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
                 <Fragment key={breakdownVar}>
@@ -286,13 +198,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* DATA TABLE CARD */}
-          <Grid
-            item
-            xs={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={tableRef}
-            {...highlightMatch("#table")}
-          >
+          <Grid item xs={12} md={SINGLE_COLUMN_WIDTH}>
             <LazyLoad offset={800} height={750} once>
               {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
                 <Fragment key={breakdownVar}>
@@ -309,13 +215,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* AGE ADJUSTED TABLE CARD */}
-          <Grid
-            item
-            xs={12}
-            md={SINGLE_COLUMN_WIDTH}
-            ref={ageAdjRef}
-            {...highlightMatch("#age-adjusted")}
-          >
+          <Grid item xs={12} md={SINGLE_COLUMN_WIDTH}>
             <LazyLoad offset={800} height={800} once>
               <AgeAdjustedTableCard
                 fips={props.fips}

--- a/frontend/src/reports/Report.module.scss
+++ b/frontend/src/reports/Report.module.scss
@@ -69,22 +69,3 @@
 .SeeOurDataSourcesButton {
   margin-bottom: 2 rem;
 }
-
-.HighlightedCard {
-  animation-name: fadeBackground;
-  animation-duration: 10s;
-  animation-delay: 5s;
-  // HIGHLIGHT_SCROLL_DELAY and HIGHLIGHT_CANCEL_DELAY are set in urlutils.tsx
-  animation-iteration-count: 1;
-  animation-timing-function: ease-in;
-  animation-fill-mode: both;
-}
-
-@keyframes fadeBackground {
-  from {
-    background-color: rgba(11, 82, 64, 1);
-  }
-  to {
-    background-color: rgba(11, 82, 64, 0);
-  }
-}

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -42,7 +42,6 @@ interface ReportProviderProps {
   showLifeLineAlert: boolean;
   setMadLib: Function;
   doScrollToData?: boolean;
-  scrollToRef?: string;
 }
 
 function ReportProvider(props: ReportProviderProps) {
@@ -95,7 +94,6 @@ function ReportProvider(props: ReportProviderProps) {
                 getMadLibWithUpdatedValue(props.madLib, 3, fips.code)
               )
             }
-            scrollToRef={props.scrollToRef}
           />
         );
       case "comparegeos":

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -8,10 +8,6 @@ import { MadLibId, PhraseSelections } from "./MadLibs";
 
 export const STICKY_VERSION_PARAM = "sv";
 
-export const HIGHLIGHT_SCROLL_DELAY = 2_000;
-export const HIGHLIGHT_CANCEL_DELAY = 18_000;
-// highlight delay and fade time are set in src/reports/Report.module.scss
-
 // PAGE URLS
 export const HET_URL = "https://healthequitytracker.org";
 
@@ -52,7 +48,6 @@ export const WHAT_DATA_ARE_MISSING_ID = "missingDataInfo";
 export const EXPLORE_DATA_PAGE_WHAT_DATA_ARE_MISSING_LINK =
   EXPLORE_DATA_PAGE_LINK + "#" + WHAT_DATA_ARE_MISSING_ID;
 export const WIHE_JOIN_THE_EFFORT_SECTION_ID = "join";
-export const AGE_ADJ = "age-adjusted";
 
 // Value is a comma-separated list of dataset ids. Dataset ids cannot have
 // commas in them.


### PR DESCRIPTION
Scroll to ID #1504  was buggy particularly on Safari / Safari iOS. Will hold on this feature for now and hopefully figure out a reliable way to link external users directly to a specific card