### PR TITLE
BugFix for Map Color Scale

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -58,7 +58,7 @@ import { useLocation } from 'react-router-dom'
 import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import { HIV_DETERMINANTS } from '../data/variables/HivProvider'
 import { useState } from 'react'
-import { RATE_MAP_SCALE } from '../charts/mapHelpers'
+import { RATE_MAP_SCALE, getMapScheme } from '../charts/mapHelpers'
 import { Legend } from '../charts/Legend'
 import GeoContext, { getPopulationPhrase } from './ui/GeoContext'
 import TerritoryCircles from './ui/TerritoryCircles'
@@ -337,6 +337,13 @@ function MapCardWithKey(props: MapCardProps) {
           ? highestValues.concat(lowestValues)
           : dataForActiveBreakdownFilter
 
+        const isSummaryLegend = hasSelfButNotChildGeoData ?? props.fips.isCounty()
+
+        const [mapScheme, mapMin] = getMapScheme({
+          metricId: metricConfig.metricId,
+          isSummaryLegend,
+        })
+
         return (
           <>
             <MultiMapDialog
@@ -437,6 +444,7 @@ function MapCardWithKey(props: MapCardProps) {
                           !props.fips.isUsa() && !hasSelfButNotChildGeoData
                         }
                         signalListeners={signalListeners}
+                        mapConfig={{ mapScheme, mapMin }}
                       />
                       {props.fips.isUsa() && (
                         <Grid
@@ -474,10 +482,9 @@ function MapCardWithKey(props: MapCardProps) {
                         sameDotSize={true}
                         direction={mapIsWide ? 'vertical' : 'horizontal'}
                         description={'Legend for rate map'}
-                        isSummaryLegend={
-                          hasSelfButNotChildGeoData || props.fips.isCounty()
-                        }
+                        isSummaryLegend={isSummaryLegend}
                         fipsTypeDisplayName={fipsTypeDisplayName}
+                        mapConfig={{ mapScheme, mapMin }}
                       />
                     </Grid>
 

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -27,6 +27,7 @@ import { CAWP_DATA_TYPES } from '../data/variables/CawpProvider'
 import TerritoryCircles from './ui/TerritoryCircles'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
+import { getMapScheme } from "../charts/mapHelpers"
 
 export interface UnknownsMapCardProps {
   // Variable the map will evaluate for unknowns
@@ -193,6 +194,14 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
 
         const hasChildGeo = props.fips.getChildFipsTypeDisplayName() !== ''
 
+        const isSummaryLegend = !hasChildGeo ?? props.fips.isCounty()
+
+        const [mapScheme, mapMin] = getMapScheme({
+          metricId: metricConfig.metricId,
+          isUnknownsMap: true,
+          isSummaryLegend,
+        })
+
         return (
           <CardContent>
             <ChartTitle title={chartTitle} />
@@ -212,6 +221,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
                   geoData={geoData}
                   filename={chartTitle}
                   countColsToAdd={countColsToAdd}
+                  mapConfig={{ mapScheme, mapMin }}
                 />
                 {props.fips.isUsa() && unknowns.length > 0 && (
                   <TerritoryCircles

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -34,7 +34,7 @@ import {
   getWomenRaceLabel,
 } from '../../data/variables/CawpProvider'
 import { useDownloadCardImage } from '../../utils/hooks/useDownloadCardImage'
-import { RATE_MAP_SCALE } from '../../charts/mapHelpers'
+import { RATE_MAP_SCALE, getMapScheme } from '../../charts/mapHelpers'
 import CloseIcon from '@mui/icons-material/Close'
 import TerritoryCircles from './TerritoryCircles'
 import MapBreadcrumbs from './MapBreadcrumbs'
@@ -100,6 +100,8 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
       }
     },
   }
+
+  const [mapScheme, mapMin] = getMapScheme({ metricId: props.metricConfig.metricId })
 
   return (
     <Dialog
@@ -192,6 +194,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                       !props.fips.isUsa() && !props.hasSelfButNotChildGeoData
                     }
                     signalListeners={multimapSignalListeners}
+                    mapConfig={{ mapScheme, mapMin }}
                   />
                 )}
 
@@ -256,6 +259,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                       sameDotSize={true}
                       direction={pageIsTiny ? 'vertical' : 'horizontal'}
                       description={'Consistent legend for all displayed maps'}
+                      mapConfig={{ mapScheme, mapMin }}
                     />
                   </Grid>
                 </Grid>

--- a/frontend/src/cards/ui/TerritoryCircles.tsx
+++ b/frontend/src/cards/ui/TerritoryCircles.tsx
@@ -5,6 +5,7 @@ import {
   type MetricConfig,
 } from '../../data/config/MetricConfig'
 import { Fips, TERRITORY_CODES } from '../../data/utils/Fips'
+import { getMapScheme } from '../../charts/mapHelpers'
 
 interface TerritoryCirclesProps {
   data: Array<Record<string, any>>
@@ -19,13 +20,17 @@ interface TerritoryCirclesProps {
 }
 
 export default function TerritoryCircles(props: TerritoryCirclesProps) {
+  const [mapScheme, mapMin] = getMapScheme({
+    metricId: props.metricConfig.metricId,
+    isUnknownsMap: props.isUnknownsMap
+  })
+
   return (
     <Grid
       container
       flexWrap={props.mapIsWide ? 'nowrap' : undefined}
       flexDirection={'row'}
       justifyContent={props.isUnknownsMap ? 'flex-end' : undefined}
-      // justifyContent={'flex-end'}
     >
       {TERRITORY_CODES.map((code) => {
         const fips = new Fips(code)
@@ -50,6 +55,7 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
               geoData={props.geoData}
               overrideShapeWithCircle={true}
               countColsToAdd={props.countColsToAdd}
+              mapConfig={{ mapScheme, mapMin }}
             />
           </Grid>
         )

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -10,7 +10,6 @@ import {
   LEGEND_TEXT_FONT,
   MISSING_PLACEHOLDER_VALUES,
   NO_DATA_MESSAGE,
-  getMapScheme
 } from './Legend'
 import { useMediaQuery } from '@mui/material'
 import {
@@ -40,7 +39,6 @@ import {
   ZERO_DATASET,
   VALID_DATASET,
   getHelperLegend,
-  UNKNOWNS_MAP_SCHEME,
 } from './mapHelpers'
 import { CAWP_DETERMINANTS } from '../data/variables/CawpProvider'
 import { type Legend } from 'vega'
@@ -91,13 +89,13 @@ export interface ChoroplethMapProps {
   }
   listExpanded?: boolean
   countColsToAdd: MetricId[]
+  mapConfig: { mapScheme: string, mapMin: string }
+  isSummaryLegend?: boolean
 }
 
 export function ChoroplethMap(props: ChoroplethMapProps) {
   const zeroData = props.data.filter((row) => row[props.metric.metricId] === 0)
   const isCawp = CAWP_DETERMINANTS.includes(props.metric.metricId)
-
-  const [mapScheme, mapMin] = getMapScheme(props.metric.metricId, props.isUnknownsMap)
 
   // render Vega map async as it can be slow
   const [shouldRenderMap, setShouldRenderMap] = useState(false)
@@ -252,9 +250,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       /* metricId */ props.metric.metricId,
       /* scaleType */ props.isUnknownsMap ? UNKNOWNS_MAP_SCALE : RATE_MAP_SCALE,
       /* fieldRange? */ props.fieldRange,
-      /* scaleColorScheme? */ props.isUnknownsMap
-        ? UNKNOWNS_MAP_SCHEME
-        : mapScheme,
+      /* scaleColorScheme? */ props.mapConfig.mapScheme,
       /* isTerritoryCircle? */ props.fips.isTerritory()
     )
 
@@ -269,7 +265,7 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       // ZEROS
       createShapeMarks(
         /* datasetName= */ ZERO_DATASET,
-        /* fillColor= */ { value: mapMin },
+        /* fillColor= */ { value: props.mapConfig.mapMin },
         /* hoverColor= */ DARK_BLUE,
         /* tooltipExpression= */ zeroTooltipValue,
         /* overrideShapeWithCircle */ props.overrideShapeWithCircle,
@@ -431,6 +427,8 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
     LEGEND_WIDTH,
     legendData,
     props.isUnknownsMap,
+    props.mapConfig.mapScheme,
+    props.mapConfig.mapMin,
     yOffsetNoDataLegend,
     xOffsetNoDataLegend,
     props,

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -96,7 +96,8 @@ export interface ChoroplethMapProps {
 export function ChoroplethMap(props: ChoroplethMapProps) {
   const zeroData = props.data.filter((row) => row[props.metric.metricId] === 0)
   const isCawp = CAWP_DETERMINANTS.includes(props.metric.metricId)
-  const [mapScheme, mapMin] = getMapScheme(props.metric.metricId)
+
+  const [mapScheme, mapMin] = getMapScheme(props.metric.metricId, props.isUnknownsMap)
 
   // render Vega map async as it can be slow
   const [shouldRenderMap, setShouldRenderMap] = useState(false)

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -11,8 +11,6 @@ import { Grid } from '@mui/material'
 import { type GeographicBreakdown } from '../data/query/Breakdowns'
 import { CAWP_DETERMINANTS } from '../data/variables/CawpProvider'
 import { LESS_THAN_1 } from '../data/utils/Constants'
-import { BLACK_WOMEN_METRICS } from '../data/variables/HivProvider'
-import { type MetricId } from '../data/config/MetricConfig'
 
 const COLOR_SCALE = 'color_scale'
 const ZERO_SCALE = 'zero_scale'
@@ -59,31 +57,11 @@ export interface LegendProps {
   direction: 'horizontal' | 'vertical'
   isSummaryLegend?: boolean
   fipsTypeDisplayName?: GeographicBreakdown
-}
-
-const MAP_COLOR_SCHEME = 'darkgreen'
-const UNKNOWN_MAP_COLOR_SCHEME = 'greenblue'
-const MAP_BW_MAP_COLOR_SCHEME = 'plasma'
-
-export function getMapScheme(metricId: MetricId, isUnknownsMap?: boolean) {
-  let mapScheme = MAP_COLOR_SCHEME;
-  let mapMin = sass.mapMin;
-
-  if (isUnknownsMap) {
-    mapScheme = UNKNOWN_MAP_COLOR_SCHEME
-    mapMin = sass.unknownMapMin
-  } else if (BLACK_WOMEN_METRICS.includes(metricId)) {
-    mapScheme = MAP_BW_MAP_COLOR_SCHEME
-    mapMin = sass.mapBwMin
-  }
-
-  return [mapScheme, mapMin];
+  mapConfig: { mapScheme: string, mapMin: string }
 }
 
 export function Legend(props: LegendProps) {
   const isCawp = CAWP_DETERMINANTS.includes(props.metric.metricId)
-
-  const [mapScheme, mapMin] = getMapScheme(props.metric.metricId)
 
   const orient = props.direction === 'vertical' ? 'left' : 'right'
 
@@ -116,7 +94,7 @@ export function Legend(props: LegendProps) {
       name: COLOR_SCALE,
       type: props.scaleType,
       domain: { data: DATASET_VALUES, field: props.metric.metricId },
-      range: { scheme: mapScheme, count: legendColorCount },
+      range: { scheme: props.mapConfig.mapScheme, count: legendColorCount },
     }
 
     if (props.fieldRange) {
@@ -266,7 +244,7 @@ export function Legend(props: LegendProps) {
             field: props.metric.metricId,
           },
           range: {
-            scheme: mapScheme,
+            scheme: props.mapConfig.mapScheme,
             count: props.isSummaryLegend ? 1 : legendColorCount,
           },
         },
@@ -274,7 +252,7 @@ export function Legend(props: LegendProps) {
           name: ZERO_SCALE,
           type: ORDINAL,
           domain: { data: ZERO_VALUES, field: 'zero' },
-          range: [mapMin],
+          range: [props.mapConfig.mapMin],
         },
         {
           name: ZERO_DOT_SCALE,
@@ -320,7 +298,9 @@ export function Legend(props: LegendProps) {
     props.fieldRange,
     props.data,
     props.sameDotSize,
-    props,
+    props.mapConfig.mapMin,
+    props.mapConfig.mapScheme,
+    props
   ])
 
   return (

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -35,8 +35,6 @@ export const NO_DATA_MESSAGE = 'no data'
 export const EQUAL_DOT_SIZE = 200
 export const DEFAULT_LEGEND_COLOR_COUNT = 6
 
-export const UNKNOWN_MAP_SCHEME = 'greenblue'
-
 const ZERO_BUCKET_LABEL = '0'
 
 /*
@@ -63,20 +61,31 @@ export interface LegendProps {
   fipsTypeDisplayName?: GeographicBreakdown
 }
 
-export function getMapScheme(metricId: MetricId) {
-  let mapScheme = BLACK_WOMEN_METRICS.includes(metricId) ? 'plasma' : 'darkgreen'
-  let mapMin = BLACK_WOMEN_METRICS.includes(metricId) ? sass.mapBwMin : sass.mapMin
+const MAP_COLOR_SCHEME = 'darkgreen'
+const UNKNOWN_MAP_COLOR_SCHEME = 'greenblue'
+const MAP_BW_MAP_COLOR_SCHEME = 'plasma'
 
-  return [mapScheme, mapMin]
+export function getMapScheme(metricId: MetricId, isUnknownsMap?: boolean) {
+  let mapScheme = MAP_COLOR_SCHEME;
+  let mapMin = sass.mapMin;
 
+  if (isUnknownsMap) {
+    mapScheme = UNKNOWN_MAP_COLOR_SCHEME
+    mapMin = sass.unknownMapMin
+  } else if (BLACK_WOMEN_METRICS.includes(metricId)) {
+    mapScheme = MAP_BW_MAP_COLOR_SCHEME
+    mapMin = sass.mapBwMin
+  }
+
+  return [mapScheme, mapMin];
 }
 
 export function Legend(props: LegendProps) {
   const isCawp = CAWP_DETERMINANTS.includes(props.metric.metricId)
+
   const [mapScheme, mapMin] = getMapScheme(props.metric.metricId)
 
-  const { direction } = props
-  const orient = direction === 'vertical' ? 'left' : 'right'
+  const orient = props.direction === 'vertical' ? 'left' : 'right'
 
   const zeroData = props.data?.filter((row) => row[props.metric.metricId] === 0)
 

--- a/frontend/src/charts/mapHelpers.ts
+++ b/frontend/src/charts/mapHelpers.ts
@@ -19,6 +19,8 @@ import { type FieldRange, type Row } from '../data/utils/DatasetTypes'
 import { ORDINAL } from './utils'
 import sass from '../styles/variables.module.scss'
 import { LESS_THAN_1, raceNameToCodeMap } from '../data/utils/Constants'
+import { BLACK_WOMEN_METRICS } from '../data/variables/HivProvider'
+
 
 export const MISSING_DATASET = 'MISSING_DATASET'
 export const US_PROJECTION = 'US_PROJECTION'
@@ -42,6 +44,7 @@ export const UNKNOWNS_MAP_SCALE: ScaleType = 'symlog'
 
 export const MAP_SCHEME = 'darkgreen'
 export const UNKNOWNS_MAP_SCHEME = 'greenblue'
+export const MAP_BW_SCHEME = 'plasma'
 
 export const UNKNOWN_SCALE_SPEC: any = {
   name: UNKNOWN_SCALE,
@@ -388,4 +391,30 @@ export function setupColorScale(
   }
 
   return colorScale
+}
+
+interface GetMapSchemeProps {
+  metricId: MetricId
+  isUnknownsMap?: boolean
+  isSummaryLegend?: boolean
+}
+
+export function getMapScheme({
+  metricId,
+  isSummaryLegend,
+  isUnknownsMap,
+}: GetMapSchemeProps) {
+  let mapScheme = MAP_SCHEME
+  let mapMin = isSummaryLegend ? sass.mapMid : sass.mapMin
+
+  if (isUnknownsMap) {
+    mapScheme = UNKNOWNS_MAP_SCHEME
+    mapMin = sass.unknownMapMin
+  }
+  if (BLACK_WOMEN_METRICS.includes(metricId)) {
+    mapScheme = MAP_BW_SCHEME
+    mapMin = isSummaryLegend ? sass.mapBwMid : sass.mapBwMin
+  }
+
+  return [mapScheme, mapMin]
 }

--- a/frontend/src/styles/variables.module.scss
+++ b/frontend/src/styles/variables.module.scss
@@ -47,7 +47,7 @@ $alt-dark: #5f6368;
 $alt-grey: #bdbdbd;
 $alt-red: #d32f2f;
 
-// colors from VEGA map
+// colors for VEGA map
 $map-min: #134b3a;
 $map-lightest: #f2e62f;
 $map-lighter: #b9ce3a;
@@ -57,7 +57,7 @@ $map-dark: #027e47;
 $map-darker: #185e49;
 $map-darkest: #134b3a;
 
-// colors from VEGA map black women
+// colors from VEGA map (Black women)
 $map-bw-min: #320161;
 $map-bw-lightest: #febc2b;
 $map-bw-lighter: #f48849;
@@ -67,7 +67,8 @@ $map-bw-dark: #8b0aa5;
 $map-bw-darker: #5402a3;
 $map-bw-darkest: #320161;
 
-// roughly spaced out 7 colors from VEGA unknowns map
+// roughly spaced out 7 colors from VEGA map (unknown)
+$unknown-map-min: #eceecc;
 $unknown-map-least: #d3eece;
 $unknown-map-lesser: #b8e3be;
 $unknown-map-less: #92d4be;
@@ -206,6 +207,7 @@ $z-top: 999;
   mapBwDarker: $map-bw-darker;
   mapBwDarkest: $map-bw-darkest;
 
+  unknownMapMin: $unknown-map-min;
   unknownMapLeast: $unknown-map-least;
   unknownMapLesser: $unknown-map-lesser;
   unknownMapLess: $unknown-map-less;

--- a/frontend/src/styles/variables.module.scss
+++ b/frontend/src/styles/variables.module.scss
@@ -47,7 +47,7 @@ $alt-dark: #5f6368;
 $alt-grey: #bdbdbd;
 $alt-red: #d32f2f;
 
-// colors for VEGA map
+// colors from VEGA map (yellowgreen)
 $map-min: #134b3a;
 $map-lightest: #f2e62f;
 $map-lighter: #b9ce3a;
@@ -57,7 +57,7 @@ $map-dark: #027e47;
 $map-darker: #185e49;
 $map-darkest: #134b3a;
 
-// colors from VEGA map (Black women)
+// colors from VEGA map (Black women - plasma)
 $map-bw-min: #320161;
 $map-bw-lightest: #febc2b;
 $map-bw-lighter: #f48849;
@@ -67,7 +67,7 @@ $map-bw-dark: #8b0aa5;
 $map-bw-darker: #5402a3;
 $map-bw-darkest: #320161;
 
-// roughly spaced out 7 colors from VEGA map (unknown)
+// roughly spaced out 7 colors from VEGA map (unknown - greenblue)
 $unknown-map-min: #eceecc;
 $unknown-map-least: #d3eece;
 $unknown-map-lesser: #b8e3be;


### PR DESCRIPTION
## Description
**This PR fixes the following issues**: 
- The color used to display the zero-value legend differs from the color used to fill the related area on the map. 
- The per 100k map and the unknowns map have the same color for areas that are `0` or `<1`.

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
_Bug on DEV_
![image](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/e2764dd4-5c65-4e13-9255-3283becedc46)

_Bug on PROD_
![Screenshot 2023-05-12 at 4 33 53 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/31843198-4f55-48f3-aed4-c2d152abab46)

## Has this been tested? How?

It was tested locally.

## Screenshots (if appropriate):

_Correct zero-value color showing for Unknowns VEGA map_
![Screenshot 2023-05-12 at 4 20 03 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/0b6bcdcc-e1af-477d-a4a6-9dac2a6ac742)

_Correct zero-value color showing for the regular VEGA map_
![Screenshot 2023-05-12 at 4 19 03 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/fc80242e-73b6-44c1-bd02-3b1b3ed33407)

_Correct summary-value colors showing for all VEGA maps_
![Screenshot 2023-05-12 at 4 18 41 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/fbb255ed-81fc-4a16-8a50-bd9fc5389a0b)

_Correct display for Multi Map_
![Screenshot 2023-05-12 at 4 30 56 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/3e30a72d-005f-4593-b60a-da6fb58c7532)

## Types of changes

- Bug fix

## Post-merge TODO
I have inspected frontend changes and run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎