### PR TITLE
Don't make Vega show "0 per 100k"

### DIFF
--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -174,7 +174,10 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     const geographyName = props.showCounties
       ? countyOrEquivalent
       : stateOrTerritory;
-    const tooltipDatum = `format(datum.${props.metric.metricId}, ',')`;
+
+    // tooltip hover values above zero should get formatted commas; 0 should display as less than 1
+    const tooltipDatum = `if (datum.${props.metric.metricId} > 0, format(datum.${props.metric.metricId}, ','), '< 1')`;
+
     // TODO: would be nice to use addMetricDisplayColumn for the tooltips here so that data formatting is consistent.
     const tooltipLabel =
       props.isUnknownsMap && props.metric.unknownsVegaLabel

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -175,8 +175,11 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       ? countyOrEquivalent
       : stateOrTerritory;
 
-    // tooltip hover values above zero should get formatted commas; 0 should display as less than 1
-    const tooltipDatum = `if (datum.${props.metric.metricId} > 0, format(datum.${props.metric.metricId}, ','), '< 1')`;
+    const tooltipDatum =
+      props.metric.type === "per100k"
+        ? // formatted tooltip hover 100k values above zero should display as less than 1
+          `if (datum.${props.metric.metricId} > 0, format(datum.${props.metric.metricId}, ','), '<1')`
+        : `format(datum.${props.metric.metricId}, ',')`;
 
     // TODO: would be nice to use addMetricDisplayColumn for the tooltips here so that data formatting is consistent.
     const tooltipLabel =

--- a/frontend/src/data/config/MetricConfig.test.ts
+++ b/frontend/src/data/config/MetricConfig.test.ts
@@ -5,7 +5,6 @@ describe("Test Metric Config Functions", () => {
     expect(isPctType("pct_incidence")).toBe(true);
     expect(isPctType("pct_relative_inequity")).toBe(true);
     expect(isPctType("pct_share")).toBe(true);
-
     expect(isPctType("per100k")).toBe(false);
     expect(isPctType("something broken" as MetricType)).toBe(false);
   });
@@ -15,5 +14,6 @@ describe("Test Metric Config Functions", () => {
     expect(formatFieldValue("pct_incidence", 33, true)).toBe("33.0");
     expect(formatFieldValue("pct_share", 3, false)).toBe("3.0%");
     expect(formatFieldValue("per100k", 30_000, false)).toBe("30,000");
+    expect(formatFieldValue("per100k", 0, false)).toBe("<1");
   });
 });

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -298,7 +298,7 @@ export function formatFieldValue(
   }
 
   // if values are numeric but rounded down to 0, instead replace with "less than 1"
-  if (value === 0 && metricType === "per100k") return "< 1";
+  if (value === 0 && metricType === "per100k") return "<1";
 
   const isRatio = metricType.includes("ratio");
   let formatOptions = isPctType(metricType) ? { minimumFractionDigits: 1 } : {};

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -296,6 +296,10 @@ export function formatFieldValue(
   if (value === null || value === undefined) {
     return "";
   }
+
+  // if values are numeric but rounded down to 0, instead replace with "less than 1"
+  if (value === 0 && metricType === "per100k") return "< 1";
+
   const isRatio = metricType.includes("ratio");
   let formatOptions = isPctType(metricType) ? { minimumFractionDigits: 1 } : {};
   const formattedValue =


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1864--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.13239&dt1=covid_deaths&onboard=false" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

Relatively small case counts will round down to "0 per 100k", but this can mask the very real impact to those small number of people. Rather than display 0, it's better to use "<1" which conveys the same information but makes it clear the value wasn't necessarily exactly 0.  

- changes in the vega map hover tooltip formatting
- changes in the `formatFieldValue()` util which changes it everywhere else like the bar charts, tables, highest lowest, etc. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

item from #1852 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

<img width="956" alt="Screen Shot 2022-10-27 at 8 30 36 AM" src="https://user-images.githubusercontent.com/41567007/198321264-01de78bc-b8c7-47cd-afb4-eafee9d390a1.png">
<img width="956" alt="Screen Shot 2022-10-27 at 8 32 28 AM" src="https://user-images.githubusercontent.com/41567007/198321276-033e8633-9a0d-4cb0-b3b4-74d0b6bd07ab.png">
<img width="979" alt="Screen Shot 2022-10-27 at 8 33 54 AM" src="https://user-images.githubusercontent.com/41567007/198321285-da1202a0-8795-4411-84fb-2099b0a3fd20.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- New feature (non-breaking change which adds functionality or content)
