### PR TITLE
Adds by `Age` and by `Sex` populations for American Samoa

### DIFF
--- a/data/acs_2010/acs_2010_population-by_age_territory.json
+++ b/data/acs_2010/acs_2010_population-by_age_territory.json
@@ -1,5 +1,65 @@
 [
   {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "population": "55519",
+    "age": "ALL"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "0-9",
+    "population": "13146"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "10-19",
+    "population": "12576"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "20-29",
+    "population": "7215"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "30-39",
+    "population": "7110"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "40-49",
+    "population": "6989"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "50-59",
+    "population": "4735"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "60-69",
+    "population": "2438"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "70-79",
+    "population": "993"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "age": "80+",
+    "population": "317"
+  },
+  {
     "state_fips": "66",
     "state_name": "Guam",
     "age": "All",

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -8,13 +8,13 @@
   {
     "state_fips": "60",
     "state_name": "American Samoa",
-    "population": "55519",
+    "population": "28170",
     "sex": "Male"
   },
   {
     "state_fips": "60",
     "state_name": "American Samoa",
-    "population": "55519",
+    "population": "27349",
     "sex": "Female"
   },
   {

--- a/data/acs_2010/acs_2010_population-by_sex_territory.json
+++ b/data/acs_2010/acs_2010_population-by_sex_territory.json
@@ -1,5 +1,23 @@
 [
   {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "population": "55519",
+    "sex": "ALL"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "population": "55519",
+    "sex": "Male"
+  },
+  {
+    "state_fips": "60",
+    "state_name": "American Samoa",
+    "population": "55519",
+    "sex": "Female"
+  },
+  {
     "state_fips": "66",
     "state_name": "Guam",
     "sex": "All",


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
In the course of #1518 we discovered 2010 population data for American Samoa; that PR only had breakdowns by race, but the ACS2010 files also include breakdowns by Age and Sex. These will be displayed in the population card for American Samoa, and will be available for any future datasets we add that include rates for AS

ACS site: https://www.census.gov/data/datasets/2010/dec/american-samoa.html
Table: AS1_0000001_040.html


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

Representation of territories when possible if a large priority of the HET


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually copied from table


## Screenshots (if appropriate):
<img width="433" alt="Screen Shot 2022-04-26 at 9 52 09 PM" src="https://user-images.githubusercontent.com/41567007/165436648-b7ad3953-8cb7-459d-9c10-0497e8cd806d.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- New feature (non-breaking change which adds functionality)

