### PR TITLE
Appends "identifying as" phrase to highest lowest text for CAWP

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -391,6 +391,7 @@ function MapCardWithKey(props: MapCardProps) {
                     dataForActiveBreakdownFilter.length > 1 && (
                       <HighestLowestList
                         variableConfig={props.variableConfig}
+                        selectedRaceSuffix={selectedRaceSuffix}
                         metricConfig={metricConfig}
                         listExpanded={listExpanded}
                         setListExpanded={setListExpanded}

--- a/frontend/src/cards/ui/HighestLowestList.tsx
+++ b/frontend/src/cards/ui/HighestLowestList.tsx
@@ -33,6 +33,8 @@ export interface HighestLowestListProps {
   qualifierItems?: string[];
   // message to display under a list with qualifiers
   qualifierMessage?: string;
+  // optional suffix to alter the selected metric (used for CAWP "identifying as Black women")
+  selectedRaceSuffix?: string;
 }
 
 /*
@@ -135,7 +137,11 @@ export function HighestLowestList(props: HighestLowestListProps) {
 
           <p>
             All rates are reported as:{" "}
-            <b>{props.metricConfig.fullCardTitleName}</b>.
+            <b>
+              {props.metricConfig.fullCardTitleName}
+              {props.selectedRaceSuffix}
+            </b>
+            .
           </p>
           <p>
             Consider the possible impact of{" "}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1760--health-equity-tracker.netlify.app/exploredata?onboard=false&mls=1.women_in_legislative_office-3.00" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

Makes the metric more accurate in the Highest/Lowest box for CAWP. Currently we adjust the Map card title to include "identifying as women" or "identifying as white women" etc; this logic is already in place and just needed to be extended to the metric in the highest/lowest list

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

Metric would easily be misunderstood without this context




## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

manually + e2e


## Screenshots (if appropriate):

BEFORE: 

<img width="1074" alt="Screen Shot 2022-08-19 at 11 19 48 AM" src="https://user-images.githubusercontent.com/41567007/185673844-c6020035-1193-4290-9c0f-f8870745f9db.png">

AFTER:

<img width="773" alt="Screen Shot 2022-08-19 at 11 16 24 AM" src="https://user-images.githubusercontent.com/41567007/185673897-ede6a146-2ec6-48e6-b999-9079b12d4b5d.png">
<img width="773" alt="Screen Shot 2022-08-19 at 11 16 48 AM" src="https://user-images.githubusercontent.com/41567007/185673899-0d088dae-5ac6-44a8-a0e7-06b0267f4e34.png">
<img width="773" alt="Screen Shot 2022-08-19 at 11 16 57 AM" src="https://user-images.githubusercontent.com/41567007/185673901-91f65e8e-145b-4975-be86-3aa4c874cc9f.png">
<img width="773" alt="Screen Shot 2022-08-19 at 11 17 17 AM" src="https://user-images.githubusercontent.com/41567007/185673903-fbc8d735-2a38-44d7-b5ea-1ff51f8a2d27.png">




## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
