### PR TITLE
Move bucket logic to utils file

### DIFF
--- a/frontend/src/data/utils/datasetutils.ts
+++ b/frontend/src/data/utils/datasetutils.ts
@@ -6,6 +6,7 @@ import {
   UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
   UHC_DETERMINANTS,
   UHC_VOTER_AGE_DETERMINANTS,
+  ALL_UHC_DETERMINANTS,
 } from "../variables/BrfssProvider";
 import {
   RACE,
@@ -251,13 +252,6 @@ Conditionally hide some of the extra buckets from the table card, which generall
 const showAllGroupIds: VariableId[] = [
   "women_state_legislatures",
   "women_us_congress",
-];
-
-// only for UHC variables
-const ALL_UHC_DETERMINANTS = [
-  ...UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
-  ...UHC_VOTER_AGE_DETERMINANTS,
-  ...UHC_DETERMINANTS,
 ];
 
 export function getExclusionList(

--- a/frontend/src/data/utils/datasetutils.ts
+++ b/frontend/src/data/utils/datasetutils.ts
@@ -1,7 +1,28 @@
 import { IDataFrame } from "data-forge";
-import { MetricId, VariableId } from "../config/MetricConfig";
+import { MetricId, VariableConfig, VariableId } from "../config/MetricConfig";
 import { BreakdownVar, GeographicBreakdown } from "../query/Breakdowns";
-import { RACE } from "./Constants";
+import {
+  UHC_API_NH_DETERMINANTS,
+  UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
+  UHC_DETERMINANTS,
+  UHC_VOTER_AGE_DETERMINANTS,
+} from "../variables/BrfssProvider";
+import {
+  RACE,
+  ALL,
+  BROAD_AGE_BUCKETS,
+  DECADE_PLUS_5_AGE_BUCKETS,
+  VOTER_AGE_BUCKETS,
+  AGE_BUCKETS,
+  ASIAN_NH,
+  NHPI_NH,
+  API_NH,
+  NON_HISPANIC,
+  UNKNOWN,
+  UNKNOWN_ETHNICITY,
+  UNKNOWN_RACE,
+  AGE,
+} from "./Constants";
 import { Row } from "./DatasetTypes";
 
 /**
@@ -221,3 +242,63 @@ export const DATA_GAPS: Partial<
     race_and_ethnicity: ["covid_vaccinations"],
   },
 };
+
+/* 
+
+Conditionally hide some of the extra buckets from the table card, which generally should be showing only 1 complete set of buckets that show the entire population's comparison values.
+
+*/
+const showAllGroupIds: VariableId[] = [
+  "women_state_legislatures",
+  "women_us_congress",
+];
+
+// only for UHC variables
+const ALL_UHC_DETERMINANTS = [
+  ...UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
+  ...UHC_VOTER_AGE_DETERMINANTS,
+  ...UHC_DETERMINANTS,
+];
+
+export function getExclusionList(
+  currentVariable: VariableConfig,
+  currentBreakdown: BreakdownVar
+) {
+  const current100k = currentVariable.metrics.per100k.metricId;
+  const currentVariableId = currentVariable.variableId;
+  let exclusionList = [UNKNOWN, UNKNOWN_ETHNICITY, UNKNOWN_RACE];
+
+  if (!showAllGroupIds.includes(currentVariableId)) {
+    exclusionList.push(ALL);
+  }
+
+  if (currentBreakdown === RACE) {
+    exclusionList.push(NON_HISPANIC);
+  }
+
+  // UHC/BRFSS/AHR
+  if (ALL_UHC_DETERMINANTS.includes(current100k) && currentBreakdown === RACE) {
+    UHC_API_NH_DETERMINANTS.includes(current100k)
+      ? exclusionList.push(ASIAN_NH, NHPI_NH)
+      : exclusionList.push(API_NH);
+  }
+
+  if (ALL_UHC_DETERMINANTS.includes(current100k) && currentBreakdown === AGE) {
+    // get correct age buckets for this determinant
+    let determinantBuckets: any[] = [];
+    if (UHC_DECADE_PLUS_5_AGE_DETERMINANTS.includes(current100k))
+      determinantBuckets.push(...DECADE_PLUS_5_AGE_BUCKETS);
+    else if (UHC_VOTER_AGE_DETERMINANTS.includes(current100k))
+      determinantBuckets.push(...VOTER_AGE_BUCKETS);
+    else if (UHC_DETERMINANTS.includes(current100k))
+      determinantBuckets.push(...BROAD_AGE_BUCKETS);
+
+    // remove all of the other age groups
+    const irrelevantAgeBuckets = AGE_BUCKETS.filter(
+      (bucket) => !determinantBuckets.includes(bucket)
+    );
+    exclusionList.push(...irrelevantAgeBuckets);
+  }
+
+  return exclusionList;
+}

--- a/frontend/src/data/variables/BrfssProvider.ts
+++ b/frontend/src/data/variables/BrfssProvider.ts
@@ -48,21 +48,27 @@ export const UHC_DETERMINANTS: MetricId[] = [
   "asthma_ratio_age_adjusted",
 ];
 
-export const UHC_DECADE_PLUS_5_AGE_DETERMINANTS: MetricId[] = [
-  "suicide_pct_share",
-  "suicide_per_100k",
-  "suicide_ratio_age_adjusted",
-];
-
 export const UHC_VOTER_AGE_DETERMINANTS: MetricId[] = [
   "voter_participation_pct_share",
   "voter_participation_per_100k",
   "voter_participation_ratio_age_adjusted",
 ];
 
+export const UHC_DECADE_PLUS_5_AGE_DETERMINANTS: MetricId[] = [
+  "suicide_pct_share",
+  "suicide_per_100k",
+  "suicide_ratio_age_adjusted",
+];
+
 export const UHC_API_NH_DETERMINANTS: MetricId[] = [
   "preventable_hospitalizations_pct_share",
   "preventable_hospitalizations_per_100k",
+];
+
+export const ALL_UHC_DETERMINANTS = [
+  ...UHC_VOTER_AGE_DETERMINANTS,
+  ...UHC_DECADE_PLUS_5_AGE_DETERMINANTS,
+  ...UHC_DETERMINANTS,
 ];
 
 class BrfssProvider extends VariableProvider {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="http://localhost:3000/exploredata?mls=1.suicide-3.00&demo=age" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a>   

## Description
<!--- Describe your changes in detail -->


On most of our cards/visualizations we only display demographic groups for which we have incidence data. However, on the table card, we want to show a full "set" of buckets even if some are missing data, so that the user can see a complete picture of that region's population for comparison.

Once we complete #1474 I think we can eliminate a lot of this condition logic, by simply including on the backend the "empty" or population-only rows that we need to complete the full "set" of buckets. 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

in preparation for #1585 


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

manually


## Screenshots (if appropriate):

> standard races
<img width="920" alt="Screen Shot 2022-05-16 at 10 52 16 AM" src="https://user-images.githubusercontent.com/41567007/168644546-c86282bb-9011-45b6-beca-2b8712f5c8df.png">

> non-standard races
<img width="919" alt="Screen Shot 2022-05-16 at 10 52 37 AM" src="https://user-images.githubusercontent.com/41567007/168644553-491bbc43-65fc-4d19-8a3c-9fee8e54719f.png">

> only a single race has incidence data
<img width="919" alt="Screen Shot 2022-05-16 at 10 53 18 AM" src="https://user-images.githubusercontent.com/41567007/168644558-cb75938a-2116-480a-aaea-607cb93fbb0b.png">

> unique age buckets
<img width="919" alt="Screen Shot 2022-05-16 at 10 53 57 AM" src="https://user-images.githubusercontent.com/41567007/168644561-ee0a68c0-8341-4e90-861b-4e753fa7bd42.png">

> "age" breakdown isn't available but this will default to showing all population compares even if incidence isn't available
<img width="919" alt="Screen Shot 2022-05-16 at 10 54 26 AM" src="https://user-images.githubusercontent.com/41567007/168644564-f0bf0d29-98f1-4f94-adee-49216d7daa65.png">

> almost standard races, except asian and NHPI are combined to API
<img width="919" alt="Screen Shot 2022-05-16 at 10 56 01 AM" src="https://user-images.githubusercontent.com/41567007/168644570-e0df7f64-6615-448b-b803-bb72fd9b9c2b.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Chore (developer productivity fix that doesn't affect the user)
