### PR TITLE
Hide empty AgeAdjust; show on compare if other dropdown is AgeAdjusted

### DIFF
--- a/frontend/playwright-tests/otherInternalPageRoutes.spec.ts
+++ b/frontend/playwright-tests/otherInternalPageRoutes.spec.ts
@@ -88,7 +88,7 @@ test('Contact Tab Loads', async ({ page }) => {
     await page.goto(CONTACT_TAB_LINK, { waitUntil: "networkidle" });
     await expect(page).toBeAccessible()
     const mainHeading = page.locator('#main');
-    await expect(mainHeading).toContainText([`Let's`, `move`, `equity`, `forward`]);
+    await expect(mainHeading).toContainText([`Let's move`], { useInnerText: true });
 });
 
 

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -12,11 +12,11 @@ test.describe('Home to COVID Vax by Age', () => {
     test('Home to Tracker', async ({ page }) => {
 
         // Landing Page Loads
-        await page.goto('/', { waitUntil: "networkidle" }); 
+        await page.goto('/', { waitUntil: "networkidle" });
         await expect(page).toBeAccessible()
 
         const mainHeading = page.locator('#main');
-        await expect(mainHeading).toContainText(['Advancing', 'Health', 'Equity']);
+        await expect(mainHeading).toContainText('Advancing Health Equity');
 
         // Clicking large CTA button takes us to the tracker
         const exploreButton = page.locator('a:has-text("Explore the Health Equity Tracker")')
@@ -27,9 +27,9 @@ test.describe('Home to COVID Vax by Age', () => {
     test('Tracker Default (skip Welcome) to Covid Vax', async ({ page }) => {
 
         // Load Tracker Default (with url param to bypass problematic warm welcome)
-        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${SKIP_WELCOME}`, { waitUntil: "networkidle" }); 
+        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${SKIP_WELCOME}`, { waitUntil: "networkidle" });
         await expect(page).toBeAccessible()
-    
+
         // changes madlib to VAXX properly
         const madLibTopic = page.locator('button:has-text("COVID-19")')
         madLibTopic.click();

--- a/frontend/src/reports/OneVariableReport.tsx
+++ b/frontend/src/reports/OneVariableReport.tsx
@@ -213,18 +213,20 @@ export function OneVariableReport(props: OneVariableReportProps) {
           </Grid>
 
           {/* AGE ADJUSTED TABLE CARD */}
-          <Grid item xs={12} md={SINGLE_COLUMN_WIDTH} id="age-adjusted">
-            <LazyLoad offset={800} height={800} once>
-              <AgeAdjustedTableCard
-                fips={props.fips}
-                variableConfig={variableConfig}
-                dropdownVarId={props.dropdownVarId}
-                breakdownVar={currentBreakdown}
-                setVariableConfigWithParam={setVariableConfigWithParam}
-                jumpToData={props.jumpToData}
-              />
-            </LazyLoad>
-          </Grid>
+          {variableConfig.metrics.age_adjusted_ratio.ageAdjusted && (
+            <Grid item xs={12} md={SINGLE_COLUMN_WIDTH} id="age-adjusted">
+              <LazyLoad offset={800} height={800} once>
+                <AgeAdjustedTableCard
+                  fips={props.fips}
+                  variableConfig={variableConfig}
+                  dropdownVarId={props.dropdownVarId}
+                  breakdownVar={currentBreakdown}
+                  setVariableConfigWithParam={setVariableConfigWithParam}
+                  jumpToData={props.jumpToData}
+                />
+              </LazyLoad>
+            </Grid>
+          )}
         </Grid>
       )}
     </Grid>

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -131,6 +131,10 @@ function TwoVariableReport(props: {
   const breakdownIsShown = (breakdownVar: string) =>
     currentBreakdown === breakdownVar;
 
+  const showAgeAdjustCardRow =
+    variableConfig1?.metrics?.age_adjusted_ratio?.ageAdjusted ||
+    variableConfig2?.metrics?.age_adjusted_ratio?.ageAdjusted;
+
   return (
     <Grid container spacing={1} alignItems="flex-start">
       {/* POPULATION CARD(S) AND 2 SETS OF TOGGLE CONTROLS */}
@@ -334,35 +338,37 @@ function TwoVariableReport(props: {
 
       {/* SIDE-BY-SIDE AGE-ADJUSTED TABLE CARDS */}
 
-      <RowOfTwoOptionalMetrics
-        id="age-adjusted"
-        // specific data type
-        variableConfig1={variableConfig1}
-        variableConfig2={variableConfig2}
-        // parent variable
-        dropdownVarId1={props.dropdownVarId1}
-        dropdownVarId2={props.dropdownVarId2}
-        fips1={props.fips1}
-        fips2={props.fips2}
-        updateFips1={props.updateFips1Callback}
-        updateFips2={props.updateFips2Callback}
-        jumpToData={props.jumpToData}
-        createCard={(
-          variableConfig: VariableConfig,
-          fips: Fips,
-          updateFips: (fips: Fips) => void,
-          dropdownVarId?: DropdownVarId,
-          jumpToData?: Function
-        ) => (
-          <AgeAdjustedTableCard
-            fips={fips}
-            variableConfig={variableConfig}
-            breakdownVar={currentBreakdown}
-            dropdownVarId={dropdownVarId}
-            jumpToData={jumpToData}
-          />
-        )}
-      />
+      {showAgeAdjustCardRow && (
+        <RowOfTwoOptionalMetrics
+          id="age-adjusted"
+          // specific data type
+          variableConfig1={variableConfig1}
+          variableConfig2={variableConfig2}
+          // parent variable
+          dropdownVarId1={props.dropdownVarId1}
+          dropdownVarId2={props.dropdownVarId2}
+          fips1={props.fips1}
+          fips2={props.fips2}
+          updateFips1={props.updateFips1Callback}
+          updateFips2={props.updateFips2Callback}
+          jumpToData={props.jumpToData}
+          createCard={(
+            variableConfig: VariableConfig,
+            fips: Fips,
+            updateFips: (fips: Fips) => void,
+            dropdownVarId?: DropdownVarId,
+            jumpToData?: Function
+          ) => (
+            <AgeAdjustedTableCard
+              fips={fips}
+              variableConfig={variableConfig}
+              breakdownVar={currentBreakdown}
+              dropdownVarId={dropdownVarId}
+              jumpToData={jumpToData}
+            />
+          )}
+        />
+      )}
     </Grid>
   );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1730--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.covid_vaccinations-5.00&mlp=comparevars&dt1=covid_deaths&onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

As we add more cards that only occasionally have data (AgeAdjust, upcoming TrendCards), we need to move away from the "all cards all the time" pattern, which ends up littering the screen with redundant missing data alerts. See also #1711 

This PR:
- hides AgeAdjust card on the normal, OneVariable report if the condition isn't age-adjusted
- hides both AgeAdjust cards on the compare TwoVariable report if neither conditions are age-adjusted
- shows the full card plus the "missing data" empty card on the compare view if one condition Is age-adjusted and the other is not. The idea here is to keep related cards in vertical alignment for easier comparisons


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

In preparation for #1699, where we will need to hide empty `<TrendCard />` for most of the data sets that aren't time-seriesed yet

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Visually

## Screenshots (if appropriate):

![Screen Shot 2022-08-02 at 12 25 12 PM](https://user-images.githubusercontent.com/41567007/182448243-001db1fd-7618-4360-bac6-1ff212e80c64.png)
![Screen Shot 2022-08-02 at 12 25 43 PM](https://user-images.githubusercontent.com/41567007/182448247-5be006db-cc33-4a68-b99c-513c863e6d66.png)
![Screen Shot 2022-08-02 at 12 26 55 PM](https://user-images.githubusercontent.com/41567007/182448249-b14e54ba-e0ce-4c8e-b02d-229757c8a938.png)
![Screen Shot 2022-08-02 at 12 27 11 PM](https://user-images.githubusercontent.com/41567007/182448253-29a7c65f-aa75-45c8-a075-606066359745.png)


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
