### PR TITLE
Fix demographic selector bug

### DIFF
--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -387,7 +387,7 @@ export function Report(props: ReportProps) {
               // Mode selectors are in sidebar only on larger screens
               trackerMode={props.trackerMode}
               setTrackerMode={props.setTrackerMode}
-              trackerDemographic={defaultDemo}
+              trackerDemographic={currentBreakdown}
               setDemoWithParam={setDemoWithParam}
               isRaceBySex={isRaceBySex}
             />


### PR DESCRIPTION
## Description

- instead of prop drilling the actual state, we were drilling the default value (that default should only be used when initializing the state)

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->

bug

## Has this been tested? How?

manually


BUG

https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/b56338ca-81e3-449e-9c8a-5f1b1abba387


FIXED


https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/591bff6b-8bd6-45b6-8c72-4494f79b2cbe




## Types of changes
- Bug fix
