### PR TITLE
revert linter pin; issue fixed upstream

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -30,7 +30,7 @@ jobs:
 
       # Lint using Super Linter. See https://github.com/github/super-linter.
       - name: Lint Code Base
-        uses: github/super-linter@v4.9.5
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false  # Only validate new or changed files


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->

superlinter was breaking due to a race condition with their action vs their docker image. They've fixed it and the most recent patch should be working
