### PR TITLE
FRONTEND: Adds new HIV resources

### DIFF
--- a/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
+++ b/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
@@ -307,3 +307,33 @@ export const COVID_VACCINATION_RESOURCES: ResourceGroup = {
     },
   ],
 }
+
+export const HIV_RESOURCES: ResourceGroup = {
+  heading: 'HIV',
+  resources: [
+    {
+      name: 'CDC - HIV Risk and Prevention',
+      url: 'https://www.cdc.gov/hiv/risk/index.html'
+    },
+    {
+      name: 'CDC - HIV Surveillance Reports',
+      url: 'https://www.cdc.gov/hiv/library/reports/hiv-surveillance.html',
+    },
+    {
+      name: 'CDC - Resource Library',
+      url: 'https://www.cdc.gov/hiv/library/index.html',
+    },
+    {
+      name: 'HIV Care Continuum',
+      url: 'https://www.hiv.gov/federal-response/policies-issues/hiv-aids-care-continuum/',
+    },
+    {
+      name: 'HIV Treatment as Prevention',
+      url: 'https://www.hiv.gov/tasp/',
+    },
+    {
+      name: 'The HIV/AIDS Epidemic in the United States: The Basics',
+      url: 'https://www.kff.org/hivaids/fact-sheet/the-hivaids-epidemic-in-the-united-states-the-basics/',
+    },
+  ]
+}

--- a/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
+++ b/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
@@ -332,6 +332,10 @@ export const HIV_RESOURCES: ResourceGroup = {
       url: 'https://www.hiv.gov/tasp/',
     },
     {
+      name: 'State of the epidemic - substantial progress and the challenges that remain',
+      url: 'https://www.gileadhiv.com/landscape/state-of-epidemic/?gclid=CjwKCAjwpayjBhAnEiwA-7enayp3t_H2vxCFiD3RyOj8BCnw08eN_TlIO1TH86kJaZfvuBxBlpB3RxoCuL4QAvD_BwE&gclsrc=aw.ds'
+    },
+    {
       name: 'The HIV/AIDS Epidemic in the United States: The Basics',
       url: 'https://www.kff.org/hivaids/fact-sheet/the-hivaids-epidemic-in-the-united-states-the-basics/',
     },

--- a/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
+++ b/frontend/src/pages/WhatIsHealthEquity/ResourcesData.ts
@@ -332,12 +332,20 @@ export const HIV_RESOURCES: ResourceGroup = {
       url: 'https://www.hiv.gov/tasp/',
     },
     {
+      name: 'PrEP vs. PEP',
+      url: 'https://hivinfo.nih.gov/understanding-hiv/infographics/prep-vs-pep',
+    },
+    {
       name: 'State of the epidemic - substantial progress and the challenges that remain',
       url: 'https://www.gileadhiv.com/landscape/state-of-epidemic/?gclid=CjwKCAjwpayjBhAnEiwA-7enayp3t_H2vxCFiD3RyOj8BCnw08eN_TlIO1TH86kJaZfvuBxBlpB3RxoCuL4QAvD_BwE&gclsrc=aw.ds'
     },
     {
       name: 'The HIV/AIDS Epidemic in the United States: The Basics',
       url: 'https://www.kff.org/hivaids/fact-sheet/the-hivaids-epidemic-in-the-united-states-the-basics/',
+    },
+    {
+      name: 'e-Health Literacy Scale, Patient Attitudes, Medication Adherence, and Internal Locus of Control',
+      url: 'https://www.ncbi.nlm.nih.gov/pmc/articles/PMC10169461/',
     },
   ]
 }

--- a/frontend/src/pages/WhatIsHealthEquity/ResourcesTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/ResourcesTab.tsx
@@ -12,6 +12,7 @@ import {
   COVID_RESOURCES,
   COVID_VACCINATION_RESOURCES,
   ECONOMIC_EQUITY_RESOURCES,
+  HIV_RESOURCES
 } from './ResourcesData'
 
 function ResourcesTab() {
@@ -39,6 +40,7 @@ function ResourcesTab() {
             MENTAL_HEALTH_RESOURCES,
             COVID_RESOURCES,
             COVID_VACCINATION_RESOURCES,
+            HIV_RESOURCES
           ].map(({ heading, resources }) => {
             // first heading should get a "main" id for Playwright testing and our a11y setups
             const id = heading === 'Health Equity' ? 'main' : heading


### PR DESCRIPTION
## Description

- Added 7 new resource links on HIV

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Closes #2212

## Has this been tested? How?
I manually tested the links.

## Screenshots (if appropriate):

![Screenshot 2023-05-22 at 4 20 13 PM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/61563633-c42b-427a-8c58-75dd684d5dca)

## Types of changes
- New content or feature

## Post-merge TODO
I have inspected frontend changes and run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎