### PR TITLE
Adds nightly e2e for diabetes

### DIFF
--- a/frontend/playwright-tests/diabetes.nightly.spec.ts
+++ b/frontend/playwright-tests/diabetes.nightly.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 
-test('test', async ({ page }) => {
+test('Diabetes', async ({ page }) => {
   await page.goto('/exploredata?mls=1.diabetes-3.00&group1=All')
   await page.getByText('Race and Ethnicity:').click()
   await page.locator('.MuiBackdrop-root').click()

--- a/frontend/playwright-tests/diabetes.nightly.spec.ts
+++ b/frontend/playwright-tests/diabetes.nightly.spec.ts
@@ -1,0 +1,33 @@
+import { test } from '@playwright/test'
+
+test('test', async ({ page }) => {
+  await page.goto('/exploredata?mls=1.diabetes-3.00&group1=All')
+  await page.getByText('Race and Ethnicity:').click()
+  await page.locator('.MuiBackdrop-root').click()
+  await page
+    .locator('#rate-map')
+    .getByRole('heading', { name: 'Diabetes in the United States' })
+    .click()
+  await page.getByLabel('open the topic info modal').click()
+  await page.getByLabel('close topic info modal').click()
+  await page.getByText('Demographic').nth(2).click()
+  await page.getByText('Off').nth(1).click()
+  await page.locator('#menu- div').first().click()
+  await page
+    .locator('#rate-chart')
+    .getByRole('heading', { name: 'Diabetes in the United States' })
+    .click()
+  await page
+    .getByRole('heading', { name: 'Share of total diabetes cases' })
+    .click()
+  await page
+    .getByRole('heading', { name: 'Population vs. distribution' })
+    .click()
+  await page.getByRole('heading', { name: 'Breakdown summary for' }).click()
+  await page.getByText('Share this report:').click()
+  await page
+    .locator('#definitionsList')
+    .getByText('Diabetes', { exact: true })
+    .click()
+  await page.getByText('Do you have information that').click()
+})


### PR DESCRIPTION
# Description and Motivation
Closes #2565

## Has this been tested? How?

Using vscode terminal

<img width="904" alt="diabetes" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/14945785/05b4e578-32ba-45e6-ac4c-31885694b28a">


## Types of changes

(leave all that apply)


- New content or feature


## New frontend preview link is below in the Netlify comment 😎
