### PR TITLE
HIV rename population percent column (backend)

### DIFF
--- a/python/datasources/cdc_hiv.py
+++ b/python/datasources/cdc_hiv.py
@@ -45,7 +45,7 @@ demo_dict = {
 
 pct_share_dict = {
     std_col.HIV_DIAGNOSES: std_col.HIV_DIAGNOSES_PCT_SHARE,
-    std_col.POPULATION_COL: std_col.POPULATION_PCT_COL
+    std_col.POPULATION_COL: std_col.HIV_POPULATION_PCT
 }
 
 
@@ -104,7 +104,7 @@ class CDCHIVData(DataSource):
 
                 df = self.generate_breakdown_df(breakdown, geo_level)
 
-                float_cols = [std_col.POPULATION_PCT_COL,
+                float_cols = [std_col.HIV_POPULATION_PCT,
                               std_col.HIV_DIAGNOSES,
                               std_col.HIV_DIAGNOSES_PER_100K,
                               std_col.HIV_DIAGNOSES_PCT_SHARE
@@ -140,7 +140,7 @@ class CDCHIVData(DataSource):
             std_col.HIV_DIAGNOSES,
             std_col.HIV_DIAGNOSES_PER_100K,
             std_col.HIV_DIAGNOSES_PCT_SHARE,
-            std_col.POPULATION_PCT_COL]
+            std_col.HIV_POPULATION_PCT]
 
         source_dfs = []
         missing_data = ['Data suppressed', 'Data not available']

--- a/python/datasources/cdc_hiv.py
+++ b/python/datasources/cdc_hiv.py
@@ -45,7 +45,7 @@ demo_dict = {
 
 pct_share_dict = {
     std_col.HIV_DIAGNOSES: std_col.HIV_DIAGNOSES_PCT_SHARE,
-    std_col.POPULATION_COL: std_col.POPULATION_PCT_COL
+    std_col.POPULATION_COL: std_col.HIV_POPULATION_PCT,
 }
 
 
@@ -104,7 +104,7 @@ class CDCHIVData(DataSource):
 
                 df = self.generate_breakdown_df(breakdown, geo_level)
 
-                float_cols = [std_col.POPULATION_PCT_COL,
+                float_cols = [std_col.HIV_POPULATION_PCT,
                               std_col.HIV_DIAGNOSES,
                               std_col.HIV_DIAGNOSES_PER_100K,
                               std_col.HIV_DIAGNOSES_PCT_SHARE
@@ -140,7 +140,7 @@ class CDCHIVData(DataSource):
             std_col.HIV_DIAGNOSES,
             std_col.HIV_DIAGNOSES_PER_100K,
             std_col.HIV_DIAGNOSES_PCT_SHARE,
-            std_col.POPULATION_PCT_COL]
+            std_col.HIV_POPULATION_PCT]
 
         source_dfs = []
         missing_data = ['Data suppressed', 'Data not available']

--- a/python/datasources/cdc_hiv.py
+++ b/python/datasources/cdc_hiv.py
@@ -45,7 +45,7 @@ demo_dict = {
 
 pct_share_dict = {
     std_col.HIV_DIAGNOSES: std_col.HIV_DIAGNOSES_PCT_SHARE,
-    std_col.POPULATION_COL: std_col.HIV_POPULATION_PCT,
+    std_col.POPULATION_COL: std_col.POPULATION_PCT_COL
 }
 
 
@@ -104,7 +104,7 @@ class CDCHIVData(DataSource):
 
                 df = self.generate_breakdown_df(breakdown, geo_level)
 
-                float_cols = [std_col.HIV_POPULATION_PCT,
+                float_cols = [std_col.POPULATION_PCT_COL,
                               std_col.HIV_DIAGNOSES,
                               std_col.HIV_DIAGNOSES_PER_100K,
                               std_col.HIV_DIAGNOSES_PCT_SHARE
@@ -140,7 +140,7 @@ class CDCHIVData(DataSource):
             std_col.HIV_DIAGNOSES,
             std_col.HIV_DIAGNOSES_PER_100K,
             std_col.HIV_DIAGNOSES_PCT_SHARE,
-            std_col.HIV_POPULATION_PCT]
+            std_col.POPULATION_PCT_COL]
 
         source_dfs = []
         missing_data = ['Data suppressed', 'Data not available']

--- a/python/ingestion/standardized_columns.py
+++ b/python/ingestion/standardized_columns.py
@@ -126,6 +126,7 @@ INCARCERATED_PREFIX = "incarcerated"
 HIV_DIAGNOSES = 'hiv_diagnoses'
 HIV_DIAGNOSES_PER_100K = 'hiv_diagnoses_per_100k'
 HIV_DIAGNOSES_PCT_SHARE = 'hiv_diagnoses_pct_share'
+HIV_POPULATION_PCT = 'hiv_population_pct'
 
 
 RaceTuple = namedtuple("RaceTuple", [

--- a/python/ingestion/standardized_columns.py
+++ b/python/ingestion/standardized_columns.py
@@ -126,6 +126,7 @@ INCARCERATED_PREFIX = "incarcerated"
 HIV_DIAGNOSES = 'hiv_diagnoses'
 HIV_DIAGNOSES_PER_100K = 'hiv_diagnoses_per_100k'
 HIV_DIAGNOSES_PCT_SHARE = 'hiv_diagnoses_pct_share'
+HIV_POPULATION_PCT = "hiv_population_pct"
 
 
 RaceTuple = namedtuple("RaceTuple", [

--- a/python/ingestion/standardized_columns.py
+++ b/python/ingestion/standardized_columns.py
@@ -126,7 +126,6 @@ INCARCERATED_PREFIX = "incarcerated"
 HIV_DIAGNOSES = 'hiv_diagnoses'
 HIV_DIAGNOSES_PER_100K = 'hiv_diagnoses_per_100k'
 HIV_DIAGNOSES_PCT_SHARE = 'hiv_diagnoses_pct_share'
-HIV_POPULATION_PCT = 'hiv_population_pct'
 
 
 RaceTuple = namedtuple("RaceTuple", [

--- a/python/tests/data/cdc_hiv/golden_data/age_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+county_name,county_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 Autauga County,01001,2019,13-24,,,,18.0
 Autauga County,01001,2019,25-34,,,,15.7
 Autauga County,01001,2019,35-44,0.0,0.0,0.0,15.6

--- a/python/tests/data/cdc_hiv/golden_data/age_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+county_name,county_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 Autauga County,01001,2019,13-24,,,,18.0
 Autauga County,01001,2019,25-34,,,,15.7
 Autauga County,01001,2019,35-44,0.0,0.0,0.0,15.6

--- a/python/tests/data/cdc_hiv/golden_data/age_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 United States,00,2019,13-24,7638.0,15.0,20.9,18.5
 United States,00,2019,25-34,13075.0,28.4,35.8,16.2
 United States,00,2019,35-44,7114.0,17.1,19.5,14.6

--- a/python/tests/data/cdc_hiv/golden_data/age_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 United States,00,2019,13-24,7638.0,15.0,20.9,18.5
 United States,00,2019,25-34,13075.0,28.4,35.8,16.2
 United States,00,2019,35-44,7114.0,17.1,19.5,14.6

--- a/python/tests/data/cdc_hiv/golden_data/age_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 Alabama,01,2019,13-24,165.0,21.7,26.0,18.4
 Alabama,01,2019,25-34,219.0,33.8,34.5,15.7
 Alabama,01,2019,35-44,118.0,19.9,18.6,14.4

--- a/python/tests/data/cdc_hiv/golden_data/age_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/age_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+state_name,state_fips,time_period,age,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 Alabama,01,2019,13-24,165.0,21.7,26.0,18.4
 Alabama,01,2019,25-34,219.0,33.8,34.5,15.7
 Alabama,01,2019,35-44,118.0,19.9,18.6,14.4

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
+county_name,county_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
 Autauga County,01001,2019,All,7.0,15.0,100.0,100.0,ALL
 Autauga County,01001,2019,American Indian and Alaska Native (NH),0.0,0.0,0.0,0.4,AIAN_NH
 Autauga County,01001,2019,Asian (NH),0.0,0.0,0.0,1.1,ASIAN_NH

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
+county_name,county_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
 Autauga County,01001,2019,All,7.0,15.0,100.0,100.0,ALL
 Autauga County,01001,2019,American Indian and Alaska Native (NH),0.0,0.0,0.0,0.4,AIAN_NH
 Autauga County,01001,2019,Asian (NH),0.0,0.0,0.0,1.1,ASIAN_NH

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
+state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
 United States,00,2019,American Indian and Alaska Native (NH),204.0,10.2,0.6,2.3,AIAN_NH
 United States,00,2019,Asian (NH),733.0,4.5,2.0,2.1,ASIAN_NH
 United States,00,2019,Black or African American (NH),15471.0,45.5,42.4,23.1,BLACK_NH

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
+state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
 United States,00,2019,American Indian and Alaska Native (NH),204.0,10.2,0.6,2.3,AIAN_NH
 United States,00,2019,Asian (NH),733.0,4.5,2.0,2.1,ASIAN_NH
 United States,00,2019,Black or African American (NH),15471.0,45.5,42.4,23.1,BLACK_NH

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
+state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
 Alabama,01,2019,All,635.0,15.4,100.0,100.0,ALL
 Alabama,01,2019,American Indian and Alaska Native (NH),1.0,4.1,0.2,0.6,AIAN_NH
 Alabama,01,2019,Asian (NH),1.0,1.6,0.2,1.5,ASIAN_NH

--- a/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/race_and_ethnicity_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct,race_category_id
+state_name,state_fips,time_period,race_and_ethnicity,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct,race_category_id
 Alabama,01,2019,All,635.0,15.4,100.0,100.0,ALL
 Alabama,01,2019,American Indian and Alaska Native (NH),1.0,4.1,0.2,0.6,AIAN_NH
 Alabama,01,2019,Asian (NH),1.0,1.6,0.2,1.5,ASIAN_NH

--- a/python/tests/data/cdc_hiv/golden_data/sex_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+county_name,county_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 Autauga County,01001,2019,All,7.0,15.0,100.0,100.0
 Autauga County,01001,2019,Female,,,,52.1
 Autauga County,01001,2019,Male,,,,47.9

--- a/python/tests/data/cdc_hiv/golden_data/sex_county_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_county_output.csv
@@ -1,4 +1,4 @@
-county_name,county_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+county_name,county_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 Autauga County,01001,2019,All,7.0,15.0,100.0,100.0
 Autauga County,01001,2019,Female,,,,52.1
 Autauga County,01001,2019,Male,,,,47.9

--- a/python/tests/data/cdc_hiv/golden_data/sex_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 United States,00,2019,Female,6939.0,4.9,19.0,51.6
 United States,00,2019,Male,29589.0,21.9,81.0,48.4
 United States,00,2019,All,36528.0,13.2,100.0,100.0

--- a/python/tests/data/cdc_hiv/golden_data/sex_national_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_national_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 United States,00,2019,Female,6939.0,4.9,19.0,51.6
 United States,00,2019,Male,29589.0,21.9,81.0,48.4
 United States,00,2019,All,36528.0,13.2,100.0,100.0

--- a/python/tests/data/cdc_hiv/golden_data/sex_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
+state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
 Alabama,01,2019,All,635.0,15.4,100.0,100.0
 Alabama,01,2019,Female,135.0,6.3,21.3,52.2
 Alabama,01,2019,Male,500.0,25.3,78.7,47.8

--- a/python/tests/data/cdc_hiv/golden_data/sex_state_output.csv
+++ b/python/tests/data/cdc_hiv/golden_data/sex_state_output.csv
@@ -1,4 +1,4 @@
-state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,hiv_population_pct
+state_name,state_fips,time_period,sex,hiv_diagnoses,hiv_diagnoses_per_100k,hiv_diagnoses_pct_share,population_pct
 Alabama,01,2019,All,635.0,15.4,100.0,100.0
 Alabama,01,2019,Female,135.0,6.3,21.3,52.2
 Alabama,01,2019,Male,500.0,25.3,78.7,47.8


### PR DESCRIPTION
## Description

Renames the `population_pct` column on the HIV data frame to `hiv_population_pct.`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

This prevents renaming the column on the front end. 

## Has this been tested? How?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested locally and on airflow.

## Screenshots (if appropriate):
![Screenshot 2023-02-13 at 4 21 24 PM](https://user-images.githubusercontent.com/72993442/218577255-df3814d7-0a59-46f0-b4ad-060ee487e2f5.png)

## Types of changes
<!--- Leave all that apply: -->
- Bug fix (non-breaking change which fixes an issue)

## Which of our [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/) will this feature primarily benefit and how?
<!--- Leave any that apply: -->
- Data Diver: contributes to the body of knowledge surrounding health equity (e.g., analysts, researchers, professors in academic or corporate settings)
- Data Interpreter: connects others by translating complex data into something actionable (e.g., think tank or legislative settings)
- Informer: helps everyday people understand important current events (e.g., journalists working in storytelling settings)
- Persuader: the passage of legislation by presenting concise and compelling arguments (e.g., staff members, policy advisors in legislative or nonprofit settings)

<!--- include any details specific to the targeted persona and how this will advance health equity -->

