### PR TITLE
Fixing rendering issue in `useResponsiveWidth` hook

### DIFF
--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -41,6 +41,7 @@ import useEscape from '../../utils/hooks/useEscape'
 import { getMinMaxGroups } from '../../data/utils/DatasetTimeUtils'
 import { type DemographicGroup } from '../../data/utils/Constants'
 import ChartTitle from '../../cards/ChartTitle'
+import { useResponsiveWidth } from '../../utils/hooks/useResponsiveWidth'
 
 /* Define type interface */
 export interface TrendsChartProps {
@@ -74,8 +75,6 @@ export function TrendsChart({
   const { groupLabel } = axisConfig ?? {}
 
   /* Refs */
-  // parent container ref - used for setting svg width
-  const containerRef = useRef(null)
   // tooltip wrapper ref
   const toolTipRef = useRef(null)
 
@@ -92,10 +91,8 @@ export function TrendsChart({
     useState<DemographicGroup[]>(defaultGroups)
 
   // manages dynamic svg width
-  const [[width, isMobile], setWidth] = useState<[number, boolean]>([
-    STARTING_WIDTH,
-    false,
-  ])
+  const [containerRef, width] = useResponsiveWidth(STARTING_WIDTH)
+  const [isMobile, setIsMobile] = useState<boolean>(false)
 
   const isCompareMode = window.location.href.includes('compare')
 
@@ -117,20 +114,9 @@ export function TrendsChart({
   /* Effects */
   // resets svg width on window resize, only sets listener after first render (so ref is defined)
   useEffect(() => {
-    function setDimensions() {
-      const isMobile = window.innerWidth < MOBILE_BREAKPOINT
-      setWidth([
-        // @ts-expect-error
-        containerRef.current?.getBoundingClientRect().width,
-        isMobile,
-      ])
-    }
-    setDimensions()
-    window.addEventListener('resize', setDimensions)
-    return () => {
-      window.removeEventListener('resize', setDimensions)
-    }
-  }, [])
+    const isMobile = window.innerWidth < MOBILE_BREAKPOINT
+    setIsMobile(isMobile)
+  }, [isMobile])
 
   // resets tooltip parent width on data, filter, or hover change
   // allows to dynamically position tooltip to left of hover line

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -92,7 +92,7 @@ export function TrendsChart({
 
   // manages dynamic svg width
   const [containerRef, width] = useResponsiveWidth(STARTING_WIDTH)
-  const [isMobile, setIsMobile] = useState<boolean>(false)
+  const isMobile = window.innerWidth < MOBILE_BREAKPOINT
 
   const isCompareMode = window.location.href.includes('compare')
 
@@ -110,13 +110,6 @@ export function TrendsChart({
 
   // Stores width of tooltip to allow dynamic tooltip positioning
   const [tooltipWidth, setTooltipWidth] = useState<number>(0)
-
-  /* Effects */
-  // resets svg width on window resize, only sets listener after first render (so ref is defined)
-  useEffect(() => {
-    const mobile = window.innerWidth < MOBILE_BREAKPOINT
-    setIsMobile(mobile)
-  }, [])
 
   // resets tooltip parent width on data, filter, or hover change
   // allows to dynamically position tooltip to left of hover line

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -267,48 +267,29 @@ export function TrendsChart({
           isSkinny ? styles.FilterWrapperSkinny : styles.FilterWrapperWide
         }
       >
-        {isMobile ? (
-          <>
-            {/* Filter */}
-            {data && (
-              <FilterLegend
-                data={data}
-                selectedGroups={selectedTrendGroups}
-                handleClick={handleClick}
-                handleMinMaxClick={handleMinMaxClick}
-                groupLabel={groupLabel}
-                isSkinny={isSkinny}
-                chartWidth={width}
-                demographicType={demographicType}
-                legendId={`legend-filter-label-${axisConfig.type}-${
-                  isCompareCard ? '2' : '1'
-                }`}
-              />
-            )}
-            {/* Chart Title MOBILE BELOW LEGEND */}
-            <ChartTitle title={chartTitle} />
-          </>
-        ) : (
-          <>
-            {/* Chart Title DESKTOP ABOVE LEGEND */}
-            <ChartTitle title={chartTitle} />
-            {/* Filter */}
-            {data && (
-              <FilterLegend
-                data={data}
-                selectedGroups={selectedTrendGroups}
-                handleClick={handleClick}
-                handleMinMaxClick={handleMinMaxClick}
-                groupLabel={groupLabel}
-                isSkinny={isSkinny}
-                chartWidth={width}
-                demographicType={demographicType}
-                legendId={`legend-filter-label-${axisConfig.type}-${
-                  isCompareCard ? '2' : '1'
-                }`}
-              />
-            )}
-          </>
+        {!isMobile && (
+          // Render Chart Title DESKTOP ABOVE LEGEND
+          <ChartTitle title={chartTitle} />
+        )}
+        {/* Filter */}
+        {data && (
+          <FilterLegend
+            data={data}
+            selectedGroups={selectedTrendGroups}
+            handleClick={handleClick}
+            handleMinMaxClick={handleMinMaxClick}
+            groupLabel={groupLabel}
+            isSkinny={isSkinny}
+            chartWidth={width}
+            demographicType={demographicType}
+            legendId={`legend-filter-label-${axisConfig.type}-${
+              isCompareCard ? '2' : '1'
+            }`}
+          />
+        )}
+        {isMobile && (
+          // Render Chart Title MOBILE BELOW LEGEND
+          <ChartTitle title={chartTitle} />
         )}
       </div>
       {/* Tooltip */}

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -92,7 +92,9 @@ export function TrendsChart({
 
   // manages dynamic svg width
   const [containerRef, width] = useResponsiveWidth(STARTING_WIDTH)
-  const isMobile = window.innerWidth < MOBILE_BREAKPOINT
+  const [isMobile, setIsMobile] = useState(
+    window.innerWidth < MOBILE_BREAKPOINT
+  )
 
   const isCompareMode = window.location.href.includes('compare')
 
@@ -110,6 +112,18 @@ export function TrendsChart({
 
   // Stores width of tooltip to allow dynamic tooltip positioning
   const [tooltipWidth, setTooltipWidth] = useState<number>(0)
+
+  useEffect(() => {
+    function handleIsMobile() {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+
+    window.addEventListener('resize', handleIsMobile)
+
+    return () => {
+      window.removeEventListener('resize', handleIsMobile)
+    }
+  }, [])
 
   // resets tooltip parent width on data, filter, or hover change
   // allows to dynamically position tooltip to left of hover line

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -114,8 +114,8 @@ export function TrendsChart({
   /* Effects */
   // resets svg width on window resize, only sets listener after first render (so ref is defined)
   useEffect(() => {
-    const isMobile = window.innerWidth < MOBILE_BREAKPOINT
-    setIsMobile(isMobile)
+    const mobile = window.innerWidth < MOBILE_BREAKPOINT
+    setIsMobile(mobile)
   }, [])
 
   // resets tooltip parent width on data, filter, or hover change

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -116,7 +116,7 @@ export function TrendsChart({
   useEffect(() => {
     const isMobile = window.innerWidth < MOBILE_BREAKPOINT
     setIsMobile(isMobile)
-  }, [isMobile])
+  }, [])
 
   // resets tooltip parent width on data, filter, or hover change
   // allows to dynamically position tooltip to left of hover line

--- a/frontend/src/utils/hooks/useResponsiveWidth.tsx
+++ b/frontend/src/utils/hooks/useResponsiveWidth.tsx
@@ -4,6 +4,7 @@ export function useResponsiveWidth(
   defaultWidth: number
 ): [RefObject<HTMLDivElement>, number] {
   const [width, setWidth] = useState<number>(defaultWidth)
+  // Initial spec state is set in useEffect when default geo is set
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
 
   const forceUpdate = () => { setWidth((prevWidth) => prevWidth + 1); }
@@ -19,9 +20,8 @@ export function useResponsiveWidth(
         }
       }
     }
-    // Initial width calculation
-    handleResize()
 
+    handleResize()
     window.addEventListener('resize', handleResize)
 
     return () => {

--- a/frontend/src/utils/hooks/useResponsiveWidth.tsx
+++ b/frontend/src/utils/hooks/useResponsiveWidth.tsx
@@ -4,35 +4,30 @@ export function useResponsiveWidth(
   defaultWidth: number
 ): [RefObject<HTMLDivElement>, number] {
   const [width, setWidth] = useState<number>(defaultWidth)
-  // Trigger a re-render when the width changes
-  const [, setForceUpdate] = useState({})
-  // Initial spec state is set in useEffect when default geo is set
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
 
-  const forceUpdate = () => { setForceUpdate({}); }
+  const forceUpdate = () => { setWidth((prevWidth) => prevWidth + 1); }
 
   useEffect(() => {
     const element = ref.current
 
-    if (element && width === defaultWidth) {
-      const newWidth = element.offsetWidth || defaultWidth
-      setWidth(newWidth)
-    }
-
     const handleResize = () => {
       if (element) {
         const newWidth = element.offsetWidth || defaultWidth
-        setWidth(newWidth)
-        forceUpdate()
+        if (newWidth !== width) {
+          setWidth(newWidth)
+        }
       }
     }
+    // Initial width calculation
+    handleResize()
 
     window.addEventListener('resize', handleResize)
 
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [width, defaultWidth, forceUpdate])
+  }, [defaultWidth, width, forceUpdate])
 
   return [ref, width]
 }

--- a/frontend/src/utils/hooks/useResponsiveWidth.tsx
+++ b/frontend/src/utils/hooks/useResponsiveWidth.tsx
@@ -7,7 +7,9 @@ export function useResponsiveWidth(
   // Initial spec state is set in useEffect when default geo is set
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
 
-  const forceUpdate = () => { setWidth((prevWidth) => prevWidth + 1); }
+  const forceUpdate = () => {
+    setWidth((prevWidth) => prevWidth + 1)
+  }
 
   useEffect(() => {
     const element = ref.current

--- a/frontend/src/utils/hooks/useResponsiveWidth.tsx
+++ b/frontend/src/utils/hooks/useResponsiveWidth.tsx
@@ -4,17 +4,26 @@ export function useResponsiveWidth(
   defaultWidth: number
 ): [RefObject<HTMLDivElement>, number] {
   const [width, setWidth] = useState<number>(defaultWidth)
+  // Trigger a re-render when the width changes
+  const [, setForceUpdate] = useState({})
   // Initial spec state is set in useEffect when default geo is set
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
 
+  const forceUpdate = () => { setForceUpdate({}); }
+
   useEffect(() => {
-    if (ref?.current) {
-      setWidth(ref.current.offsetWidth)
+    const element = ref.current
+
+    if (element && width === defaultWidth) {
+      const newWidth = element.offsetWidth || defaultWidth
+      setWidth(newWidth)
     }
 
     const handleResize = () => {
-      if (ref?.current) {
-        setWidth(ref.current.offsetWidth)
+      if (element) {
+        const newWidth = element.offsetWidth || defaultWidth
+        setWidth(newWidth)
+        forceUpdate()
       }
     }
 
@@ -23,7 +32,7 @@ export function useResponsiveWidth(
     return () => {
       window.removeEventListener('resize', handleResize)
     }
-  }, [ref])
+  }, [width, defaultWidth, forceUpdate])
 
   return [ref, width]
 }


### PR DESCRIPTION
## Description
This PR addresses an issue where specific visualizations fail to render correctly when users refresh the page. This behavior is unpredictable as it only occurs sometimes when the user refreshes the page or navigates to a new visualization and only affects some visualizations (viz that are not lazy-loaded). 

The issue occurs when the hook attempts to access the ref before the component it uses has finished rendering (returning 0 as the width) or if the Vega viz attempts to load or render before the ref's width has been updated from its default value. 

- Added the `useResponsiveWidth()` hook to the D3 viz. 
- Added the `forceUpdate()` function to ensure that the width state stays updated in response to changes in `defaultWidth` or window resizing.

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
A refreshed page should provide users with the same information and visualizations they had before the refresh.

## Has this been tested? How?
Tested locally.

## Screenshots (if appropriate):
_Bug_
<img width="1188" alt="Screenshot 2023-09-12 at 10 17 52 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/b0c2c565-e39e-4738-b468-006e7701178d">

## Types of changes
- Bug fix

## Post-merge TODO
I have inspected frontend changes and run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎