### PR TITLE
Pins GitHub actions to Node 16

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,10 +19,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Run tests with Node.js 16.13.0
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: 16.13.0
+        node-version: 16
     - run: npm install
     - run: npm run cspell
     - run: npm run build

--- a/.github/workflows/urlsScheduled.yml
+++ b/.github/workflows/urlsScheduled.yml
@@ -15,10 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Run tests with Node.js 16.13.0
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v3
       with:
-        node-version: 16.13.0
+        node-version: 16
     - run: npm install
     - run: npm run build
     - run: npm run url

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -101,7 +101,7 @@
     "extends": "react-app"
   },
   "engines": {
-    "node": ">=12.19.0",
+    "node": ">=16",
     "npm": ">=6.14.8"
   },
   "browserslist": {


### PR DESCRIPTION
## Description

- Pins GitHub actions that now default to node 18 to node 16
- sets node engine to 16 in `package.json`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

All of our jest tests the imported files using `data-forge` were failing to run. Something must break when running on node 18 (the new default) instead of node 16, so for now this PR pins our yaml files to node 16

https://github.com/actions/runner-images/issues/7002

## Has this been tested? How?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tests are passing again

## Types of changes
<!--- Leave all that apply: -->
- Chore (developer productivity fix that doesn't affect the user)
