### PR TITLE
test pr; should create a second test-age table when svi pipeline is run

### DIFF
--- a/python/datasources/cdc_svi_county.py
+++ b/python/datasources/cdc_svi_county.py
@@ -58,6 +58,9 @@ class CDCSviCounty(DataSource):
         gcs_to_bq_util.add_df_to_bq(
             df, dataset, "age", column_types=column_types)
 
+        gcs_to_bq_util.add_df_to_bq(
+            df, dataset, "age-test", column_types=column_types)
+
     def generate_for_bq(self, df):
 
         df = df.rename(columns=columns_to_standard)


### PR DESCRIPTION
## Description

- bulleted high-level changes

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

## Has this been tested? How?

## Screenshots (if appropriate):

## Types of changes
- Bug fix
- New content or feature
- Refactor / chore

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎