### PR TITLE
Fix for HIV Stigma charts not displaying

### DIFF
--- a/frontend/src/data/providers/HivProvider.ts
+++ b/frontend/src/data/providers/HivProvider.ts
@@ -165,7 +165,8 @@ class HivProvider extends VariableProvider {
 
     df = this.filterByGeo(df, breakdowns)
 
-    const mostRecentYear = '2021'
+    let mostRecentYear = '2021'
+    if (metricQuery.metricIds.includes('hiv_stigma_index')) mostRecentYear = '2019'
 
     df = this.filterByTimeView(df, timeView, mostRecentYear)
     df = this.renameGeoColumns(df, breakdowns)

--- a/frontend/src/data/providers/HivProvider.ts
+++ b/frontend/src/data/providers/HivProvider.ts
@@ -80,6 +80,11 @@ export const GENDER_METRICS: MetricId[] = [
   'hiv_prevalence_total_trans_women',
 ]
 
+export const STIGMA_METRICS: MetricId[] = [
+  'hiv_stigma_index',
+  'hiv_stigma_pct_share',
+]
+
 export const HIV_DETERMINANTS: MetricId[] = [
   ...BLACK_WOMEN_METRICS,
   ...CARE_METRICS,
@@ -88,8 +93,7 @@ export const HIV_DETERMINANTS: MetricId[] = [
   ...PREP_METRICS,
   ...PREVALENCE_METRICS,
   ...GENDER_METRICS,
-  'hiv_stigma_index',
-  'hiv_stigma_pct_share',
+  ...STIGMA_METRICS,
   'hiv_population_pct', // population shares of 13+
 ]
 


### PR DESCRIPTION
## Description
- Updates the source year for HIV stigma. 

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
We currently only have 2021 data for prevalence, diagnoses, PrEP, and linkage to HIV care. Stigma is sourced from 2019. 

## Has this been tested? How?
Tested locally. 

## Screenshots (if approp
_Bug_:
<img width="1210" alt="Screenshot 2023-08-22 at 2 37 31 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/52ea9663-b429-42d5-8d1a-2699422d5b95">
riate):

_Fix_:
<img width="1315" alt="Screenshot 2023-08-22 at 2 38 02 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/878076bc-f0ea-42ef-9974-8d9b7507f4a3">

## Types of changes
- Bug fix

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎