### PR TITLE
BUGFIX: Fixes incorrect metric symbol when on mobile

### DIFF
--- a/frontend/src/charts/SimpleHorizontalBarChart.tsx
+++ b/frontend/src/charts/SimpleHorizontalBarChart.tsx
@@ -59,10 +59,9 @@ function getSpec(
   }
 
   // create bar label as array or string
-  const singleLineLabel = `datum.${tooltipMetricDisplayColumnName} +
-  "${usePercentSuffix ? SINGLE_LINE_PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K}"`
-
-  const multiLine100kLabel = `[datum.${tooltipMetricDisplayColumnName}, "${PER_100K}"]`
+  const symbol = usePercentSuffix ? SINGLE_LINE_PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K
+  const singleLineLabel = `datum.${tooltipMetricDisplayColumnName} + "${symbol}"`
+  const multiLine100kLabel = `[datum.${tooltipMetricDisplayColumnName}, "${symbol}"]`
 
   const createBarLabel = () => {
     if (chartIsSmall) {

--- a/frontend/src/charts/SimpleHorizontalBarChart.tsx
+++ b/frontend/src/charts/SimpleHorizontalBarChart.tsx
@@ -21,13 +21,10 @@ import sass from '../styles/variables.module.scss'
 import { useMediaQuery } from '@mui/material'
 import { CAWP_DETERMINANTS } from '../data/providers/CawpProvider'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
+import { createBarLabel } from './mapHelpers'
 
 // determine where (out of 100) to flip labels inside/outside the bar
 const LABEL_SWAP_CUTOFF_PERCENT = 66
-
-// nested quotation mark format needed for Vega
-const PER_100K = ' per 100k'
-const SINGLE_LINE_PERCENT = '%'
 
 function getSpec(
   altText: string,
@@ -59,15 +56,7 @@ function getSpec(
   }
 
   // create bar label as array or string
-  const symbol = usePercentSuffix ? SINGLE_LINE_PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K
-  const singleLineLabel = `datum.${tooltipMetricDisplayColumnName} + "${symbol}"`
-  const multiLine100kLabel = `[datum.${tooltipMetricDisplayColumnName}, "${symbol}"]`
-
-  const createBarLabel = () => {
-    if (chartIsSmall) {
-      return multiLine100kLabel
-    } else return singleLineLabel
-  }
+  const barLabel = createBarLabel(chartIsSmall, measure, tooltipMetricDisplayColumnName, usePercentSuffix)
 
   const legends = showLegend
     ? [
@@ -185,7 +174,7 @@ function getSpec(
             y: { scale: 'y', field: breakdownVar, band: 0.8 },
             limit: { signal: 'width / 3' },
             text: {
-              signal: createBarLabel(),
+              signal: barLabel,
             },
           },
         },

--- a/frontend/src/charts/mapHelpers.test.ts
+++ b/frontend/src/charts/mapHelpers.test.ts
@@ -2,6 +2,7 @@ import { MetricId } from '../data/config/MetricConfig'
 import { Fips } from '../data/utils/Fips'
 import {
   buildTooltipTemplate,
+  createBarLabel,
   getCountyAddOn,
   getHighestLowestGroupsByFips,
 } from './mapHelpers'
@@ -104,5 +105,52 @@ describe('Test getHighestLowestGroupsByFips()', () => {
         lowest: 'Other',
       },
     })
+  })
+})
+
+
+describe('Test createBarLabel()', () => {
+  test('If chartIsSmall is true and usePercentSuffix is false, it should return multiLineLabel', () => {
+    const chartIsSmall = true
+    const usePercentSuffix = false
+    const measure = 'hiv_prevalence_per_100k'
+    const tooltipMetricDisplayColumnName = 'hiv_prevalence_per_100k__DISPLAY_true'
+
+    const result = createBarLabel(chartIsSmall, measure, tooltipMetricDisplayColumnName, usePercentSuffix)
+
+    expect(result).toEqual('[datum.hiv_prevalence_per_100k__DISPLAY_true, " per 100k"]')
+  })
+
+  test('If chartIsSmall and usePercentSuffix are true, it should return singleLineLabel', () => {
+    const chartIsSmall = true
+    const usePercentSuffix = true
+    const measure = 'pct_share_of_us_congress'
+    const tooltipMetricDisplayColumnName = 'pct_share_of_us_congress__DISPLAY_true'
+
+    const result = createBarLabel(chartIsSmall, measure, tooltipMetricDisplayColumnName, usePercentSuffix)
+
+    expect(result).toEqual('datum.pct_share_of_us_congress__DISPLAY_true + "%"')
+  })
+
+  test('If chartIsSmall is false and usePercentSuffix is true, it should return singleLineLabel', () => {
+    const chartIsSmall = false
+    const usePercentSuffix = false
+    const measure = 'hiv_stigma_index'
+    const tooltipMetricDisplayColumnName = 'hiv_stigma_index__DISPLAY_true'
+
+    const result = createBarLabel(chartIsSmall, measure, tooltipMetricDisplayColumnName, usePercentSuffix)
+
+    expect(result).toEqual('datum.hiv_stigma_index__DISPLAY_true + ""')
+  })
+
+  test('If chartIsSmall and usePercentSuffix are false, it should return singleLineLabel', () => {
+    const chartIsSmall = false
+    const usePercentSuffix = false
+    const measure = 'asthma_per_100k'
+    const tooltipMetricDisplayColumnName = 'asthma_per_100k__DISPLAY_true'
+
+    const result = createBarLabel(chartIsSmall, measure, tooltipMetricDisplayColumnName, usePercentSuffix)
+
+    expect(result).toEqual('datum.asthma_per_100k__DISPLAY_true + " per 100k"')
   })
 })

--- a/frontend/src/charts/mapHelpers.ts
+++ b/frontend/src/charts/mapHelpers.ts
@@ -502,9 +502,9 @@ export function createBarLabel(
   usePercentSuffix: boolean,
 ) {
   const PER_100K = ' per 100k'
-  const SINGLE_LINE_PERCENT = '%'
+  const PERCENT = '%'
 
-  const symbol = usePercentSuffix ? SINGLE_LINE_PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K
+  const symbol = usePercentSuffix ? PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K
   const singleLineLabel = `datum.${tooltipMetricDisplayColumnName} + "${symbol}"`
   const multiLineLabel = `[datum.${tooltipMetricDisplayColumnName}, "${symbol}"]`
   

--- a/frontend/src/charts/mapHelpers.ts
+++ b/frontend/src/charts/mapHelpers.ts
@@ -494,3 +494,23 @@ export function getMapGroupLabel(
     ? `${measureType} overall`
     : `Rate for ${selectedGroup ?? 'selected group'}`
 }
+
+export function createBarLabel(
+  chartIsSmall: boolean,
+  measure: MetricId,
+  tooltipMetricDisplayColumnName: string,
+  usePercentSuffix: boolean,
+) {
+  const PER_100K = ' per 100k'
+  const SINGLE_LINE_PERCENT = '%'
+
+  const symbol = usePercentSuffix ? SINGLE_LINE_PERCENT : measure === 'hiv_stigma_index' ? '' : PER_100K
+  const singleLineLabel = `datum.${tooltipMetricDisplayColumnName} + "${symbol}"`
+  const multiLineLabel = `[datum.${tooltipMetricDisplayColumnName}, "${symbol}"]`
+  
+  if (chartIsSmall && !usePercentSuffix) {
+    return multiLineLabel
+  } else {
+    return singleLineLabel
+  }
+}


### PR DESCRIPTION
## Description

- Moves function to `mapHelpers.ts` file. 
- Adds `chartIsSmall && !usePercentSuffix` logic back to the previously removed function in the last PR. 
- Adds Playwright tests for the `createBarLabel` function. 

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Fixes #2274

## Has this been tested? How?
Playwright tests have been written to ensure the correct strings are generated.  

## Screenshots (if appropriate):
_Bug_
![Screenshot 2023-07-12 at 11 01 54 AM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/dbd2b0e4-c5e2-465a-8ed8-d90cbd147b14)

_Fix_


## Types of changes
- Bug fix
![Screenshot 2023-07-12 at 11 02 57 AM](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/a2b6211a-5ca1-4e30-9e04-9642b194d376)

## Post-merge TODO
I have inspected frontend changes and run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎