### PR TITLE
upgrade gcs_to_bq_util to work with pandas 1.4.x

### DIFF
--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -167,6 +167,7 @@ def load_values_blob_as_df(blob):
 
        blob: google.cloud.storage.blob.Blob object"""
     json_string = blob.download_as_string()
+    json_string = json_string.decode('utf-8')
     return values_json_to_df(json_string)
 
 

--- a/python/tests/test_gcs_to_bq.py
+++ b/python/tests/test_gcs_to_bq.py
@@ -22,7 +22,7 @@ class GcsToBqTest(TestCase):
         """Tests that data in json list format is loaded into a
            pandas.DataFrame object using the first row as a header."""
         mock_attrs = {
-            'download_as_string.return_value': json.dumps(self._test_data)}
+            'download_as_string.return_value': json.dumps(self._test_data).encode('utf-8')}
         mock_blob = Mock(**mock_attrs)
         frame = gcs_to_bq_util.load_values_blob_as_df(mock_blob)
 


### PR DESCRIPTION
- pandas.read_json needs to take in a decoded string
- previously it was being read in from gcs as bytes
- see https://github.com/pandas-dev/pandas/issues/46935

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
ACS pipelines broke after upgrading to pandas 1.4.3 in #1648

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Ran the pipelines

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
