### PR TITLE
BACKEND: Adding missed age adjustment test files for HIV

### DIFF
--- a/python/datasources/age_adjust_cdc_hiv.py
+++ b/python/datasources/age_adjust_cdc_hiv.py
@@ -19,7 +19,7 @@ from ingestion.constants import (
     STATE_LEVEL
 )
 
-SINGLE_YEAR = '2019'
+SINGLE_YEAR = '2021'
 REFERENCE_POPULATION = Race.ALL.value
 BASE_POPULATION = Race.WHITE_NH.value
 

--- a/python/tests/data/cdc_hiv_age_adjustment/by_race_age_national.csv
+++ b/python/tests/data/cdc_hiv_age_adjustment/by_race_age_national.csv
@@ -1,49 +1,49 @@
 time_period,state_name,state_fips,age,race_category_id,hiv_deaths_estimated_total,population,race_and_ethnicity
-2019,United States,00,All,ALL,16230,276063213,All
-2019,United States,00,All,MULTI_NH,1087,4863049,Two or more races (NH)
-2019,United States,00,All,WHITE_NH,5234,171541840,White (NH)
-2019,United States,00,All,NHPI_NH,14,491319,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,All,HISP,2740,46954313,Hispanic or Latino
-2019,United States,00,All,BLACK_NH,6992,33981764,Black or African American (NH)
-2019,United States,00,All,ASIAN_NH,101,16234313,Asian (NH)
-2019,United States,00,All,AIAN_NH,58,1996615,American Indian and Alaska Native (NH)
-2019,United States,00,55+,ALL,9590,96467960,All
-2019,United States,00,45-54,ALL,3625,40860323,All
-2019,United States,00,35-44,ALL,1787,41674444,All
-2019,United States,00,25-34,ALL,1095,46003684,All
-2019,United States,00,13-24,ALL,133,51056802,All
-2019,United States,00,55+,MULTI_NH,642,868877,Two or more races (NH)
-2019,United States,00,45-54,MULTI_NH,244,513659,Two or more races (NH)
-2019,United States,00,35-44,MULTI_NH,134,686276,Two or more races (NH)
-2019,United States,00,25-34,MULTI_NH,58,1028364,Two or more races (NH)
-2019,United States,00,13-24,MULTI_NH,9,1765873,Two or more races (NH)
-2019,United States,00,55+,WHITE_NH,3367,70674145,White (NH)
-2019,United States,00,45-54,WHITE_NH,1152,25174229,White (NH)
-2019,United States,00,35-44,WHITE_NH,444,23591659,White (NH)
-2019,United States,00,25-34,WHITE_NH,248,25208812,White (NH)
-2019,United States,00,13-24,WHITE_NH,23,26892995,White (NH)
-2019,United States,00,55+,NHPI_NH,6,123381,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,45-54,NHPI_NH,5,72655,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,35-44,NHPI_NH,2,90190,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,25-34,NHPI_NH,1,103499,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,13-24,NHPI_NH,0,101594,Native Hawaiian and Pacific Islander (NH)
-2019,United States,00,55+,HISP,1483,9673321,Hispanic or Latino
-2019,United States,00,45-54,HISP,664,7101099,Hispanic or Latino
-2019,United States,00,35-44,HISP,360,8641425,Hispanic or Latino
-2019,United States,00,25-34,HISP,207,9538109,Hispanic or Latino
-2019,United States,00,13-24,HISP,26,12000359,Hispanic or Latino
-2019,United States,00,55+,BLACK_NH,4019,9930422,Black or African American (NH)
-2019,United States,00,45-54,BLACK_NH,1516,5106130,Black or African American (NH)
-2019,United States,00,35-44,BLACK_NH,818,5323598,Black or African American (NH)
-2019,United States,00,25-34,BLACK_NH,566,6529276,Black or African American (NH)
-2019,United States,00,13-24,BLACK_NH,73,7092338,Black or African American (NH)
-2019,United States,00,55+,ASIAN_NH,45,4597606,Asian (NH)
-2019,United States,00,45-54,ASIAN_NH,27,2604640,Asian (NH)
-2019,United States,00,35-44,ASIAN_NH,19,3039508,Asian (NH)
-2019,United States,00,25-34,ASIAN_NH,8,3219268,Asian (NH)
-2019,United States,00,13-24,ASIAN_NH,2,2773291,Asian (NH)
-2019,United States,00,55+,AIAN_NH,24,600208,American Indian and Alaska Native (NH)
-2019,United States,00,45-54,AIAN_NH,17,287911,American Indian and Alaska Native (NH)
-2019,United States,00,35-44,AIAN_NH,10,301788,American Indian and Alaska Native (NH)
-2019,United States,00,25-34,AIAN_NH,7,376356,American Indian and Alaska Native (NH)
-2019,United States,00,13-24,AIAN_NH,0,430352,American Indian and Alaska Native (NH)
+2021,United States,00,All,ALL,16230,276063213,All
+2021,United States,00,All,MULTI_NH,1087,4863049,Two or more races (NH)
+2021,United States,00,All,WHITE_NH,5234,171541840,White (NH)
+2021,United States,00,All,NHPI_NH,14,491319,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,All,HISP,2740,46954313,Hispanic or Latino
+2021,United States,00,All,BLACK_NH,6992,33981764,Black or African American (NH)
+2021,United States,00,All,ASIAN_NH,101,16234313,Asian (NH)
+2021,United States,00,All,AIAN_NH,58,1996615,American Indian and Alaska Native (NH)
+2021,United States,00,55+,ALL,12124,96467960,All
+2021,United States,00,45-54,ALL,3783,40860323,All
+2021,United States,00,35-44,ALL,2247,41674444,All
+2021,United States,00,25-34,ALL,1360,46003684,All
+2021,United States,00,13-24,ALL,109,51056802,All
+2021,United States,00,55+,MULTI_NH,920,868877,Two or more races (NH)
+2021,United States,00,45-54,MULTI_NH,288,513659,Two or more races (NH)
+2021,United States,00,35-44,MULTI_NH,163,686276,Two or more races (NH)
+2021,United States,00,25-34,MULTI_NH,99,1028364,Two or more races (NH)
+2021,United States,00,13-24,MULTI_NH,8,1765873,Two or more races (NH)
+2021,United States,00,55+,WHITE_NH,4047,70674145,White (NH)
+2021,United States,00,45-54,WHITE_NH,1116,25174229,White (NH)
+2021,United States,00,35-44,WHITE_NH,566,23591659,White (NH)
+2021,United States,00,25-34,WHITE_NH,278,25208812,White (NH)
+2021,United States,00,13-24,WHITE_NH,18,26892995,White (NH)
+2021,United States,00,55+,NHPI_NH,6,123381,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,45-54,NHPI_NH,5,72655,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,35-44,NHPI_NH,3,90190,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,25-34,NHPI_NH,0,103499,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,13-24,NHPI_NH,0,101594,Native Hawaiian and Pacific Islander (NH)
+2021,United States,00,55+,HISP,1937,9673321,Hispanic or Latino
+2021,United States,00,45-54,HISP,746,7101099,Hispanic or Latino
+2021,United States,00,35-44,HISP,488,8641425,Hispanic or Latino
+2021,United States,00,25-34,HISP,297,9538109,Hispanic or Latino
+2021,United States,00,13-24,HISP,30,12000359,Hispanic or Latino
+2021,United States,00,55+,BLACK_NH,5119,9930422,Black or African American (NH)
+2021,United States,00,45-54,BLACK_NH,1578,5106130,Black or African American (NH)
+2021,United States,00,35-44,BLACK_NH,990,5323598,Black or African American (NH)
+2021,United States,00,25-34,BLACK_NH,662,6529276,Black or African American (NH)
+2021,United States,00,13-24,BLACK_NH,53,7092338,Black or African American (NH)
+2021,United States,00,55+,ASIAN_NH,61,4597606,Asian (NH)
+2021,United States,00,45-54,ASIAN_NH,35,2604640,Asian (NH)
+2021,United States,00,35-44,ASIAN_NH,17,3039508,Asian (NH)
+2021,United States,00,25-34,ASIAN_NH,12,3219268,Asian (NH)
+2021,United States,00,13-24,ASIAN_NH,0,2773291,Asian (NH)
+2021,United States,00,55+,AIAN_NH,33,600208,American Indian and Alaska Native (NH)
+2021,United States,00,45-54,AIAN_NH,15,287911,American Indian and Alaska Native (NH)
+2021,United States,00,35-44,AIAN_NH,20,301788,American Indian and Alaska Native (NH)
+2021,United States,00,25-34,AIAN_NH,12,376356,American Indian and Alaska Native (NH)
+2021,United States,00,13-24,AIAN_NH,0,430352,American Indian and Alaska Native (NH)

--- a/python/tests/data/cdc_hiv_age_adjustment/golden_data/race_and_ethnicity_national_time_series-with_age_adjust.csv
+++ b/python/tests/data/cdc_hiv_age_adjustment/golden_data/race_and_ethnicity_national_time_series-with_age_adjust.csv
@@ -1,19 +1,19 @@
-time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity,hiv_deaths_ratio_age_adjusted
-2019,United States,00,Two or more races (NH),MULTI_NH,684.0,1087.0,1102.0,,52753.0,35.3,81.3,,22.4,22.7,1084.8,2.5,6.7,3.0,,5.1,,1.8,2.5,0.0,272.2,66.7,,183.3,13.1
-2019,United States,00,White (NH),WHITE_NH,6817.0,5234.0,9063.0,180239.0,303234.0,29.0,82.6,59.9,3.1,5.3,176.8,24.8,32.2,24.8,65.5,29.1,24.7,62.1,24.4,1.6,-48.1,-60.1,165.2,-53.1,1.0
-2019,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,53.0,14.0,66.0,,878.0,,80.3,,2.8,13.4,178.7,0.2,0.1,0.2,,0.1,,0.2,0.2,0.0,-50.0,0.0,,-50.0,1.1
-2019,United States,00,Hispanic or Latino,HISP,8004.0,2740.0,9889.0,45069.0,240651.0,32.7,84.4,14.4,5.8,21.1,512.5,29.1,16.9,27.1,16.4,23.1,25.7,17.0,28.0,3.9,-0.6,59.4,-36.2,35.9,2.8
-2019,United States,00,Black or African American (NH),BLACK_NH,11179.0,6992.0,15471.0,37590.0,423711.0,30.8,78.4,8.0,20.6,45.5,1246.9,40.7,43.1,42.4,13.7,40.7,38.5,12.3,42.2,-3.6,250.4,244.7,-64.4,230.9,8.0
-2019,United States,00,Asian (NH),ASIAN_NH,570.0,101.0,733.0,,15447.0,32.4,83.0,,0.6,4.5,95.2,2.1,0.6,2.0,,1.5,,5.9,2.0,5.0,-89.8,-66.1,,-74.6,0.2
-2019,United States,00,American Indian and Alaska Native (NH),AIAN_NH,172.0,58.0,204.0,,3118.0,,83.5,,2.9,10.2,156.2,0.6,0.4,0.6,,0.3,,0.7,0.6,0.0,-42.9,-14.3,,-57.1,1.1
-2017,United States,00,Two or more races (NH),MULTI_NH,823.0,1074.0,1367.0,,52513.0,35.7,80.0,,23.6,30.0,1153.8,3.1,6.6,3.6,,5.3,,1.7,3.0,3.3,288.2,111.8,,211.8,
-2017,United States,00,White (NH),WHITE_NH,6864.0,5238.0,9628.0,104686.0,294749.0,28.2,81.0,33.6,3.1,5.6,171.8,25.9,32.0,25.1,67.5,29.6,25.5,63.0,24.9,4.0,-49.2,-60.2,164.7,-53.0,
-2017,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,33.0,9.0,50.0,,774.0,,80.5,,1.9,10.6,164.1,0.1,0.1,0.1,,0.1,,0.2,0.1,0.0,-50.0,-50.0,,-50.0,
-2017,United States,00,Hispanic or Latino,HISP,6803.0,2694.0,9925.0,23486.0,224917.0,32.2,78.4,7.8,6.0,22.1,500.3,25.7,16.5,25.9,15.1,22.6,24.5,16.5,25.5,0.8,0.0,57.0,-38.4,37.0,
-2017,United States,00,Black or African American (NH),BLACK_NH,11180.0,7198.0,16223.0,19838.0,404974.0,33.3,75.3,4.2,21.6,48.6,1214.0,42.2,44.0,42.3,12.8,40.7,38.9,12.2,43.6,-3.2,260.7,246.7,-67.1,233.6,
-2017,United States,00,Asian (NH),ASIAN_NH,684.0,88.0,923.0,,13794.0,26.1,81.1,,0.6,5.9,88.6,2.6,0.5,2.4,,1.4,,5.7,2.5,4.0,-91.2,-57.9,,-75.4,
-2017,United States,00,American Indian and Alaska Native (NH),AIAN_NH,130.0,47.0,200.0,,2842.0,,83.3,,2.4,10.2,145.1,0.5,0.3,0.5,,0.3,,0.7,0.5,0.0,-57.1,-28.6,,-57.1,
-2017,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,7052.0,,,,5.3,,,,,,,4.5,,10.8,,,,,,-58.3,,
-2019,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,12285.0,,,,9.4,,,,,,,4.5,,10.8,,,,,,-58.3,,
-2017,United States,00,All,ALL,26517.0,16350.0,38316.0,155062.0,995297.0,30.7,77.8,12.7,6.0,14.1,365.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,
-2019,United States,00,All,ALL,27479.0,16230.0,36528.0,275182.0,1040522.0,31.2,81.3,22.6,5.9,13.2,376.9,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,
+time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity,hiv_deaths_ratio_age_adjusted_x,hiv_deaths_ratio_age_adjusted_y
+2021,United States,00,Two or more races (NH),MULTI_NH,684.0,1087.0,1102.0,,52753.0,35.3,81.3,,22.4,22.7,1084.8,2.5,6.7,3.0,,5.1,,1.8,2.5,0.0,272.2,66.7,,183.3,15.7,15.7
+2021,United States,00,White (NH),WHITE_NH,6817.0,5234.0,9063.0,180239.0,303234.0,29.0,82.6,59.9,3.1,5.3,176.8,24.8,32.2,24.8,65.5,29.1,24.7,62.1,24.4,1.6,-48.1,-60.1,165.2,-53.1,1.0,1.0
+2021,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,53.0,14.0,66.0,,878.0,,80.3,,2.8,13.4,178.7,0.2,0.1,0.2,,0.1,,0.2,0.2,0.0,-50.0,0.0,,-50.0,1.0,1.0
+2021,United States,00,Hispanic or Latino,HISP,8004.0,2740.0,9889.0,45069.0,240651.0,32.7,84.4,14.4,5.8,21.1,512.5,29.1,16.9,27.1,16.4,23.1,25.7,17.0,28.0,3.9,-0.6,59.4,-36.2,35.9,3.1,3.1
+2021,United States,00,Black or African American (NH),BLACK_NH,11179.0,6992.0,15471.0,37590.0,423711.0,30.8,78.4,8.0,20.6,45.5,1246.9,40.7,43.1,42.4,13.7,40.7,38.5,12.3,42.2,-3.6,250.4,244.7,-64.4,230.9,8.5,8.5
+2021,United States,00,Asian (NH),ASIAN_NH,570.0,101.0,733.0,,15447.0,32.4,83.0,,0.6,4.5,95.2,2.1,0.6,2.0,,1.5,,5.9,2.0,5.0,-89.8,-66.1,,-74.6,0.3,0.3
+2021,United States,00,American Indian and Alaska Native (NH),AIAN_NH,172.0,58.0,204.0,,3118.0,,83.5,,2.9,10.2,156.2,0.6,0.4,0.6,,0.3,,0.7,0.6,0.0,-42.9,-14.3,,-57.1,1.3,1.3
+2017,United States,00,Two or more races (NH),MULTI_NH,823.0,1074.0,1367.0,,52513.0,35.7,80.0,,23.6,30.0,1153.8,3.1,6.6,3.6,,5.3,,1.7,3.0,3.3,288.2,111.8,,211.8,,
+2017,United States,00,White (NH),WHITE_NH,6864.0,5238.0,9628.0,104686.0,294749.0,28.2,81.0,33.6,3.1,5.6,171.8,25.9,32.0,25.1,67.5,29.6,25.5,63.0,24.9,4.0,-49.2,-60.2,164.7,-53.0,,
+2017,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,33.0,9.0,50.0,,774.0,,80.5,,1.9,10.6,164.1,0.1,0.1,0.1,,0.1,,0.2,0.1,0.0,-50.0,-50.0,,-50.0,,
+2017,United States,00,Hispanic or Latino,HISP,6803.0,2694.0,9925.0,23486.0,224917.0,32.2,78.4,7.8,6.0,22.1,500.3,25.7,16.5,25.9,15.1,22.6,24.5,16.5,25.5,0.8,0.0,57.0,-38.4,37.0,,
+2017,United States,00,Black or African American (NH),BLACK_NH,11180.0,7198.0,16223.0,19838.0,404974.0,33.3,75.3,4.2,21.6,48.6,1214.0,42.2,44.0,42.3,12.8,40.7,38.9,12.2,43.6,-3.2,260.7,246.7,-67.1,233.6,,
+2017,United States,00,Asian (NH),ASIAN_NH,684.0,88.0,923.0,,13794.0,26.1,81.1,,0.6,5.9,88.6,2.6,0.5,2.4,,1.4,,5.7,2.5,4.0,-91.2,-57.9,,-75.4,,
+2017,United States,00,American Indian and Alaska Native (NH),AIAN_NH,130.0,47.0,200.0,,2842.0,,83.3,,2.4,10.2,145.1,0.5,0.3,0.5,,0.3,,0.7,0.5,0.0,-57.1,-28.6,,-57.1,,
+2017,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,7052.0,,,,5.3,,,,,,,4.5,,10.8,,,,,,-58.3,,,
+2021,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,12285.0,,,,9.4,,,,,,,4.5,,10.8,,,,,,-58.3,,,
+2017,United States,00,All,ALL,26517.0,16350.0,38316.0,155062.0,995297.0,30.7,77.8,12.7,6.0,14.1,365.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,,
+2021,United States,00,All,ALL,27479.0,16230.0,36528.0,275182.0,1040522.0,31.2,81.3,22.6,5.9,13.2,376.9,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,,

--- a/python/tests/data/cdc_hiv_age_adjustment/golden_data/race_and_ethnicity_state_time_series-with_age_adjust.csv
+++ b/python/tests/data/cdc_hiv_age_adjustment/golden_data/race_and_ethnicity_state_time_series-with_age_adjust.csv
@@ -1,11 +1,11 @@
 time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity,hiv_deaths_ratio_age_adjusted
-2019,Alabama,01,Two or more races (NH),MULTI_NH,13,23,14,,832,,92.9,,46.0,28.0,1665.4,2.6,8.5,2.2,,6.0,,1.2,2.2,18.2,608.3,83.3,,400.0,25.8
-2019,Alabama,01,White (NH),WHITE_NH,119,69,151,,3700,,78.3,,2.5,5.5,133.9,23.6,25.4,23.8,,26.7,,66.9,23.8,-0.8,-62.0,-64.4,,-60.1,1.0
-2019,Alabama,01,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,148.4,0.0,0.0,0.0,,0.02,,0.05,0.0,,-100.0,-100.0,,-60.0,
-2019,Alabama,01,Hispanic or Latino,HISP,11,5,15,,499,,84.6,,3.2,9.7,321.9,2.2,1.8,2.4,,3.6,,3.8,2.0,10.0,-52.6,-36.8,,-5.3,2.9
-2019,Alabama,01,Black or African American (NH),BLACK_NH,361,170,453,,8731,,79.0,,15.8,42.2,813.6,71.5,62.5,71.3,,63.0,,26.0,71.6,-0.1,140.4,174.2,,142.3,7.2
-2019,Alabama,01,Asian (NH),ASIAN_NH,0,1,1,,36,,0.0,,1.6,1.6,58.8,0.0,0.4,0.2,,0.3,,1.5,0.2,-100.0,-73.3,-86.7,,-80.0,0.6
-2019,Alabama,01,American Indian and Alaska Native (NH),AIAN_NH,1,1,1,,6,,100.0,,4.1,4.1,24.4,0.2,0.4,0.2,,0.04,,0.6,0.2,0.0,-33.3,-66.7,,-93.3,1.7
+2021,Alabama,01,Two or more races (NH),MULTI_NH,13,23,14,,832,,92.9,,46.0,28.0,1665.4,2.6,8.5,2.2,,6.0,,1.2,2.2,18.2,608.3,83.3,,400.0,25.8
+2021,Alabama,01,White (NH),WHITE_NH,119,69,151,,3700,,78.3,,2.5,5.5,133.9,23.6,25.4,23.8,,26.7,,66.9,23.8,-0.8,-62.0,-64.4,,-60.1,1.0
+2021,Alabama,01,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,148.4,0.0,0.0,0.0,,0.02,,0.05,0.0,,-100.0,-100.0,,-60.0,
+2021,Alabama,01,Hispanic or Latino,HISP,11,5,15,,499,,84.6,,3.2,9.7,321.9,2.2,1.8,2.4,,3.6,,3.8,2.0,10.0,-52.6,-36.8,,-5.3,2.9
+2021,Alabama,01,Black or African American (NH),BLACK_NH,361,170,453,,8731,,79.0,,15.8,42.2,813.6,71.5,62.5,71.3,,63.0,,26.0,71.6,-0.1,140.4,174.2,,142.3,7.2
+2021,Alabama,01,Asian (NH),ASIAN_NH,0,1,1,,36,,0.0,,1.6,1.6,58.8,0.0,0.4,0.2,,0.3,,1.5,0.2,-100.0,-73.3,-86.7,,-80.0,0.6
+2021,Alabama,01,American Indian and Alaska Native (NH),AIAN_NH,1,1,1,,6,,100.0,,4.1,4.1,24.4,0.2,0.4,0.2,,0.04,,0.6,0.2,0.0,-33.3,-66.7,,-93.3,1.7
 2017,Alaska,02,Two or more races (NH),MULTI_NH,0,1,0,,39,,0.0,,3.1,0.0,121.5,0.0,14.3,0.0,,5.5,,5.3,0.0,,169.8,-100.0,,3.8,
 2017,Alaska,02,White (NH),WHITE_NH,9,5,10,,285,,100.0,,1.3,2.6,74.4,32.1,71.4,33.3,,40.0,,63.4,31.0,3.5,12.6,-47.5,,-36.9,
 2017,Alaska,02,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,39.9,0.0,0.0,0.0,,0.4,,1.2,0.0,,-100.0,-100.0,,-66.7,
@@ -14,4 +14,4 @@ time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,h
 2017,Alaska,02,Asian (NH),ASIAN_NH,0,0,0,,23,,0.0,,0.0,0.0,57.9,0.0,0.0,0.0,,3.2,,6.6,0.0,,-100.0,-100.0,,-51.5,
 2017,Alaska,02,American Indian and Alaska Native (NH),AIAN_NH,13,0,13,,186,,100.0,,0.0,15.7,225.3,46.4,0.0,43.3,,26.1,,13.7,44.8,3.6,-100.0,216.1,,90.5,
 2017,Alaska,02,All,ALL,28,7,30,125.0,713,,96.6,5.3,1.2,5.0,118.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,
-2019,Alabama,01,All,ALL,505,272,635,1835.0,13849,,79.2,16.7,6.6,15.4,335.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,
+2021,Alabama,01,All,ALL,505,272,635,1835.0,13849,,79.2,16.7,6.6,15.4,335.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,

--- a/python/tests/data/cdc_hiv_age_adjustment/race_and_ethnicity_national_time_series.csv
+++ b/python/tests/data/cdc_hiv_age_adjustment/race_and_ethnicity_national_time_series.csv
@@ -1,19 +1,19 @@
-time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity
-2019,United States,00,Two or more races (NH),MULTI_NH,684.0,1087.0,1102.0,,52753.0,35.3,81.3,,22.4,22.7,1084.8,2.5,6.7,3.0,,5.1,,1.8,2.5,0.0,272.2,66.7,,183.3
-2019,United States,00,White (NH),WHITE_NH,6817.0,5234.0,9063.0,180239.0,303234.0,29.0,82.6,59.9,3.1,5.3,176.8,24.8,32.2,24.8,65.5,29.1,24.7,62.1,24.4,1.6,-48.1,-60.1,165.2,-53.1
-2019,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,53.0,14.0,66.0,,878.0,,80.3,,2.8,13.4,178.7,0.2,0.1,0.2,,0.1,,0.2,0.2,0.0,-50.0,0.0,,-50.0
-2019,United States,00,Hispanic or Latino,HISP,8004.0,2740.0,9889.0,45069.0,240651.0,32.7,84.4,14.4,5.8,21.1,512.5,29.1,16.9,27.1,16.4,23.1,25.7,17.0,28.0,3.9,-0.6,59.4,-36.2,35.9
-2019,United States,00,Black or African American (NH),BLACK_NH,11179.0,6992.0,15471.0,37590.0,423711.0,30.8,78.4,8.0,20.6,45.5,1246.9,40.7,43.1,42.4,13.7,40.7,38.5,12.3,42.2,-3.6,250.4,244.7,-64.4,230.9
-2019,United States,00,Asian (NH),ASIAN_NH,570.0,101.0,733.0,,15447.0,32.4,83.0,,0.6,4.5,95.2,2.1,0.6,2.0,,1.5,,5.9,2.0,5.0,-89.8,-66.1,,-74.6
-2019,United States,00,American Indian and Alaska Native (NH),AIAN_NH,172.0,58.0,204.0,,3118.0,,83.5,,2.9,10.2,156.2,0.6,0.4,0.6,,0.3,,0.7,0.6,0.0,-42.9,-14.3,,-57.1
-2017,United States,00,Two or more races (NH),MULTI_NH,823.0,1074.0,1367.0,,52513.0,35.7,80.0,,23.6,30.0,1153.8,3.1,6.6,3.6,,5.3,,1.7,3.0,3.3,288.2,111.8,,211.8
-2017,United States,00,White (NH),WHITE_NH,6864.0,5238.0,9628.0,104686.0,294749.0,28.2,81.0,33.6,3.1,5.6,171.8,25.9,32.0,25.1,67.5,29.6,25.5,63.0,24.9,4.0,-49.2,-60.2,164.7,-53.0
-2017,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,33.0,9.0,50.0,,774.0,,80.5,,1.9,10.6,164.1,0.1,0.1,0.1,,0.1,,0.2,0.1,0.0,-50.0,-50.0,,-50.0
-2017,United States,00,Hispanic or Latino,HISP,6803.0,2694.0,9925.0,23486.0,224917.0,32.2,78.4,7.8,6.0,22.1,500.3,25.7,16.5,25.9,15.1,22.6,24.5,16.5,25.5,0.8,0.0,57.0,-38.4,37.0
-2017,United States,00,Black or African American (NH),BLACK_NH,11180.0,7198.0,16223.0,19838.0,404974.0,33.3,75.3,4.2,21.6,48.6,1214.0,42.2,44.0,42.3,12.8,40.7,38.9,12.2,43.6,-3.2,260.7,246.7,-67.1,233.6
-2017,United States,00,Asian (NH),ASIAN_NH,684.0,88.0,923.0,,13794.0,26.1,81.1,,0.6,5.9,88.6,2.6,0.5,2.4,,1.4,,5.7,2.5,4.0,-91.2,-57.9,,-75.4
-2017,United States,00,American Indian and Alaska Native (NH),AIAN_NH,130.0,47.0,200.0,,2842.0,,83.3,,2.4,10.2,145.1,0.5,0.3,0.5,,0.3,,0.7,0.5,0.0,-57.1,-28.6,,-57.1
-2017,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,7052.0,,,,5.3,,,,,,,4.5,,10.8,,,,,,-58.3,
-2019,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,12285.0,,,,9.4,,,,,,,4.5,,10.8,,,,,,-58.3,
-2017,United States,00,All,ALL,26517.0,16350.0,38316.0,155062.0,995297.0,30.7,77.8,12.7,6.0,14.1,365.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0
-2019,United States,00,All,ALL,27479.0,16230.0,36528.0,275182.0,1040522.0,31.2,81.3,22.6,5.9,13.2,376.9,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0
+time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity,hiv_deaths_ratio_age_adjusted
+2021,United States,00,Two or more races (NH),MULTI_NH,684.0,1087.0,1102.0,,52753.0,35.3,81.3,,22.4,22.7,1084.8,2.5,6.7,3.0,,5.1,,1.8,2.5,0.0,272.2,66.7,,183.3,15.7
+2021,United States,00,White (NH),WHITE_NH,6817.0,5234.0,9063.0,180239.0,303234.0,29.0,82.6,59.9,3.1,5.3,176.8,24.8,32.2,24.8,65.5,29.1,24.7,62.1,24.4,1.6,-48.1,-60.1,165.2,-53.1,1.0
+2021,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,53.0,14.0,66.0,,878.0,,80.3,,2.8,13.4,178.7,0.2,0.1,0.2,,0.1,,0.2,0.2,0.0,-50.0,0.0,,-50.0,1.0
+2021,United States,00,Hispanic or Latino,HISP,8004.0,2740.0,9889.0,45069.0,240651.0,32.7,84.4,14.4,5.8,21.1,512.5,29.1,16.9,27.1,16.4,23.1,25.7,17.0,28.0,3.9,-0.6,59.4,-36.2,35.9,3.1
+2021,United States,00,Black or African American (NH),BLACK_NH,11179.0,6992.0,15471.0,37590.0,423711.0,30.8,78.4,8.0,20.6,45.5,1246.9,40.7,43.1,42.4,13.7,40.7,38.5,12.3,42.2,-3.6,250.4,244.7,-64.4,230.9,8.5
+2021,United States,00,Asian (NH),ASIAN_NH,570.0,101.0,733.0,,15447.0,32.4,83.0,,0.6,4.5,95.2,2.1,0.6,2.0,,1.5,,5.9,2.0,5.0,-89.8,-66.1,,-74.6,0.3
+2021,United States,00,American Indian and Alaska Native (NH),AIAN_NH,172.0,58.0,204.0,,3118.0,,83.5,,2.9,10.2,156.2,0.6,0.4,0.6,,0.3,,0.7,0.6,0.0,-42.9,-14.3,,-57.1,1.3
+2017,United States,00,Two or more races (NH),MULTI_NH,823.0,1074.0,1367.0,,52513.0,35.7,80.0,,23.6,30.0,1153.8,3.1,6.6,3.6,,5.3,,1.7,3.0,3.3,288.2,111.8,,211.8,
+2017,United States,00,White (NH),WHITE_NH,6864.0,5238.0,9628.0,104686.0,294749.0,28.2,81.0,33.6,3.1,5.6,171.8,25.9,32.0,25.1,67.5,29.6,25.5,63.0,24.9,4.0,-49.2,-60.2,164.7,-53.0,
+2017,United States,00,Native Hawaiian and Pacific Islander (NH),NHPI_NH,33.0,9.0,50.0,,774.0,,80.5,,1.9,10.6,164.1,0.1,0.1,0.1,,0.1,,0.2,0.1,0.0,-50.0,-50.0,,-50.0,
+2017,United States,00,Hispanic or Latino,HISP,6803.0,2694.0,9925.0,23486.0,224917.0,32.2,78.4,7.8,6.0,22.1,500.3,25.7,16.5,25.9,15.1,22.6,24.5,16.5,25.5,0.8,0.0,57.0,-38.4,37.0,
+2017,United States,00,Black or African American (NH),BLACK_NH,11180.0,7198.0,16223.0,19838.0,404974.0,33.3,75.3,4.2,21.6,48.6,1214.0,42.2,44.0,42.3,12.8,40.7,38.9,12.2,43.6,-3.2,260.7,246.7,-67.1,233.6,
+2017,United States,00,Asian (NH),ASIAN_NH,684.0,88.0,923.0,,13794.0,26.1,81.1,,0.6,5.9,88.6,2.6,0.5,2.4,,1.4,,5.7,2.5,4.0,-91.2,-57.9,,-75.4,
+2017,United States,00,American Indian and Alaska Native (NH),AIAN_NH,130.0,47.0,200.0,,2842.0,,83.3,,2.4,10.2,145.1,0.5,0.3,0.5,,0.3,,0.7,0.5,0.0,-57.1,-28.6,,-57.1,
+2017,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,7052.0,,,,5.3,,,,,,,4.5,,10.8,,,,,,-58.3,,
+2021,United States,00,Unrepresented race (NH),OTHER_NONSTANDARD_NH,,,,12285.0,,,,9.4,,,,,,,4.5,,10.8,,,,,,-58.3,,
+2017,United States,00,All,ALL,26517.0,16350.0,38316.0,155062.0,995297.0,30.7,77.8,12.7,6.0,14.1,365.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,
+2021,United States,00,All,ALL,27479.0,16230.0,36528.0,275182.0,1040522.0,31.2,81.3,22.6,5.9,13.2,376.9,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0,

--- a/python/tests/data/cdc_hiv_age_adjustment/race_and_ethnicity_state_time_series.csv
+++ b/python/tests/data/cdc_hiv_age_adjustment/race_and_ethnicity_state_time_series.csv
@@ -1,11 +1,11 @@
 time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,hiv_deaths,hiv_diagnoses,hiv_prep,hiv_prevalence,hiv_stigma_index,hiv_care_linkage,hiv_prep_coverage,hiv_deaths_per_100k,hiv_diagnoses_per_100k,hiv_prevalence_per_100k,hiv_care_pct_share,hiv_deaths_pct_share,hiv_diagnoses_pct_share,hiv_prep_pct_share,hiv_prevalence_pct_share,hiv_prep_population_pct,hiv_population_pct,hiv_care_population_pct,hiv_care_pct_relative_inequity,hiv_deaths_pct_relative_inequity,hiv_diagnoses_pct_relative_inequity,hiv_prep_pct_relative_inequity,hiv_prevalence_pct_relative_inequity
-2019,Alabama,01,Two or more races (NH),MULTI_NH,13,23,14,,832,,92.9,,46.0,28.0,1665.4,2.6,8.5,2.2,,6.0,,1.2,2.2,18.2,608.3,83.3,,400.0
-2019,Alabama,01,White (NH),WHITE_NH,119,69,151,,3700,,78.3,,2.5,5.5,133.9,23.6,25.4,23.8,,26.7,,66.9,23.8,-0.8,-62.0,-64.4,,-60.1
-2019,Alabama,01,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,148.4,0.0,0.0,0.0,,0.02,,0.05,0.0,,-100.0,-100.0,,-60.0
-2019,Alabama,01,Hispanic or Latino,HISP,11,5,15,,499,,84.6,,3.2,9.7,321.9,2.2,1.8,2.4,,3.6,,3.8,2.0,10.0,-52.6,-36.8,,-5.3
-2019,Alabama,01,Black or African American (NH),BLACK_NH,361,170,453,,8731,,79.0,,15.8,42.2,813.6,71.5,62.5,71.3,,63.0,,26.0,71.6,-0.1,140.4,174.2,,142.3
-2019,Alabama,01,Asian (NH),ASIAN_NH,0,1,1,,36,,0.0,,1.6,1.6,58.8,0.0,0.4,0.2,,0.3,,1.5,0.2,-100.0,-73.3,-86.7,,-80.0
-2019,Alabama,01,American Indian and Alaska Native (NH),AIAN_NH,1,1,1,,6,,100.0,,4.1,4.1,24.4,0.2,0.4,0.2,,0.04,,0.6,0.2,0.0,-33.3,-66.7,,-93.3
+2021,Alabama,01,Two or more races (NH),MULTI_NH,13,23,14,,832,,92.9,,46.0,28.0,1665.4,2.6,8.5,2.2,,6.0,,1.2,2.2,18.2,608.3,83.3,,400.0
+2021,Alabama,01,White (NH),WHITE_NH,119,69,151,,3700,,78.3,,2.5,5.5,133.9,23.6,25.4,23.8,,26.7,,66.9,23.8,-0.8,-62.0,-64.4,,-60.1
+2021,Alabama,01,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,148.4,0.0,0.0,0.0,,0.02,,0.05,0.0,,-100.0,-100.0,,-60.0
+2021,Alabama,01,Hispanic or Latino,HISP,11,5,15,,499,,84.6,,3.2,9.7,321.9,2.2,1.8,2.4,,3.6,,3.8,2.0,10.0,-52.6,-36.8,,-5.3
+2021,Alabama,01,Black or African American (NH),BLACK_NH,361,170,453,,8731,,79.0,,15.8,42.2,813.6,71.5,62.5,71.3,,63.0,,26.0,71.6,-0.1,140.4,174.2,,142.3
+2021,Alabama,01,Asian (NH),ASIAN_NH,0,1,1,,36,,0.0,,1.6,1.6,58.8,0.0,0.4,0.2,,0.3,,1.5,0.2,-100.0,-73.3,-86.7,,-80.0
+2021,Alabama,01,American Indian and Alaska Native (NH),AIAN_NH,1,1,1,,6,,100.0,,4.1,4.1,24.4,0.2,0.4,0.2,,0.04,,0.6,0.2,0.0,-33.3,-66.7,,-93.3
 2017,Alaska,02,Two or more races (NH),MULTI_NH,0,1,0,,39,,0.0,,3.1,0.0,121.5,0.0,14.3,0.0,,5.5,,5.3,0.0,,169.8,-100.0,,3.8
 2017,Alaska,02,White (NH),WHITE_NH,9,5,10,,285,,100.0,,1.3,2.6,74.4,32.1,71.4,33.3,,40.0,,63.4,31.0,3.5,12.6,-47.5,,-36.9
 2017,Alaska,02,Native Hawaiian and Pacific Islander (NH),NHPI_NH,0,0,0,,3,,0.0,,0.0,0.0,39.9,0.0,0.0,0.0,,0.4,,1.2,0.0,,-100.0,-100.0,,-66.7
@@ -14,4 +14,4 @@ time_period,state_name,state_fips,race_and_ethnicity,race_category_id,hiv_care,h
 2017,Alaska,02,Asian (NH),ASIAN_NH,0,0,0,,23,,0.0,,0.0,0.0,57.9,0.0,0.0,0.0,,3.2,,6.6,0.0,,-100.0,-100.0,,-51.5
 2017,Alaska,02,American Indian and Alaska Native (NH),AIAN_NH,13,0,13,,186,,100.0,,0.0,15.7,225.3,46.4,0.0,43.3,,26.1,,13.7,44.8,3.6,-100.0,216.1,,90.5
 2017,Alaska,02,All,ALL,28,7,30,125.0,713,,96.6,5.3,1.2,5.0,118.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0
-2019,Alabama,01,All,ALL,505,272,635,1835.0,13849,,79.2,16.7,6.6,15.4,335.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0
+2021,Alabama,01,All,ALL,505,272,635,1835.0,13849,,79.2,16.7,6.6,15.4,335.4,100.0,100.0,100.0,100.0,100.0,100.0,100.0,100.0,0.0,0.0,0.0,0.0,0.0


### PR DESCRIPTION
This PR adds the updated code for age adjustments for HIV that were missed in #2307. 