### PR TITLE
Improves territory labels

### DIFF
--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -207,4 +207,7 @@ jobs:
         working-directory: ./airflow
         run: |
           ./upload-dags.sh
-
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.8

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -439,11 +439,7 @@ function MapCardWithKey(props: MapCardProps) {
                         signalListeners={signalListeners}
                       />
                       {props.fips.isUsa() && (
-                        <Grid
-                          item
-                          xs={12}
-                          sx={{ display: { xs: 'block', sm: 'none' } }}
-                        >
+                        <Grid item xs={12}>
                           <TerritoryCircles
                             mapIsWide={mapIsWide}
                             data={displayData}
@@ -456,7 +452,7 @@ function MapCardWithKey(props: MapCardProps) {
                         </Grid>
                       )}
                     </Grid>
-                    {/* Legend & Location Info */}
+                    {/* Legend */}
                     <Grid
                       container
                       justifyItems={'center'}
@@ -488,7 +484,7 @@ function MapCardWithKey(props: MapCardProps) {
                       justifyContent={'space-between'}
                       alignItems={'center'}
                     >
-                      <Grid item xs={props.fips.isUsa() ? 6 : 12}>
+                      <Grid item>
                         <GeoContext
                           fips={props.fips}
                           updateFipsCallback={props.updateFipsCallback}
@@ -497,23 +493,6 @@ function MapCardWithKey(props: MapCardProps) {
                           sviQueryResponse={sviQueryResponse}
                         />
                       </Grid>
-                      {props.fips.isUsa() && (
-                        <Grid
-                          item
-                          sm={6}
-                          sx={{ display: { xs: 'none', sm: 'block' } }}
-                        >
-                          <TerritoryCircles
-                            mapIsWide={mapIsWide}
-                            data={displayData}
-                            countColsToAdd={countColsToAdd}
-                            listExpanded={listExpanded}
-                            metricConfig={metricConfig}
-                            signalListeners={signalListeners}
-                            geoData={geoData}
-                          />
-                        </Grid>
-                      )}
                     </Grid>
                   </Grid>
 

--- a/frontend/src/cards/ui/TerritoryCircles.module.scss
+++ b/frontend/src/cards/ui/TerritoryCircles.module.scss
@@ -1,0 +1,9 @@
+@import '../../styles/variables.module';
+@import '../../styles/globals.scss';
+
+.TerritoryLabel {
+  font-size: $smallest;
+  line-height: $lhTight;
+  margin-top: -4px;
+  margin-bottom: 4px;
+}

--- a/frontend/src/cards/ui/TerritoryCircles.tsx
+++ b/frontend/src/cards/ui/TerritoryCircles.tsx
@@ -5,6 +5,7 @@ import {
   type MetricConfig,
 } from '../../data/config/MetricConfig'
 import { Fips, TERRITORY_CODES } from '../../data/utils/Fips'
+import styles from './TerritoryCircles.module.scss'
 
 interface TerritoryCirclesProps {
   data: Array<Record<string, any>>
@@ -25,17 +26,17 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
       flexWrap={props.mapIsWide ? 'nowrap' : undefined}
       flexDirection={'row'}
       justifyContent={props.isUnknownsMap ? 'flex-end' : undefined}
-      // justifyContent={'flex-end'}
     >
-      {TERRITORY_CODES.map((code) => {
-        const fips = new Fips(code)
+      {Object.entries(TERRITORY_CODES).map(([fipsCode, postalCode]) => {
+        const fips = new Fips(fipsCode)
         return (
           <Grid
             item
-            key={code}
+            key={fipsCode}
             xs={4}
-            md={props.mapIsWide ? 2 : 4}
-            lg={props.mapIsWide ? 1 : 2}
+            md={4}
+            lg={props.mapIsWide ? 2 : 4}
+            component={'figure'}
           >
             <ChoroplethMap
               signalListeners={props.signalListeners}
@@ -51,6 +52,9 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
               overrideShapeWithCircle={true}
               countColsToAdd={props.countColsToAdd}
             />
+            <figcaption className={styles.TerritoryLabel}>
+              {postalCode}
+            </figcaption>
           </Grid>
         )
       })}

--- a/frontend/src/cards/ui/TerritoryCircles.tsx
+++ b/frontend/src/cards/ui/TerritoryCircles.tsx
@@ -21,23 +21,11 @@ interface TerritoryCirclesProps {
 
 export default function TerritoryCircles(props: TerritoryCirclesProps) {
   return (
-    <Grid
-      container
-      flexWrap={props.mapIsWide ? 'nowrap' : undefined}
-      flexDirection={'row'}
-      justifyContent={props.isUnknownsMap ? 'flex-end' : undefined}
-    >
+    <Grid container flexDirection={'row'} justifyContent={'flex-end'}>
       {Object.entries(TERRITORY_CODES).map(([fipsCode, postalCode]) => {
         const fips = new Fips(fipsCode)
         return (
-          <Grid
-            item
-            key={fipsCode}
-            xs={4}
-            md={4}
-            lg={props.mapIsWide ? 2 : 4}
-            component={'figure'}
-          >
+          <Grid item key={fipsCode} sx={{ width: 40 }} component={'figure'}>
             <ChoroplethMap
               signalListeners={props.signalListeners}
               metric={props.metricConfig}

--- a/frontend/src/charts/ChoroplethMap.tsx
+++ b/frontend/src/charts/ChoroplethMap.tsx
@@ -10,7 +10,7 @@ import {
   LEGEND_TEXT_FONT,
   MISSING_PLACEHOLDER_VALUES,
   NO_DATA_MESSAGE,
-  getMapScheme
+  getMapScheme,
 } from './Legend'
 import { useMediaQuery } from '@mui/material'
 import {
@@ -18,7 +18,6 @@ import {
   buildTooltipTemplate,
   CIRCLE_PROJECTION,
   COLOR_SCALE,
-  createCircleTextMark,
   createInvisibleAltMarks,
   createShapeMarks,
   formatPreventZero100k,
@@ -294,19 +293,12 @@ export function ChoroplethMap(props: ChoroplethMapProps) {
       ),
     ]
 
-    if (props.overrideShapeWithCircle) {
-      // Visible Territory Abbreviations
-      marks.push(createCircleTextMark(VALID_DATASET))
-      marks.push(createCircleTextMark(ZERO_DATASET))
-      marks.push(createCircleTextMark(MISSING_DATASET))
-    } else {
-      marks.push(
-        createInvisibleAltMarks(
-          /* tooltipDatum */ tooltipDatum,
-          /*  tooltipLabel */ tooltipLabel
-        )
+    marks.push(
+      createInvisibleAltMarks(
+        /* tooltipDatum */ tooltipDatum,
+        /*  tooltipLabel */ tooltipLabel
       )
-    }
+    )
 
     const altText = makeAltText(
       /* data */ props.data,

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -1,6 +1,10 @@
 import { useState, useEffect } from 'react'
 import { Vega } from 'react-vega'
-import { isPctType, type MetricConfig } from '../data/config/MetricConfig'
+import {
+  isPctType,
+  type MetricConfig,
+  type MetricId,
+} from '../data/config/MetricConfig'
 import { type FieldRange } from '../data/utils/DatasetTypes'
 import sass from '../styles/variables.module.scss'
 import { ORDINAL } from './utils'
@@ -12,7 +16,6 @@ import { type GeographicBreakdown } from '../data/query/Breakdowns'
 import { CAWP_DETERMINANTS } from '../data/variables/CawpProvider'
 import { LESS_THAN_1 } from '../data/utils/Constants'
 import { BLACK_WOMEN_METRICS } from '../data/variables/HivProvider'
-import { type MetricId } from '../data/config/MetricConfig'
 
 const COLOR_SCALE = 'color_scale'
 const ZERO_SCALE = 'zero_scale'
@@ -64,11 +67,14 @@ export interface LegendProps {
 }
 
 export function getMapScheme(metricId: MetricId) {
-  let mapScheme = BLACK_WOMEN_METRICS.includes(metricId) ? 'plasma' : 'darkgreen'
-  let mapMin = BLACK_WOMEN_METRICS.includes(metricId) ? sass.mapBwMin : sass.mapMin
+  const mapScheme = BLACK_WOMEN_METRICS.includes(metricId)
+    ? 'plasma'
+    : 'darkgreen'
+  const mapMin = BLACK_WOMEN_METRICS.includes(metricId)
+    ? sass.mapBwMin
+    : sass.mapMin
 
   return [mapScheme, mapMin]
-
 }
 
 export function Legend(props: LegendProps) {

--- a/frontend/src/charts/mapHelpers.ts
+++ b/frontend/src/charts/mapHelpers.ts
@@ -228,27 +228,6 @@ export function createShapeMarks(
   return marks
 }
 
-export function createCircleTextMark(datasetName: string) {
-  return {
-    type: 'text',
-    interactive: false,
-    aria: false,
-    from: { data: datasetName + '_MARK' },
-    encode: {
-      enter: {
-        align: { value: 'center' },
-        baseline: { value: 'middle' },
-        fontSize: { value: 13 },
-        text: { field: 'datum.properties.abbreviation' },
-      },
-      update: {
-        x: { field: 'x' },
-        y: { field: 'y' },
-      },
-    },
-  }
-}
-
 /* ALT MARKS: verbose, invisible text for screen readers showing valid data (incl territories) */
 export function createInvisibleAltMarks(
   tooltipDatum: string,

--- a/frontend/src/data/utils/Fips.ts
+++ b/frontend/src/data/utils/Fips.ts
@@ -1,4 +1,4 @@
-import { GeographicBreakdown } from "../query/Breakdowns"
+import { type GeographicBreakdown } from '../query/Breakdowns'
 
 export const USA_DISPLAY_NAME = 'United States'
 // Fake FIPS code used to represent totals in USA for convenience
@@ -15,14 +15,14 @@ export const NORTHERN_MARIANA_ISLANDS = '69'
 export const PUERTO_RICO = '72'
 export const VIRGIN_ISLANDS = '78'
 
-export const TERRITORY_CODES = [
-  AMERICAN_SAMOA,
-  GUAM,
-  NORTHERN_MARIANA_ISLANDS,
-  PUERTO_RICO,
-  VIRGIN_ISLANDS,
-  DC,
-]
+export const TERRITORY_CODES = {
+  [AMERICAN_SAMOA]: 'AS',
+  [GUAM]: 'GU',
+  [NORTHERN_MARIANA_ISLANDS]: 'MP',
+  [PUERTO_RICO]: 'PR',
+  [VIRGIN_ISLANDS]: 'VI',
+  [DC]: 'DC',
+}
 
 export const ISLAND_AREAS_FIPS = [
   GUAM,
@@ -57,11 +57,17 @@ class Fips {
   }
 
   isState() {
-    return this.isStateOrTerritory() && !TERRITORY_CODES.includes(this.code)
+    return (
+      this.isStateOrTerritory() &&
+      !Object.keys(TERRITORY_CODES).includes(this.code)
+    )
   }
 
   isTerritory() {
-    return this.isStateOrTerritory() && TERRITORY_CODES.includes(this.code)
+    return (
+      this.isStateOrTerritory() &&
+      Object.keys(TERRITORY_CODES).includes(this.code)
+    )
   }
 
   isIslandArea() {
@@ -82,7 +88,6 @@ class Fips {
     } else if (this.isCounty()) {
       return 'county'
     }
-
   }
 
   getUppercaseFipsTypeDisplayName() {


### PR DESCRIPTION
## Description

- rather than rendering the 2 letter postals atop the Vega circles using Vega's text rendering (which were often impossible to read and difficult to style conditionally), we can simply render the wanted text as real text in the circle components. We wrapped the entire circle map and label in the `<figure>` tag, and then per the spec wrapped the postal label as a `<figcaption>` being the last child element of the parent figure.
- converts the territory codes array into a map of fips -> postal
- updates other functions that used the array
- uses fixed width for more consistent layout rather than mui breakpoints
- linting

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

fixes #1766 

## Has this been tested? How?

visually at multiple breakpoints / compare modes (below)

## Screenshots (if appropriate):
<img width="1407" alt="Screen Shot 2023-05-15 at 10 24 08 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/0b686d9c-1632-4976-b3a4-810e9bb6f152">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 24 45 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/6dc6fbb2-6808-49ea-a991-b5e53112d8e8">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 25 31 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/90415715-6ccb-4b5a-806f-5f04ded7de84">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 25 49 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/6ecf119c-0777-48a2-8712-d60ea0102d1f">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 26 17 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/0e18d78b-9346-4bc4-bcb8-710d695cb0fa">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 26 52 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/001654ac-e2b6-47dc-92e9-9de44aab853d">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 27 30 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/ee69f59f-f5ae-4819-85fb-629255253f4d">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 27 55 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/678f079c-57c1-49fe-8773-ff8c0dc46a87">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 28 08 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/904f4594-7fa4-4996-926c-835cce4c8c78">
<img width="1407" alt="Screen Shot 2023-05-15 at 10 28 16 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/4d4c501a-027b-4aee-a000-bed8d8360b23">


hover has full territory name / unknowns map working as expected
<img width="505" alt="Screen Shot 2023-05-15 at 10 34 40 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/bebed41b-0d1f-4665-9818-fa9b51f0062b">
<img width="590" alt="Screen Shot 2023-05-15 at 10 34 59 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/fb03b2af-1e73-478d-bfb6-c6a954eab6f0">

SCREEN READER:

https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/d5c2eeba-cbe0-472d-820b-cfaa87e3a7c1

## Types of changes
- Bug fix


## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎