### PR TITLE
Adds util fn for setting BQ column_types

### DIFF
--- a/python/datasources/bjs_incarceration.py
+++ b/python/datasources/bjs_incarceration.py
@@ -348,16 +348,14 @@ class BJSIncarcerationData(DataSource):
                 df = self.generate_breakdown_df(
                     breakdown, geo_level, table_lookup[table_name], children_tables)
 
-                # set / add BQ types
-                column_types = {c: 'STRING' for c in df.columns}
-                for col in BJS_DATA_TYPES:
-                    column_types[std_col.generate_column_name(
-                        col, std_col.PER_100K_SUFFIX)] = 'FLOAT'
-                    column_types[std_col.generate_column_name(
-                        col, std_col.PCT_SHARE_SUFFIX)] = 'FLOAT'
-                column_types[std_col.POPULATION_PCT_COL] = 'FLOAT'
-                if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
-                    column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
+                float_cols = [std_col.POPULATION_PCT_COL]
+                for data_type in BJS_DATA_TYPES:
+                    float_cols.append(std_col.generate_column_name(
+                        data_type, std_col.PER_100K_SUFFIX))
+                    float_cols.append(std_col.generate_column_name(
+                        data_type, std_col.PCT_SHARE_SUFFIX))
+                column_types = gcs_to_bq_util.get_bq_column_types(
+                    df, float_cols=float_cols)
 
                 gcs_to_bq_util.add_df_to_bq(
                     df, dataset, table_name, column_types=column_types)

--- a/python/datasources/bjs_incarceration.py
+++ b/python/datasources/bjs_incarceration.py
@@ -349,11 +349,11 @@ class BJSIncarcerationData(DataSource):
                     breakdown, geo_level, table_lookup[table_name], children_tables)
 
                 float_cols = [std_col.POPULATION_PCT_COL]
-                for data_type in BJS_DATA_TYPES:
-                    float_cols.append(std_col.generate_column_name(
-                        data_type, std_col.PER_100K_SUFFIX))
-                    float_cols.append(std_col.generate_column_name(
-                        data_type, std_col.PCT_SHARE_SUFFIX))
+                for prefix in BJS_DATA_TYPES:
+                    for suffix in [std_col.PER_100K_SUFFIX, std_col.PCT_SHARE_SUFFIX]:
+                        float_cols.append(std_col.generate_column_name(
+                            prefix, suffix))
+
                 column_types = gcs_to_bq_util.get_bq_column_types(
                     df, float_cols=float_cols)
 

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -247,19 +247,11 @@ class CAWPData(DataSource):
         df_state_leg_totals = get_state_leg_totals_as_df()
         df_us_congress_totals = get_congress_totals_as_df()
 
-        # set column types for BigQuery
-        column_types = {}
-        column_types[std_col.STATE_NAME_COL] = 'STRING'
-        column_types[std_col.WOMEN_STATE_LEG_PCT] = 'DECIMAL'
-        column_types[std_col.WOMEN_STATE_LEG_PCT_SHARE] = 'DECIMAL'
-        column_types[std_col.WOMEN_US_CONGRESS_PCT] = 'DECIMAL'
-        column_types[std_col.WOMEN_US_CONGRESS_PCT_SHARE] = 'DECIMAL'
-        column_types[std_col.RACE_CATEGORY_ID_COL] = 'STRING'
-        column_types[std_col.STATE_FIPS_COL] = 'STRING'
-        column_types[std_col.POPULATION_PCT_COL] = 'DECIMAL'
-        column_types[std_col.RACE_COL] = "STRING"
-        column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
-        column_types[std_col.RACE_OR_HISPANIC_COL] = "STRING"
+        float_cols = [
+            std_col.WOMEN_STATE_LEG_PCT, std_col.WOMEN_STATE_LEG_PCT_SHARE,
+            std_col.WOMEN_US_CONGRESS_PCT, std_col.WOMEN_US_CONGRESS_PCT_SHARE,
+            std_col.POPULATION_PCT_COL
+        ]
 
         # make two tables
         for geo_level in [STATE_LEVEL, NATIONAL_LEVEL]:
@@ -273,6 +265,9 @@ class CAWPData(DataSource):
                 breakdown_df, std_col.RACE_COL, geo_level)
             breakdown_df = breakdown_df.drop(columns=[std_col.POPULATION_COL])
             std_col.add_race_columns_from_category_id(breakdown_df)
+
+            column_types = gcs_to_bq_util.get_bq_column_types(
+                breakdown_df, float_cols)
 
             gcs_to_bq_util.add_df_to_bq(
                 breakdown_df, dataset, table_name, column_types=column_types)

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -267,7 +267,7 @@ class CAWPData(DataSource):
             std_col.add_race_columns_from_category_id(breakdown_df)
 
             column_types = gcs_to_bq_util.get_bq_column_types(
-                breakdown_df, float_cols)
+                breakdown_df, float_cols=float_cols)
 
             gcs_to_bq_util.add_df_to_bq(
                 breakdown_df, dataset, table_name, column_types=column_types)

--- a/python/datasources/cdc_svi_county.py
+++ b/python/datasources/cdc_svi_county.py
@@ -52,8 +52,7 @@ class CDCSviCounty(DataSource):
 
         df = self.generate_for_bq(df)
 
-        column_types = {c: 'STRING' for c in df.columns}
-        column_types[std_col.SVI] = 'FLOAT'
+        column_types = gcs_to_bq_util.get_bq_column_types(df, [std_col.SVI])
 
         gcs_to_bq_util.add_df_to_bq(
             df, dataset, "age", column_types=column_types)

--- a/python/datasources/cdc_svi_county.py
+++ b/python/datasources/cdc_svi_county.py
@@ -52,7 +52,8 @@ class CDCSviCounty(DataSource):
 
         df = self.generate_for_bq(df)
 
-        column_types = gcs_to_bq_util.get_bq_column_types(df, [std_col.SVI])
+        column_types = gcs_to_bq_util.get_bq_column_types(
+            df, float_cols=[std_col.SVI])
 
         gcs_to_bq_util.add_df_to_bq(
             df, dataset, "age", column_types=column_types)

--- a/python/datasources/vera_incarceration_county.py
+++ b/python/datasources/vera_incarceration_county.py
@@ -270,17 +270,14 @@ class VeraIncarcerationCounty(DataSource):
             df = self.generate_for_bq(
                 df, data_type, demo_type, df_children_partial)
 
-            # set BigQuery types object
-            bq_column_types = {c: 'STRING' for c in df.columns}
-            if std_col.RACE_INCLUDES_HISPANIC_COL in df.columns:
-                bq_column_types[std_col.RACE_INCLUDES_HISPANIC_COL] = 'BOOL'
-            bq_column_types[RATE_COL_MAP[data_type]] = 'FLOAT'
-            bq_column_types[CHILDREN] = 'FLOAT'
-            bq_column_types[PCT_SHARE_COL_MAP[data_type]] = 'FLOAT'
-            bq_column_types[PCT_SHARE_COL_MAP[POP]] = 'FLOAT'
-
+            float_cols = [
+                RATE_COL_MAP[data_type], CHILDREN,
+                PCT_SHARE_COL_MAP[data_type], PCT_SHARE_COL_MAP[POP],
+            ]
+            column_types = gcs_to_bq_util.get_bq_column_types(
+                df, float_cols=float_cols)
             gcs_to_bq_util.add_df_to_bq(
-                df, dataset, table_name, column_types=bq_column_types)
+                df, dataset, table_name, column_types=column_types)
 
     def generate_for_bq(self, df, data_type, demo_type, df_children):
 

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -386,7 +386,7 @@ def fetch_json_from_web(url):
     return json.loads(r.text)
 
 
-def get_bq_column_types(df, float_cols: List[str]):
+def get_bq_column_types(df, float_cols: List[str] = []):
     """ Generates the column_types dict needed for each data source's add_df_to_bq()
     Parameters:
         df: dataframe to be sent to BQ

--- a/python/ingestion/gcs_to_bq_util.py
+++ b/python/ingestion/gcs_to_bq_util.py
@@ -378,14 +378,6 @@ def fetch_zip_as_files(url):
     return files
 
 
-def fetch_json_from_web(url):
-    """
-    fetches json from a URL
-    """
-    r = requests.get(url)
-    return json.loads(r.text)
-
-
 def get_bq_column_types(df, float_cols: List[str] = []):
     """ Generates the column_types dict needed for each data source's add_df_to_bq()
     Parameters:

--- a/python/tests/test_gcs_to_bq.py
+++ b/python/tests/test_gcs_to_bq.py
@@ -3,13 +3,25 @@ from datetime import datetime, timezone
 from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
-
+import pandas as pd
 import numpy as np
 from freezegun import freeze_time
 from pandas import DataFrame
 from pandas.testing import assert_frame_equal
 
 from ingestion import gcs_to_bq_util  # pylint: disable=no-name-in-module
+
+
+def test_get_bq_column_types():
+    fake_df = pd.DataFrame({
+        'state_fips': ["01", "02", "03"],
+        'some_condition_per_100k': [None, 1, 2],
+    })
+    column_types = gcs_to_bq_util.get_bq_column_types(
+        fake_df, ['some_condition_per_100k'])
+    expected_column_types = {'state_fips': 'STRING',
+                             'some_condition_per_100k': 'FLOAT'}
+    assert column_types == expected_column_types
 
 
 class GcsToBqTest(TestCase):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Rather than each data source re-inventing a new way of setting the BQ `column_types`, we should have a util function that will handle this consistently across all sources
- starts by settings STRING for all columns of incoming df
- overwrites the specified columns that contain our metric values with FLOAT. We don't need to use INT because a) it is problematic on BQ especially with null values, and also b) our frontend will strip off any trailing `.0`s that aren't needed for conditions like `per 100k` where we only want to show whole numbers
- detects if it includes the `race_includes_ethnicity` and sets to BOOLEAN with a note to remove this once we do away with the multiple race columns on the backend

Refactors the following datasources to use this new fn:
- cawp
- svi
- bjs
- vera 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

in service of #1851 
more details on BQ type issue here: #1662

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- automated test added for new util fn
- existing tests per data source still pass

all refactored data sources build properly on my airflow:
- [x] cawp
- [x] svi
- [x] bjs
- [x] vera 


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Refactor (code improvement that doesn't affect UI)
- Chore (developer productivity fix that doesn't affect the user)
