### PR TITLE
Adds nightly e2e for ras antagonists adherence

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -109,7 +109,7 @@
     "cspell": "cspell '../**/*.{ts,tsx,scss,md,py}' --no-progress --no-must-find-files --gitignore",
     "dev": "env-cmd -f .env.development npm run start -- --host",
     "e2e-staging": "export PLAYWRIGHT_BASE_URL=https://dev.healthequitytracker.org &&  npx playwright install chromium && npx playwright test --project=E2E_NIGHTLY --workers 5",
-    "e2e-prod": "export PLAYWRIGHT_BASE_URL=https://healthequitytracker.org &&  npx playwright install chromium && npx playwright test --project=E2E_NIGHTLY --workers 5",
+    "e2e-prod": "export PLAYWRIGHT_BASE_URL=https://healthequitytracker.org && npx playwright install chromium && npx playwright test --project=E2E_NIGHTLY --workers 5",
     "e2e": "npx playwright install chromium && npx playwright test --project=E2E_NIGHTLY --workers 2",
     "e2e-new": "npx playwright codegen http://localhost:3000",
     "lint": "eslint --fix src",

--- a/frontend/playwright-tests/rasantagonistsadherence.nightly.spec.ts
+++ b/frontend/playwright-tests/rasantagonistsadherence.nightly.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '@playwright/test'
+
+test('test', async ({ page }) => {
+  await page.goto(
+    '/exploredata?mls=1.medicare_cardiovascular-3.00&group1=All&dt1=ras_antagonists_adherence'
+  )
+  await page.getByText('Race and Ethnicity:').click()
+  await page.locator('.MuiBackdrop-root').click()
+  await page
+    .locator('#rate-map')
+    .getByRole('heading', {
+      name: 'Population adherent to RAS-Antagonists in the United States',
+    })
+    .click()
+  await page.getByLabel('open the topic info modal').click()
+  await page.getByLabel('close topic info modal').click()
+  await page.getByText('Demographic', { exact: true }).nth(2).click()
+  await page.getByText('Off').nth(1).click()
+  await page.locator('#menu- div').first().click()
+  await page
+    .locator('#rate-chart')
+    .getByRole('heading', {
+      name: 'Population adherent to RAS-Antagonists in the United States',
+    })
+    .click()
+  await page
+    .getByRole('heading', {
+      name: 'Adherent beneficiary population with unknown race and ethnicity in the United States',
+    })
+    .click()
+  await page
+    .getByRole('heading', {
+      name: 'Breakdown summary for adherence to renin angiotensin system antagonists in the United States',
+    })
+    .click()
+  await page.getByText('Share this report:').click()
+  await page.getByRole('heading', { name: 'Definitions:' }).click()
+  await page
+    .getByText('Medication Utilization in the Medicare Population')
+    .click()
+  await page.getByText('Adherence to RASA', { exact: true }).click()
+  await page.getByRole('heading', { name: 'What data are missing?' }).click()
+  await page
+    .getByText(
+      'Do you have information that belongs on the Health Equity Tracker? We would love'
+    )
+    .click()
+})


### PR DESCRIPTION
# Description and Motivation
Closes #2582

## Has this been tested? How?

Using vscode terminal.

<img width="935" alt="rasa-adherence" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/14945785/93f3f563-d834-4ad6-82ce-ba97fc7cb7d3">


## Types of changes

(leave all that apply)


- New content or feature


## New frontend preview link is below in the Netlify comment 😎
