### PR TITLE
Fix screenshot capture of visible div section

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -39,8 +39,8 @@ function CardWrapper(props: {
   const [screenshotTargetRef, downloadTargetScreenshot] = useDownloadCardImage(
     props.downloadTitle,
     props.elementsToHide,
-    props.expanded,
-    props.scrollToHash
+    props.scrollToHash,
+    props.expanded
   )
 
   const loadingComponent = (

--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -8,7 +8,10 @@ import { WithMetadataAndMetrics } from '../data/react/WithLoadingOrErrorUI'
 import { Sources } from './ui/Sources'
 import { type MapOfDatasetMetadata } from '../data/utils/DatasetTypes'
 import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
-import { useDownloadCardImage } from '../utils/hooks/useDownloadCardImage'
+import {
+  type HiddenElements,
+  useDownloadCardImage,
+} from '../utils/hooks/useDownloadCardImage'
 import CardOptionsMenu from './ui/CardOptionsMenu'
 
 function CardWrapper(props: {
@@ -30,7 +33,7 @@ function CardWrapper(props: {
   isCensusNotAcs?: boolean
   scrollToHash: ScrollableHashId
   reportTitle: string
-  elementsToHide?: string[]
+  elementsToHide?: HiddenElements[]
   expanded?: boolean
 }) {
   const [screenshotTargetRef, downloadTargetScreenshot] = useDownloadCardImage(

--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -9,7 +9,7 @@ import { Sources } from './ui/Sources'
 import { type MapOfDatasetMetadata } from '../data/utils/DatasetTypes'
 import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import {
-  type ElementHashIdsHiddenOnScreenshot,
+  type ElementHashIdHiddenOnScreenshot,
   useDownloadCardImage,
 } from '../utils/hooks/useDownloadCardImage'
 import CardOptionsMenu from './ui/CardOptionsMenu'
@@ -33,7 +33,7 @@ function CardWrapper(props: {
   isCensusNotAcs?: boolean
   scrollToHash: ScrollableHashId
   reportTitle: string
-  elementsToHide?: ElementHashIdsHiddenOnScreenshot[]
+  elementsToHide?: ElementHashIdHiddenOnScreenshot[]
   expanded?: boolean
 }) {
   const [screenshotTargetRef, downloadTargetScreenshot] = useDownloadCardImage(

--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -9,7 +9,7 @@ import { Sources } from './ui/Sources'
 import { type MapOfDatasetMetadata } from '../data/utils/DatasetTypes'
 import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import {
-  type HiddenElements,
+  type ElementHashIdsHiddenOnScreenshot,
   useDownloadCardImage,
 } from '../utils/hooks/useDownloadCardImage'
 import CardOptionsMenu from './ui/CardOptionsMenu'
@@ -33,7 +33,7 @@ function CardWrapper(props: {
   isCensusNotAcs?: boolean
   scrollToHash: ScrollableHashId
   reportTitle: string
-  elementsToHide?: HiddenElements[]
+  elementsToHide?: ElementHashIdsHiddenOnScreenshot[]
   expanded?: boolean
 }) {
   const [screenshotTargetRef, downloadTargetScreenshot] = useDownloadCardImage(

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -23,7 +23,7 @@ import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import CAWPOverlappingRacesAlert from './ui/CAWPOverlappingRacesAlert'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 export interface DisparityBarChartCardProps {
   key?: string
@@ -89,7 +89,9 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'population-vs-distribution'
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -23,7 +23,7 @@ import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import CAWPOverlappingRacesAlert from './ui/CAWPOverlappingRacesAlert'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 export interface DisparityBarChartCardProps {
   key?: string
@@ -90,7 +90,7 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'population-vs-distribution'
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -23,6 +23,7 @@ import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import CAWPOverlappingRacesAlert from './ui/CAWPOverlappingRacesAlert'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 export interface DisparityBarChartCardProps {
   key?: string
@@ -88,7 +89,7 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'population-vs-distribution'
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -85,6 +85,7 @@ import ChartTitle from './ChartTitle'
 import { useParamState } from '../utils/hooks/useParamState'
 import { POPULATION, SVI } from '../data/providers/GeoContextProvider'
 import { RATE_MAP_SCALE } from '../charts/mapGlobals'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
 
@@ -262,7 +263,7 @@ function MapCardWithKey(props: MapCardProps) {
     setScale({ domain, range })
   }
 
-  const elementsToHide = [
+  const elementsToHide: HiddenElements[] = [
     '#map-group-dropdown',
     '#download-card-image-button',
     '#card-options-menu',

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -85,7 +85,7 @@ import ChartTitle from './ChartTitle'
 import { useParamState } from '../utils/hooks/useParamState'
 import { POPULATION, SVI } from '../data/providers/GeoContextProvider'
 import { RATE_MAP_SCALE } from '../charts/mapGlobals'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
 
@@ -263,7 +263,7 @@ function MapCardWithKey(props: MapCardProps) {
     setScale({ domain, range })
   }
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#map-group-dropdown',
     '#download-card-image-button',
     '#card-options-menu',

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -85,7 +85,7 @@ import ChartTitle from './ChartTitle'
 import { useParamState } from '../utils/hooks/useParamState'
 import { POPULATION, SVI } from '../data/providers/GeoContextProvider'
 import { RATE_MAP_SCALE } from '../charts/mapGlobals'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
 
@@ -263,7 +263,7 @@ function MapCardWithKey(props: MapCardProps) {
     setScale({ domain, range })
   }
 
-  const elementsToHide: HiddenElements[] = [
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
     '#map-group-dropdown',
     '#download-card-image-button',
     '#card-options-menu',

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -37,7 +37,7 @@ import styles from '../charts/trendsChart/Trends.module.scss'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -115,7 +115,7 @@ export function RateTrendsChartCard(props: RateTrendsChartCardProps) {
   const HASH_ID: ScrollableHashId = 'rates-over-time'
   const cardHeaderTitle = reportProviderSteps[HASH_ID].label
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -37,7 +37,7 @@ import styles from '../charts/trendsChart/Trends.module.scss'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -103,7 +103,9 @@ export function RateTrendsChartCard(props: RateTrendsChartCardProps) {
   const HASH_ID: ScrollableHashId = 'rates-over-time'
   const cardHeaderTitle = reportProviderSteps[HASH_ID].label
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -37,6 +37,7 @@ import styles from '../charts/trendsChart/Trends.module.scss'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -102,7 +103,7 @@ export function RateTrendsChartCard(props: RateTrendsChartCardProps) {
   const HASH_ID: ScrollableHashId = 'rates-over-time'
   const cardHeaderTitle = reportProviderSteps[HASH_ID].label
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/ShareTrendsChartCard.tsx
+++ b/frontend/src/cards/ShareTrendsChartCard.tsx
@@ -40,7 +40,7 @@ import { generateChartTitle } from '../charts/utils'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -108,7 +108,9 @@ export function ShareTrendsChartCard(props: ShareTrendsChartCardProps) {
 
   if (!inequityQuery || !metricConfigInequitable?.metricId) return <></>
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/ShareTrendsChartCard.tsx
+++ b/frontend/src/cards/ShareTrendsChartCard.tsx
@@ -40,7 +40,7 @@ import { generateChartTitle } from '../charts/utils'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -110,7 +110,7 @@ export function ShareTrendsChartCard(props: ShareTrendsChartCardProps) {
 
   if (!inequityQuery || !metricConfigInequitable?.metricId) return <></>
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/ShareTrendsChartCard.tsx
+++ b/frontend/src/cards/ShareTrendsChartCard.tsx
@@ -40,6 +40,7 @@ import { generateChartTitle } from '../charts/utils'
 import { HIV_DETERMINANTS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -107,7 +108,7 @@ export function ShareTrendsChartCard(props: ShareTrendsChartCardProps) {
 
   if (!inequityQuery || !metricConfigInequitable?.metricId) return <></>
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/SimpleBarChartCard.tsx
+++ b/frontend/src/cards/SimpleBarChartCard.tsx
@@ -30,7 +30,7 @@ import {
   DATATYPES_NEEDING_13PLUS,
   GENDER_METRICS,
 } from '../data/providers/HivProvider'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -100,7 +100,7 @@ function SimpleBarChartCardWithKey(props: SimpleBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'rate-chart'
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/SimpleBarChartCard.tsx
+++ b/frontend/src/cards/SimpleBarChartCard.tsx
@@ -30,7 +30,7 @@ import {
   DATATYPES_NEEDING_13PLUS,
   GENDER_METRICS,
 } from '../data/providers/HivProvider'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -100,7 +100,9 @@ function SimpleBarChartCardWithKey(props: SimpleBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'rate-chart'
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/SimpleBarChartCard.tsx
+++ b/frontend/src/cards/SimpleBarChartCard.tsx
@@ -30,6 +30,7 @@ import {
   DATATYPES_NEEDING_13PLUS,
   GENDER_METRICS,
 } from '../data/providers/HivProvider'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -99,7 +100,7 @@ function SimpleBarChartCardWithKey(props: SimpleBarChartCardProps) {
 
   const HASH_ID: ScrollableHashId = 'rate-chart'
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -38,7 +38,7 @@ import {
 } from '../data/providers/HivProvider'
 import GenderDataShortAlert from './ui/GenderDataShortAlert'
 import { type CountColsMap } from './MapCard'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 // We need to get this property, but we want to show it as
 // part of the "population_pct" column, and not as its own column
@@ -130,7 +130,9 @@ export function TableCard(props: TableCardProps) {
 
   const HASH_ID: ScrollableHashId = 'data-table'
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -38,6 +38,7 @@ import {
 } from '../data/providers/HivProvider'
 import GenderDataShortAlert from './ui/GenderDataShortAlert'
 import { type CountColsMap } from './MapCard'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 // We need to get this property, but we want to show it as
 // part of the "population_pct" column, and not as its own column
@@ -129,7 +130,7 @@ export function TableCard(props: TableCardProps) {
 
   const HASH_ID: ScrollableHashId = 'data-table'
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/TableCard.tsx
+++ b/frontend/src/cards/TableCard.tsx
@@ -38,7 +38,7 @@ import {
 } from '../data/providers/HivProvider'
 import GenderDataShortAlert from './ui/GenderDataShortAlert'
 import { type CountColsMap } from './MapCard'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 // We need to get this property, but we want to show it as
 // part of the "population_pct" column, and not as its own column
@@ -130,7 +130,7 @@ export function TableCard(props: TableCardProps) {
 
   const HASH_ID: ScrollableHashId = 'data-table'
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -28,7 +28,7 @@ import TerritoryCircles from './ui/TerritoryCircles'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
 import { getMapScheme } from '../charts/mapHelperFunctions'
-import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 export interface UnknownsMapCardProps {
   // Variable the map will evaluate for unknowns
@@ -106,7 +106,9 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
 
   const HASH_ID: ScrollableHashId = 'unknown-demographic-map'
 
-  const elementsToHide: HiddenElements[] = ['#card-options-menu']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#card-options-menu',
+  ]
 
   return (
     <CardWrapper

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -28,7 +28,7 @@ import TerritoryCircles from './ui/TerritoryCircles'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
 import { getMapScheme } from '../charts/mapHelperFunctions'
-import { type ElementHashIdsHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
+import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
 
 export interface UnknownsMapCardProps {
   // Variable the map will evaluate for unknowns
@@ -110,7 +110,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
 
   const HASH_ID: ScrollableHashId = 'unknown-demographic-map'
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#card-options-menu',
   ]
 

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -28,6 +28,7 @@ import TerritoryCircles from './ui/TerritoryCircles'
 import ChartTitle from './ChartTitle'
 import { generateChartTitle } from '../charts/utils'
 import { getMapScheme } from '../charts/mapHelperFunctions'
+import { type HiddenElements } from '../utils/hooks/useDownloadCardImage'
 
 export interface UnknownsMapCardProps {
   // Variable the map will evaluate for unknowns
@@ -105,7 +106,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
 
   const HASH_ID: ScrollableHashId = 'unknown-demographic-map'
 
-  const elementsToHide = ['#card-options-menu']
+  const elementsToHide: HiddenElements[] = ['#card-options-menu']
 
   return (
     <CardWrapper

--- a/frontend/src/cards/ui/AltTableView.tsx
+++ b/frontend/src/cards/ui/AltTableView.tsx
@@ -24,6 +24,10 @@ import { makeA11yTableData } from '../../data/utils/DatasetTimeUtils'
 import { type Row } from '../../data/utils/DatasetTypes'
 import { DATA_TAB_LINK } from '../../utils/internalRoutes'
 import styles from './AltTableView.module.scss'
+import {
+  ALT_TABLE_VIEW_1_PARAM_KEY,
+  ALT_TABLE_VIEW_2_PARAM_KEY,
+} from '../../utils/urlutils'
 
 interface AltTableViewProps {
   expanded: boolean
@@ -66,7 +70,11 @@ export default function AltTableView(props: AltTableViewProps) {
       height={props.expanded ? 'auto' : 47}
       onAnimationEnd={() => window.dispatchEvent(new Event('resize'))}
       className={styles.AltTableExpanderBox}
-      id={props.isCompareCard ? 'alt-table-view-2' : 'alt-table-view'}
+      id={
+        props.isCompareCard
+          ? ALT_TABLE_VIEW_2_PARAM_KEY
+          : ALT_TABLE_VIEW_1_PARAM_KEY
+      }
     >
       <div className={styles.CollapseButton}>
         <IconButton

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -37,7 +37,7 @@ import {
   getWomenRaceLabel,
 } from '../../data/providers/CawpProvider'
 import {
-  type ElementHashIdsHiddenOnScreenshot,
+  type ElementHashIdHiddenOnScreenshot,
   useDownloadCardImage,
 } from '../../utils/hooks/useDownloadCardImage'
 import { getMapScheme } from '../../charts/mapHelperFunctions'
@@ -103,7 +103,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
     DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]
   } groups`
 
-  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+  const elementsToHide: ElementHashIdHiddenOnScreenshot[] = [
     '#multi-map-close-button1',
     '#multi-map-close-button2',
     '#card-options-menu',

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   Box,
   Grid,
@@ -36,7 +36,10 @@ import {
   CAWP_DETERMINANTS,
   getWomenRaceLabel,
 } from '../../data/providers/CawpProvider'
-import { useDownloadCardImage } from '../../utils/hooks/useDownloadCardImage'
+import {
+  type HiddenElements,
+  useDownloadCardImage,
+} from '../../utils/hooks/useDownloadCardImage'
 import { getMapScheme } from '../../charts/mapHelperFunctions'
 import TerritoryCircles from './TerritoryCircles'
 import MapBreadcrumbs from './MapBreadcrumbs'
@@ -100,8 +103,19 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
     DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]
   } groups`
 
-  const [screenshotTargetRef, downloadTargetScreenshot] =
-    useDownloadCardImage(title)
+  const elementsToHide: HiddenElements[] = ['#multi-map-close-button']
+
+  const footerContentRef = useRef(null)
+
+  const scrollToHash: ScrollableHashId = 'rate-map'
+
+  const [screenshotTargetRef, downloadTargetScreenshot] = useDownloadCardImage(
+    title,
+    elementsToHide,
+    scrollToHash,
+    false,
+    footerContentRef
+  )
 
   /* handle clicks on sub-geos in multimap view */
   const multimapSignalListeners: any = {
@@ -192,6 +206,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     aria-label="close multiple maps modal"
                     onClick={props.handleClose}
                     color="primary"
+                    id={'multi-map-close-button'}
                   >
                     <CloseIcon />
                   </Button>
@@ -369,7 +384,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
       </DialogContent>
 
       {/* MODAL FOOTER */}
-      <footer>
+      <footer ref={footerContentRef}>
         <div className={styles.FooterSourcesContainer}>
           {isMobile ? (
             <Button

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -37,7 +37,7 @@ import {
   getWomenRaceLabel,
 } from '../../data/providers/CawpProvider'
 import {
-  type HiddenElements,
+  type ElementHashIdsHiddenOnScreenshot,
   useDownloadCardImage,
 } from '../../utils/hooks/useDownloadCardImage'
 import { getMapScheme } from '../../charts/mapHelperFunctions'
@@ -103,7 +103,11 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
     DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]
   } groups`
 
-  const elementsToHide: HiddenElements[] = ['#multi-map-close-button']
+  const elementsToHide: ElementHashIdsHiddenOnScreenshot[] = [
+    '#multi-map-close-button1',
+    '#multi-map-close-button2',
+    '#card-options-menu',
+  ]
 
   const footerContentRef = useRef(null)
 
@@ -206,7 +210,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
                     aria-label="close multiple maps modal"
                     onClick={props.handleClose}
                     color="primary"
-                    id={'multi-map-close-button'}
+                    id={'multi-map-close-button1'}
                   >
                     <CloseIcon />
                   </Button>
@@ -391,6 +395,7 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
               aria-label="close multiple maps modal"
               onClick={props.handleClose}
               color="primary"
+              id={'multi-map-close-button2'}
             >
               Close
             </Button>

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -138,231 +138,234 @@ export function MultiMapDialog(props: MultiMapDialogProps) {
       maxWidth={false}
       scroll="paper"
       aria-labelledby="modalTitle"
-      ref={screenshotTargetRef}
     >
       <DialogContent dividers={true}>
-        <Grid
-          container
-          justifyContent="space-between"
-          component="ul"
-          sx={{ p: 0 }}
-        >
-          {/* card heading row */}
-          <Grid item xs={12} container justifyContent={'space-between'}>
-            {/* mobile-only card options button */}
-            {isMobile && (
-              <Grid
-                item
-                xs={12}
-                sx={{ display: { xs: 'flex', sm: 'none' }, mb: 3 }}
-                container
-                justifyContent={'flex-end'}
-              >
-                <CardOptionsMenu
-                  downloadTargetScreenshot={downloadTargetScreenshot}
-                  reportTitle={props.reportTitle}
-                  scrollToHash={props.scrollToHash}
-                />
-              </Grid>
-            )}
-            {/* Modal Title */}
-            <Grid item xs={12} sm={9} md={10}>
-              <Typography
-                id="modalTitle"
-                variant="h6"
-                component="h2"
-                lineHeight={sass.lhModalHeading}
-              >
-                {title}
-              </Typography>
-            </Grid>
-            {/* desktop-only close button */}
-            {!isMobile && (
-              <Grid
-                item
-                sx={{
-                  display: { xs: 'none', sm: 'flex' },
-                  mr: { xs: 1, md: 0 },
-                  mb: 3,
-                }}
-                sm={1}
-                container
-              >
-                <Button
-                  aria-label="close multiple maps modal"
-                  onClick={props.handleClose}
-                  color="primary"
-                >
-                  <CloseIcon />
-                </Button>
-              </Grid>
-            )}
-          </Grid>
-
-          {/* Multiples Maps */}
-          {props.demographicGroups.map((demographicGroup) => {
-            const mapLabel = CAWP_DETERMINANTS.includes(
-              props.metricConfig.metricId
-            )
-              ? getWomenRaceLabel(demographicGroup)
-              : demographicGroup
-            const dataForValue = props.data.filter(
-              (row: Row) => row[props.demographicType] === demographicGroup
-            )
-            return (
-              <Grid
-                xs={12}
-                sm={6}
-                md={4}
-                lg={3}
-                item
-                key={`${demographicGroup}-grid-item`}
-                className={styles.SmallMultipleMap}
-                component="li"
-                onClick={(e: any) => {
-                  props.handleMapGroupClick(null, demographicGroup)
-                }}
-              >
-                <b>{mapLabel}</b>
-                {props.metricConfig && dataForValue.length > 0 && (
-                  <ChoroplethMap
-                    demographicType={props.demographicType}
-                    activeDemographicGroup={demographicGroup}
-                    countColsMap={props.countColsMap}
-                    data={dataForValue}
-                    fieldRange={props.fieldRange}
-                    filename={title}
-                    fips={props.fips}
-                    geoData={props.geoData}
-                    hideLegend={true}
-                    key={demographicGroup}
-                    legendData={props.data}
-                    metric={props.metricConfig}
-                    showCounties={
-                      !props.fips.isUsa() && !props.hasSelfButNotChildGeoData
-                    }
-                    signalListeners={multimapSignalListeners}
-                    mapConfig={{ mapScheme, mapMin }}
-                    isMulti={true}
-                    scaleConfig={scale}
-                    highestLowestGeosMode={false}
-                  />
-                )}
-
-                {/* TERRITORIES (IF NATIONAL VIEW) */}
-                {props.metricConfig &&
-                  props.fips.isUsa() &&
-                  dataForValue.length && (
-                    <Grid container>
-                      <TerritoryCircles
-                        demographicType={props.demographicType}
-                        countColsMap={props.countColsMap}
-                        data={dataForValue}
-                        geoData={props.geoData}
-                        mapIsWide={false}
-                        metricConfig={props.metricConfig}
-                        signalListeners={multimapSignalListeners}
-                        scaleConfig={scale}
-                        isMulti={true}
-                        activeDemographicGroup={demographicGroup}
-                        highestLowestGeosMode={false}
-                      />
-                    </Grid>
-                  )}
-              </Grid>
-            )
-          })}
-
-          {/* LEGEND */}
-          <Grid item container xs={12} justifyContent="start">
-            <Legend
-              dataTypeConfig={props.dataTypeConfig}
-              metric={props.metricConfig}
-              legendTitle={props.metricConfig.shortLabel}
-              data={props.data}
-              scaleType={RATE_MAP_SCALE}
-              sameDotSize={true}
-              description={'Consistent legend for all displayed maps'}
-              mapConfig={{ mapScheme, mapMin }}
-              stackingDirection={props.pageIsSmall ? 'vertical' : 'horizontal'}
-              columns={props.pageIsSmall ? 2 : 6}
-              handleScaleChange={handleScaleChange}
-              isMulti={true}
-            />
-          </Grid>
-
-          {/* Population Breadcrumbs + Legend */}
+        <div ref={screenshotTargetRef}>
           <Grid
             container
-            justifyContent={'space-between'}
-            alignItems={'flex-end'}
-            item
-            xs={12}
-            className={styles.SmallMultipleLegendMap}
+            justifyContent="space-between"
+            component="ul"
+            sx={{ p: 0 }}
           >
-            {/* DESKTOP BREADCRUMBS */}
-            <Grid
-              sx={{ display: { xs: 'none', md: 'flex' } }}
-              container
-              item
-              xs={12}
-              md={6}
-              justifyContent={'start'}
-            >
-              <MapBreadcrumbs
-                fips={props.fips}
-                updateFipsCallback={props.updateFipsCallback}
-                scrollToHashId={'rate-map'}
-                endNote={props.totalPopulationPhrase}
+            {/* card heading row */}
+            <Grid item xs={12} container justifyContent={'space-between'}>
+              {/* mobile-only card options button */}
+              {isMobile && (
+                <Grid
+                  item
+                  xs={12}
+                  sx={{ display: { xs: 'flex', sm: 'none' }, mb: 3 }}
+                  container
+                  justifyContent={'flex-end'}
+                >
+                  <CardOptionsMenu
+                    downloadTargetScreenshot={downloadTargetScreenshot}
+                    reportTitle={props.reportTitle}
+                    scrollToHash={props.scrollToHash}
+                  />
+                </Grid>
+              )}
+              {/* Modal Title */}
+              <Grid item xs={12} sm={9} md={10}>
+                <Typography
+                  id="modalTitle"
+                  variant="h6"
+                  component="h2"
+                  lineHeight={sass.lhModalHeading}
+                >
+                  {title}
+                </Typography>
+              </Grid>
+              {/* desktop-only close button */}
+              {!isMobile && (
+                <Grid
+                  item
+                  sx={{
+                    display: { xs: 'none', sm: 'flex' },
+                    mr: { xs: 1, md: 0 },
+                    mb: 3,
+                  }}
+                  sm={1}
+                  container
+                >
+                  <Button
+                    aria-label="close multiple maps modal"
+                    onClick={props.handleClose}
+                    color="primary"
+                  >
+                    <CloseIcon />
+                  </Button>
+                </Grid>
+              )}
+            </Grid>
+
+            {/* Multiples Maps */}
+            {props.demographicGroups.map((demographicGroup) => {
+              const mapLabel = CAWP_DETERMINANTS.includes(
+                props.metricConfig.metricId
+              )
+                ? getWomenRaceLabel(demographicGroup)
+                : demographicGroup
+              const dataForValue = props.data.filter(
+                (row: Row) => row[props.demographicType] === demographicGroup
+              )
+              return (
+                <Grid
+                  xs={12}
+                  sm={6}
+                  md={4}
+                  lg={3}
+                  item
+                  key={`${demographicGroup}-grid-item`}
+                  className={styles.SmallMultipleMap}
+                  component="li"
+                  onClick={(e: any) => {
+                    props.handleMapGroupClick(null, demographicGroup)
+                  }}
+                >
+                  <b>{mapLabel}</b>
+                  {props.metricConfig && dataForValue.length > 0 && (
+                    <ChoroplethMap
+                      demographicType={props.demographicType}
+                      activeDemographicGroup={demographicGroup}
+                      countColsMap={props.countColsMap}
+                      data={dataForValue}
+                      fieldRange={props.fieldRange}
+                      filename={title}
+                      fips={props.fips}
+                      geoData={props.geoData}
+                      hideLegend={true}
+                      key={demographicGroup}
+                      legendData={props.data}
+                      metric={props.metricConfig}
+                      showCounties={
+                        !props.fips.isUsa() && !props.hasSelfButNotChildGeoData
+                      }
+                      signalListeners={multimapSignalListeners}
+                      mapConfig={{ mapScheme, mapMin }}
+                      isMulti={true}
+                      scaleConfig={scale}
+                      highestLowestGeosMode={false}
+                    />
+                  )}
+
+                  {/* TERRITORIES (IF NATIONAL VIEW) */}
+                  {props.metricConfig &&
+                    props.fips.isUsa() &&
+                    dataForValue.length && (
+                      <Grid container>
+                        <TerritoryCircles
+                          demographicType={props.demographicType}
+                          countColsMap={props.countColsMap}
+                          data={dataForValue}
+                          geoData={props.geoData}
+                          mapIsWide={false}
+                          metricConfig={props.metricConfig}
+                          signalListeners={multimapSignalListeners}
+                          scaleConfig={scale}
+                          isMulti={true}
+                          activeDemographicGroup={demographicGroup}
+                          highestLowestGeosMode={false}
+                        />
+                      </Grid>
+                    )}
+                </Grid>
+              )
+            })}
+
+            {/* LEGEND */}
+            <Grid item container xs={12} justifyContent="start">
+              <Legend
+                dataTypeConfig={props.dataTypeConfig}
+                metric={props.metricConfig}
+                legendTitle={props.metricConfig.shortLabel}
+                data={props.data}
+                scaleType={RATE_MAP_SCALE}
+                sameDotSize={true}
+                description={'Consistent legend for all displayed maps'}
+                mapConfig={{ mapScheme, mapMin }}
+                stackingDirection={
+                  props.pageIsSmall ? 'vertical' : 'horizontal'
+                }
+                columns={props.pageIsSmall ? 2 : 6}
+                handleScaleChange={handleScaleChange}
+                isMulti={true}
               />
             </Grid>
 
-            {/* MOBILE BREADCRUMBS */}
+            {/* Population Breadcrumbs + Legend */}
             <Grid
-              sx={{ mt: 3, display: { xs: 'flex', md: 'none' } }}
               container
+              justifyContent={'space-between'}
+              alignItems={'flex-end'}
               item
               xs={12}
-              justifyContent={'center'}
+              className={styles.SmallMultipleLegendMap}
             >
-              <MapBreadcrumbs
-                fips={props.fips}
-                updateFipsCallback={props.updateFipsCallback}
-                scrollToHashId={'rate-map'}
-                endNote={props.totalPopulationPhrase}
-              />
-            </Grid>
-          </Grid>
+              {/* DESKTOP BREADCRUMBS */}
+              <Grid
+                sx={{ display: { xs: 'none', md: 'flex' } }}
+                container
+                item
+                xs={12}
+                md={6}
+                justifyContent={'start'}
+              >
+                <MapBreadcrumbs
+                  fips={props.fips}
+                  updateFipsCallback={props.updateFipsCallback}
+                  scrollToHashId={'rate-map'}
+                  endNote={props.totalPopulationPhrase}
+                />
+              </Grid>
 
-          {/* Missing Groups */}
-          {props.demographicGroupsNoData.length > 0 && (
-            <Grid item container justifyContent="center" xs={12} xl={7}>
-              <Box my={3}>
-                <Alert severity="warning">
-                  <p className={styles.NoDataWarning}>
-                    Insufficient {props.metricConfig.shortLabel} data reported
-                    at the {props.fips.getChildFipsTypeDisplayName()} level for
-                    the following groups:{' '}
-                    {props.demographicGroupsNoData.map((group, i) => (
-                      <span key={group}>
-                        <b>{group}</b>
-                        {i < props.demographicGroupsNoData.length - 1 && '; '}
-                      </span>
-                    ))}
-                  </p>
+              {/* MOBILE BREADCRUMBS */}
+              <Grid
+                sx={{ mt: 3, display: { xs: 'flex', md: 'none' } }}
+                container
+                item
+                xs={12}
+                justifyContent={'center'}
+              >
+                <MapBreadcrumbs
+                  fips={props.fips}
+                  updateFipsCallback={props.updateFipsCallback}
+                  scrollToHashId={'rate-map'}
+                  endNote={props.totalPopulationPhrase}
+                />
+              </Grid>
+            </Grid>
+
+            {/* Missing Groups */}
+            {props.demographicGroupsNoData.length > 0 && (
+              <Grid item container justifyContent="center" xs={12} xl={7}>
+                <Box my={3}>
+                  <Alert severity="warning">
+                    <p className={styles.NoDataWarning}>
+                      Insufficient {props.metricConfig.shortLabel} data reported
+                      at the {props.fips.getChildFipsTypeDisplayName()} level
+                      for the following groups:{' '}
+                      {props.demographicGroupsNoData.map((group, i) => (
+                        <span key={group}>
+                          <b>{group}</b>
+                          {i < props.demographicGroupsNoData.length - 1 && '; '}
+                        </span>
+                      ))}
+                    </p>
+                  </Alert>
+                </Box>
+              </Grid>
+            )}
+
+            <Grid container justifyContent={'center'}>
+              <Grid item xs={12}>
+                <Alert icon={<></>} severity="info" role="note">
+                  <DataTypeDefinitionsList />
                 </Alert>
-              </Box>
-            </Grid>
-          )}
-
-          <Grid container justifyContent={'center'}>
-            <Grid item xs={12}>
-              <Alert icon={<></>} severity="info" role="note">
-                <DataTypeDefinitionsList />
-              </Alert>
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
+        </div>
       </DialogContent>
 
       {/* MODAL FOOTER */}

--- a/frontend/src/utils/hooks/useDownloadCardImage.tsx
+++ b/frontend/src/utils/hooks/useDownloadCardImage.tsx
@@ -27,7 +27,7 @@ const BOTTOM_PADDING = 120
 const URL_FONT_SIZE = 14
 const URL_FONT_STYLE = '"Inter",sans-serif'
 
-export type ElementHashIdsHiddenOnScreenshot =
+export type ElementHashIdHiddenOnScreenshot =
   | '#card-options-menu'
   | '#download-card-image-button'
   | '#map-group-dropdown'
@@ -36,7 +36,7 @@ export type ElementHashIdsHiddenOnScreenshot =
 
 export function useDownloadCardImage(
   cardTitle: string,
-  hiddenElements: ElementHashIdsHiddenOnScreenshot[] = [],
+  hiddenElements: ElementHashIdHiddenOnScreenshot[] = [],
   scrollToHash: ScrollableHashId,
   dropdownOpen?: boolean,
   footerContentRef?: React.RefObject<HTMLDivElement>

--- a/frontend/src/utils/hooks/useDownloadCardImage.tsx
+++ b/frontend/src/utils/hooks/useDownloadCardImage.tsx
@@ -20,9 +20,14 @@ const BOTTOM_PADDING = 120
 const URL_FONT_SIZE = 14
 const URL_FONT_STYLE = '"Inter",sans-serif'
 
+export type HiddenElements =
+  | '#card-options-menu'
+  | '#download-card-image-button'
+  | '#map-group-dropdown'
+
 export function useDownloadCardImage(
   cardTitle: string,
-  hiddenElements: string[] = [],
+  hiddenElements: HiddenElements[] = [],
   dropdownOpen?: boolean,
   scrollToHash: string = ''
 ) {

--- a/frontend/src/utils/hooks/useDownloadCardImage.tsx
+++ b/frontend/src/utils/hooks/useDownloadCardImage.tsx
@@ -27,15 +27,16 @@ const BOTTOM_PADDING = 120
 const URL_FONT_SIZE = 14
 const URL_FONT_STYLE = '"Inter",sans-serif'
 
-export type HiddenElements =
+export type ElementHashIdsHiddenOnScreenshot =
   | '#card-options-menu'
   | '#download-card-image-button'
   | '#map-group-dropdown'
-  | '#multi-map-close-button'
+  | '#multi-map-close-button1'
+  | '#multi-map-close-button2'
 
 export function useDownloadCardImage(
   cardTitle: string,
-  hiddenElements: HiddenElements[] = [],
+  hiddenElements: ElementHashIdsHiddenOnScreenshot[] = [],
   scrollToHash: ScrollableHashId,
   dropdownOpen?: boolean,
   footerContentRef?: React.RefObject<HTMLDivElement>
@@ -154,10 +155,11 @@ export function useDownloadCardImage(
       })
 
       if (footerContentRef) {
-        const elementToHide = footerContentRef.current?.querySelector(
-          '#card-options-menu'
-        ) as HTMLElement
-        if (elementToHide) elementToHide.style.visibility = 'hidden'
+        hiddenElements.forEach((element) => {
+          const elementToHide: HTMLElement =
+            footerContentRef.current?.querySelector(element) as HTMLElement
+          if (elementToHide) elementToHide.style.visibility = 'hidden'
+        })
       }
 
       if (dropdownElement)
@@ -195,10 +197,12 @@ export function useDownloadCardImage(
       if (dropdownElement) dropdownElement.style.visibility = 'visible'
 
       if (footerContentRef) {
-        const elementToHide = footerContentRef.current?.querySelector(
-          '#card-options-menu'
-        ) as HTMLElement
-        if (elementToHide) elementToHide.style.visibility = 'visible'
+        hiddenElements.forEach((element) => {
+          const elementToHide = footerContentRef.current?.querySelector(
+            element
+          ) as HTMLElement
+          if (elementToHide) elementToHide.style.visibility = 'visible'
+        })
       }
 
       // Restore specified elements for the screenshot

--- a/frontend/src/utils/hooks/useDownloadCardImage.tsx
+++ b/frontend/src/utils/hooks/useDownloadCardImage.tsx
@@ -2,12 +2,19 @@ import { createRef, useState, useEffect } from 'react'
 import html2canvas from 'html2canvas'
 import { createFileName } from 'use-react-screenshot'
 import sass from '../../styles/variables.module.scss'
+import { type ScrollableHashId } from './useStepObserver'
+import {
+  ALT_TABLE_VIEW_1_PARAM_KEY,
+  ALT_TABLE_VIEW_2_PARAM_KEY,
+  HIGHEST_LOWEST_GEOS_1_PARAM_KEY,
+  HIGHEST_LOWEST_GEOS_2_PARAM_KEY,
+} from '../urlutils'
 
 const DROPDOWN_ELEMENT_IDS = [
-  '#alt-table-view',
-  '#alt-table-view-2',
-  '#highest-lowest-list',
-  '#highest-lowest-list-2',
+  ALT_TABLE_VIEW_1_PARAM_KEY,
+  ALT_TABLE_VIEW_2_PARAM_KEY,
+  HIGHEST_LOWEST_GEOS_1_PARAM_KEY,
+  HIGHEST_LOWEST_GEOS_2_PARAM_KEY,
 ]
 
 const LOGO_FONT_COLOR = sass.altGreen
@@ -28,8 +35,8 @@ export type HiddenElements =
 export function useDownloadCardImage(
   cardTitle: string,
   hiddenElements: HiddenElements[] = [],
-  dropdownOpen?: boolean,
-  scrollToHash: string = ''
+  scrollToHash: ScrollableHashId = 'rate-map',
+  dropdownOpen?: boolean
 ) {
   const screenshotTargetRef = createRef<HTMLDivElement>()
   const [dropdownElement, setDropdownElement] = useState<HTMLElement>()
@@ -39,7 +46,7 @@ export function useDownloadCardImage(
 
   useEffect(() => {
     const element = DROPDOWN_ELEMENT_IDS.map((dropdownId) =>
-      screenshotTargetRef.current?.querySelector(dropdownId)
+      screenshotTargetRef.current?.querySelector(`#${dropdownId}`)
     ).find((element) => element !== null) as HTMLElement
 
     setDropdownElement(element)

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -38,6 +38,8 @@ export const MULTIPLE_MAPS_1_PARAM_KEY = 'multiple-maps'
 export const MULTIPLE_MAPS_2_PARAM_KEY = 'multiple-maps2'
 export const HIGHEST_LOWEST_GEOS_1_PARAM_KEY = 'highest-lowest-geos'
 export const HIGHEST_LOWEST_GEOS_2_PARAM_KEY = 'highest-lowest-geos2'
+export const ALT_TABLE_VIEW_1_PARAM_KEY = 'alt-table-view1'
+export const ALT_TABLE_VIEW_2_PARAM_KEY = 'alt-table-view2'
 
 // Ensures backwards compatibility for external links to old DataTypeIds
 export function swapOldDatatypeParams(oldParam: string) {


### PR DESCRIPTION
## Description

This PR fixes the issue where only the viewable portion of the div is saved to the screenshot when viewing the multi-map.

- [x] Types the elementsToHide prop. 
- [x] Uses the typed param key variables instead of the ID strings (will add the alt table views to params in a separate PR). 
- [x] Adds a ref to the footer when viewing the multi-map (the ref for the content cannot be placed on the modal itself, so two refs are needed to capture the content and footer info separately). 

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Fixes #2343.

## Has this been tested? How?
Tested locally.

## Screenshots (if appropriate):
_Desktop View_
![HIV prevalence in the United States across all race and ethnicity groups from Health Equity Tracker Sep 2023](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/998977dd-5d0d-4e94-9ef6-af87574f925a)

_Mobile View_
![HIV prevalence in the United States across all race and ethnicity groups from Health Equity Tracker Sep 2023 (16)](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/8eda6e5a-f93d-49b6-8b3e-74b2e4bf3971)

## Types of changes
- Bug fix
- Refactor/chore

## Post-merge TODO
I have inspected frontend changes and run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎