### PR TITLE
Split test build

### DIFF
--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -1,5 +1,7 @@
 name: Deploy to Infra Test
 
+# TODO: only run services below that are required for backend deployment
+
 on:
   push:
     branches: [infra-test]
@@ -16,7 +18,7 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref_name }}
+          ref: infra-test
       - id: auth
         uses: google-github-actions/auth@v1
         with:
@@ -41,7 +43,7 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref_name }}
+          ref: infra-test
       - id: auth
         uses: google-github-actions/auth@v1
         with:
@@ -66,7 +68,7 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref_name }}
+          ref: infra-test
       - id: auth
         uses: google-github-actions/auth@v1
         with:
@@ -91,7 +93,7 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref_name }}
+          ref: infra-test
       - id: auth
         uses: google-github-actions/auth@v1
         with:
@@ -116,7 +118,8 @@ jobs:
       - name: Check Out Code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref_name }}
+          # don't update dev.healthequitytracker.org frontend with push to infra-test branch
+          ref: main
       - id: auth
         uses: google-github-actions/auth@v1
         with:

--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -207,4 +207,7 @@ jobs:
         working-directory: ./airflow
         run: |
           ./upload-dags.sh
-
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8


### PR DESCRIPTION
when a push happens on `infra-test`, checkout the `infra-test` code for all the HET INFRA TEST builds except for `frontend-service` which will use `main` code so as to keep the testing only for the backend code