### PR TITLE
Fix click empty map warning

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -66,7 +66,7 @@ function MapCardWithKey(props: MapCardProps) {
   const signalListeners: any = {
     click: (...args: any) => {
       const clickedData = args[1];
-      props.updateFipsCallback(new Fips(clickedData.id));
+      clickedData.id && props.updateFipsCallback(new Fips(clickedData.id));
     },
   };
 

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -66,7 +66,7 @@ function MapCardWithKey(props: MapCardProps) {
   const signalListeners: any = {
     click: (...args: any) => {
       const clickedData = args[1];
-      clickedData.id && props.updateFipsCallback(new Fips(clickedData.id));
+      clickedData?.id && props.updateFipsCallback(new Fips(clickedData.id));
     },
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1574--health-equity-tracker.netlify.app/" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

Before, clicking on the white space around a geo would trigger a warning in dev tools because `id` was `undefined`. This simply adds a check to make sure `clickedData.id` exists

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Manually on various settings. Click to geo still works as expected


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
