### PR TITLE
Map(s) maintain group(s) via URL param

### DIFF
--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -66,12 +66,6 @@ test.describe('Home to COVID Vax by Age', () => {
         // back button works properly for demographic toggle changes
         await page.goBack()
         await expect(page).not.toHaveURL(/.*demo=age/);
-
-
-        // Changing selected group in map card should update map and URL param
-        await page.getByRole('button', { name: 'Demographic Race/ethnicity' }).click();
-        await page.getByRole('option', { name: 'Age' }).click();
-        await expect(page).toHaveURL(/.*demo=age/);
     });
 
     test('Covid Vax Select Map Group', async ({ page }) => {

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -70,14 +70,6 @@ test.describe('Home to COVID Vax by Age', () => {
 
     test('Covid Vax Select Map Group', async ({ page }) => {
 
-        // Starting with COVID VAX
-        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${VAX_USA_RACE}`, { waitUntil: "domcontentloaded" });
-
-        // Changing selected group in map card should update map and URL param
-        await page.locator("#groupMenu-00-covid_vaccinations").click()
-        await page.getByRole('button', { name: 'Hispanic or Latino' }).click();
-        await expect(page).toHaveURL(/.*group1=Hisp%7ELat/);
-
         // Starting with COVID VAX - HISPANIC in URL PARAM
         await page.goto(`http://localhost:3000/exploredata?mls=1.covid_vaccinations-3.00&group1=Hisp%7ELat&group2=All`, { waitUntil: "networkidle" });
 

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -62,10 +62,33 @@ test.describe('Home to COVID Vax by Age', () => {
         await page.getByRole('option', { name: 'Age' }).click();
         await expect(page).toHaveURL(/.*demo=age/);
 
+
         // back button works properly for demographic toggle changes
         await page.goBack()
         await expect(page).not.toHaveURL(/.*demo=age/);
 
+
+        // Changing selected group in map card should update map and URL param
+        await page.getByRole('button', { name: 'Demographic Race/ethnicity' }).click();
+        await page.getByRole('option', { name: 'Age' }).click();
+        await expect(page).toHaveURL(/.*demo=age/);
+    });
+
+    test('Covid Vax Select Map Group', async ({ page }) => {
+
+        // Starting with COVID VAX
+        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${VAX_USA_RACE}`, { waitUntil: "networkidle" });
+
+        // Changing selected group in map card should update map and URL param
+        await page.getByRole('button', { name: 'All' }).click();
+        await page.getByRole('button', { name: 'Hispanic or Latino' }).click();
+        await expect(page).toHaveURL(/.*group1=Hisp%7ELat/);
+
+        // Starting with COVID VAX - HISPANIC in URL PARAM
+        await page.goto(`http://localhost:3000/exploredata?mls=1.covid_vaccinations-3.00&group1=Hisp%7ELat&group2=All`, { waitUntil: "networkidle" });
+
+        // Map card should be on incoming group selection
+        await expect(page.getByRole('heading', { name: 'Hispanic or Latino' })).toBeVisible()
     });
 
 

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -62,19 +62,10 @@ test.describe('Home to COVID Vax by Age', () => {
         await page.getByRole('option', { name: 'Age' }).click();
         await expect(page).toHaveURL(/.*demo=age/);
 
-
         // back button works properly for demographic toggle changes
         await page.goBack()
         await expect(page).not.toHaveURL(/.*demo=age/);
-    });
 
-    test('Covid Vax Select Map Group', async ({ page }) => {
-
-        // Starting with COVID VAX - HISPANIC in URL PARAM
-        await page.goto(`http://localhost:3000/exploredata?mls=1.covid_vaccinations-3.00&group1=Hisp%7ELat&group2=All`, { waitUntil: "networkidle" });
-
-        // Map card should be on incoming group selection
-        await expect(page.getByRole('heading', { name: 'Hispanic or Latino' })).toBeVisible()
     });
 
 

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -74,7 +74,7 @@ test.describe('Home to COVID Vax by Age', () => {
         await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${VAX_USA_RACE}`, { waitUntil: "networkidle" });
 
         // Changing selected group in map card should update map and URL param
-        await page.getByRole('button', { name: 'All' }).click();
+        await page.locator("#groupMenu-00-covid_vaccinations").click()
         await page.getByRole('button', { name: 'Hispanic or Latino' }).click();
         await expect(page).toHaveURL(/.*group1=Hisp%7ELat/);
 

--- a/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
+++ b/frontend/playwright-tests/userFlow-HomeToVaxAge.spec.ts
@@ -71,7 +71,7 @@ test.describe('Home to COVID Vax by Age', () => {
     test('Covid Vax Select Map Group', async ({ page }) => {
 
         // Starting with COVID VAX
-        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${VAX_USA_RACE}`, { waitUntil: "networkidle" });
+        await page.goto(`${EXPLORE_DATA_PAGE_LINK}?${VAX_USA_RACE}`, { waitUntil: "domcontentloaded" });
 
         // Changing selected group in map card should update map and URL param
         await page.locator("#groupMenu-00-covid_vaccinations").click()

--- a/frontend/playwright-tests/userFlow-TrackerToCovidDeathsDenverVsCO.spec.ts
+++ b/frontend/playwright-tests/userFlow-TrackerToCovidDeathsDenverVsCO.spec.ts
@@ -84,7 +84,7 @@ test('Clear topic button from Compare Locations mode returns tracker to default 
     await page.getByRole('button', { name: 'Clear topic selection' }).click();
 
     // should return to default page (with explicit params)
-    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity');
+    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity&demo=sex&group1=All&group2=All');
 });
 
 test('Clear topic button from Compare Topics mode returns tracker to default state', async ({ page }) => {
@@ -99,7 +99,7 @@ test('Clear topic button from Compare Topics mode returns tracker to default sta
     await page.getByRole('button', { name: 'Clear topic selection' }).click();
 
     // should return to default page (with explicit params)
-    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity');
+    await expect(page).toHaveURL('http://localhost:3000/exploredata?mls=1.default-3.00&mlp=disparity&group1=All&group2=All');
 
 });
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -26,7 +26,7 @@ const config: PlaywrightTestConfig = {
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
   reporter: process.env.CI ? 'github' : 'list',
-  workers: 8,
+  workers: 1,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     browserName: 'chromium',

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -18,9 +18,9 @@ const config: PlaywrightTestConfig = {
   },
   testDir: './playwright-tests',
   /* Maximum time one test can run for. */
-  timeout: process.env.CI ? 240 * 1000 : 120 * 1000,
+  timeout: process.env.CI ? 360 * 1000 : 120 * 1000,
   expect: {
-    timeout: process.env.CI ? 240 * 1000 : 120 * 1000
+    timeout: process.env.CI ? 360 * 1000 : 120 * 1000
   },
   /* run all tests, even those within a shared file, in parallel  */
   fullyParallel: true,

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -131,7 +131,6 @@ function MapCardWithKey(props: MapCardProps) {
     : MAP1_GROUP_PARAM
 
   const initialGroupParam: string = getParameter(MAP_GROUP_PARAM, ALL)
-
   const initialGroup = getDemographicGroupFromGroupParam(initialGroupParam)
 
   const [listExpanded, setListExpanded] = useState(false)

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -389,7 +389,6 @@ function MapCardWithKey(props: MapCardProps) {
                           // It doesn't support changing breakdown type
                           if (filterSelection) {
                             setActiveBreakdownFilter(filterSelection)
-                            // TODO: demo type change needs to reset group to ALL
                             const groupCode =
                               getGroupParamFromDemographicGroup(filterSelection)
                             setParameter(MAP_GROUP_PARAM, groupCode)

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -64,6 +64,14 @@ import { Legend } from '../charts/Legend'
 import GeoContext from './ui/GeoContext'
 import TerritoryCircles from './ui/TerritoryCircles'
 import { GridView } from '@mui/icons-material'
+import {
+  MAP1_GROUP_PARAM,
+  MAP2_GROUP_PARAM,
+  getDemographicGroupFromGroupParam,
+  getGroupParamFromDemographicGroup,
+  getParameter,
+  setParameter,
+} from '../utils/urlutils'
 
 const SIZE_OF_HIGHEST_LOWEST_RATES_LIST = 5
 
@@ -73,6 +81,7 @@ export interface MapCardProps {
   variableConfig: VariableConfig
   updateFipsCallback: (fips: Fips) => void
   currentBreakdown: BreakdownVar
+  isCompareCard?: boolean
 }
 
 // This wrapper ensures the proper key is set to create a new instance when required (when
@@ -117,9 +126,17 @@ function MapCardWithKey(props: MapCardProps) {
     },
   }
 
+  const MAP_GROUP_PARAM = props.isCompareCard
+    ? MAP2_GROUP_PARAM
+    : MAP1_GROUP_PARAM
+
+  const initialGroupParam: string = getParameter(MAP_GROUP_PARAM, ALL)
+
+  const initialGroup = getDemographicGroupFromGroupParam(initialGroupParam)
+
   const [listExpanded, setListExpanded] = useState(false)
   const [activeBreakdownFilter, setActiveBreakdownFilter] =
-    useState<DemographicGroup>(ALL)
+    useState<DemographicGroup>(initialGroup)
 
   const [smallMultiplesDialogOpen, setSmallMultiplesDialogOpen] =
     useAutoFocusDialog()
@@ -306,6 +323,19 @@ function MapCardWithKey(props: MapCardProps) {
           ? highestValues.concat(lowestValues)
           : dataForActiveBreakdownFilter
 
+        // if a previously selected group is no longer valid, reset to ALL
+        let dropdownValue = ALL
+        if (
+          filterOptions[
+            BREAKDOWN_VAR_DISPLAY_NAMES[props.currentBreakdown]
+          ].includes(activeBreakdownFilter)
+        ) {
+          dropdownValue = activeBreakdownFilter
+        } else {
+          setActiveBreakdownFilter(ALL)
+          setParameter(MAP_GROUP_PARAM, ALL)
+        }
+
         return (
           <>
             <MultiMapDialog
@@ -350,7 +380,7 @@ function MapCardWithKey(props: MapCardProps) {
                         setSmallMultiplesDialogOpen={
                           setSmallMultiplesDialogOpen
                         }
-                        value={activeBreakdownFilter}
+                        value={dropdownValue}
                         options={filterOptions}
                         onOptionUpdate={(
                           newBreakdownDisplayName,
@@ -360,6 +390,10 @@ function MapCardWithKey(props: MapCardProps) {
                           // It doesn't support changing breakdown type
                           if (filterSelection) {
                             setActiveBreakdownFilter(filterSelection)
+                            // TODO: demo type change needs to reset group to ALL
+                            const groupCode =
+                              getGroupParamFromDemographicGroup(filterSelection)
+                            setParameter(MAP_GROUP_PARAM, groupCode)
                           }
                         }}
                       />

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -113,7 +113,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
               </Button>
             </Grid>
             {/* Modal Title */}
-            <Grid xs={12} sm={9} md={10}>
+            <Grid item xs={12} sm={9} md={10}>
               <Typography id="modalTitle" variant="h6" component="h2">
                 {title}
               </Typography>

--- a/frontend/src/data/utils/Constants.ts
+++ b/frontend/src/data/utils/Constants.ts
@@ -146,35 +146,43 @@ export const RACE_GROUPS = [
 // ENUMERATE THOSE PROPERTIES TO CREATE A RACE-GROUP TYPE
 export type RaceAndEthnicityGroup = (typeof RACE_GROUPS)[number]
 
-export const raceNameToCodeMap: Partial<Record<RaceAndEthnicityGroup, string>> =
-  {
-    // race and ethnicity NH CDC COVID
-    All: 'All',
-    [NHPI_NH]: 'NHPI (NH)',
-    [HISPANIC]: 'Hisp/Lat',
-    [AIAN_NH]: 'AI/AN (NH)',
-    [BLACK_NH]: 'Black (NH)',
-    [MULTI_OR_OTHER_STANDARD_NH]: '2/Unr (NH)',
-    [WHITE_NH]: 'White (NH)',
-    [ASIAN_NH]: 'Asian (NH)',
-    // CDC HIV
-    [MULTI_NH]: 'Two+ (NH)',
-    [OTHER_NONSTANDARD_NH]: 'OTHER (NH)',
-    // Incarceration
-    [API_NH]: 'A/NHPI (NH)',
-    //  race and ethnicity CAWP
-    [ALL_W]: 'All',
-    [AAPI_W]: 'AAPI',
-    [MENA_W]: 'MENA',
-    [AIANNH_W]: 'AI/AN/NH',
-    [AIAN_API_W]: 'AIAN_API',
-    [HISP_W]: 'Hisp/Lat',
-    [MULTI_W]: 'Two+',
-    [BLACK_W]: 'Black',
-    [WHITE_W]: 'White',
-    [UNKNOWN_W]: 'Unknown',
-    [OTHER_W]: 'Unrepr.',
-  }
+export const raceNameToCodeMap: Record<RaceAndEthnicityGroup, string> = {
+  // race and ethnicity NH CDC COVID
+  All: 'All',
+  [NHPI_NH]: 'NHPI (NH)',
+  [HISPANIC]: 'Hisp/Lat',
+  [AIAN_NH]: 'AI/AN (NH)',
+  [BLACK_NH]: 'Black (NH)',
+  [MULTI_OR_OTHER_STANDARD_NH]: '2/Unr (NH)',
+  [WHITE_NH]: 'White (NH)',
+  [ASIAN_NH]: 'Asian (NH)',
+  // CDC HIV
+  [MULTI_NH]: 'Two+ (NH)',
+  [OTHER_NONSTANDARD_NH]: 'OTHER (NH)',
+  // Incarceration
+  [API_NH]: 'A/NHPI (NH)',
+  //  race and ethnicity CAWP
+  [ALL_W]: 'All W',
+  [AAPI_W]: 'AAPI W',
+  [MENA_W]: 'MENA W',
+  [AIANNH_W]: 'AI/AN/NH W',
+  [AIAN_API_W]: 'AIAN_API W',
+  [HISP_W]: 'Hisp/Lat W',
+  [MULTI_W]: 'Two+ W',
+  [BLACK_W]: 'Black W',
+  [WHITE_W]: 'White W',
+  [UNKNOWN_W]: 'Unknown W',
+  [OTHER_W]: 'Unrepr. W',
+  // Hispanic-Inclusive Races (Poverty/Uninsurance)
+  [NHPI]: 'NHPI',
+  [AIAN]: 'AI/AN',
+  [BLACK]: 'Black',
+  [MULTI_OR_OTHER_STANDARD]: '2/Unr',
+  [MULTI]: 'Two+',
+  [OTHER_STANDARD]: 'Unrepr.',
+  [WHITE]: 'White',
+  [ASIAN]: 'Asian',
+}
 
 // AGE DEMOGRAPHIC  GROUP OPTIONS
 export const DECADE_AGE_BUCKETS = [

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -11,11 +11,11 @@ import {
   type MadLibId,
 } from '../../utils/MadLibs'
 import {
-  DATA_TYPE_1_PARAM,
-  DEMOGRAPHIC_PARAM,
   getParameter,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
+  MAP1_GROUP_PARAM,
+  MAP2_GROUP_PARAM,
   parseMls,
   psSubscribe,
   setParameter,
@@ -34,6 +34,7 @@ import { useLocation } from 'react-router-dom'
 import DefaultHelperBox from './DefaultHelperBox'
 import useDeprecatedParamRedirects from '../../utils/hooks/useDeprecatedParamRedirects'
 import MadLibUI from './MadLibUI'
+import { ALL } from '../../data/utils/Constants'
 // import DisclaimerAlert from '../../reports/ui/DisclaimerAlert'
 
 const Onboarding = lazy(async () => await import('./Onboarding'))
@@ -107,14 +108,23 @@ function ExploreDataPage(props: ExploreDataPageProps) {
   }, [])
 
   const setMadLibWithParam = (ml: MadLib) => {
+    const groupParam1 = getParameter(MAP1_GROUP_PARAM, ALL)
+    const groupParam2 = getParameter(MAP2_GROUP_PARAM, ALL)
     setParameters([
       {
         name: MADLIB_SELECTIONS_PARAM,
         value: stringifyMls(ml.activeSelections),
       },
-      { name: DATA_TYPE_1_PARAM, value: null },
-      { name: DEMOGRAPHIC_PARAM, value: null },
+      {
+        name: MAP1_GROUP_PARAM,
+        value: groupParam1,
+      },
+      {
+        name: MAP2_GROUP_PARAM,
+        value: groupParam2,
+      },
     ])
+
     setMadLib(ml)
   }
 

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -35,7 +35,6 @@ import DefaultHelperBox from './DefaultHelperBox'
 import useDeprecatedParamRedirects from '../../utils/hooks/useDeprecatedParamRedirects'
 import MadLibUI from './MadLibUI'
 import { ALL } from '../../data/utils/Constants'
-// import DisclaimerAlert from '../../reports/ui/DisclaimerAlert'
 
 const Onboarding = lazy(async () => await import('./Onboarding'))
 

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -1,10 +1,10 @@
 import styles from './LandingPage.module.scss'
+import { ReactRouterLinkButton } from '../../utils/urlutils'
 import {
   ARTICLES_KEY_4,
   fetchLandingPageNewsData,
-  ReactRouterLinkButton,
   REACT_QUERY_OPTIONS,
-} from '../../utils/urlutils'
+} from '../../utils/blogUtils'
 import {
   Button,
   Grid,

--- a/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
@@ -8,7 +8,7 @@ import {
   DYNAMIC_COPY_KEY,
   fetchCopyData,
   REACT_QUERY_OPTIONS,
-} from '../../utils/urlutils'
+} from '../../utils/blogUtils'
 import {
   NEWS_TAB_LINK,
   WIHE_JOIN_THE_EFFORT_SECTION_ID,

--- a/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/AllPosts.tsx
@@ -2,12 +2,14 @@ import { Box, Card, Grid, Typography, Skeleton } from '@mui/material'
 import { useEffect, useState } from 'react'
 import styles from './News.module.scss'
 import {
-  fetchNewsData,
   useUrlSearchParams,
-  ARTICLES_KEY,
-  REACT_QUERY_OPTIONS,
   LinkWithStickyParams,
 } from '../../../utils/urlutils'
+import {
+  fetchNewsData,
+  ARTICLES_KEY,
+  REACT_QUERY_OPTIONS,
+} from '../../../utils/blogUtils'
 import { NEWS_TAB_LINK, CONTACT_TAB_LINK } from '../../../utils/internalRoutes'
 import { Helmet } from 'react-helmet-async'
 import ArticleFilters from './ArticleFilters'

--- a/frontend/src/pages/WhatIsHealthEquity/News/SinglePost.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/News/SinglePost.tsx
@@ -2,13 +2,12 @@ import { Box, Button, Grid, Typography, Skeleton } from '@mui/material'
 import { useState, useEffect } from 'react'
 import styles from './News.module.scss'
 import { Link, Redirect, useParams } from 'react-router-dom'
+import { ReactRouterLinkButton, getHtml } from '../../../utils/urlutils'
 import {
   fetchNewsData,
-  ReactRouterLinkButton,
   ARTICLES_KEY,
   REACT_QUERY_OPTIONS,
-  getHtml,
-} from '../../../utils/urlutils'
+} from '../../../utils/blogUtils'
 import { NEWS_TAB_LINK } from '../../../utils/internalRoutes'
 import { Helmet } from 'react-helmet-async'
 import NewsPreviewCard from './NewsPreviewCard'

--- a/frontend/src/reports/TwoVariableReport.tsx
+++ b/frontend/src/reports/TwoVariableReport.tsx
@@ -285,7 +285,9 @@ function TwoVariableReport(props: {
               createCard={(
                 variableConfig: VariableConfig,
                 fips: Fips,
-                updateFips: (fips: Fips) => void
+                updateFips: (fips: Fips) => void,
+                _dropdown: any,
+                isCompareCard?: boolean
               ) => (
                 <MapCard
                   variableConfig={variableConfig}
@@ -294,6 +296,7 @@ function TwoVariableReport(props: {
                     updateFips(fips)
                   }}
                   currentBreakdown={currentBreakdown}
+                  isCompareCard={isCompareCard}
                 />
               )}
             />

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -65,6 +65,7 @@ export function getMadLibWithUpdatedValue(
     ...originalMadLib.activeSelections,
   }
   updatePhraseSelections[phraseSegmentIndex] = newValue
+
   return {
     ...originalMadLib,
     activeSelections: updatePhraseSelections,

--- a/frontend/src/utils/blogUtils.ts
+++ b/frontend/src/utils/blogUtils.ts
@@ -1,0 +1,45 @@
+import axios from 'axios'
+
+// WORDPRESS CONFIG
+export const NEWS_URL = 'https://hetblog.dreamhosters.com/'
+export const WP_API = 'wp-json/wp/v2/' // "?rest_route=/wp/v2/"
+export const ALL_POSTS = 'posts'
+export const ALL_MEDIA = 'media'
+export const ALL_CATEGORIES = 'categories'
+export const ALL_AUTHORS = 'authors'
+export const ALL_PAGES = 'pages' // for dynamic copy
+export const WP_EMBED_PARAM = '_embed'
+export const WP_PER_PAGE_PARAM = 'per_page='
+export const MAX_FETCH = 100
+
+// PAGE IDS FOR WORDPRESS DYNAMIC COPY
+export const WIHE_PAGE_ID = 37 // hard coded id where dynamic copy is stored
+
+// REACT QUERY
+export const ARTICLES_KEY = 'cached_wp_articles'
+export const ARTICLES_KEY_4 = 'cached_wp_articles_first_four'
+export const DYNAMIC_COPY_KEY = 'cached_wp_dynamic_copy'
+export const REACT_QUERY_OPTIONS = {
+  cacheTime: 1000 * 60 * 5, // never garbage collect, always default to cache
+  staleTime: 1000 * 30, // treat cache data as fresh and don't refetch
+}
+
+export async function fetchNewsData() {
+  return await axios.get(
+    `${
+      NEWS_URL + WP_API + ALL_POSTS
+    }?${WP_EMBED_PARAM}&${WP_PER_PAGE_PARAM}${MAX_FETCH}`
+  )
+}
+
+export async function fetchLandingPageNewsData() {
+  return await axios.get(
+    `${
+      NEWS_URL + WP_API + ALL_POSTS
+    }?${WP_EMBED_PARAM}&${WP_PER_PAGE_PARAM}${4}`
+  )
+}
+
+export async function fetchCopyData() {
+  return await axios.get(`${NEWS_URL + WP_API + ALL_PAGES}/${WIHE_PAGE_ID}`)
+}

--- a/frontend/src/utils/hooks/useFontSize.tsx
+++ b/frontend/src/utils/hooks/useFontSize.tsx
@@ -10,7 +10,6 @@ export function useFontSize() {
 
   // we need to implement useEffect to rerender so that Vega will draw the title correctly
   useEffect(() => {
-    console.log(sass.fontTitle)
     if (isComparing && isSmall) {
       setFontsize(parseInt(sass.vegaSmallTitle))
     } else {

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -1,5 +1,4 @@
 import Button from '@mui/material/Button'
-import axios from 'axios'
 import React from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { type VariableId } from '../data/config/MetricConfig'
@@ -9,7 +8,6 @@ import { type MadLibId, type PhraseSelections } from './MadLibs'
 import {
   raceNameToCodeMap,
   type DemographicGroup,
-  ALL,
 } from '../data/utils/Constants'
 
 export const STICKY_VERSION_PARAM = 'sv'
@@ -44,50 +42,6 @@ export function swapOldDatatypeParams(oldParam: string) {
     hospitalizations: 'covid_hospitalizations',
   }
   return swaps[oldParam] || oldParam
-}
-
-// WORDPRESS CONFIG
-export const NEWS_URL = 'https://hetblog.dreamhosters.com/'
-export const WP_API = 'wp-json/wp/v2/' // "?rest_route=/wp/v2/"
-export const ALL_POSTS = 'posts'
-export const ALL_MEDIA = 'media'
-export const ALL_CATEGORIES = 'categories'
-export const ALL_AUTHORS = 'authors'
-export const ALL_PAGES = 'pages' // for dynamic copy
-export const WP_EMBED_PARAM = '_embed'
-export const WP_PER_PAGE_PARAM = 'per_page='
-export const MAX_FETCH = 100
-
-// PAGE IDS FOR WORDPRESS DYNAMIC COPY
-export const WIHE_PAGE_ID = 37 // hard coded id where dynamic copy is stored
-
-// REACT QUERY
-export const ARTICLES_KEY = 'cached_wp_articles'
-export const ARTICLES_KEY_4 = 'cached_wp_articles_first_four'
-export const DYNAMIC_COPY_KEY = 'cached_wp_dynamic_copy'
-export const REACT_QUERY_OPTIONS = {
-  cacheTime: 1000 * 60 * 5, // never garbage collect, always default to cache
-  staleTime: 1000 * 30, // treat cache data as fresh and don't refetch
-}
-
-export async function fetchNewsData() {
-  return await axios.get(
-    `${
-      NEWS_URL + WP_API + ALL_POSTS
-    }?${WP_EMBED_PARAM}&${WP_PER_PAGE_PARAM}${MAX_FETCH}`
-  )
-}
-
-export async function fetchLandingPageNewsData() {
-  return await axios.get(
-    `${
-      NEWS_URL + WP_API + ALL_POSTS
-    }?${WP_EMBED_PARAM}&${WP_PER_PAGE_PARAM}${4}`
-  )
-}
-
-export async function fetchCopyData() {
-  return await axios.get(`${NEWS_URL + WP_API + ALL_PAGES}/${WIHE_PAGE_ID}`)
 }
 
 export function useUrlSearchParams() {
@@ -315,15 +269,18 @@ export function getGroupParamFromDemographicGroup(
 export function getDemographicGroupFromGroupParam(
   groupParam: string
 ): DemographicGroup {
-  const raceCodeFromParam = groupParam
+  const groupCodeFromParam = groupParam
     ?.replaceAll('.NH', ' (NH)')
     ?.replaceAll('_', ' ')
     ?.replaceAll('~', '/')
     ?.replaceAll('PLUS', '+')
 
-  return (
+  // if group code is in race map, reverse lookup to get full group name
+  // otherwise the age and sex groups are the full names
+  const groupName =
     Object.entries(raceNameToCodeMap).find(
-      (entry) => entry[1] === raceCodeFromParam
-    )?.[0] ?? ALL
-  )
+      (entry) => entry[1] === groupCodeFromParam
+    )?.[0] ?? groupCodeFromParam
+
+  return groupName
 }

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -6,6 +6,11 @@ import { type VariableId } from '../data/config/MetricConfig'
 import { getLogger } from './globals'
 import { EXPLORE_DATA_PAGE_LINK } from './internalRoutes'
 import { type MadLibId, type PhraseSelections } from './MadLibs'
+import {
+  raceNameToCodeMap,
+  type DemographicGroup,
+  ALL,
+} from '../data/utils/Constants'
 
 export const STICKY_VERSION_PARAM = 'sv'
 
@@ -21,15 +26,15 @@ export const MADLIB_PHRASE_PARAM = 'mlp'
 // mls=0:1,2:5
 export const MADLIB_SELECTIONS_PARAM = 'mls'
 
-// Value is index of the tab to jump to
-export const TAB_PARAM = 'tab'
-
 // 'true' or 'false' will override the cookie to show or hide the onboarding flow
 export const SHOW_ONBOARDING_PARAM = 'onboard'
 
 export const DEMOGRAPHIC_PARAM = 'demo'
 export const DATA_TYPE_1_PARAM = 'dt1'
 export const DATA_TYPE_2_PARAM = 'dt2'
+
+export const MAP1_GROUP_PARAM = 'group1'
+export const MAP2_GROUP_PARAM = 'group2'
 
 // Ensures backwards compatibility for external links to old VariableIds
 export function swapOldDatatypeParams(oldParam: string) {
@@ -291,4 +296,34 @@ export function getHtml(item: any, asString?: boolean) {
   const span = document.createElement('span')
   span.innerHTML = item
   return span.textContent ?? span.innerText
+}
+
+/* for converting selected group long name into URL safe param value */
+export function getGroupParamFromDemographicGroup(
+  groupLongName: DemographicGroup
+): string {
+  const groupCode = raceNameToCodeMap[groupLongName] ?? groupLongName
+
+  return groupCode
+    .replaceAll(' (NH)', '.NH')
+    .replaceAll(' ', '_')
+    .replaceAll('/', '~')
+    .replaceAll('+', 'PLUS')
+}
+
+/* for extracting selected group long name from URL safe param value */
+export function getDemographicGroupFromGroupParam(
+  groupParam: string
+): DemographicGroup {
+  const raceCodeFromParam = groupParam
+    ?.replaceAll('.NH', ' (NH)')
+    ?.replaceAll('_', ' ')
+    ?.replaceAll('~', '/')
+    ?.replaceAll('PLUS', '+')
+
+  return (
+    Object.entries(raceNameToCodeMap).find(
+      (entry) => entry[1] === raceCodeFromParam
+    )?.[0] ?? ALL
+  )
 }


### PR DESCRIPTION
## Description

- adds new params for map1 and map2 group
- encodes/decodes group names and groups in a way that is URL safe and human readable for easier link sharing
- updates url params whenever the map card adjusts its internal selected group state
- resets to `All` if the new topic doesn't contain the exact same race group (e.g. moving to/from NH races, or moving between `Sex` and `Age` breakdowns where the groups can't be the same)
- [x] fix weirdness where changing topics from SEX or AGE setting resets to RACE
- [x] maintains group selections across topic changes
- [x] maintains group selections across compare mode changes
- refactors to move `blogUtils` out of `urlutils`

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

closes #2167 

## Has this been tested? How?

- [x] manually
- [x] adds simple playwright test to ensure map group gets set based on URL params

## Screenshots (if appropriate):

<img width="1331" alt="Screen Shot 2023-05-02 at 2 11 07 PM" src="https://user-images.githubusercontent.com/41567007/235775104-6efeaa63-4190-42b2-8234-ea19e09396d9.png">


## Types of changes
- New content or feature

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎