### PR TITLE
Fix unmocked test call in KFF Vaxx

### DIFF
--- a/python/datasources/kff_vaccination.py
+++ b/python/datasources/kff_vaccination.py
@@ -61,7 +61,9 @@ KFF_TERRITORIES = ['Guam', 'Puerto Rico', 'Northern Mariana Islands']
 def get_data_url(data_type):
     """Gets the latest url from the kff's github data repo for the given data type
 
-    data_type: string value representing which url to get from the github api; must be either 'pct_total' or 'pct_share'
+    data_type: string value representing which url to get from
+    the github api; must be either 'pct_total', 'pct_share',
+    or 'pct_population'
     """
     data_types_to_strings = {
         'pct_total': 'Percent of Total Population that has Received a COVID-19 Vaccine by RaceEthnicity',
@@ -70,7 +72,9 @@ def get_data_url(data_type):
     }
     df = gcs_to_bq_util.load_json_as_df_from_web_based_on_key(
         BASE_GITHUB_API_URL, "tree")
+
     df = df.loc[df['path'].str.contains(data_types_to_strings[data_type])]
+
     urls = df.loc[df['path'] == df['path'].max()].url
 
     if len(urls) != 1:

--- a/python/tests/data/kff_vaccination/github_file_list.json
+++ b/python/tests/data/kff_vaccination/github_file_list.json
@@ -30,6 +30,21 @@
     "url": "some-other-up-to-date-url"
   },
   {
+    "path": "01/02/2021Distribution of Vaccinations, Cases, Deaths",
+    "mode": "100644",
+    "type": "blob",
+    "sha": "0262c9e6f28e2223d139581bea382ed538c87850",
+    "size": 24486,
+    "url": "some-old-population-url"
+  },
+  {
+    "path": "01/04/2021Distribution of Vaccinations, Cases, Deaths",
+    "mode": "040000",
+    "type": "tree",
+    "sha": "ef13c95955d7d31150c369686b2f359f1a22c31e",
+    "url": "some-up-to-date-population-url"
+  },
+  {
     "path": "some-other-pattern",
     "mode": "100644",
     "type": "blob",

--- a/python/tests/datasources/test_kff_vaccination.py
+++ b/python/tests/datasources/test_kff_vaccination.py
@@ -48,6 +48,8 @@ def testGetDataUrlPctShare(mock_json: mock.MagicMock):
     assert get_data_url('pct_share') == "some-other-up-to-date-url"
 
 
+@mock.patch('ingestion.gcs_to_bq_util.load_json_as_df_from_web_based_on_key',
+            return_value=get_github_file_list_as_df())
 @mock.patch('ingestion.gcs_to_bq_util.load_csv_as_df_from_web',
             return_value=get_state_totals_test_data_as_df())
 @mock.patch('ingestion.github_util.decode_json_from_url_into_df')
@@ -56,7 +58,9 @@ def testGetDataUrlPctShare(mock_json: mock.MagicMock):
 def testWriteToBq(
         mock_bq: mock.MagicMock,
         mock_csv: mock.MagicMock,
-        mock_csv_web: mock.MagicMock):
+        mock_csv_web: mock.MagicMock,
+        mock_json: mock.MagicMock
+):
     mock_csv.side_effect = [
         get_percentage_of_race_test_data_as_df(),
         get_pct_share_race_test_data_as_df(),


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->

the third call to github to retrieve the right url for "population_pct_share" was unmocked 

- mocks call in test missing the mock
- adds line to fake github file to handle population_pct_share

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1524

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

all tests pass (with internet disconneted)

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

