### PR TITLE
Fix WIIIDE screens not showing 2nd chart on load

### DIFF
--- a/frontend/src/reports/OneVariableReport.tsx
+++ b/frontend/src/reports/OneVariableReport.tsx
@@ -198,21 +198,19 @@ export function OneVariableReport(props: OneVariableReportProps) {
                   id="rates-over-time"
                   className={styles.ScrollPastHeader}
                 >
-                  <LazyLoad offset={600} height={750} once>
-                    {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
-                      <Fragment key={breakdownVar}>
-                        {breakdownIsShown(breakdownVar) &&
-                          // only show time series 100k chart if MetricConfig for current condition has a card title
-                          variableConfig.timeSeriesData && (
-                            <RateTrendsChartCard
-                              variableConfig={variableConfig}
-                              breakdownVar={breakdownVar}
-                              fips={props.fips}
-                            />
-                          )}
-                      </Fragment>
-                    ))}
-                  </LazyLoad>
+                  {DEMOGRAPHIC_BREAKDOWNS.map((breakdownVar) => (
+                    <Fragment key={breakdownVar}>
+                      {breakdownIsShown(breakdownVar) &&
+                        // only show time series 100k chart if MetricConfig for current condition has a card title
+                        variableConfig.timeSeriesData && (
+                          <RateTrendsChartCard
+                            variableConfig={variableConfig}
+                            breakdownVar={breakdownVar}
+                            fips={props.fips}
+                          />
+                        )}
+                    </Fragment>
+                  ))}
                 </Grid>
 
                 {/* 100K BAR CHART CARD */}

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -40,6 +40,11 @@ import { ScrollableHashId } from "../utils/hooks/useStepObserver";
 import styles from "./Report.module.scss";
 import { Helmet } from "react-helmet-async";
 
+const NON_LAZYLOADED_CARDS: ScrollableHashId[] = [
+  "rate-map",
+  "rates-over-time",
+];
+
 /* Takes dropdownVar and fips inputs for each side-by-side column.
 Input values for each column can be the same. */
 function TwoVariableReport(props: {
@@ -521,7 +526,7 @@ function TwoVariableReport(props: {
 }
 
 function RowOfTwoOptionalMetrics(props: {
-  id: string;
+  id: ScrollableHashId;
   variableConfig1: VariableConfig | undefined;
   variableConfig2: VariableConfig | undefined;
   fips1: Fips;
@@ -546,6 +551,7 @@ function RowOfTwoOptionalMetrics(props: {
   // Needed for type safety, used when the card does not need to use the fips update callback
   const unusedFipsCallback = () => {};
 
+  const dontLazyLoadCard = NON_LAZYLOADED_CARDS.includes(props.id);
   return (
     <>
       <Grid
@@ -556,8 +562,21 @@ function RowOfTwoOptionalMetrics(props: {
         tabIndex={-1}
         style={{ scrollMarginTop: props.headerScrollMargin }}
       >
-        <LazyLoad offset={800} height={750} once>
-          {props.variableConfig1 && (
+        {/* render with or without LazyLoad wrapped based on card id */}
+        {props.variableConfig1 && dontLazyLoadCard && (
+          <>
+            {props.createCard(
+              props.variableConfig1,
+              props.fips1,
+              props.updateFips1 || unusedFipsCallback,
+              props.dropdownVarId1,
+              /* isCompareCard */ false
+            )}
+          </>
+        )}
+
+        <LazyLoad offset={800} height={750}>
+          {props.variableConfig1 && !dontLazyLoadCard && (
             <>
               {props.createCard(
                 props.variableConfig1,
@@ -578,8 +597,20 @@ function RowOfTwoOptionalMetrics(props: {
         id={`${props.id}2`}
         style={{ scrollMarginTop: props.headerScrollMargin }}
       >
+        {props.variableConfig2 && dontLazyLoadCard && (
+          <>
+            {props.createCard(
+              props.variableConfig2,
+              props.fips2,
+              props.updateFips2 || unusedFipsCallback,
+              props.dropdownVarId2,
+              /* isCompareCard */ true
+            )}
+          </>
+        )}
+
         <LazyLoad offset={800} height={600} once>
-          {props.variableConfig2 && (
+          {props.variableConfig2 && !dontLazyLoadCard && (
             <>
               {props.createCard(
                 props.variableConfig2,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1848--health-equity-tracker.netlify.app/exploredata?onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

Before, the `<LazyLoad>` wrapper was preventing a card from showing until the user manually scrolled. This generally was fine but on very large / zoomed out screens that got refreshed, it made it look like there weren't any more cards below the map. 

This ensure `rate-map` and `rates-over-time` cards show automatically on both One- and TwoVariable reports


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

ensure users know there are more cards

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

manually

## Screenshots (if appropriate):

PROBLEM (One- and TwoVariable)

<img width="1604" alt="Screen Shot 2022-10-13 at 8 25 06 AM" src="https://user-images.githubusercontent.com/41567007/195624557-12ceefad-682a-431c-93c8-bc3339e1aebb.png">

<img width="1594" alt="Screen Shot 2022-10-13 at 9 08 12 AM" src="https://user-images.githubusercontent.com/41567007/195635225-499214b9-8b7f-43eb-86e4-2e8066936544.png">


FIXED

<img width="1604" alt="Screen Shot 2022-10-13 at 8 25 22 AM" src="https://user-images.githubusercontent.com/41567007/195624641-d1788f1e-14db-497c-91a1-2ed2bce273f0.png">

<img width="1594" alt="Screen Shot 2022-10-13 at 9 08 26 AM" src="https://user-images.githubusercontent.com/41567007/195635276-cd346880-967e-4fc0-b1e5-e62cd7e5413e.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

