### PR TITLE
Fix the legend fix for ranges that include NaN

### DIFF
--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -266,7 +266,8 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       colorScale["domainMax"] = props.fieldRange.max;
       colorScale["domainMin"] = props.fieldRange.min;
     }
-    if (legendLowerBound < legendUpperBound) {
+
+    if (legendLowerBound < legendUpperBound || isNaN(legendLowerBound)) {
       // if there is a range, adjust slope of the linear behavior of symlog around 0.
       if (props.scaleType === "symlog") colorScale["constant"] = 0.01;
     } else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1903--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.00&dt1=covid_deaths" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

didn't notice this bug on covid cases since the lower bound was a number. deaths and hosps were causing issue though; fixed by accounting for NaN


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1902 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
manually

## Screenshots (if appropriate):

<img width="1792" alt="Screen Shot 2022-11-19 at 12 43 23 PM" src="https://user-images.githubusercontent.com/41567007/202868700-f67e682e-f216-40c6-bb03-a869cd0716be.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
