### PR TITLE
Improves CSS defaults

### DIFF
--- a/frontend/src/Footer.tsx
+++ b/frontend/src/Footer.tsx
@@ -8,11 +8,11 @@ import { Button } from '@mui/material'
 import { ReactRouterLinkButton } from './utils/urlutils'
 import {
   EXPLORE_DATA_PAGE_LINK,
-  DATA_CATALOG_PAGE_LINK,
   TERMS_OF_USE_PAGE_LINK,
   FAQ_TAB_LINK,
   CONTACT_TAB_LINK,
   NEWS_PAGE_LINK,
+  METHODOLOGY_PAGE_LINK,
 } from './utils/internalRoutes'
 import AppbarLogo from './assets/AppbarLogo.png'
 import PartnerSatcher from './assets/PartnerSatcher.png'
@@ -45,7 +45,7 @@ function Footer() {
           >
             {[
               ['Explore Data', EXPLORE_DATA_PAGE_LINK],
-              ['Downloads and Methods', DATA_CATALOG_PAGE_LINK],
+              ['Methods', METHODOLOGY_PAGE_LINK],
               ['News', NEWS_PAGE_LINK],
               ['FAQs', `${FAQ_TAB_LINK}`, 'Frequently Asked Questions'],
               ['Contact Us', `${CONTACT_TAB_LINK}`],

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,9 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
-/* DEFINE CSS VARIABLES / CUSTOM PROPERTIES */
 @layer base {
+  #root {
+    height: 100%;
+  }
+  html {
+    scroll-behavior: smooth;
+    height: 100%;
+  }
+  ,
+  body {
+    margin: 0;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    height: 100%;
+    background: white;
+  }
+
+  /* DEFINE CSS VARIABLES / CUSTOM PROPERTIES */
   :root {
+    font-size: 100%;
     /* non-tailwind values */
     --hex-share-icon-gray: #757575;
 
@@ -98,5 +115,9 @@
     --z-middle: 0;
     --z-almost-top: 3;
     --z-top: 999;
+  }
+  /* TODO: why doesnt var(--alt-green) work here? should try to avoid hard coded colors */
+  a {
+    color: #0b5240;
   }
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,6 +3,9 @@
 @tailwind utilities;
 
 @layer base {
+  * {
+    box-sizing: border-box;
+  }
   #root {
     height: 100%;
   }

--- a/frontend/src/pages/News/ShareYourStory.tsx
+++ b/frontend/src/pages/News/ShareYourStory.tsx
@@ -3,15 +3,15 @@ import HetBigCTA from '../../styles/HetComponents/HetBigCTA'
 export default function ShareYourStory() {
   return (
     <div className='flex w-full items-center justify-center text-start'>
-      <div className='flex max-w-md flex-wrap justify-center'>
+      <div className='flex max-w-md flex-wrap justify-center p-5'>
         <div className='pb-4 pl-16 pr-16 pt-24'>
           <h2
             id='main'
-            className='m-0 text-center font-serif text-bigHeader font-light text-alt-green'
+            className='m-0 text-center font-serif text-header font-light text-alt-green md:text-bigHeader'
           >
             Call for Community Writers
           </h2>
-          <h3 className='m-0 pb-4	text-center font-sansText	text-smallestHeader font-normal'>
+          <h3 className='m-0 pb-4	text-center font-sansText text-title	font-normal md:text-smallestHeader'>
             Share Your Story and Amplify Your Voice
           </h3>
         </div>

--- a/frontend/src/styles/HetComponents/HetBigCTA.tsx
+++ b/frontend/src/styles/HetComponents/HetBigCTA.tsx
@@ -12,10 +12,10 @@ export default function HetBigCTA(props: HetBigCTAProps) {
     <Button
       id={props.id}
       variant='contained'
-      className='rounded-2xl px-8 py-5 text-exploreButton text-white'
+      className='rounded-2xl px-8 py-5'
       href={props.href}
     >
-      {props.children}
+      <span className='text-exploreButton text-white'>{props.children}</span>
     </Button>
   )
 }

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -1,7 +1,3 @@
 @import 'normalize.css';
 @import './variables.module.scss';
 @import 'mixins';
-
-* {
-  box-sizing: border-box;
-}

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -5,28 +5,3 @@
 * {
   box-sizing: border-box;
 }
-
-:root {
-  font-size: 100%;
-}
-
-#root {
-  height: 100%;
-}
-
-html {
-  height: 100%;
-}
-
-body {
-  margin: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  height: 100%;
-  background: white;
-}
-
-a:link,
-a:visited {
-  color: $alt-green;
-}


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- fixes footer link to reflect split of downloads/methods; should have been done in #2499 
- removes base level css from index.scss and moves it into index.css, part of #2521
- uses `<span>` inside `<HetBigCTA>` for better specificity allowing us to color the text white when normal links are default green
- fixes #2480

## Has this been tested? How?

manually confirmed colors are correct across all pages

## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
