### PR TITLE
Fixes age-adjust card missing unknowns 

### DIFF
--- a/frontend/src/cards/AgeAdjustedTableCard.tsx
+++ b/frontend/src/cards/AgeAdjustedTableCard.tsx
@@ -26,6 +26,7 @@ import {
   WHITE_NH,
   MULTI_OR_OTHER_STANDARD_NH,
   AGE,
+  SEX,
 } from "../data/utils/Constants";
 import Alert from "@material-ui/lab/Alert";
 import Divider from "@material-ui/core/Divider";
@@ -122,10 +123,10 @@ export function AgeAdjustedTableCard(props: AgeAdjustedTableCardProps) {
       {([raceQueryResponse, ageQueryResponse]) => {
         const [knownRaceData] = splitIntoKnownsAndUnknowns(
           raceQueryResponse.data,
-          "race_and_ethnicity"
+          RACE
         );
 
-        const isWrongBreakdownVar = props.breakdownVar === "sex";
+        const isWrongBreakdownVar = props.breakdownVar === SEX;
         const noRatios = knownRaceData.every(
           (row) => row[ratioId] === undefined
         );
@@ -188,7 +189,7 @@ export function AgeAdjustedTableCard(props: AgeAdjustedTableCardProps) {
             {/* values are present or partially null, implying we have at least some age-adjustments */}
             {!raceQueryResponse.dataIsMissing() &&
               !noRatios &&
-              props.breakdownVar !== "sex" && (
+              props.breakdownVar !== SEX && (
                 <div className={styles.TableChart}>
                   <AgeAdjustedTableChart
                     data={knownRaceData}

--- a/frontend/src/cards/AgeAdjustedTableCard.tsx
+++ b/frontend/src/cards/AgeAdjustedTableCard.tsx
@@ -122,7 +122,7 @@ export function AgeAdjustedTableCard(props: AgeAdjustedTableCardProps) {
       {([raceQueryResponse, ageQueryResponse]) => {
         const [knownRaceData] = splitIntoKnownsAndUnknowns(
           raceQueryResponse.data,
-          props.breakdownVar
+          "race_and_ethnicity"
         );
 
         const isWrongBreakdownVar = props.breakdownVar === "sex";

--- a/frontend/src/cards/ui/UnknownsAlert.tsx
+++ b/frontend/src/cards/ui/UnknownsAlert.tsx
@@ -13,6 +13,7 @@ import { Fips } from "../../data/utils/Fips";
 import { VisualizationType } from "../../charts/utils";
 import { splitIntoKnownsAndUnknowns } from "../../data/utils/datasetutils";
 import { WHAT_DATA_ARE_MISSING_ID } from "../../utils/internalRoutes";
+import { AGE } from "../../data/utils/Constants";
 
 export const RACE_OR_ETHNICITY = "race or ethnicity";
 
@@ -47,7 +48,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
     const validAgeData: Row[] = props.ageQueryResponse.getValidRowsForField(
       props.metricConfig.metricId
     );
-    const [, ageUnknowns] = splitIntoKnownsAndUnknowns(validAgeData, "age");
+    const [, ageUnknowns] = splitIntoKnownsAndUnknowns(validAgeData, AGE);
     additionalAgeUnknowns = ageUnknowns;
   }
 

--- a/frontend/src/cards/ui/UnknownsAlert.tsx
+++ b/frontend/src/cards/ui/UnknownsAlert.tsx
@@ -47,12 +47,7 @@ function UnknownsAlert(props: UnknownsAlertProps) {
     const validAgeData: Row[] = props.ageQueryResponse.getValidRowsForField(
       props.metricConfig.metricId
     );
-
-    const [, ageUnknowns] = splitIntoKnownsAndUnknowns(
-      validAgeData,
-      props.breakdownVar
-    );
-
+    const [, ageUnknowns] = splitIntoKnownsAndUnknowns(validAgeData, "age");
     additionalAgeUnknowns = ageUnknowns;
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Preview Link
<!--- Come back and edit this link after saving the PR -->
<!--- Replace 1234 with this PR's actual number  -->
<a href="https://deploy-preview-1922--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.00&mlp=disparity&demo=age&dt1=deaths#age-adjusted-risk" target="_blank">
  <img width="150"  src="https://healthequitytracker.org/img/appbar/AppbarLogo.png" alt="" /><br />
Click to demo updates </a> 

## Description
<!--- Describe your changes in detail -->

It was making queries based on the incoming breakdown selected, however instead it should always make the race query based on race and age query based on age; if it's SEX it should suppress and show nothing

Also, another bug i hadn't noticed is the additional "unknown age" % weren't always working, that should be fixed now

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1915 

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

visually

## Screenshots (if appropriate):

<img width="1036" alt="Screen Shot 2022-12-05 at 11 24 28 AM" src="https://user-images.githubusercontent.com/41567007/205714048-b73e4628-cc08-4474-9451-df1b94b99cb4.png">


## Types of changes
<!--- What types of changes does your code introduce? Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)
