### PR TITLE
Test the `infra-test` setup

### DIFF
--- a/python/datasources/cdc_svi_county.py
+++ b/python/datasources/cdc_svi_county.py
@@ -58,6 +58,9 @@ class CDCSviCounty(DataSource):
         gcs_to_bq_util.add_df_to_bq(
             df, dataset, "age", column_types=column_types)
 
+        gcs_to_bq_util.add_df_to_bq(
+            df, dataset, "age-test", column_types=column_types)
+
     def generate_for_bq(self, df):
 
         df = df.rename(columns=columns_to_standard)


### PR DESCRIPTION
adds a step to the SVI pipeline that should write an additional table `age-test` when the SVI dag is run. by merging this to `infra-test` in the HET repo, it should trigger the GitHub action that will deploy only the backend to InfraTest GCP, and then we should be able to run the test pipeline for SVI and see these new tables created in the INFRA TEST bigquery