### PR TITLE
specifies that the age-adjusted ratios are cloud sql FLOATS

### DIFF
--- a/python/datasources/age_adjust_cdc_restricted.py
+++ b/python/datasources/age_adjust_cdc_restricted.py
@@ -99,6 +99,8 @@ class AgeAdjustCDCRestricted(DataSource):
         # standardization of the data has been done by this point.
         for table_name, df in table_names_to_dfs.items():
             column_types = get_col_types(df)
+            column_types[std_col.COVID_HOSP_RATIO_AGE_ADJUSTED] = 'FLOAT'
+            column_types[std_col.COVID_DEATH_RATIO_AGE_ADJUSTED] = 'FLOAT'
 
             # Clean up column names.
             self.clean_frame_column_names(df)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
previously the age-adjusted ratios were STRINGS, now they are FLOATS

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
A potential solution for #1647


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
