### PR TITLE
Dynamically adjusts scroll-margin based on number of Madlib wrapped lines / height

### DIFF
--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@material-ui/core";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useCookies } from "react-cookie";
 import { STATUS } from "react-joyride";
 import Carousel from "react-material-ui-carousel";
@@ -52,6 +52,8 @@ function ExploreDataPage() {
   const [showStickyLifeline, setShowStickyLifeline] = useState(false);
   const [showIncarceratedChildrenAlert, setShowIncarceratedChildrenAlert] =
     useState(false);
+
+  const madLibHeaderRef = useRef<HTMLInputElement>(null);
 
   // Set up initial mad lib values based on defaults and query params
   const params = useSearchParams();
@@ -218,6 +220,11 @@ function ExploreDataPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [madLib]);
 
+  /* on changes that affect the height of the sticky madlib header */
+  useEffect(() => {
+    console.log(madLibHeaderRef.current?.clientHeight);
+  }, [madLib, showIncarceratedChildrenAlert, showStickyLifeline]);
+
   return (
     <>
       <Onboarding
@@ -232,6 +239,7 @@ function ExploreDataPage() {
         <div
           className={styles.CarouselContainer}
           id="onboarding-start-your-search"
+          ref={madLibHeaderRef}
         >
           <Carousel
             className={`Carousel ${styles.Carousel}`}

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@material-ui/core";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
-import React, { useEffect, useLayoutEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { STATUS } from "react-joyride";
 import Carousel from "react-material-ui-carousel";
@@ -40,7 +40,6 @@ import { urlMap } from "../../utils/externalUrls";
 import { VariableConfig } from "../../data/config/MetricConfig";
 import { INCARCERATION_IDS } from "../../data/variables/IncarcerationProvider";
 import useScrollPosition from "../../utils/hooks/useScrollPosition";
-import { useResponsiveWidth } from "../../utils/hooks/useResponsiveWidth";
 
 const EXPLORE_DATA_ID = "main";
 
@@ -195,10 +194,6 @@ function ExploreDataPage() {
     ]);
   };
 
-  const [madLibHeaderRef, pageWidth] = useResponsiveWidth(
-    window.innerWidth || 1000
-  );
-
   /* on any changes to the madlib settings */
   useEffect(() => {
     // scroll browser screen to top
@@ -223,25 +218,42 @@ function ExploreDataPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [madLib]);
 
+  const [pageWidth, setPageWidth] = useState(window.innerWidth);
+
+  function handlePageWidthChange() {
+    setPageWidth(window.innerWidth);
+  }
+
+  useEffect(() => {
+    window.addEventListener("resize", handlePageWidthChange);
+    return () => window.removeEventListener("resize", handlePageWidthChange);
+  }, []);
+
   const [headerScrollMargin, setHeaderScrollMargin] = useState(0);
 
   /* on changes that affect the height of the sticky madlib header */
-  useLayoutEffect(() => {
-    const isSticky = pageWidth > 960;
-    const stickyHeaderHeight =
-      (isSticky && madLibHeaderRef.current?.clientHeight) || 0;
-    setHeaderScrollMargin(stickyHeaderHeight);
-  }, [
-    madLib,
-    showIncarceratedChildrenAlert,
-    showStickyLifeline,
-    pageWidth,
-    madLibHeaderRef,
-  ]);
+  useEffect(() => {
+    const isWideEnoughForStickyHeader = window.innerWidth > 960;
+
+    const stickyHeaderEl = document.querySelector(
+      "#onboarding-start-your-search"
+    );
+
+    const headerHeight = stickyHeaderEl?.clientHeight || 0;
+    console.log({ headerHeight });
+
+    setHeaderScrollMargin(isWideEnoughForStickyHeader ? headerHeight : 0);
+  }, [madLib, showIncarceratedChildrenAlert, showStickyLifeline, pageWidth]);
 
   useEffect(() => {
-    console.log(headerScrollMargin);
+    console.log({ headerScrollMargin });
   }, [headerScrollMargin]);
+
+  // const headerRef = useRef<HTMLDivElement>(null)
+
+  // useLayoutEffect(() => {
+  //   setHeaderScrollMargin(headerRef?.current?.clientHeight || 0)
+  // })
 
   return (
     <>
@@ -257,7 +269,7 @@ function ExploreDataPage() {
         <div
           className={styles.CarouselContainer}
           id="onboarding-start-your-search"
-          ref={madLibHeaderRef}
+          // ref={headerRef}
         >
           <Carousel
             className={`Carousel ${styles.Carousel}`}

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -220,14 +220,28 @@ function ExploreDataPage() {
 
   const [pageWidth, setPageWidth] = useState(window.innerWidth);
 
-  function handlePageWidthChange() {
-    setPageWidth(window.innerWidth);
+  // function handlePageWidthChange() {
+  //   setPageWidth(window.innerWidth);
+  // }
+
+  function handleHeaderHeightChange() {
+    const stickyHeaderEl = document.querySelector(
+      "#onboarding-start-your-search"
+    );
+
+    const headerHeight = stickyHeaderEl?.clientHeight || 0;
+    setHeaderScrollMargin(headerHeight);
   }
 
   useEffect(() => {
-    window.addEventListener("resize", handlePageWidthChange);
-    return () => window.removeEventListener("resize", handlePageWidthChange);
+    window.addEventListener("resize", handleHeaderHeightChange);
+    return () => window.removeEventListener("resize", handleHeaderHeightChange);
   }, []);
+
+  // useEffect(() => {
+  //   window.addEventListener("resize", handlePageWidthChange);
+  //   return () => window.removeEventListener("resize", handlePageWidthChange);
+  // }, []);
 
   const [headerScrollMargin, setHeaderScrollMargin] = useState(0);
 
@@ -243,7 +257,13 @@ function ExploreDataPage() {
     console.log({ headerHeight });
 
     setHeaderScrollMargin(isWideEnoughForStickyHeader ? headerHeight : 0);
-  }, [madLib, showIncarceratedChildrenAlert, showStickyLifeline, pageWidth]);
+  }, [
+    sticking,
+    madLib,
+    showIncarceratedChildrenAlert,
+    showStickyLifeline,
+    pageWidth,
+  ]);
 
   useEffect(() => {
     console.log({ headerScrollMargin });

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,6 +1,6 @@
 import { Grid } from "@material-ui/core";
 import NavigateNextIcon from "@material-ui/icons/NavigateNext";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import { STATUS } from "react-joyride";
 import Carousel from "react-material-ui-carousel";
@@ -40,6 +40,7 @@ import { urlMap } from "../../utils/externalUrls";
 import { VariableConfig } from "../../data/config/MetricConfig";
 import { INCARCERATION_IDS } from "../../data/variables/IncarcerationProvider";
 import useScrollPosition from "../../utils/hooks/useScrollPosition";
+import { useResponsiveWidth } from "../../utils/hooks/useResponsiveWidth";
 
 const EXPLORE_DATA_ID = "main";
 
@@ -52,8 +53,6 @@ function ExploreDataPage() {
   const [showStickyLifeline, setShowStickyLifeline] = useState(false);
   const [showIncarceratedChildrenAlert, setShowIncarceratedChildrenAlert] =
     useState(false);
-
-  const madLibHeaderRef = useRef<HTMLInputElement>(null);
 
   // Set up initial mad lib values based on defaults and query params
   const params = useSearchParams();
@@ -196,6 +195,10 @@ function ExploreDataPage() {
     ]);
   };
 
+  const [madLibHeaderRef, pageWidth] = useResponsiveWidth(
+    window.innerWidth || 1000
+  );
+
   /* on any changes to the madlib settings */
   useEffect(() => {
     // scroll browser screen to top
@@ -220,10 +223,25 @@ function ExploreDataPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [madLib]);
 
+  const [headerScrollMargin, setHeaderScrollMargin] = useState(0);
+
   /* on changes that affect the height of the sticky madlib header */
+  useLayoutEffect(() => {
+    const isSticky = pageWidth > 960;
+    const stickyHeaderHeight =
+      (isSticky && madLibHeaderRef.current?.clientHeight) || 0;
+    setHeaderScrollMargin(stickyHeaderHeight);
+  }, [
+    madLib,
+    showIncarceratedChildrenAlert,
+    showStickyLifeline,
+    pageWidth,
+    madLibHeaderRef,
+  ]);
+
   useEffect(() => {
-    console.log(madLibHeaderRef.current?.clientHeight);
-  }, [madLib, showIncarceratedChildrenAlert, showStickyLifeline]);
+    console.log(headerScrollMargin);
+  }, [headerScrollMargin]);
 
   return (
     <>
@@ -293,6 +311,7 @@ function ExploreDataPage() {
             setMadLib={setMadLibWithParam}
             doScrollToData={doScrollToData}
             isScrolledToTop={!sticking}
+            headerScrollMargin={headerScrollMargin}
           />
         </div>
       </div>

--- a/frontend/src/reports/OneVariableReport.tsx
+++ b/frontend/src/reports/OneVariableReport.tsx
@@ -47,6 +47,7 @@ export interface OneVariableReportProps {
   isScrolledToTop: boolean;
   reportSteps?: StepData[];
   setReportSteps?: Function;
+  headerScrollMargin: number;
 }
 
 export function OneVariableReport(props: OneVariableReportProps) {
@@ -134,6 +135,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
               md={SINGLE_COLUMN_WIDTH}
               id="population"
               className={styles.ScrollPastHeader}
+              style={{ scrollMarginTop: props.headerScrollMargin }}
             >
               <PopulationCard jumpToData={props.jumpToData} fips={props.fips} />
             </Grid>
@@ -164,6 +166,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                 md={SINGLE_COLUMN_WIDTH}
                 id="map"
                 className={styles.ScrollPastHeader}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 <MapCard
                   variableConfig={variableConfig}
@@ -185,6 +188,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                 md={SINGLE_COLUMN_WIDTH}
                 id="bar"
                 className={styles.ScrollPastHeader}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 <LazyLoad offset={600} height={750} once>
                   {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
@@ -210,6 +214,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                 md={SINGLE_COLUMN_WIDTH}
                 id="unknowns"
                 className={styles.ScrollPastHeader}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 <LazyLoad offset={800} height={750} once>
                   {variableConfig.metrics["pct_share"] && (
@@ -234,6 +239,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                 md={SINGLE_COLUMN_WIDTH}
                 id="disparity"
                 className={styles.ScrollPastHeader}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 <LazyLoad offset={800} height={750} once>
                   {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
@@ -258,6 +264,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                 md={SINGLE_COLUMN_WIDTH}
                 id="table"
                 className={styles.ScrollPastHeader}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 <LazyLoad offset={800} height={750} once>
                   {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
@@ -282,6 +289,7 @@ export function OneVariableReport(props: OneVariableReportProps) {
                   md={SINGLE_COLUMN_WIDTH}
                   id="age-adjusted"
                   className={styles.ScrollPastHeader}
+                  style={{ scrollMarginTop: props.headerScrollMargin }}
                 >
                   <LazyLoad offset={800} height={800} once>
                     <AgeAdjustedTableCard

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -32,7 +32,7 @@ import { Box } from "@material-ui/core";
 import DefinitionsList from "./ui/DefinitionsList";
 import LifelineAlert from "./ui/LifelineAlert";
 import LazyLoad from "react-lazyload";
-import IncarceratedChildrenLongAlert from "./ui/IncarceratedChildrenLongAlert";
+// import IncarceratedChildrenLongAlert from "./ui/IncarceratedChildrenLongAlert";
 import { StepData } from "../utils/hooks/useStepObserver";
 
 export const SINGLE_COLUMN_WIDTH = 12;
@@ -46,6 +46,7 @@ interface ReportProviderProps {
   doScrollToData?: boolean;
   showIncarceratedChildrenAlert: boolean;
   isScrolledToTop: boolean;
+  headerScrollMargin: number;
 }
 
 function ReportProvider(props: ReportProviderProps) {
@@ -103,6 +104,7 @@ function ReportProvider(props: ReportProviderProps) {
             isScrolledToTop={props.isScrolledToTop}
             reportSteps={reportSteps}
             setReportSteps={setReportSteps}
+            headerScrollMargin={props.headerScrollMargin}
           />
         );
       case "comparegeos":
@@ -131,6 +133,7 @@ function ReportProvider(props: ReportProviderProps) {
             isScrolledToTop={props.isScrolledToTop}
             reportSteps={reportSteps}
             setReportSteps={setReportSteps}
+            headerScrollMargin={props.headerScrollMargin}
           />
         );
       case "comparevars":
@@ -157,6 +160,7 @@ function ReportProvider(props: ReportProviderProps) {
             isScrolledToTop={props.isScrolledToTop}
             reportSteps={reportSteps}
             setReportSteps={setReportSteps}
+            headerScrollMargin={props.headerScrollMargin}
           />
         );
       default:

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -175,9 +175,6 @@ function ReportProvider(props: ReportProviderProps) {
         <ShareButtons madLib={props.madLib} />
         {props.showLifeLineAlert && <LifelineAlert />}
         <DisclaimerAlert jumpToData={jumpToData} />
-        {props.showIncarceratedChildrenAlert && false && (
-          <IncarceratedChildrenLongAlert />
-        )}
 
         {getReport()}
       </div>

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -50,6 +50,7 @@ function TwoVariableReport(props: {
   isScrolledToTop: boolean;
   reportSteps?: StepData[];
   setReportSteps?: Function;
+  headerScrollMargin: number;
 }) {
   const [currentBreakdown, setCurrentBreakdown] = useState<BreakdownVar>(
     getParameter(DEMOGRAPHIC_PARAM, RACE)
@@ -166,6 +167,7 @@ function TwoVariableReport(props: {
               xs={12}
               id="population"
               className={styles.ScrollPastHeaderCompareMode}
+              style={{ scrollMarginTop: props.headerScrollMargin }}
             >
               {/*  SINGLE POPULATION CARD FOR EXPLORE RELATIONSHIPS REPORT */}
               <PopulationCard
@@ -207,6 +209,7 @@ function TwoVariableReport(props: {
                 sm={6}
                 id="population"
                 className={styles.ScrollPastHeaderCompareMode}
+                style={{ scrollMarginTop: props.headerScrollMargin }}
               >
                 {/* FIRST POPULATION CARD FOR COMPARE RATES REPORT */}
                 <PopulationCard
@@ -254,6 +257,7 @@ function TwoVariableReport(props: {
             fips2={props.fips2}
             updateFips1={props.updateFips1Callback}
             updateFips2={props.updateFips2Callback}
+            headerScrollMargin={props.headerScrollMargin}
             createCard={(
               variableConfig: VariableConfig,
               fips: Fips,
@@ -282,6 +286,7 @@ function TwoVariableReport(props: {
                   variableConfig2={variableConfig2}
                   fips1={props.fips1}
                   fips2={props.fips2}
+                  headerScrollMargin={props.headerScrollMargin}
                   createCard={(
                     variableConfig: VariableConfig,
                     fips: Fips,
@@ -305,6 +310,7 @@ function TwoVariableReport(props: {
             variableConfig2={variableConfig2}
             fips1={props.fips1}
             fips2={props.fips2}
+            headerScrollMargin={props.headerScrollMargin}
             updateFips1={props.updateFips1Callback}
             updateFips2={props.updateFips2Callback}
             createCard={(
@@ -335,6 +341,7 @@ function TwoVariableReport(props: {
                   variableConfig2={variableConfig2}
                   fips1={props.fips1}
                   fips2={props.fips2}
+                  headerScrollMargin={props.headerScrollMargin}
                   createCard={(
                     variableConfig: VariableConfig,
                     fips: Fips,
@@ -363,6 +370,7 @@ function TwoVariableReport(props: {
                 fips2={props.fips2}
                 updateFips1={props.updateFips1Callback}
                 updateFips2={props.updateFips2Callback}
+                headerScrollMargin={props.headerScrollMargin}
                 createCard={(
                   variableConfig: VariableConfig,
                   fips: Fips,
@@ -394,6 +402,7 @@ function TwoVariableReport(props: {
               updateFips1={props.updateFips1Callback}
               updateFips2={props.updateFips2Callback}
               jumpToData={props.jumpToData}
+              headerScrollMargin={props.headerScrollMargin}
               createCard={(
                 variableConfig: VariableConfig,
                 fips: Fips,
@@ -458,6 +467,7 @@ function RowOfTwoOptionalMetrics(props: {
   dropdownVarId1?: DropdownVarId;
   dropdownVarId2?: DropdownVarId;
   jumpToData?: Function;
+  headerScrollMargin: number;
 }) {
   if (!props.variableConfig1 && !props.variableConfig2) {
     return <></>;
@@ -474,6 +484,7 @@ function RowOfTwoOptionalMetrics(props: {
         sm={6}
         id={props.id}
         className={styles.ScrollPastHeaderCompareMode}
+        style={{ scrollMarginTop: props.headerScrollMargin }}
       >
         <LazyLoad offset={800} height={750} once>
           {props.variableConfig1 && (
@@ -495,6 +506,7 @@ function RowOfTwoOptionalMetrics(props: {
         sm={6}
         id={`${props.id}2`}
         className={styles.ScrollPastHeaderCompareMode}
+        style={{ scrollMarginTop: props.headerScrollMargin }}
       >
         <LazyLoad offset={800} height={600} once>
           {props.variableConfig2 && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1777--health-equity-tracker.netlify.app/exploredata?onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

- re-measures the height of the sticky header any time it changes, and adjusts the `scroll-margin` property of every card, so that the scroll-to-card feature accounts for the variable height of the header and card is always scrolled to the precise location

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1753 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

