### PR TITLE
FIX: Correct metric query for HIV diagnoses

### DIFF
--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -159,7 +159,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     metrics: {
       pct_share: {
         chartTitle: 'Share of total HIV diagnoses',
-        metricId: 'hiv_prevalence_pct_share',
+        metricId: 'hiv_diagnoses_pct_share',
         columnTitleHeader: 'Share of total HIV diagnoses',
         trendsCardTitleName: 'Inequitable share of HIV diagnoses over time',
         shortLabel: '% of HIV diagnoses',
@@ -173,7 +173,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
         },
       },
       per100k: {
-        metricId: 'hiv_prevalence_per_100k',
+        metricId: 'hiv_diagnoses_per_100k',
         chartTitle: 'HIV diagnoses',
         trendsCardTitleName: 'HIV diagnoses over time',
         columnTitleHeader: 'HIV diagnoses per 100k people',


### PR DESCRIPTION
## Description

- Fixed the issue of querying the wrong metric for HIV diagnoses.

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
This PR addresses issue #2364.

## Has this been tested? How?
Tested locally.

## Screenshots (if appropriate):
_Bug_
![image](https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/d8f3a282-02bf-47fb-84d3-91d54d25069c)

_Fix_
<img width="1170" alt="Screenshot 2023-09-08 at 10 17 15 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/933fe045-b965-48c2-be34-ce4d33956278">

## Types of changes
- Bug fix

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎