### PR TITLE
Fix for data table title

### DIFF
--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -135,7 +135,8 @@ export function TableCard(props: TableCardProps) {
                   metrics={Object.values(metricConfigs).filter(
                     (colName) => !NEVER_SHOW_PROPERTIES.includes(colName)
                   )}
-                  variable={props.variableConfig.variableFullDisplayName}
+                  variableId={props.variableConfig.variableId}
+                  variableName={props.variableConfig.variableFullDisplayName}
                   fips={props.fips}
                 />
               </div>

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -19,6 +19,7 @@ import {
   type MetricId,
   formatFieldValue,
   SYMBOL_TYPE_LOOKUP,
+  type VariableId,
 } from '../data/config/MetricConfig'
 import {
   BREAKDOWN_VAR_DISPLAY_NAMES,
@@ -54,15 +55,15 @@ export interface TableChartProps {
   data: Array<Readonly<Record<string, any>>>
   breakdownVar: BreakdownVar
   metrics: MetricConfig[]
-  variable: string
+  variableId: VariableId
+  variableName: string
   fips: Fips
 }
 
 export function TableChart(props: TableChartProps) {
   const wrap100kUnit = useMediaQuery('(max-width:500px)')
+  const { data, metrics, breakdownVar, variableId, variableName } = props
 
-  const { data, metrics, breakdownVar, variable } = props
-  const metricId = metrics[0].metricId
   let columns = metrics.map((metricConfig) => {
     return {
       Header: metricConfig.columnTitleHeader ?? metricConfig.shortLabel,
@@ -175,20 +176,21 @@ export function TableChart(props: TableChartProps) {
     paddingBottom: 10,
   }
 
-  const metricSubstrings = [
+  const VARIABLE_IDS_NEEDING_UPPERCASE = [
     'hiv_diagnoses',
     'hiv_deaths',
-    'hiv_prep',
     'hiv_prevalence',
-    'covid',
+    'hiv_prep',
+    'covid_cases',
+    'covid_deaths',
+    'covid_hospitalizations',
+    'covid_vaccinations',
     'copd',
   ]
 
-  const sentenceCaseName = metricSubstrings.some((substring) =>
-    metricId.includes(substring)
-  )
-    ? variable
-    : variable.charAt(0).toLowerCase() + variable.slice(1)
+  const sentenceCaseName = VARIABLE_IDS_NEEDING_UPPERCASE.includes(variableId)
+    ? variableName
+    : variableName.charAt(0).toLowerCase() + variableName.slice(1)
 
   return (
     <>
@@ -197,7 +199,7 @@ export function TableChart(props: TableChartProps) {
       ) : (
         <figure>
           <figcaption style={titleStyle}>
-            Data breakdown summary for {sentenceCaseName} in{' '}
+            Breakdown summary for {sentenceCaseName} in{' '}
             {props.fips.getSentenceDisplayName()}
           </figcaption>
 


### PR DESCRIPTION
## Description
This PR fixes the data table title issue where the title only displays the location of the United States.

- Refactors the condition in the sentenceCaseName function to ensure that 'hiv_care' is not included in the if clause of the ternary operator.
- Adds the `getSentenceDisplayName()` to the `TableChart.tsx` file.

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Fixes #2130

## Has this been tested? How?
Tested locally

## Screenshots (if appropriate):

- Before: ![Screenshot 2023-04-17 at 3 41 02 PM](https://user-images.githubusercontent.com/72993442/232593355-36060e1b-249c-4c54-85cd-791038ccfea8.png)
- After: ![Screenshot 2023-04-17 at 3 40 31 PM](https://user-images.githubusercontent.com/72993442/232593414-21fcf434-3c09-4569-bdc4-3ba26855c6de.png)

## Types of changes
- Bug fix

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎