### PR TITLE
Fix URL tests by not testing TEAM page

### DIFF
--- a/frontend/playwright-tests/externalUrls.spec.ts
+++ b/frontend/playwright-tests/externalUrls.spec.ts
@@ -1,6 +1,5 @@
 import { test } from '@playwright/test';
 import { urlMap } from "../src/utils/externalUrls"
-import { GOOGLE_FELLOWS, PARTNERS } from "../src/pages/AboutUs/OurTeamData"
 import { RESOURCES } from "../src/pages/WhatIsHealthEquity/ResourcesData"
 
 const knownFlakyUrls = [
@@ -26,24 +25,6 @@ for (const url of Object.values(urlMap)) {
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`${url}`, async ({ page }) => {
         const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-        // @ts-ignore: Object is possibly 'null'.
-        if (response.status() !== 200) console.log(url, response.status());
-    });
-}
-
-for (const url of PARTNERS.map(partner => partner.url)) {
-    if (!url || knownFlakyUrls.includes(url)) continue
-    test(`Team Page - Partner: ${url}`, async ({ page }) => {
-        const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-        // @ts-ignore: Object is possibly 'null'.
-        if (response.status() !== 200) console.log(url, response.status());
-    });
-}
-
-for (const url of GOOGLE_FELLOWS.filter(fellow => fellow.link).map(fellow => fellow.link)) {
-    if (!url || knownFlakyUrls.includes(url)) continue
-    test(`Team Page - Google Fellow: ${url}`, async ({ page }) => {
-        const response = await page.goto(url, { waitUntil: "domcontentloaded" })
         // @ts-ignore: Object is possibly 'null'.
         if (response.status() !== 200) console.log(url, response.status());
     });


### PR DESCRIPTION
removes url testing for TEAM page; was causing issues with imports/ts transpile (which was caused by properly loading our images from `/src` rather than `/public` as they previously were
those urls are top level sites and unlikely to break (as opposed to the RESOURCES which are specific articles or smaller sites

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
url tests pass again

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

