### PR TITLE
Fix weird iOS left-right arrow

### DIFF
--- a/frontend/src/charts/trendsChart/Axes.tsx
+++ b/frontend/src/charts/trendsChart/Axes.tsx
@@ -73,7 +73,7 @@ export function Axes({
         (getMaxNumber(data) || 0) <= 0 ? "" : "disproportionately high  →", // if there are positive numbers, append positive direction label
       bottomLabel:
         (getMinNumber(data) || 0) >= 0 ? "" : "← disproportionately low", // if there are negative numbers, append negative direction label
-      formatter: (d: number) => (d === 0 ? "=" : F.pct(d)), // if tick is 0, hide it, otherwise format as percent
+      formatter: (d: number) => (d === 0 ? "" : F.pct(d)), // if tick is 0, hide it, otherwise format as percent
     },
   };
 

--- a/frontend/src/charts/trendsChart/Axes.tsx
+++ b/frontend/src/charts/trendsChart/Axes.tsx
@@ -73,7 +73,7 @@ export function Axes({
         (getMaxNumber(data) || 0) <= 0 ? "" : "disproportionately high  →", // if there are positive numbers, append positive direction label
       bottomLabel:
         (getMinNumber(data) || 0) >= 0 ? "" : "← disproportionately low", // if there are negative numbers, append negative direction label
-      formatter: (d: number) => (d === 0 ? "↔" : F.pct(d)), // if tick is 0, hide it, otherwise format as percent
+      formatter: (d: number) => (d === 0 ? "=" : F.pct(d)), // if tick is 0, hide it, otherwise format as percent
     },
   };
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1847--health-equity-tracker.netlify.app/exploredata?onboard=false#inequities-over-time" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

remove problematic left-right arrow

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1846 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

on desktop and mobile

## Screenshots (if appropriate):

Tried Using "=" instead but decided to go with nothing 
<img width="712" alt="Screen Shot 2022-10-12 at 8 41 53 AM" src="https://user-images.githubusercontent.com/41567007/195373771-64b91600-f230-48a6-bbba-3dd1301a4b77.png">

![image](https://user-images.githubusercontent.com/41567007/195374076-6fbfe032-9849-46f4-978a-d3734236a925.jpeg)

Keeping `0` line blank
<img width="997" alt="Screen Shot 2022-10-13 at 9 11 49 AM" src="https://user-images.githubusercontent.com/41567007/195636788-1d41ee05-0993-4e95-bc79-4a15f767ce13.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
