### PR TITLE
Fixes sticky URL params

### DIFF
--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -18,12 +18,13 @@ import {
   PhraseSelections,
 } from "../../utils/MadLibs";
 import {
+  DATA_TYPE_1_PARAM,
+  DEMOGRAPHIC_PARAM,
   getParameter,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
   parseMls,
   psSubscribe,
-  setParameter,
   setParameters,
   SHOW_ONBOARDING_PARAM,
   stringifyMls,
@@ -106,7 +107,14 @@ function ExploreDataPage() {
   }, []);
 
   const setMadLibWithParam = (ml: MadLib) => {
-    setParameter(MADLIB_SELECTIONS_PARAM, stringifyMls(ml.activeSelections));
+    setParameters([
+      {
+        name: MADLIB_SELECTIONS_PARAM,
+        value: stringifyMls(ml.activeSelections),
+      },
+      { name: DATA_TYPE_1_PARAM, value: null },
+      { name: DEMOGRAPHIC_PARAM, value: null },
+    ]);
     setMadLib(ml);
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1759--health-equity-tracker.netlify.app/exploredata?onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->
This PR fixes the sticky datatype and demo param issue when selecting new MadLib topics:

- Currently, when a datatype is selected, it is generated in the URL param. When the user selects a new MadLib topic, the datatype from the previous MadLib topic remains in the URL.

- This PR fixes this issue, by removing the previously selected datatype when a new topic is selected, and populating a new datatype when one is selected from the datatype and demo buttons.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Fixes #1551

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

