### PR TITLE
Fixes chart titles on mobile

### DIFF
--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -207,6 +207,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       fill: COLOR_SCALE,
       direction: "horizontal",
       title: props.legendTitle,
+      titleFontSize: pageIsTiny ? 9 : 11,
       titleLimit: 0,
       font: LEGEND_TEXT_FONT,
       labelFont: LEGEND_TEXT_FONT,
@@ -482,7 +483,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
         encode: {
           title: {
             enter: {
-              fontSize: { value: 14 },
+              fontSize: { value: pageIsTiny ? 11 : 14 },
               font: { value: "Inter, sans-serif" },
             },
           },
@@ -531,6 +532,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     altText,
     legendLowerBound,
     legendUpperBound,
+    pageIsTiny,
   ]);
 
   const mapStyle = {

--- a/frontend/src/charts/DisparityBarChart.tsx
+++ b/frontend/src/charts/DisparityBarChart.tsx
@@ -312,7 +312,7 @@ function getSpec(
       encode: {
         title: {
           enter: {
-            fontSize: { value: 14 },
+            fontSize: { value: pageIsTiny ? 11 : 14 },
             font: { value: "Inter, sans-serif" },
           },
         },
@@ -452,7 +452,7 @@ export function DisparityBarChart(props: DisparityBarChartProps) {
   );
 
   // calculate page size to determine if tiny mobile or not
-  const pageIsTiny = useMediaQuery("(max-width:500px)");
+  const pageIsTiny = useMediaQuery("(max-width:400px)");
 
   // move AIAN and NHPI into their own properties for STATE/RACE/VACCINE (since KFF doesnt provide pop compare metrics)
   let dataFromProps = props.data;

--- a/frontend/src/charts/SimpleHorizontalBarChart.tsx
+++ b/frontend/src/charts/SimpleHorizontalBarChart.tsx
@@ -83,7 +83,7 @@ function getSpec(
       encode: {
         title: {
           enter: {
-            fontSize: { value: 14 },
+            fontSize: { value: pageIsTiny ? 11 : 14 },
             font: { value: "Inter, sans-serif" },
           },
         },

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -45,6 +45,7 @@ import { MOBILE_BREAKPOINT } from "../../App";
 import { BreakdownVar } from "../../data/query/Breakdowns";
 import useEscape from "../../utils/hooks/useEscape";
 import { getMinMaxGroups } from "../../data/utils/DatasetTimeUtils";
+import { useMediaQuery } from "@material-ui/core";
 
 /* Define type interface */
 export interface TrendsChartProps {
@@ -70,6 +71,7 @@ export function TrendsChart({
   /* Config */
   const { STARTING_WIDTH, HEIGHT, MARGIN, MOBILE } = CONFIG;
   const { groupLabel } = axisConfig || {};
+  const pageIsTiny = useMediaQuery("(max-width:400px)");
 
   /* Refs */
   // parent container ref - used for setting svg width
@@ -271,7 +273,7 @@ export function TrendsChart({
         )}
       </div>
       {/* Chart Title */}
-      <figcaption>
+      <figcaption style={{ fontSize: pageIsTiny ? 11 : 14 }}>
         <b id={chartTitleId}>{chartTitle}</b>
       </figcaption>
       {/* Tooltip */}

--- a/frontend/src/charts/utils.ts
+++ b/frontend/src/charts/utils.ts
@@ -121,6 +121,11 @@ export function createTitles({
   const time = "since Jan 2020";
   const isMobile = containerWidth < 700;
   const isComparing = window.location.href.includes("compare");
+  const timeTrackingData = [
+    "covid_cases",
+    "covid_deaths",
+    "covid_hospitalizations",
+  ].includes(variableConfig.variableId);
 
   if (trend) {
     return {
@@ -148,39 +153,40 @@ export function createTitles({
     return { chartTitle, subtitle };
   }
 
-  //If time series data add time metric
-  if (variableConfig.timeSeriesData) {
+  //If time tracking data add time metric
+  if (timeTrackingData) {
     chartTitle = population
-      ? `Population vs distribution of total ${metric} ${time} in ${location}`
+      ? `Population vs distribution of total ${metric.toLocaleLowerCase()} ${time} in ${location}`
       : `${metric} ${time} per 100k people in ${location}`;
   } else {
     chartTitle = population
-      ? `Population vs distribution of total ${metric} in ${location}`
+      ? `Population vs distribution of total ${metric.toLocaleLowerCase()} in ${location}`
       : `${metric} per 100k people in ${location}`;
   }
 
-  if (isMobile && variableConfig.timeSeriesData) {
+  if (isMobile && timeTrackingData) {
     chartTitle = population
       ? [
-          `Population vs distribution of total ${metric}`,
+          `Population vs distribution of`,
+          `total ${metric.toLocaleLowerCase()}`,
           `${time} in ${location}`,
         ]
       : [`${metric} ${time} per 100k`, `people in ${location}`];
   }
-  if (isMobile && !variableConfig.timeSeriesData) {
+  if (isMobile && !timeTrackingData) {
     chartTitle = population
       ? (chartTitle = [
-          `Population vs distribution of ${metric} in`,
+          `Population vs distribution of ${metric.toLocaleLowerCase()} in`,
           `${location}`,
         ])
       : [`${metric} per 100k people in the`, `${location}`];
   }
 
-  if (isComparing && variableConfig.timeSeriesData) {
+  if (isComparing && timeTrackingData) {
     if (containerWidth < 1400 && containerWidth > 1000) {
       chartTitle = population
         ? [
-            `Population vs distribution of total ${metric}`,
+            `Population vs distribution of total ${metric.toLocaleLowerCase()}`,
             `${time} in ${location}`,
           ]
         : [`${metric} ${time} per 100k people`, `in ${location}`];
@@ -189,24 +195,28 @@ export function createTitles({
       chartTitle = population
         ? [
             `Population vs distrbution of`,
-            `total ${metric}`,
+            `total ${metric.toLocaleLowerCase()}`,
             `${time} in ${location}`,
           ]
         : [`${metric}`, `${time} per 100k people`, `in ${location}`];
     }
   }
-  if (isComparing && !variableConfig.timeSeriesData) {
+  if (isComparing && !timeTrackingData) {
     if (containerWidth < 1400 && containerWidth > 1000) {
       chartTitle = population
         ? (chartTitle = [
-            `Population vs distribution of ${metric}`,
+            `Population vs distribution of ${metric.toLocaleLowerCase()}`,
             `in ${location}`,
           ])
         : [`${metric} per 100k people in`, `${location}`];
     }
     if (containerWidth < 1000 && containerWidth > 600) {
       chartTitle = population
-        ? [`Population vs distribution of`, `total ${metric}`, `in ${location}`]
+        ? [
+            `Population vs distribution of`,
+            `total ${metric.toLocaleLowerCase()}`,
+            `in ${location}`,
+          ]
         : [`${metric}`, `per 100k people`, `in ${location}`];
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1832--health-equity-tracker.netlify.app/exploredata?onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->
-Changed the size of font when on mobile to fit more of the text in on the Vega charts since there is not text wrapping property on SVGs.
-Broke the population vs share chart titles into more lines to prevent long titles from expanding outside the chart.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
-Currently when on mobile, some of the very long titles on the Vega charts, expand beyond the card view. 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested locally on mobile view. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

