### PR TITLE
Improves Multimap Modal Close and Legend

### DIFF
--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -224,7 +224,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
           {/* Legend */}
 
           <Grid item xs={12} className={styles.SmallMultipleLegendMap}>
-            <Box mt={pageIsTiny ? 0 : 5}>
+            <Box mt={pageIsTiny ? 0 : 3}>
               <Grid container item>
                 <Grid container justifyContent="center">
                   <b>Legend: {props.metricConfig.shortLabel}</b>

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../data/variables/CawpProvider'
 import { useDownloadCardImage } from '../../utils/hooks/useDownloadCardImage'
 import { RATE_MAP_SCALE } from '../../charts/mapHelpers'
+import CloseIcon from '@mui/icons-material/Close'
 
 export interface MultiMapDialogProps {
   // Metric the small maps will evaluate
@@ -75,7 +76,7 @@ export interface MultiMapDialogProps {
 export function MultiMapDialog(props: MultiMapDialogProps) {
   // calculate page size for responsive layout
   const theme = useTheme()
-  const pageIsWide = useMediaQuery(theme.breakpoints.up('xl'))
+  const pageIsTiny = useMediaQuery(theme.breakpoints.down('sm'))
 
   const title = `${props.metricConfig.chartTitleLines.join(
     ' '
@@ -98,15 +99,40 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
       <DialogContent dividers={true}>
         <Grid container justifyContent="space-between" component="ul">
           {/* Modal Title */}
-          <Grid
-            item
-            xs={12}
-            container
-            justifyContent={pageIsWide ? 'flex-start' : 'space-between'}
-          >
-            <Typography id="modalTitle" variant="h6" component="h2">
-              {title}
-            </Typography>
+          <Grid item xs={12} container justifyContent={'space-between'}>
+            {/* mobile close button */}
+            <Grid
+              item
+              xs={12}
+              sx={{ display: { xs: 'flex', sm: 'none' }, mb: 3 }}
+              container
+              justifyContent={'flex-end'}
+            >
+              <Button onClick={props.handleClose} color="primary">
+                <CloseIcon />
+              </Button>
+            </Grid>
+            <Grid xs={12} sm={9} md={10}>
+              <Typography id="modalTitle" variant="h6" component="h2">
+                {title}
+              </Typography>
+            </Grid>
+            {/* desktop close button */}
+            <Grid
+              item
+              sx={{
+                display: { xs: 'none', sm: 'flex' },
+                mr: { xs: 1, md: 0 },
+                mb: 3,
+              }}
+              sm={1}
+              container
+              justifyContent={'flex-end'}
+            >
+              <Button onClick={props.handleClose} color="primary">
+                <CloseIcon />
+              </Button>
+            </Grid>
           </Grid>
 
           {/* Multiples Maps */}
@@ -137,7 +163,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                   <ChoroplethMap
                     key={breakdownValue}
                     signalListeners={{
-                      click: (...args: any) => { },
+                      click: (...args: any) => {},
                     }}
                     metric={props.metricConfig}
                     legendData={props.data}
@@ -151,16 +177,17 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     hideActions={true}
                     scaleType={RATE_MAP_SCALE}
                     geoData={props.geoData}
-                    filename={`${props.metricConfig.chartTitleLines.join(' ')}${breakdownValue === 'All' ? '' : ` for ${breakdownValue}`
-                      } in ${props.fips.getSentenceDisplayName()}`}
+                    filename={`${props.metricConfig.chartTitleLines.join(' ')}${
+                      breakdownValue === 'All' ? '' : ` for ${breakdownValue}`
+                    } in ${props.fips.getSentenceDisplayName()}`}
                     countColsToAdd={props.countColsToAdd}
                   />
                 )}
 
                 {/* TERRITORIES (IF NATIONAL VIEW) */}
                 {props.metricConfig &&
-                  props.fips.isUsa() &&
-                  dataForValue.length ? (
+                props.fips.isUsa() &&
+                dataForValue.length ? (
                   <Grid container>
                     {TERRITORY_CODES.map((code) => {
                       const fips = new Fips(code)
@@ -168,7 +195,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                         <Grid item xs={4} sm={2} key={code}>
                           <ChoroplethMap
                             signalListeners={{
-                              click: (...args: any) => { },
+                              click: (...args: any) => {},
                             }}
                             metric={props.metricConfig}
                             legendData={props.data}
@@ -196,16 +223,8 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
 
           {/* Legend */}
 
-          <Grid
-            item
-            xs={12}
-            sm={6}
-            md={4}
-            lg={3}
-            xl={12}
-            className={styles.SmallMultipleLegendMap}
-          >
-            <Box mt={pageIsWide ? 10 : 0}>
+          <Grid item xs={12} className={styles.SmallMultipleLegendMap}>
+            <Box mt={pageIsTiny ? 0 : 5}>
               <Grid container item>
                 <Grid container justifyContent="center">
                   <b>Legend: {props.metricConfig.shortLabel}</b>
@@ -217,7 +236,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     legendData={props.data}
                     scaleType={RATE_MAP_SCALE}
                     sameDotSize={true}
-                    direction={pageIsWide ? 'horizontal' : 'vertical'}
+                    direction={pageIsTiny ? 'vertical' : 'horizontal'}
                     description={'Consistent legend for all displayed maps'}
                   />
                 </Grid>
@@ -256,11 +275,6 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
             metadata={props.metadata}
             downloadTargetScreenshot={downloadTargetScreenshot}
           />
-          <Grid container item xs={12} justifyContent={'flex-end'}>
-            <Button onClick={props.handleClose} color="primary">
-              Close
-            </Button>
-          </Grid>
         </div>
       </footer>
     </Dialog>

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -98,9 +98,9 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
     >
       <DialogContent dividers={true}>
         <Grid container justifyContent="space-between" component="ul">
-          {/* Modal Title */}
+          {/* card heading row */}
           <Grid item xs={12} container justifyContent={'space-between'}>
-            {/* mobile close button */}
+            {/* mobile-only close button */}
             <Grid
               item
               xs={12}
@@ -112,12 +112,13 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                 <CloseIcon />
               </Button>
             </Grid>
+            {/* Modal Title */}
             <Grid xs={12} sm={9} md={10}>
               <Typography id="modalTitle" variant="h6" component="h2">
                 {title}
               </Typography>
             </Grid>
-            {/* desktop close button */}
+            {/* desktop-only close button */}
             <Grid
               item
               sx={{


### PR DESCRIPTION
## Description

- replaces `Close` in bottom right corner with `X` in top right corner, mirroring the close button layout in the downloads section and typical modal behavior
- uses single column legend for tiny screens and two row horizontal layout for wider screens, adjusts spacing, legend is always on its own row

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

closes #2157 

## Has this been tested? How?

manually. 

## Screenshots (if appropriate):

<img width="1149" alt="Screen Shot 2023-04-26 at 11 01 04 PM" src="https://user-images.githubusercontent.com/41567007/234763680-e32eedb4-8d92-40b8-a61f-90accee5c23d.png">
<img width="1149" alt="Screen Shot 2023-04-26 at 11 01 14 PM" src="https://user-images.githubusercontent.com/41567007/234763683-30e468bb-d86c-4b85-8d33-c5eec5fc0101.png">
<img width="1149" alt="Screen Shot 2023-04-26 at 11 01 22 PM" src="https://user-images.githubusercontent.com/41567007/234763685-b4765ac5-c766-4703-a296-b12937023b41.png">
<img width="1149" alt="Screen Shot 2023-04-26 at 11 01 31 PM" src="https://user-images.githubusercontent.com/41567007/234763688-33837411-5ece-4135-8d89-7879f0eeb17f.png">
<img width="1149" alt="Screen Shot 2023-04-26 at 11 01 41 PM" src="https://user-images.githubusercontent.com/41567007/234763691-b33a2f77-0665-4fd5-b2f9-258eb67dcd6e.png">
<img width="1149" alt="Screen Shot 2023-04-26 at 11 08 00 PM" src="https://user-images.githubusercontent.com/41567007/234764636-5f519523-a076-4a6f-9d62-cfbcd8a822aa.png">


## Types of changes
- Bug fix
- New content or feature

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎