### PR TITLE
Have `<UnknownsMapCard />` handle all `0` values

### DIFF
--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -151,7 +151,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             (unknown: Row) => unknown[metricConfig.metricId] === undefined
           );
 
-        // when suppressing states with too low COVID numbers
+        // for data sets where some geos might contain `0` for every unknown pct_share, like CAWP US Congress National
         const unknownsAllZero =
           unknowns.length > 0 &&
           unknowns.every(

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -224,10 +224,11 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
               )}
 
               {/* NO UNKNOWNS INFO BOX */}
-              {showNoUnknownsInfo && (
+              {(showNoUnknownsInfo || unknownsAllZero) && (
                 <Alert severity="info" role="note">
                   No unknown values for {breakdownString} reported in this
-                  dataset.
+                  dataset at the {props.fips.getChildFipsTypeDisplayName()}{" "}
+                  level.
                 </Alert>
               )}
             </CardContent>

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -110,7 +110,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
         // MOST of the items rendered in the card refer to the unknowns at the CHILD geo level,
         //  e.g. if you look at the United States, we are dealing with the Unknown pct_share at the state level
         // the exception is the <UnknownsAlert /> which presents the amount of unknown demographic at the SELECTED level
-        const unknownRaces = mapQueryResponse
+        const unknownRaces: Row[] = mapQueryResponse
           .getValidRowsForField(currentBreakdown)
           .filter(
             (row: Row) =>

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -179,6 +179,8 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
         const showingVisualization =
           !unknownsArrayEmpty && !unknownsUndefined && !unknownsAllZero;
 
+        const hasChildGeo = props.fips.getChildFipsTypeDisplayName() !== "";
+
         return (
           <>
             <CardContent className={styles.SmallMarginContent}>
@@ -227,8 +229,14 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
               {(showNoUnknownsInfo || unknownsAllZero) && (
                 <Alert severity="info" role="note">
                   No unknown values for {breakdownString} reported in this
-                  dataset at the {props.fips.getChildFipsTypeDisplayName()}{" "}
-                  level.
+                  dataset
+                  {hasChildGeo && (
+                    <>
+                      {" "}
+                      at the {props.fips.getChildFipsTypeDisplayName()} level
+                    </>
+                  )}
+                  {"."}
                 </Alert>
               )}
             </CardContent>

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -151,6 +151,13 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             (unknown: Row) => unknown[metricConfig.metricId] === undefined
           );
 
+        // when suppressing states with too low COVID numbers
+        const unknownsAllZero =
+          unknowns.length > 0 &&
+          unknowns.every(
+            (unknown: Row) => unknown[metricConfig.metricId] === 0
+          );
+
         // show MISSING DATA ALERT if we expect the unknowns array to be empty (breakdowns/data unavailable),
         // or if the unknowns are undefined (eg COVID suppressed states)
         const showMissingDataAlert =
@@ -166,7 +173,8 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
           !noDemographicInfo;
 
         // show the UNKNOWNS MAP when there is unknowns data and it's not undefined/suppressed
-        const showingVisualization = !unknownsArrayEmpty && !unknownsUndefined;
+        const showingVisualization =
+          !unknownsArrayEmpty && !unknownsUndefined && !unknownsAllZero;
 
         return (
           <>
@@ -180,24 +188,26 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             <Divider />
 
             {/* PERCENT REPORTING UNKNOWN ALERT - contains its own logic and divider/styling */}
-            <UnknownsAlert
-              queryResponse={alertQueryResponse}
-              metricConfig={metricConfig}
-              breakdownVar={currentBreakdown}
-              displayType="map"
-              known={false}
-              overrideAndWithOr={currentBreakdown === RACE}
-              raceEthDiffMap={
-                mapQueryResponse
-                  .getValidRowsForField(currentBreakdown)
-                  .filter(
-                    (row: Row) => row[currentBreakdown] === UNKNOWN_ETHNICITY
-                  ).length !== 0
-              }
-              noDemographicInfoMap={noDemographicInfo}
-              showingVisualization={showingVisualization}
-              fips={props.fips}
-            />
+            {!unknownsAllZero && (
+              <UnknownsAlert
+                queryResponse={alertQueryResponse}
+                metricConfig={metricConfig}
+                breakdownVar={currentBreakdown}
+                displayType="map"
+                known={false}
+                overrideAndWithOr={currentBreakdown === RACE}
+                raceEthDiffMap={
+                  mapQueryResponse
+                    .getValidRowsForField(currentBreakdown)
+                    .filter(
+                      (row: Row) => row[currentBreakdown] === UNKNOWN_ETHNICITY
+                    ).length !== 0
+                }
+                noDemographicInfoMap={noDemographicInfo}
+                showingVisualization={showingVisualization}
+                fips={props.fips}
+              />
+            )}
 
             <CardContent>
               {/* MISSING DATA ALERT */}
@@ -211,7 +221,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
               )}
 
               {/* NO UNKNOWNS INFO BOX */}
-              {showNoUnknownsInfo && (
+              {(showNoUnknownsInfo || unknownsAllZero) && (
                 <Alert severity="info" role="note">
                   No unknown values for {breakdownString} reported in this
                   dataset.

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -107,6 +107,9 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
       scrollToHash={HASH_ID}
     >
       {([mapQueryResponse, alertQueryResponse], metadata, geoData) => {
+        // MOST of the items rendered in the card refer to the unknowns at the CHILD geo level,
+        //  e.g. if you look at the United States, we are dealing with the Unknown pct_share at the state level
+        // the exception is the <UnknownsAlert /> which presents the amount of unknown demographic at the SELECTED level
         const unknownRaces = mapQueryResponse
           .getValidRowsForField(currentBreakdown)
           .filter(
@@ -188,6 +191,8 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             <Divider />
 
             {/* PERCENT REPORTING UNKNOWN ALERT - contains its own logic and divider/styling */}
+            {/* This alert presents the UNKNOWN PCT_SHARE for the SELECTED GEO LEVEL,
+            as opposed to the rest of this current component which deals in CHILD GEO unknowns */}
             <UnknownsAlert
               queryResponse={alertQueryResponse}
               metricConfig={metricConfig}

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -188,26 +188,24 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
             <Divider />
 
             {/* PERCENT REPORTING UNKNOWN ALERT - contains its own logic and divider/styling */}
-            {!unknownsAllZero && (
-              <UnknownsAlert
-                queryResponse={alertQueryResponse}
-                metricConfig={metricConfig}
-                breakdownVar={currentBreakdown}
-                displayType="map"
-                known={false}
-                overrideAndWithOr={currentBreakdown === RACE}
-                raceEthDiffMap={
-                  mapQueryResponse
-                    .getValidRowsForField(currentBreakdown)
-                    .filter(
-                      (row: Row) => row[currentBreakdown] === UNKNOWN_ETHNICITY
-                    ).length !== 0
-                }
-                noDemographicInfoMap={noDemographicInfo}
-                showingVisualization={showingVisualization}
-                fips={props.fips}
-              />
-            )}
+            <UnknownsAlert
+              queryResponse={alertQueryResponse}
+              metricConfig={metricConfig}
+              breakdownVar={currentBreakdown}
+              displayType="map"
+              known={false}
+              overrideAndWithOr={currentBreakdown === RACE}
+              raceEthDiffMap={
+                mapQueryResponse
+                  .getValidRowsForField(currentBreakdown)
+                  .filter(
+                    (row: Row) => row[currentBreakdown] === UNKNOWN_ETHNICITY
+                  ).length !== 0
+              }
+              noDemographicInfoMap={noDemographicInfo}
+              showingVisualization={showingVisualization}
+              fips={props.fips}
+            />
 
             <CardContent>
               {/* MISSING DATA ALERT */}
@@ -221,7 +219,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
               )}
 
               {/* NO UNKNOWNS INFO BOX */}
-              {(showNoUnknownsInfo || unknownsAllZero) && (
+              {showNoUnknownsInfo && (
                 <Alert severity="info" role="note">
                   No unknown values for {breakdownString} reported in this
                   dataset.

--- a/frontend/src/cards/ui/UnknownsAlert.tsx
+++ b/frontend/src/cards/ui/UnknownsAlert.tsx
@@ -122,7 +122,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
   ) : (
     <>
       <CardContent className={styles.SmallMarginContent}>
-        <Alert severity="warning" role="note">
+        <Alert severity={"warning"} role="note">
           {percentageUnknown}
           {props.metricConfig.shortLabel}
           {" reported an unknown "}

--- a/frontend/src/cards/ui/UnknownsAlert.tsx
+++ b/frontend/src/cards/ui/UnknownsAlert.tsx
@@ -86,6 +86,8 @@ function UnknownsAlert(props: UnknownsAlertProps) {
   const secondaryAgePercentageUnknown =
     additionalAgeUnknowns?.[0]?.[props.metricConfig.metricId];
 
+  const showInfoSeverity = percentageUnknown === 0;
+
   const diffRaceEthnicityText = raceEthnicityDiff
     ? `This state reports race and ethnicity separately.
     ${unknowns[0][props.metricConfig.metricId]}${
@@ -113,7 +115,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
   return raceEthnicityDiff ? (
     <>
       <CardContent className={styles.SmallMarginContent}>
-        <Alert severity="warning" role="note">
+        <Alert severity={"warning"} role="note">
           {diffRaceEthnicityText}
         </Alert>
       </CardContent>
@@ -122,7 +124,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
   ) : (
     <>
       <CardContent className={styles.SmallMarginContent}>
-        <Alert severity={"warning"} role="note">
+        <Alert severity={showInfoSeverity ? "info" : "warning"} role="note">
           {percentageUnknown}
           {props.metricConfig.shortLabel}
           {" reported an unknown "}

--- a/frontend/src/cards/ui/UnknownsAlert.tsx
+++ b/frontend/src/cards/ui/UnknownsAlert.tsx
@@ -83,10 +83,10 @@ function UnknownsAlert(props: UnknownsAlertProps) {
     separately, the map shows the higher of the two metrics.`;
 
   const percentageUnknown = unknowns[0][props.metricConfig.metricId];
+  const showInfoSeverity = percentageUnknown === 0;
+
   const secondaryAgePercentageUnknown =
     additionalAgeUnknowns?.[0]?.[props.metricConfig.metricId];
-
-  const showInfoSeverity = percentageUnknown === 0;
 
   const diffRaceEthnicityText = raceEthnicityDiff
     ? `This state reports race and ethnicity separately.
@@ -115,7 +115,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
   return raceEthnicityDiff ? (
     <>
       <CardContent className={styles.SmallMarginContent}>
-        <Alert severity={"warning"} role="note">
+        <Alert severity="warning" role="note">
           {diffRaceEthnicityText}
         </Alert>
       </CardContent>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1897--health-equity-tracker.netlify.app/exploredata?mls=1.women_in_legislative_office-3.00#unknown-demographic-map" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

Before, the BRFSS based topics were suppressing the unknowns map and using a info alert to inform the user that the dataset contained no unknown demographics, since the `pct_share` unknown rows contained `undefined` values. The CAWP dataset contains `0 pct_share` for unknowns rows, and was therefor displaying a full map of zeros and using the "warning" alert.

- this PR lets the unknownmap card handle cases when the amount of unknown share is specifically ZERO
- also adjusts severity in the normal RateInfo box to be "info" if the unknown rate is ZERO since that is a GOOD thing from an equity perspective
- clarifies SELF vs CHILD geo level in the unknowns map card.... a lot of work could be done here with variable ad component naming to make it more clear

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

manually

## Screenshots (if appropriate):

<img width="1773" alt="Screen Shot 2022-11-16 at 11 37 47 AM" src="https://user-images.githubusercontent.com/41567007/202265327-92d5c1ad-60c0-456a-b9a7-5a0e4ba8d025.png">
<img width="1773" alt="Screen Shot 2022-11-16 at 11 38 10 AM" src="https://user-images.githubusercontent.com/41567007/202265367-e8f59cd5-4d9e-4489-8991-a04ffd69151a.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
