### PR TITLE
Removed SVI from territories on tooltip

### DIFF
--- a/frontend/src/cards/ui/SviAlert.tsx
+++ b/frontend/src/cards/ui/SviAlert.tsx
@@ -20,11 +20,17 @@ export const findRating = (svi: number) => {
   if (svi > 0.67) {
     return "high";
   }
-  return "medium";
+  if (svi > 0.34 && svi < 0.67) {
+    return "medium";
+  }
+  return "Insufficient data";
 };
 
 export const findVerboseRating = (svi: number) => {
   const rating = findRating(svi);
+  if (rating === "Insufficient data") {
+    return "Insufficient data";
+  }
   return `${rating[0].toUpperCase() + rating.slice(1)} vulnerability`;
 };
 

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -175,7 +175,12 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
         ? props.metric.unknownsVegaLabel
         : props.metric.shortLabel;
 
-    const tooltipValue = `{"${geographyName}": datum.properties.name, "${tooltipLabel}": ${tooltipDatum}, "County SVI": datum.rating}`;
+    const tooltipValue = () => {
+      if (props.fips.isState() || props.fips.isCounty()) {
+        return `{"${geographyName}": datum.properties.name, "${tooltipLabel}": ${tooltipDatum}, "County SVI": datum.rating}`;
+      }
+      return `{"${geographyName}": datum.properties.name, "${tooltipLabel}": ${tooltipDatum},}`;
+    };
     const missingDataTooltipValue = `{"${geographyName}": datum.properties.name, "${tooltipLabel}": "${NO_DATA_MESSAGE}", }`;
     /* SET UP LEGEND */
     let legendList = [];
@@ -357,7 +362,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
         /*datasetName=*/ VALID_DATASET,
         /*fillColor=*/ [{ scale: COLOR_SCALE, field: props.metric.metricId }],
         /*hoverColor=*/ DARK_BLUE,
-        /*tooltipExpression=*/ tooltipValue
+        /*tooltipExpression=*/ tooltipValue()
       ),
     ];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1715--health-equity-tracker.netlify.app/exploredata?onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
This PR removes the "County SVI" line from the tooltip on the Vega map when displaying territories. The SVI should only display at the county level and does not include territories at the moment. This PR also slightly refactors the `findRating` and `findVerboseRating` functions when the SVI is undefined. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
This refactor has been tested locally. 

## Screenshots (if appropriate):
![Screen Shot 2022-07-25 at 2 49 40 PM](https://user-images.githubusercontent.com/72993442/180863529-1100bc1f-7609-4c57-98c0-d9e97260cca8.png)

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Refactor (code improvement that doesn't affect UI)

