### PR TITLE
Clearing Topic Returns to Single Var/Geo Mode

### DIFF
--- a/frontend/playwright-tests/userFlow-TrackerToCovidDeathsDenverVsCO.spec.ts
+++ b/frontend/playwright-tests/userFlow-TrackerToCovidDeathsDenverVsCO.spec.ts
@@ -72,4 +72,34 @@ test('Use Table of Contents to Scroll Unknown Map Into View and Be Focused', asy
 
 });
 
+test('Clear topic button from Compare Locations mode returns tracker to default state', async ({ page }) => {
+    // start at tracker default page (implicit default params)
+    await page.goto('http://localhost:3000/exploredata');
+
+    // choose sample compare mode report
+    await page.getByRole('link', { name: 'Uninsurance in Florida & California, by sex' }).click();
+
+    // clear topic
+    await page.getByRole('button', { name: 'Uninsured Individuals', exact: true }).click();
+    await page.getByRole('button', { name: 'Clear topic selection' }).click();
+
+    // should return to default page (with explicit params)
+    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity');
+});
+
+test('Clear topic button from Compare Topics mode returns tracker to default state', async ({ page }) => {
+    // start at tracker default page (implicit default params)
+    await page.goto('http://localhost:3000/exploredata');
+
+    // choose sample compare mode report
+    await page.getByRole('link', { name: 'Prison & poverty in Georgia, by race' }).click();
+
+    // clear topic
+    await page.getByRole('button', { name: 'Poverty', exact: true }).click();
+    await page.getByRole('button', { name: 'Clear topic selection' }).click();
+
+    // should return to default page (with explicit params)
+    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity');
+
+});
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,9 +18,9 @@ const config: PlaywrightTestConfig = {
   },
   testDir: './playwright-tests',
   /* Maximum time one test can run for. */
-  timeout: process.env.CI ? 240 * 1000 : 60 * 1000,
+  timeout: process.env.CI ? 240 * 1000 : 120 * 1000,
   expect: {
-    timeout: process.env.CI ? 240 * 1000 : 60 * 1000
+    timeout: process.env.CI ? 240 * 1000 : 120 * 1000
   },
   /* run all tests, even those within a shared file, in parallel  */
   fullyParallel: true,

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,9 +18,9 @@ const config: PlaywrightTestConfig = {
   },
   testDir: './playwright-tests',
   /* Maximum time one test can run for. */
-  timeout: 240 * 1000,
+  timeout: process.env.CI ? 240 * 1000 : 60 * 1000,
   expect: {
-    timeout: 240 * 1000
+    timeout: process.env.CI ? 240 * 1000 : 60 * 1000
   },
   /* run all tests, even those within a shared file, in parallel  */
   fullyParallel: true,

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -145,8 +145,8 @@ function ExploreDataPage(props: ExploreDataPageProps) {
   const [isSticking, setIsSticking] = useState<boolean>(false)
   useScrollPosition(
     ({ pageYOffset, stickyBarOffsetFromTop }) => {
-      const toOfMadLibContainer = pageYOffset > stickyBarOffsetFromTop
-      if (toOfMadLibContainer) setIsSticking(true)
+      const topOfMadLibContainer = pageYOffset > stickyBarOffsetFromTop
+      if (topOfMadLibContainer) setIsSticking(true)
       else setIsSticking(false)
     },
     [isSticking],

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -236,7 +236,7 @@ function ExploreDataPage(props: ExploreDataPageProps) {
       </h2>
       <div id={EXPLORE_DATA_ID} tabIndex={-1} className={styles.ExploreData}>
         <div className={styles.MadLibUIContainer} id="madlib-container">
-          <MadLibUI madLib={madLib} setMadLib={setMadLibWithParam} />
+          <MadLibUI madLib={madLib} setMadLibWithParam={setMadLibWithParam} />
 
           {showStickyLifeline && (
             <p className={styles.LifelineSticky}>

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { useLocation } from 'react-router-dom'
 import { Fips } from '../../data/utils/Fips'
 import {
+  DEFAULT,
+  MADLIB_LIST,
   getMadLibWithUpdatedValue,
   insertOptionalThe,
   type MadLib,
@@ -49,10 +51,14 @@ export default function MadLibUI(props: {
                 <OptionsSelector
                   key={index}
                   value={props.madLib.activeSelections[index]}
-                  onOptionUpdate={(fipsCode: string) => {
+                  onOptionUpdate={(newValue: string) => {
+                    // madlib with updated topic
                     props.setMadLib(
-                      getMadLibWithUpdatedValue(props.madLib, index, fipsCode)
+                      getMadLibWithUpdatedValue(props.madLib, index, newValue)
                     )
+
+                    if (newValue === DEFAULT) props.setMadLib(MADLIB_LIST[0])
+
                     location.hash = ''
                     window.scrollTo({
                       top: 0,

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -12,10 +12,16 @@ import {
 } from '../../utils/MadLibs'
 import OptionsSelector from './OptionsSelector'
 import styles from './ExploreDataPage.module.scss'
+import {
+  MADLIB_PHRASE_PARAM,
+  MADLIB_SELECTIONS_PARAM,
+  setParameters,
+  stringifyMls,
+} from '../../utils/urlutils'
 
 export default function MadLibUI(props: {
   madLib: MadLib
-  setMadLib: (updatedMadLib: MadLib) => void
+  setMadLibWithParam: (updatedMadLib: MadLib) => void
 }) {
   // TODO - this isn't efficient, these should be stored in an ordered way
   function getOptionsFromPhraseSegement(
@@ -53,11 +59,23 @@ export default function MadLibUI(props: {
                   value={props.madLib.activeSelections[index]}
                   onOptionUpdate={(newValue: string) => {
                     // madlib with updated topic
-                    props.setMadLib(
+                    props.setMadLibWithParam(
                       getMadLibWithUpdatedValue(props.madLib, index, newValue)
                     )
 
-                    if (newValue === DEFAULT) props.setMadLib(MADLIB_LIST[0])
+                    if (newValue === DEFAULT) {
+                      props.setMadLibWithParam(MADLIB_LIST[0])
+                      setParameters([
+                        {
+                          name: MADLIB_SELECTIONS_PARAM,
+                          value: stringifyMls(MADLIB_LIST[0].defaultSelections),
+                        },
+                        {
+                          name: MADLIB_PHRASE_PARAM,
+                          value: MADLIB_LIST[0].id,
+                        },
+                      ])
+                    }
 
                     location.hash = ''
                     window.scrollTo({

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -42,6 +42,32 @@ export default function MadLibUI(props: {
 
   const location = useLocation()
 
+  function handleOptionUpdate(newValue: string, index: number) {
+    // madlib with updated topic
+    props.setMadLibWithParam(
+      getMadLibWithUpdatedValue(props.madLib, index, newValue)
+    )
+
+    if (newValue === DEFAULT) {
+      props.setMadLibWithParam(MADLIB_LIST[0])
+      setParameters([
+        {
+          name: MADLIB_SELECTIONS_PARAM,
+          value: stringifyMls(MADLIB_LIST[0].defaultSelections),
+        },
+        {
+          name: MADLIB_PHRASE_PARAM,
+          value: MADLIB_LIST[0].id,
+        },
+      ])
+    }
+    location.hash = ''
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    })
+  }
+
   return (
     <Grid id="madlib-box" container justifyContent="center" alignItems="center">
       <div className={styles.MadLibUI}>
@@ -57,31 +83,8 @@ export default function MadLibUI(props: {
                 <OptionsSelector
                   key={index}
                   value={props.madLib.activeSelections[index]}
-                  onOptionUpdate={(newValue: string) => {
-                    // madlib with updated topic
-                    props.setMadLibWithParam(
-                      getMadLibWithUpdatedValue(props.madLib, index, newValue)
-                    )
-
-                    if (newValue === DEFAULT) {
-                      props.setMadLibWithParam(MADLIB_LIST[0])
-                      setParameters([
-                        {
-                          name: MADLIB_SELECTIONS_PARAM,
-                          value: stringifyMls(MADLIB_LIST[0].defaultSelections),
-                        },
-                        {
-                          name: MADLIB_PHRASE_PARAM,
-                          value: MADLIB_LIST[0].id,
-                        },
-                      ])
-                    }
-
-                    location.hash = ''
-                    window.scrollTo({
-                      top: 0,
-                      behavior: 'smooth',
-                    })
+                  onOptionUpdate={(newValue) => {
+                    handleOptionUpdate(newValue, index)
                   }}
                   options={getOptionsFromPhraseSegement(phraseSegment)}
                 />

--- a/frontend/src/pages/ExploreData/OptionsSelector.module.scss
+++ b/frontend/src/pages/ExploreData/OptionsSelector.module.scss
@@ -111,7 +111,7 @@
   }
 }
 
-.GoBackButtonText {
+.ClearTopicButtonText {
   font-size: $smallest;
   padding: 5px;
 }

--- a/frontend/src/pages/ExploreData/OptionsSelector.tsx
+++ b/frontend/src/pages/ExploreData/OptionsSelector.tsx
@@ -28,7 +28,7 @@ import { usePrefersReducedMotion } from '../../utils/hooks/usePrefersReducedMoti
 import KeyboardBackspaceIcon from '@mui/icons-material/KeyboardBackspace'
 
 function OptionsSelector(props: {
-  value: VariableId | string | DefaultDropdownVarId // condition data type OR fips as string OR default setting with no topic selected
+  value: VariableId | string | DefaultDropdownVarId // VariableId OR fips as string OR default setting with no topic selected
   options: Fips[] | string[][]
   onOptionUpdate: (option: string) => void
 }) {
@@ -233,7 +233,7 @@ function OptionsSelector(props: {
                   >
                     {!noTopic && (
                       <Button
-                        className={styles.GoBackButton}
+                        className={styles.ClearTopicButton}
                         onClick={() => {
                           popover.close()
                           props.onOptionUpdate(DEFAULT)
@@ -244,7 +244,7 @@ function OptionsSelector(props: {
                             fontSize: 'small',
                           }}
                         />{' '}
-                        <span className={styles.GoBackButtonText}>
+                        <span className={styles.ClearTopicButtonText}>
                           Clear topic selection
                         </span>
                       </Button>


### PR DESCRIPTION
## Description

- clicking `Clear topic selection` in the big topic dropdown returns the tracker compare mode to `Off` even if it was in a compare mode

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #2112 

## Has this been tested? How?

- [x] adds playwright tests to confirm behavior from both compare modes
- manually

## Screenshots (if appropriate):


https://user-images.githubusercontent.com/41567007/233141184-7f260ba5-453b-4115-af1f-4ee9dee215db.mp4



## Types of changes
- Bug fix

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Preview link below in Netlify comment 😎