### PR TITLE
Improves Vega Map Card: `quantile`, legend, labels

### DIFF
--- a/frontend/src/cards/Card.module.scss
+++ b/frontend/src/cards/Card.module.scss
@@ -99,7 +99,7 @@
 
   padding-block: 0;
   margin-block: 0;
-  font-size: $text;
+  font-size: $small;
 }
 
 .TerritoryCirclesContainer {

--- a/frontend/src/cards/Card.module.scss
+++ b/frontend/src/cards/Card.module.scss
@@ -86,6 +86,22 @@
   min-width: unset !important;
 }
 
+.MapTitle {
+  font-weight: bold;
+  padding-block: 0;
+  margin-block: 0;
+  font-size: $title;
+}
+
+.MapSubtitle {
+  font-style: italic;
+  font-weight: lighter;
+
+  padding-block: 0;
+  margin-block: 0;
+  font-size: $text;
+}
+
 .TerritoryCirclesContainer {
   width: 100%;
   height: 55px;

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -1,4 +1,4 @@
-import { CardContent, Grid } from '@mui/material'
+import { CardContent, Grid, useMediaQuery, useTheme } from '@mui/material'
 import Divider from '@mui/material/Divider'
 import Alert from '@mui/material/Alert'
 import { ChoroplethMap } from '../charts/ChoroplethMap'
@@ -195,6 +195,11 @@ function MapCardWithKey(props: MapCardProps) {
 
   const HASH_ID: ScrollableHashId = 'rate-map'
 
+  const theme = useTheme()
+  const pageIsSmall = useMediaQuery(theme.breakpoints.down('md'))
+  const isCompareMode = window.location.href.includes('compare')
+  const mapIsSkinny = pageIsSmall || isCompareMode
+
   return (
     <CardWrapper
       downloadTitle={filename}
@@ -350,7 +355,7 @@ function MapCardWithKey(props: MapCardProps) {
                         <h4 className={styles.MapSubtitle}>{subtitle}</h4>
                       </figcaption>
                     </Grid>
-                    <Grid item xs={10}>
+                    <Grid item xs={12} lg={10}>
                       <ChoroplethMap
                         signalListeners={signalListeners}
                         metric={metricConfig}
@@ -411,7 +416,7 @@ function MapCardWithKey(props: MapCardProps) {
                       )}
                     </Grid>
                     {/* Legend & Location Info */}
-                    <Grid item xs={2}>
+                    <Grid item xs={12} lg={2}>
                       <Legend
                         metric={metricConfig}
                         legendTitle={metricConfig.shortLabel}
@@ -422,7 +427,7 @@ function MapCardWithKey(props: MapCardProps) {
                         }
                         scaleType={RATE_MAP_SCALE}
                         sameDotSize={true}
-                        direction={'vertical'}
+                        direction={mapIsSkinny ? 'horizontal' : 'vertical'}
                         description={'Legend for rate map'}
                       />
                     </Grid>

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -55,6 +55,7 @@ import { useCreateChartTitle } from '../utils/hooks/useCreateChartTitle'
 import { HIV_DETERMINANTS } from '../data/variables/HivProvider'
 import CountyUnavailableAlert from './ui/CountyUnavailableAlert'
 import { useState } from 'react'
+import { RATE_MAP_SCALE } from '../charts/mapHelpers'
 
 const SIZE_OF_HIGHEST_LOWEST_RATES_LIST = 5
 
@@ -358,7 +359,7 @@ function MapCardWithKey(props: MapCardProps) {
                       !props.fips.isUsa() && !hasSelfButNotChildGeoData
                     }
                     fips={props.fips}
-                    scaleType="quantize"
+                    scaleType={RATE_MAP_SCALE}
                     geoData={geoData}
                     // include card title, selected sub-group if any, and specific location in SAVE AS PNG filename
                     filename={filename}
@@ -390,7 +391,7 @@ function MapCardWithKey(props: MapCardProps) {
                               hideActions={true}
                               showCounties={false}
                               fips={fips}
-                              scaleType="quantize"
+                              scaleType={RATE_MAP_SCALE}
                               geoData={geoData}
                               overrideShapeWithCircle={true}
                               countColsToAdd={countColsToAdd}

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -198,7 +198,7 @@ function MapCardWithKey(props: MapCardProps) {
   const theme = useTheme()
   const pageIsSmall = useMediaQuery(theme.breakpoints.down('md'))
   const isCompareMode = window.location.href.includes('compare')
-  const mapIsSkinny = pageIsSmall || isCompareMode
+  const mapIsWide = !pageIsSmall && !isCompareMode
 
   return (
     <CardWrapper
@@ -355,7 +355,7 @@ function MapCardWithKey(props: MapCardProps) {
                         <h4 className={styles.MapSubtitle}>{subtitle}</h4>
                       </figcaption>
                     </Grid>
-                    <Grid item xs={12} lg={10}>
+                    <Grid item xs={12} md={mapIsWide ? 10 : 12}>
                       <ChoroplethMap
                         signalListeners={signalListeners}
                         metric={metricConfig}
@@ -416,7 +416,7 @@ function MapCardWithKey(props: MapCardProps) {
                       )}
                     </Grid>
                     {/* Legend & Location Info */}
-                    <Grid item xs={12} lg={2}>
+                    <Grid item xs={12} md={mapIsWide ? 2 : 12}>
                       <Legend
                         metric={metricConfig}
                         legendTitle={metricConfig.shortLabel}
@@ -427,7 +427,7 @@ function MapCardWithKey(props: MapCardProps) {
                         }
                         scaleType={RATE_MAP_SCALE}
                         sameDotSize={true}
-                        direction={mapIsSkinny ? 'horizontal' : 'vertical'}
+                        direction={mapIsWide ? 'vertical' : 'horizontal'}
                         description={'Legend for rate map'}
                       />
                     </Grid>

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -179,6 +179,10 @@ function MapCardWithKey(props: MapCardProps) {
     locationPhrase
   )
 
+  // TODO: remove this once we move ALL chart titles to HTML instead of VEGA
+  // TODO: and no longer need multi-line titles sent as string[]
+  if (Array.isArray(chartTitle)) chartTitle = chartTitle.join(' ')
+
   const { metricId } = metricConfig
   const subtitle = generateSubtitle({
     activeBreakdownFilter,
@@ -342,13 +346,13 @@ function MapCardWithKey(props: MapCardProps) {
                   <Grid container>
                     <Grid item xs={12}>
                       <figcaption>
-                        <b>{chartTitle}</b>
+                        <h3 className={styles.MapTitle}>{chartTitle}</h3>
+                        <h4 className={styles.MapSubtitle}>{subtitle}</h4>
                       </figcaption>
                     </Grid>
                     <Grid item xs={10}>
                       <ChoroplethMap
                         signalListeners={signalListeners}
-                        // titles={{ chartTitle, subtitle }}
                         metric={metricConfig}
                         legendTitle={metricConfig.shortLabel.toLowerCase()}
                         data={
@@ -383,10 +387,6 @@ function MapCardWithKey(props: MapCardProps) {
                               >
                                 <ChoroplethMap
                                   signalListeners={signalListeners}
-                                  // titles={{
-                                  //   chartTitle,
-                                  //   subtitle,
-                                  // }}
                                   metric={metricConfig}
                                   data={
                                     listExpanded

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -56,6 +56,7 @@ import { HIV_DETERMINANTS } from '../data/variables/HivProvider'
 import CountyUnavailableAlert from './ui/CountyUnavailableAlert'
 import { useState } from 'react'
 import { RATE_MAP_SCALE } from '../charts/mapHelpers'
+import { Legend } from '../charts/Legend'
 
 const SIZE_OF_HIGHEST_LOWEST_RATES_LIST = 5
 
@@ -338,69 +339,94 @@ function MapCardWithKey(props: MapCardProps) {
             {metricConfig && dataForActiveBreakdownFilter.length > 0 && (
               <div>
                 <CardContent>
-                  <ChoroplethMap
-                    signalListeners={signalListeners}
-                    titles={{ chartTitle, subtitle }}
-                    metric={metricConfig}
-                    legendTitle={metricConfig.shortLabel.toLowerCase()}
-                    data={
-                      listExpanded
-                        ? highestValues.concat(lowestValues)
-                        : dataForActiveBreakdownFilter
-                    }
-                    hideMissingDataTooltip={listExpanded}
-                    legendData={dataForActiveBreakdownFilter}
-                    hideActions={true}
-                    hideLegend={
-                      mapQueryResponse.dataIsMissing() ||
-                      dataForActiveBreakdownFilter.length <= 1
-                    }
-                    showCounties={
-                      !props.fips.isUsa() && !hasSelfButNotChildGeoData
-                    }
-                    fips={props.fips}
-                    scaleType={RATE_MAP_SCALE}
-                    geoData={geoData}
-                    // include card title, selected sub-group if any, and specific location in SAVE AS PNG filename
-                    filename={filename}
-                    listExpanded={listExpanded}
-                    countColsToAdd={countColsToAdd}
-                  />
-                  {/* generate additional VEGA canvases for territories on national map */}
-                  {props.fips.isUsa() && (
-                    <div className={styles.TerritoryCirclesContainer}>
-                      {TERRITORY_CODES.map((code) => {
-                        const fips = new Fips(code)
-                        return (
-                          <div className={styles.TerritoryCircle} key={code}>
-                            <ChoroplethMap
-                              signalListeners={signalListeners}
-                              titles={{
-                                chartTitle,
-                                subtitle,
-                              }}
-                              metric={metricConfig}
-                              data={
-                                listExpanded
-                                  ? highestValues.concat(lowestValues)
-                                  : dataForActiveBreakdownFilter
-                              }
-                              hideMissingDataTooltip={listExpanded}
-                              legendData={dataForActiveBreakdownFilter}
-                              hideLegend={true}
-                              hideActions={true}
-                              showCounties={false}
-                              fips={fips}
-                              scaleType={RATE_MAP_SCALE}
-                              geoData={geoData}
-                              overrideShapeWithCircle={true}
-                              countColsToAdd={countColsToAdd}
-                            />
-                          </div>
-                        )
-                      })}
-                    </div>
-                  )}
+                  <Grid container>
+                    <Grid item xs={12}>
+                      <figcaption>
+                        <b>{chartTitle}</b>
+                      </figcaption>
+                    </Grid>
+                    <Grid item xs={10}>
+                      <ChoroplethMap
+                        signalListeners={signalListeners}
+                        // titles={{ chartTitle, subtitle }}
+                        metric={metricConfig}
+                        legendTitle={metricConfig.shortLabel.toLowerCase()}
+                        data={
+                          listExpanded
+                            ? highestValues.concat(lowestValues)
+                            : dataForActiveBreakdownFilter
+                        }
+                        hideMissingDataTooltip={listExpanded}
+                        legendData={dataForActiveBreakdownFilter}
+                        hideActions={true}
+                        hideLegend={true}
+                        showCounties={
+                          !props.fips.isUsa() && !hasSelfButNotChildGeoData
+                        }
+                        fips={props.fips}
+                        scaleType={RATE_MAP_SCALE}
+                        geoData={geoData}
+                        // include card title, selected sub-group if any, and specific location in SAVE AS PNG filename
+                        filename={filename}
+                        listExpanded={listExpanded}
+                        countColsToAdd={countColsToAdd}
+                      />
+                      {/* generate additional VEGA canvases for territories on national map */}
+                      {props.fips.isUsa() && (
+                        <div className={styles.TerritoryCirclesContainer}>
+                          {TERRITORY_CODES.map((code) => {
+                            const fips = new Fips(code)
+                            return (
+                              <div
+                                className={styles.TerritoryCircle}
+                                key={code}
+                              >
+                                <ChoroplethMap
+                                  signalListeners={signalListeners}
+                                  // titles={{
+                                  //   chartTitle,
+                                  //   subtitle,
+                                  // }}
+                                  metric={metricConfig}
+                                  data={
+                                    listExpanded
+                                      ? highestValues.concat(lowestValues)
+                                      : dataForActiveBreakdownFilter
+                                  }
+                                  hideMissingDataTooltip={listExpanded}
+                                  legendData={dataForActiveBreakdownFilter}
+                                  hideLegend={true}
+                                  hideActions={true}
+                                  showCounties={false}
+                                  fips={fips}
+                                  scaleType={RATE_MAP_SCALE}
+                                  geoData={geoData}
+                                  overrideShapeWithCircle={true}
+                                  countColsToAdd={countColsToAdd}
+                                />
+                              </div>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </Grid>
+                    {/* Legend & Location Info */}
+                    <Grid item xs={2}>
+                      <Legend
+                        metric={metricConfig}
+                        legendTitle={metricConfig.shortLabel}
+                        legendData={
+                          listExpanded
+                            ? highestValues.concat(lowestValues)
+                            : dataForActiveBreakdownFilter
+                        }
+                        scaleType={RATE_MAP_SCALE}
+                        sameDotSize={true}
+                        direction={'vertical'}
+                        description={'Legend for rate map'}
+                      />
+                    </Grid>
+                  </Grid>
 
                   {!mapQueryResponse.dataIsMissing() &&
                     dataForActiveBreakdownFilter.length > 1 && (

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -35,6 +35,7 @@ import {
   getWomenRaceLabel,
 } from '../../data/variables/CawpProvider'
 import { useDownloadCardImage } from '../../utils/hooks/useDownloadCardImage'
+import { RATE_MAP_SCALE } from '../../charts/mapHelpers'
 
 export interface MultiMapDialogProps {
   // Metric the small maps will evaluate
@@ -146,7 +147,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     fips={props.fips}
                     fieldRange={props.fieldRange}
                     hideActions={true}
-                    scaleType="quantize"
+                    scaleType={RATE_MAP_SCALE}
                     geoData={props.geoData}
                     filename={`${props.metricConfig.chartTitleLines.join(' ')}${
                       breakdownValue === 'All' ? '' : ` for ${breakdownValue}`
@@ -176,7 +177,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                             showCounties={false}
                             fips={fips}
                             fieldRange={props.fieldRange}
-                            scaleType="quantize"
+                            scaleType={RATE_MAP_SCALE}
                             geoData={props.geoData}
                             overrideShapeWithCircle={true}
                             countColsToAdd={props.countColsToAdd}
@@ -213,7 +214,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     metric={props.metricConfig}
                     legendTitle={props.metricConfig.chartTitleLines.join(' ')}
                     legendData={props.data}
-                    scaleType="quantize"
+                    scaleType={RATE_MAP_SCALE}
                     sameDotSize={true}
                     direction={pageIsWide ? 'horizontal' : 'vertical'}
                     description={'Consistent legend for all displayed maps'}

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -20,7 +20,6 @@ import {
 import {
   type MetricConfig,
   type MetricId,
-  SYMBOL_TYPE_LOOKUP,
 } from '../../data/config/MetricConfig'
 import { Sources } from './Sources'
 import styles from './MultiMapDialog.module.scss'
@@ -207,12 +206,12 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
             <Box mt={pageIsWide ? 10 : 0}>
               <Grid container item>
                 <Grid container justifyContent="center">
-                  <b>Legend ({SYMBOL_TYPE_LOOKUP[props.metricConfig.type]})</b>
+                  <b>Legend: {props.metricConfig.shortLabel}</b>
                 </Grid>
                 <Grid container justifyContent="center">
                   <Legend
                     metric={props.metricConfig}
-                    legendTitle={props.metricConfig.chartTitleLines.join(' ')}
+                    legendTitle={''}
                     legendData={props.data}
                     scaleType={RATE_MAP_SCALE}
                     sameDotSize={true}

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -13,7 +13,6 @@ import {
   NO_DATA_MESSAGE,
 } from './Legend'
 import { useMediaQuery } from '@mui/material'
-import { PADDING_FOR_ACTIONS_MENU } from './utils'
 import {
   addCAWPTooltipInfo,
   buildTooltipTemplate,
@@ -477,13 +476,8 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     fontSize,
   ])
 
-  const mapStyle = {
-    width: '90%',
-    marginRight: PADDING_FOR_ACTIONS_MENU,
-  }
-
   return (
-    <div ref={ref} style={mapStyle}>
+    <div ref={ref}>
       {shouldRenderMap && (
         <Vega
           renderer="svg"

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -119,7 +119,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
 
   const yOffsetNoDataLegend = pageIsTiny ? -15 : -43
   const xOffsetNoDataLegend = pageIsTiny ? 15 : 230
-  const heightWidthRatio = 0.75
+  const heightWidthRatio = 0.5
 
   // Initial spec state is set in useEffect
   const [spec, setSpec] = useState({})

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -119,7 +119,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
 
   const yOffsetNoDataLegend = pageIsTiny ? -15 : -43
   const xOffsetNoDataLegend = pageIsTiny ? 15 : 230
-  const heightWidthRatio = pageIsTiny ? 1 : 0.5
+  const heightWidthRatio = 0.75
 
   // Initial spec state is set in useEffect
   const [spec, setSpec] = useState({})

--- a/frontend/src/charts/Legend.module.scss
+++ b/frontend/src/charts/Legend.module.scss
@@ -1,0 +1,11 @@
+@import '../styles/variables.module';
+@import '../styles/globals.scss';
+
+.Legend {
+  text-align: left;
+}
+
+.LegendTitle {
+  text-align: start;
+  font-size: $smallest;
+}

--- a/frontend/src/charts/Legend.module.scss
+++ b/frontend/src/charts/Legend.module.scss
@@ -8,4 +8,5 @@
 .LegendTitle {
   text-align: start;
   font-size: $smallest;
+  padding-left: 5px;
 }

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -21,7 +21,7 @@ export const LEGEND_SYMBOL_TYPE = 'square'
 export const LEGEND_TEXT_FONT = 'inter'
 export const NO_DATA_MESSAGE = 'no data'
 export const EQUAL_DOT_SIZE = 200
-export const LEGEND_COLOR_COUNT = 5
+export const LEGEND_COLOR_COUNT = 6
 
 /*
    Legend renders a vega chart that just contains a legend.
@@ -71,7 +71,7 @@ export function Legend(props: LegendProps) {
       ? Array(LEGEND_COLOR_COUNT).fill(EQUAL_DOT_SIZE)
       : [70, 120, 170, 220, 270, 320, 370]
 
-    const legendList = [
+    const legendList: any[] = [
       {
         fill: COLOR_SCALE,
         labelOverlap: 'greedy',
@@ -82,7 +82,7 @@ export function Legend(props: LegendProps) {
         labelFont: LEGEND_TEXT_FONT,
         direction: props.direction,
         orient: 'left',
-        columns: props.direction === 'horizontal' ? 2 : 1,
+        columns: props.direction === 'horizontal' ? 3 : 1,
       },
       {
         fill: UNKNOWN_SCALE,
@@ -93,6 +93,18 @@ export function Legend(props: LegendProps) {
         orient: props.direction === 'vertical' ? 'left' : 'right',
       },
     ]
+
+    if (props.metric.type === 'pct_share') {
+      legendList[0].encode = {
+        labels: {
+          update: {
+            text: {
+              signal: `datum.label + '%'`,
+            },
+          },
+        },
+      }
+    }
 
     // 0 should appear first, then numbers, then "insufficient"
     if (isCawp) legendList.reverse()

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -82,6 +82,7 @@ export function Legend(props: LegendProps) {
         labelFont: LEGEND_TEXT_FONT,
         direction: props.direction,
         orient: 'left',
+        columns: 2,
       },
       {
         fill: UNKNOWN_SCALE,

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -82,7 +82,7 @@ export function Legend(props: LegendProps) {
         labelFont: LEGEND_TEXT_FONT,
         direction: props.direction,
         orient: 'left',
-        columns: 2,
+        columns: props.direction === 'horizontal' ? 2 : 1,
       },
       {
         fill: UNKNOWN_SCALE,

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { Vega } from 'react-vega'
 import { useResponsiveWidth } from '../utils/hooks/useResponsiveWidth'
 import { type MetricConfig } from '../data/config/MetricConfig'
@@ -7,6 +7,8 @@ import sass from '../styles/variables.module.scss'
 import { ORDINAL } from './utils'
 import { type ScaleType } from './mapHelpers'
 import { CAWP_DETERMINANTS } from '../data/variables/CawpProvider'
+import styles from './Legend.module.scss'
+
 const COLOR_SCALE = 'color_scale'
 const DOT_SIZE_SCALE = 'dot_size_scale'
 export const UNKNOWN_SCALE = 'unknown_scale'
@@ -17,9 +19,9 @@ const DATASET_VALUES = 'dataset_values'
 export const MISSING_PLACEHOLDER_VALUES = 'missing_data'
 export const LEGEND_SYMBOL_TYPE = 'square'
 export const LEGEND_TEXT_FONT = 'inter'
-export const NO_DATA_MESSAGE = 'insufficient or suppressed data'
+export const NO_DATA_MESSAGE = 'no data'
 export const EQUAL_DOT_SIZE = 200
-export const LEGEND_COLOR_COUNT = 7
+export const LEGEND_COLOR_COUNT = 5
 
 /*
    Legend renders a vega chart that just contains a legend.
@@ -167,7 +169,8 @@ export function Legend(props: LegendProps) {
   ])
 
   return (
-    <div ref={ref}>
+    <div className={styles.Legend} ref={ref}>
+      <span className={styles.LegendTitle}>{props.legendTitle}</span>
       <Vega renderer="svg" spec={spec} width={width} actions={false} />
     </div>
   )

--- a/frontend/src/charts/mapHelpers.ts
+++ b/frontend/src/charts/mapHelpers.ts
@@ -34,6 +34,8 @@ export const LEGEND_DATASET = 'LEGEND_DATASET'
 
 export type ScaleType = 'quantize' | 'quantile' | 'symlog'
 
+export const RATE_MAP_SCALE: ScaleType = 'quantile'
+
 export const UNKNOWN_SCALE_SPEC: any = {
   name: UNKNOWN_SCALE,
   type: ORDINAL,

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -394,8 +394,8 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'covid_cases_per_100k',
-          chartTitleLines: ['COVID-19 cases since Jan 2020', 'per 100k people'],
-          trendsCardTitleName: 'Monthly COVID-19 cases per 100k people',
+          chartTitleLines: ['COVID-19 cases since Jan 2020'],
+          trendsCardTitleName: 'Monthly COVID-19 cases per 100k',
           columnTitleHeader: 'Rates of COVID-19 cases',
           shortLabel: 'cases per 100k',
           type: 'per100k',
@@ -449,12 +449,9 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'covid_deaths_per_100k',
-          chartTitleLines: [
-            'COVID-19 deaths since Jan 2020',
-            'per 100k people',
-          ],
+          chartTitleLines: ['COVID-19 deaths since Jan 2020'],
           columnTitleHeader: 'Rates of COVID-19 deaths',
-          trendsCardTitleName: 'Monthly COVID-19 deaths per 100k people',
+          trendsCardTitleName: 'Monthly COVID-19 deaths per 100k',
           shortLabel: 'deaths per 100k',
           type: 'per100k',
           isMonthly: true,
@@ -511,13 +508,9 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'covid_hosp_per_100k',
-          chartTitleLines: [
-            'COVID-19 hospitalizations since Jan 2020',
-            'per 100k people',
-          ],
+          chartTitleLines: ['COVID-19 hospitalizations since Jan 2020'],
           columnTitleHeader: 'Rates of COVID-19 hospitalizations',
-          trendsCardTitleName:
-            'Monthly COVID-19 hospitalizations per 100k people',
+          trendsCardTitleName: 'Monthly COVID-19 hospitalizations per 100k',
           shortLabel: 'hospitalizations per 100k',
           type: 'per100k',
           isMonthly: true,

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -618,7 +618,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
           columnTitleHeader: 'Share of total linkage to HIV care',
           trendsCardTitleName:
             'Inequitable share of linkage to HIV care over time',
-          shortLabel: '% of linkage to HIV care',
+          shortLabel: '% linkage',
           type: 'pct_share',
           populationComparisonMetric: {
             chartTitleLines: [
@@ -633,10 +633,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'hiv_care_linkage',
-          chartTitleLines: ['Rates of linkage to HIV care'],
-          trendsCardTitleName: 'Rates of HIV care over time',
+          chartTitleLines: ['Linkage to HIV care'],
+          trendsCardTitleName: 'Rates of linkage to HIV care over time',
           columnTitleHeader: 'Linkage to HIV care',
-          shortLabel: '% linkage to HIV care',
+          shortLabel: '% linkage',
           type: 'pct_share',
         },
         pct_relative_inequity: {
@@ -685,10 +685,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'hiv_diagnoses_per_100k',
-          chartTitleLines: ['New HIV diagnoses', 'per 100k people'],
+          chartTitleLines: ['New HIV diagnoses'],
           trendsCardTitleName: 'Rates of new HIV diagnoses over time',
-          columnTitleHeader: 'New HIV diagnoses per 100k people',
-          shortLabel: 'new HIV diagnoses per 100k',
+          columnTitleHeader: 'New HIV diagnoses per 100k',
+          shortLabel: 'diagnoses per 100k',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -736,10 +736,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'hiv_deaths_per_100k',
-          chartTitleLines: ['HIV deaths', 'per 100k people'],
+          chartTitleLines: ['HIV deaths'],
           trendsCardTitleName: 'Rates of HIV deaths over time',
           columnTitleHeader: 'HIV deaths per 100k people',
-          shortLabel: 'HIV deaths per 100k',
+          shortLabel: 'deaths per 100k',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -788,7 +788,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'hiv_prep_coverage',
-          chartTitleLines: ['Rates of PrEP coverage'],
+          chartTitleLines: ['PrEP coverage'],
           trendsCardTitleName: 'Rates of PrEP coverage over time',
           columnTitleHeader: 'PrEP coverage',
           shortLabel: '% PrEP coverage',
@@ -839,7 +839,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'hiv_prevalence_per_100k',
-          chartTitleLines: ['HIV prevalence', 'per 100k people'],
+          chartTitleLines: ['HIV prevalence'],
           trendsCardTitleName: 'Rates of HIV prevalence over time',
           columnTitleHeader: 'HIV prevalence per 100k people',
           shortLabel: 'HIV prevalence per 100k',
@@ -891,7 +891,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'suicide_per_100k',
-          chartTitleLines: ['Suicides', 'per 100k people'],
+          chartTitleLines: ['Suicides'],
           trendsCardTitleName: 'Rates of suicide over time',
           columnTitleHeader: 'Suicides per 100k people',
           shortLabel: 'suicides per 100k',
@@ -943,10 +943,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'depression_per_100k',
-          chartTitleLines: ['Cases of depression', 'per 100k people'],
+          chartTitleLines: ['Depression'],
           trendsCardTitleName: 'Rates of depression over time',
-          columnTitleHeader: 'Cases of depression per 100k people',
-          shortLabel: 'cases of depression per 100k',
+          columnTitleHeader: 'Cases of depression per 100k adults',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -996,10 +996,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'excessive_drinking_per_100k',
-          columnTitleHeader: 'Excessive drinking cases per 100k people',
-          chartTitleLines: ['Excessive drinking cases', 'per 100k people'],
+          columnTitleHeader: 'Excessive drinking cases per 100k adults',
+          chartTitleLines: ['Excessive drinking cases'],
           trendsCardTitleName: 'Rates of excessive drinking over time',
-          shortLabel: 'cases of excessive drinking per 100k',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -1052,10 +1052,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'non_medical_drug_use_per_100k',
-          columnTitleHeader: 'Non-medical drug use per 100k people',
-          chartTitleLines: ['Non-medical drug use', 'per 100k people'],
+          columnTitleHeader: 'Non-medical drug use per 100k adults',
+          chartTitleLines: ['Non-medical drug use'],
           trendsCardTitleName: 'Rates of non-medical drug use over time',
-          shortLabel: 'cases of non-medical drug use per 100k',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -1108,13 +1108,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'frequent_mental_distress_per_100k',
-          chartTitleLines: [
-            'Frequent mental distress cases',
-            'per 100k people',
-          ],
-          columnTitleHeader: 'Frequent mental distress cases per 100k people',
+          chartTitleLines: ['Frequent mental distress'],
+          columnTitleHeader: 'Frequent mental distress cases per 100k adults',
           trendsCardTitleName: 'Rates of frequent mental distress over time',
-          shortLabel: 'frequent mental distress cases per 100k',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -1165,10 +1162,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'diabetes_per_100k',
-          chartTitleLines: ['Diabetes', 'per 100k people'],
-          columnTitleHeader: 'Diabetes cases per 100k people',
+          chartTitleLines: ['Diabetes'],
+          columnTitleHeader: 'Diabetes cases per 100k adults',
           trendsCardTitleName: 'Rates of diabetes over time',
-          shortLabel: 'diabetes cases per 100k',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -1217,10 +1214,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
         },
         per100k: {
           metricId: 'copd_per_100k',
-          chartTitleLines: ['COPD cases', 'per 100k people'],
-          columnTitleHeader: 'COPD cases per 100k people',
+          chartTitleLines: ['COPD'],
+          columnTitleHeader: 'COPD cases per 100k adults',
           trendsCardTitleName: 'Rates of COPD over time',
-          shortLabel: 'COPD cases per 100k',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_relative_inequity: {
@@ -1242,8 +1239,8 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
   health_insurance: [
     {
       variableId: 'health_insurance',
-      variableDisplayName: 'Uninsured individuals',
-      variableFullDisplayName: 'Uninsured individuals',
+      variableDisplayName: 'Uninsured people',
+      variableFullDisplayName: 'Uninsured people',
       variableDefinition: `Health insurance coverage in the ACS and other Census Bureau surveys define coverage to
         include plans and programs that provide comprehensive health coverage. Plans that provide
         insurance only for specific conditions or situations such as cancer and long-term care policies
@@ -1253,23 +1250,23 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'uninsured_per_100k',
-          chartTitleLines: ['Uninsured individuals', 'per 100k people'],
-          columnTitleHeader: 'Uninsured individuals per 100k people',
+          chartTitleLines: ['Uninsured people'],
+          columnTitleHeader: 'Uninsured people per 100k',
           trendsCardTitleName: 'Rates of uninsurance over time',
-          shortLabel: 'uninsured individuals per 100k',
+          shortLabel: 'uninsured people per 100k',
           type: 'per100k',
         },
         pct_share: {
-          chartTitleLines: ['Share of uninsured individuals'],
+          chartTitleLines: ['Share of uninsured people'],
           metricId: 'uninsured_pct_share',
           trendsCardTitleName: 'Inequitable share of uninsurance over time',
-          columnTitleHeader: 'Share of uninsured individuals',
+          columnTitleHeader: 'Share of uninsured people',
           shortLabel: '% of uninsured',
           type: 'pct_share',
           populationComparisonMetric: {
             chartTitleLines: [
               'Population vs. distribution of',
-              'total uninsured individuals',
+              'total uninsured people',
             ],
             metricId: 'uninsured_population_pct',
             columnTitleHeader: populationPctTitle,
@@ -1298,19 +1295,15 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
     {
       variableId: 'poverty',
       variableDisplayName: 'Poverty',
-      variableFullDisplayName: 'Individuals below the poverty line',
+      variableFullDisplayName: 'People below the poverty line',
       variableDefinition: `Following the Office of Management and Budget's (OMB) Statistical Policy Directive 14, the Census Bureau uses a set of money income thresholds that vary by family size and composition to determine who is in poverty. If a family's total income is less than the family's threshold, then that family and every individual in it is considered in poverty. The official poverty thresholds do not vary geographically, but they are updated for inflation using the Consumer Price Index (CPI-U). The official poverty definition uses money income before taxes and does not include capital gains or noncash benefits (such as public housing, Medicaid, and food stamps).`,
       metrics: {
         per100k: {
           metricId: 'poverty_per_100k',
-          chartTitleLines: [
-            'Individuals below the poverty line',
-            'per 100k people',
-          ],
-          columnTitleHeader:
-            'Individuals below the poverty line per 100k people',
+          chartTitleLines: ['People below the poverty line'],
+          columnTitleHeader: 'People below the poverty line per 100k',
           trendsCardTitleName: 'Rates of poverty over time',
-          shortLabel: 'individuals below the poverty line per 100k',
+          shortLabel: 'poverty per 100k',
           type: 'per100k',
         },
         pct_share: {
@@ -1323,7 +1316,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
           populationComparisonMetric: {
             chartTitleLines: [
               'Population vs. distribution of',
-              'total individuals below the provery line',
+              'total people below the poverty line',
             ],
             metricId: 'poverty_population_pct',
             columnTitleHeader: populationPctTitle,
@@ -1357,11 +1350,12 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'preventable_hospitalizations_per_100k',
-          chartTitleLines: ['Preventable hospitalizations', 'per 100k people'],
+          chartTitleLines: ['Preventable hospitalizations'],
           trendsCardTitleName:
             'Rates of preventable hospitalizations over time',
-          columnTitleHeader: 'Preventable hospitalizations per 100k people',
-          shortLabel: 'preventable hospitalizations per 100k',
+          columnTitleHeader:
+            'Preventable hospitalizations per 100k adult Medicare enrollees',
+          shortLabel: 'cases per 100k',
           type: 'per100k',
         },
         pct_share: {
@@ -1413,10 +1407,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'avoided_care_per_100k',
-          chartTitleLines: ['Care avoidance due to cost', 'per 100k people'],
+          chartTitleLines: ['Care avoidance due to cost'],
           trendsCardTitleName: 'Rates of care avoidance over time',
-          columnTitleHeader: 'Care avoidance due to cost per 100k people',
-          shortLabel: 'individuals who avoided care per 100k',
+          columnTitleHeader: 'Care avoidance due to cost per 100k adults',
+          shortLabel: 'avoidance per 100k adults',
           type: 'per100k',
         },
         pct_share: {
@@ -1467,10 +1461,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'asthma_per_100k',
-          chartTitleLines: ['Asthma cases', 'per 100k people'],
-          columnTitleHeader: 'Asthma cases per 100k people',
+          chartTitleLines: ['Asthma'],
+          columnTitleHeader: 'Asthma cases per 100k adults',
           trendsCardTitleName: 'Rates of asthma over time',
-          shortLabel: 'asthma per 100k',
+          shortLabel: 'asthma per 100k adults',
           type: 'per100k',
         },
         pct_share: {
@@ -1519,13 +1513,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'cardiovascular_diseases_per_100k',
-          chartTitleLines: [
-            'Cases of cardiovascular diseases',
-            'per 100k people',
-          ],
+          chartTitleLines: ['Cardiovascular diseases'],
           trendsCardTitleName: 'Rates of cardiovascular diseases over time',
-          columnTitleHeader: 'Cases of cardiovascular diseases per 100k people',
-          shortLabel: 'cases of cardiovascular diseases per 100k',
+          columnTitleHeader: 'Cases of cardiovascular diseases per 100k adults',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_share: {
@@ -1577,10 +1568,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'chronic_kidney_disease_per_100k',
-          chartTitleLines: ['Chronic kidney disease', 'per 100k people'],
+          chartTitleLines: ['Chronic kidney disease'],
           trendsCardTitleName: 'Rates of chronic kidney disease over time',
-          columnTitleHeader: 'Chronic kidney disease per 100k people',
-          shortLabel: 'cases of chronic kidney disease per 100k',
+          columnTitleHeader: 'Chronic kidney disease per 100k adults',
+          shortLabel: 'cases per 100k adults',
           type: 'per100k',
         },
         pct_share: {
@@ -1632,10 +1623,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'voter_participation_per_100k',
-          columnTitleHeader: 'Participating Voters per 100k people',
-          chartTitleLines: ['Voter participation', 'per 100k people'],
+          columnTitleHeader: 'Participating Voters per 100k U.S. citizens',
+          chartTitleLines: ['Voter participation'],
           trendsCardTitleName: 'Rates of voter participation over time',
-          shortLabel: 'voters per 100k',
+          shortLabel: 'voters per 100k citizens',
           type: 'per100k',
         },
         pct_share: {
@@ -1691,7 +1682,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
             'Yearly rates of US Congress members identifying as women',
           columnTitleHeader: 'Share of Congress for women of each race',
           chartTitleLines: [
-            'Current year rates of US Congress',
+            'Current rates of US Congress',
             'members identifying as women',
           ],
           shortLabel: '% women in Congress',
@@ -1802,7 +1793,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
     {
       variableId: 'prison',
       variableDisplayName: 'Prison',
-      variableFullDisplayName: 'Individuals in prison',
+      variableFullDisplayName: 'People in prison',
       surveyCollectedData: true,
       timeSeriesData: true,
       variableDefinition: `Individuals of any age, including children, under the jurisdiction of an adult prison facility. ‘Age’ reports at the national level include only the subset of this jurisdictional population who have been sentenced to one year or more, which accounted for 97% of the total U.S. prison population in 2020. For all national reports, this rate includes both state and federal prisons. For state and territory level reports, only the prisoners under the jurisdiction of that geography are included. For county level reports, Vera reports the
@@ -1810,10 +1801,10 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
       metrics: {
         per100k: {
           metricId: 'prison_per_100k',
-          chartTitleLines: ['Individuals in prison', 'per 100k people'],
+          chartTitleLines: ['Prison incarceration'],
           trendsCardTitleName: 'Rates of prison incarceration over time',
-          columnTitleHeader: 'Individuals in prison per 100k people',
-          shortLabel: 'individuals in prison per 100k',
+          columnTitleHeader: 'People in prison per 100k',
+          shortLabel: 'prison per 100k',
           type: 'per100k',
         },
         pct_share: {
@@ -1827,7 +1818,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
           populationComparisonMetric: {
             chartTitleLines: [
               'Population vs. distribution of',
-              'total individuals in prison',
+              'total people in prison',
             ],
             metricId: 'incarceration_population_pct',
             columnTitleHeader: 'Total population share',
@@ -1866,17 +1857,17 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
     {
       variableId: 'jail',
       variableDisplayName: 'Jail',
-      variableFullDisplayName: 'Individuals in jail',
+      variableFullDisplayName: 'People in jail',
       surveyCollectedData: true,
       timeSeriesData: true,
       variableDefinition: `Individuals of any age, including children, confined in a local, adult jail facility. AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Jails are locally operated short-term facilities that hold inmates awaiting trial or sentencing or both, and inmates sentenced to a term of less than one year, typically misdemeanants. Definitions may vary by state.`,
       metrics: {
         per100k: {
           metricId: 'jail_per_100k',
-          chartTitleLines: ['Individuals in jail', 'per 100k people'],
+          chartTitleLines: ['Jail incarceration'],
           trendsCardTitleName: 'Rates of jail incarceration over time',
-          columnTitleHeader: 'Individuals in jail per 100k people',
-          shortLabel: 'individuals in jail per 100k',
+          columnTitleHeader: 'People in jail per 100k',
+          shortLabel: 'jail per 100k',
           type: 'per100k',
         },
         pct_share: {
@@ -1890,7 +1881,7 @@ export const METRIC_CONFIG: Record<DropdownVarId, VariableConfig[]> = {
           populationComparisonMetric: {
             chartTitleLines: [
               'Population vs. distribution of',
-              'total individuals in jail',
+              'total people in jail',
             ],
             metricId: 'incarceration_population_pct',
             columnTitleHeader: 'Total population share',


### PR DESCRIPTION
## Description

- move MapCard maps back to `quantile`
- use MultiMap style legend inside MapCard to prevent bunching
- [x] prefer vertical legend but switch to horizontal columns on mobile or compare mode
- reduce number of color buckets from 7 to 5
- many changes to MetricConfig: prefer `people` to `individuals`; use only condition name in map card title, specific measurement succinctly in legend; clarify denominator as `adults` or `citizens` rather than just `people`
- use `no data` for legend; if needed we should specify `suppressed` and/or `unavailable` as a footer `Note.` rather than cramming it into the legend

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

#2137 

## Has this been tested? How?

## Screenshots (if appropriate):

BEFORE: EXAMPLE "BUNCHING" WITH QUANTILE
<img width="1254" alt="Screen Shot 2023-04-19 at 11 49 04 AM" src="https://user-images.githubusercontent.com/41567007/233158620-c57a97be-c5be-4b6f-a35a-39ece7d85470.png">


AFTER: USE % AS NEEDED IN LEGEND
<img width="1160" alt="Screen Shot 2023-04-20 at 10 14 51 AM" src="https://user-images.githubusercontent.com/41567007/233435084-6931d7fe-42cf-4964-8c56-4a870e48fe2d.png">


AFTER: AT VARIOUS BREAKPOINTS
<img width="1366" alt="Screen Shot 2023-04-20 at 8 50 10 AM" src="https://user-images.githubusercontent.com/41567007/233405454-97b8a9b7-c799-4688-8bf8-186bed6095c5.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 50 17 AM" src="https://user-images.githubusercontent.com/41567007/233405458-6ee44e79-5546-49f7-a91c-d358fc7f3cb6.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 50 23 AM" src="https://user-images.githubusercontent.com/41567007/233405461-3eb7e180-faf5-4bba-b7e4-8d0ab726e9a7.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 54 01 AM" src="https://user-images.githubusercontent.com/41567007/233405466-fca2c392-d888-4b0b-b41e-5de4fce588bb.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 54 11 AM" src="https://user-images.githubusercontent.com/41567007/233405468-d972d61b-002d-4238-9bbe-2a61c28fbe31.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 54 22 AM" src="https://user-images.githubusercontent.com/41567007/233405472-a8b846a3-a533-41f3-b157-7acbf5b0b921.png">
<img width="1366" alt="Screen Shot 2023-04-20 at 8 54 33 AM" src="https://user-images.githubusercontent.com/41567007/233405475-8e577d83-a65f-4896-963e-0f7999a87045.png">



## Types of changes
- Bug fix
- New content or feature

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎