### PR TITLE
Adds categories to Metric Config

### DIFF
--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -85,6 +85,14 @@ export type AgeAdjustedDataTypeId =
   | 'covid_hospitalizations'
   | 'hiv_deaths'
 
+export type CategoryTypeId =
+  | 'behavioral-health'
+  | 'chronic-disease'
+  | 'covid'
+  | 'hiv'
+  | 'pdoh'
+  | 'sdoh'
+
 // IDs for the sub-data types (if any) for theDropDownId
 export type DataTypeId =
   | DropdownVarId
@@ -156,6 +164,7 @@ export interface InfoWithCitations {
   text: string
   citations?: Citation[]
 }
+
 export interface DataTypeConfig {
   dataTypeId: DataTypeId
   dataTypeShortLabel: string
@@ -179,6 +188,7 @@ export interface DataTypeConfig {
   timeSeriesData?: boolean
   dataTableTitle?: string
   mapConfig?: MapConfig
+  categoryId?: CategoryTypeId
 }
 
 export const SYMBOL_TYPE_LOOKUP: Record<MetricType, string> = {

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -63,6 +63,7 @@ import {
   PREVENTABLE_HOSP_METRICS,
   SDOH_CATEGORY_DROPDOWNIDS,
 } from './MetricConfigSDOH'
+import { type CategoryTypeId } from '../../utils/MadLibs'
 
 const dropdownVarIds = [
   ...CHRONIC_DISEASE_CATEGORY_DROPDOWNIDS,
@@ -84,14 +85,6 @@ export type AgeAdjustedDataTypeId =
   | 'covid_deaths'
   | 'covid_hospitalizations'
   | 'hiv_deaths'
-
-export type CategoryTypeId =
-  | 'behavioral-health'
-  | 'chronic-disease'
-  | 'covid'
-  | 'hiv'
-  | 'pdoh'
-  | 'sdoh'
 
 // IDs for the sub-data types (if any) for theDropDownId
 export type DataTypeId =

--- a/frontend/src/data/config/MetricConfigBehavioralHealth.ts
+++ b/frontend/src/data/config/MetricConfigBehavioralHealth.ts
@@ -30,6 +30,7 @@ export type BehavioralHealthMetricId =
 
 export const DEPRESSION_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'behavioral-health',
     dataTypeId: 'depression',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'Depression cases',
@@ -67,6 +68,7 @@ export const DEPRESSION_METRICS: DataTypeConfig[] = [
 
 export const EXCESSIVE_DRINKING_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'behavioral-health',
     dataTypeId: 'excessive_drinking',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'Excessive drinking cases',
@@ -105,6 +107,7 @@ export const EXCESSIVE_DRINKING_METRICS: DataTypeConfig[] = [
 
 export const SUBSTANCE_MISUSE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'behavioral-health',
     // parent data type
     dataTypeId: 'non_medical_drug_use',
     dataTypeShortLabel: 'Opioid and other non-medical drug use',
@@ -145,6 +148,7 @@ export const SUBSTANCE_MISUSE_METRICS: DataTypeConfig[] = [
 
 export const FREQUENT_MENTAL_DISTRESS_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'behavioral-health',
     dataTypeId: 'frequent_mental_distress',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'Frequent mental distress cases',
@@ -183,6 +187,7 @@ export const FREQUENT_MENTAL_DISTRESS_METRICS: DataTypeConfig[] = [
 
 export const SUICIDE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'behavioral-health',
     dataTypeId: 'suicide',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'Suicides',

--- a/frontend/src/data/config/MetricConfigChronicDisease.ts
+++ b/frontend/src/data/config/MetricConfigChronicDisease.ts
@@ -27,6 +27,7 @@ export type ChronicDiseaseMetricId =
 
 export const ASTHMA_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'chronic-disease',
     dataTypeId: 'asthma',
     dataTypeShortLabel: 'Asthma',
     fullDisplayName: 'Asthma cases',
@@ -64,6 +65,7 @@ export const ASTHMA_METRICS: DataTypeConfig[] = [
 
 export const CARDIOVASCULAR_DISEASES_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'chronic-disease',
     dataTypeId: 'cardiovascular_diseases',
     dataTypeShortLabel: 'Cardiovascular diseases',
     fullDisplayName: 'Cases of cardiovascular diseases',
@@ -102,6 +104,7 @@ export const CARDIOVASCULAR_DISEASES_METRICS: DataTypeConfig[] = [
 
 export const CHRONIC_KIDNEY_DISEASE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'chronic-disease',
     dataTypeId: 'chronic_kidney_disease',
     dataTypeShortLabel: 'Chronic kidney disease',
     surveyCollectedData: true,
@@ -140,6 +143,7 @@ export const CHRONIC_KIDNEY_DISEASE_METRICS: DataTypeConfig[] = [
 
 export const DIABETES_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'chronic-disease',
     dataTypeId: 'diabetes',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'Diabetes',
@@ -177,6 +181,7 @@ export const DIABETES_METRICS: DataTypeConfig[] = [
 
 export const COPD_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'chronic-disease',
     dataTypeId: 'copd',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'COPD',

--- a/frontend/src/data/config/MetricConfigCovidCategory.ts
+++ b/frontend/src/data/config/MetricConfigCovidCategory.ts
@@ -45,6 +45,7 @@ export type CovidCategoryMetricId =
 
 export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'covid',
     dataTypeId: 'covid_cases',
     dataTypeShortLabel: 'Cases',
     fullDisplayName: 'COVID-19 cases',
@@ -89,6 +90,7 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'covid',
     dataTypeId: 'covid_deaths',
     dataTypeShortLabel: 'Deaths',
     fullDisplayName: 'COVID-19 deaths',
@@ -140,6 +142,7 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'covid',
     dataTypeId: 'covid_hospitalizations',
     dataTypeShortLabel: 'Hospitalizations',
     fullDisplayName: 'COVID-19 hospitalizations',
@@ -196,6 +199,7 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
 
 export const COVID_VACCINATION_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'covid',
     dataTypeId: 'covid_vaccinations',
     dataTypeShortLabel: 'Vaccinations',
     fullDisplayName: 'COVID-19 vaccinations',

--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -66,6 +66,7 @@ export type HivCategoryMetricId =
 
 export const HIV_CARE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_care',
     dataTypeShortLabel: 'Linkage to HIV care',
     fullDisplayName: 'Linkage to HIV care',
@@ -113,6 +114,7 @@ export const HIV_CARE_METRICS: DataTypeConfig[] = [
 
 export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_prevalence',
     dataTypeShortLabel: 'Prevalence',
     fullDisplayName: 'HIV prevalence',
@@ -154,6 +156,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_diagnoses',
     dataTypeShortLabel: 'New diagnoses',
     fullDisplayName: 'New HIV diagnoses',
@@ -196,6 +199,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_deaths',
     dataTypeShortLabel: 'Deaths',
     fullDisplayName: 'HIV deaths',
@@ -248,6 +252,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
 
 export const HIV_STIGMA_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_stigma',
     dataTypeShortLabel: 'Stigma',
     fullDisplayName: 'HIV stigma',
@@ -284,6 +289,7 @@ export const HIV_STIGMA_METRICS: DataTypeConfig[] = [
 
 export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_prevalence_black_women',
     mapConfig: womenMapConfig,
     dataTypeShortLabel: 'Prevalence for Black Women',
@@ -427,6 +433,7 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
 
 export const HIV_PREP_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'hiv',
     dataTypeId: 'hiv_prep',
     dataTypeShortLabel: 'PrEP coverage',
     fullDisplayName: 'PrEP coverage',

--- a/frontend/src/data/config/MetricConfigPDOH.ts
+++ b/frontend/src/data/config/MetricConfigPDOH.ts
@@ -46,6 +46,7 @@ export type PDOHMetricId =
 
 export const VOTER_PARTICIPATION_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'pdoh',
     dataTypeId: 'voter_participation',
     dataTypeShortLabel: 'Voter participation',
     fullDisplayName: 'Voter participation',
@@ -84,6 +85,7 @@ export const VOTER_PARTICIPATION_METRICS: DataTypeConfig[] = [
 
 export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'pdoh',
     dataTypeId: 'women_in_us_congress',
     mapConfig: womenMapConfig,
     dataTypeShortLabel: 'US Congress',
@@ -143,6 +145,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'pdoh',
     dataTypeId: 'women_in_state_legislature',
     mapConfig: womenMapConfig,
     dataTypeShortLabel: 'State legislatures', // DATA TOGGLE
@@ -206,6 +209,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
 
 export const INCARCERATION_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'pdoh',
     dataTypeId: 'prison',
     dataTypeShortLabel: 'Prison',
     fullDisplayName: 'People in prison',
@@ -257,6 +261,7 @@ export const INCARCERATION_METRICS: DataTypeConfig[] = [
     },
   },
   {
+    categoryId: 'pdoh',
     dataTypeId: 'jail',
     dataTypeShortLabel: 'Jail',
     fullDisplayName: 'People in jail',

--- a/frontend/src/data/config/MetricConfigSDOH.ts
+++ b/frontend/src/data/config/MetricConfigSDOH.ts
@@ -30,6 +30,7 @@ export type SDOHMetricId =
 
 export const UNINSURANCE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'sdoh',
     dataTypeId: 'health_insurance',
     dataTypeShortLabel: 'Uninsured people',
     fullDisplayName: 'Uninsured people',
@@ -79,6 +80,7 @@ export const UNINSURANCE_METRICS: DataTypeConfig[] = [
 
 export const POVERTY_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'sdoh',
     dataTypeId: 'poverty',
     dataTypeShortLabel: 'Poverty',
     fullDisplayName: 'People below the poverty line',
@@ -124,6 +126,7 @@ export const POVERTY_METRICS: DataTypeConfig[] = [
 
 export const CARE_AVOIDANCE_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'sdoh',
     dataTypeId: 'avoided_care',
     dataTypeShortLabel: 'Avoided Care',
     fullDisplayName: 'Care avoidance due to cost',
@@ -162,6 +165,7 @@ export const CARE_AVOIDANCE_METRICS: DataTypeConfig[] = [
 
 export const PREVENTABLE_HOSP_METRICS: DataTypeConfig[] = [
   {
+    categoryId: 'sdoh',
     dataTypeId: 'preventable_hospitalizations',
     mapConfig: medicareMapConfig,
     dataTypeShortLabel: 'Preventable hospitalizations',

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -33,7 +33,7 @@ export const MADLIB_MODE_MAP: Record<string, MadLibId> = {
 
 export const CategoryMap = {
   'behavioral-health': 'Behavioral Health',
-  'black-womens-health': `Black Women's Health`,
+  'black-women-health': `Black Women's Health`,
   'chronic-disease': 'Chronic Disease',
   covid: 'COVID-19',
   hiv: 'HIV',

--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -31,16 +31,20 @@ export const MADLIB_MODE_MAP: Record<string, MadLibId> = {
   Topics: 'comparevars',
 }
 
-// wording used for determinant categories in the selectable dropdown on /exploredata
-export type CategoryId =
-  | 'HIV'
-  | `Black Women's Health`
-  | 'COVID-19'
-  | 'Chronic Disease'
-  | 'Behavioral Health'
-  | 'Political Determinants of Health'
-  | 'Social Determinants of Health'
-  | 'Medication Utilization in Medicare Population'
+export const CategoryMap = {
+  'behavioral-health': 'Behavioral Health',
+  'black-womens-health': `Black Women's Health`,
+  'chronic-disease': 'Chronic Disease',
+  covid: 'COVID-19',
+  hiv: 'HIV',
+  medicare: 'Medication Utilization in Medicare Population',
+  pdoh: 'Political Determinants of Health',
+  sdoh: 'Social Determinants of Health',
+}
+
+export type CategoryTypeId = keyof typeof CategoryMap
+
+export type CategoryTitle = (typeof CategoryMap)[CategoryTypeId]
 
 export interface MadLib {
   readonly id: MadLibId
@@ -161,7 +165,7 @@ export const SELECTED_DROPDOWN_OVERRIDES: Partial<
 }
 
 export interface Category {
-  readonly title: CategoryId
+  readonly title: CategoryTitle
   readonly options: DropdownVarId[]
   readonly definition?: string
 }

--- a/frontend/src/utils/hooks/useStepObserver.ts
+++ b/frontend/src/utils/hooks/useStepObserver.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
+import { scrollIntoView } from 'seamless-scroll-polyfill'
 
 export interface StepData {
   label: string
@@ -116,7 +117,9 @@ export function useStepObserver(
         if (urlHashOverrideRef.current === hashId) {
           const targetElem = document.querySelector(`#${hashId as string}`)
           if (targetElem) {
-            targetElem.scrollIntoView({ behavior: 'smooth' })
+            scrollIntoView(targetElem, {
+              behavior: 'smooth',
+            })
           }
         }
       }, 500)

--- a/frontend/src/utils/hooks/useStepObserver.ts
+++ b/frontend/src/utils/hooks/useStepObserver.ts
@@ -1,6 +1,5 @@
 import { useEffect, useState, useRef } from 'react'
 import { useLocation } from 'react-router-dom'
-import { scrollIntoView } from 'seamless-scroll-polyfill'
 
 export interface StepData {
   label: string
@@ -117,9 +116,7 @@ export function useStepObserver(
         if (urlHashOverrideRef.current === hashId) {
           const targetElem = document.querySelector(`#${hashId as string}`)
           if (targetElem) {
-            scrollIntoView(targetElem, {
-              behavior: 'smooth',
-            })
+            targetElem.scrollIntoView({ behavior: 'smooth' })
           }
         }
       }, 500)


### PR DESCRIPTION
## Description

- Adds the categoryId option to the metric config for routing to the methodology page, i.e., `methodology/topics/pdoh`

## Motivation and Context
<!--- use keywords (eg "closes #144" or "fixes #4323") -->
Breaking out a logic from PR #2431. 

Currently components like `TopicInfoModal` link to a section on the methodology page; now that our new methodology will have separate pages for each category, we need to determine the route and section for each metric.

## Has this been tested? How?
Tested locally

## Types of changes
- Refactor/chore

## Post-merge TODO
I have inspected frontend changes and/or run affected data pipelines:
- [ ] on DEV
- [ ] on PROD

## Any target [user persona(s)](https://docs.google.com/document/d/1EASpK_THTE_uy_Yk0sut2GTVd3w5pKtKH7LpLtF-0co/)?

## Preview link below in Netlify comment 😎