### PR TITLE
Adds nightly e2e for ccb adherence

### DIFF
--- a/frontend/playwright-tests/ccb-adherence.nightly.spec.ts
+++ b/frontend/playwright-tests/ccb-adherence.nightly.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@playwright/test'
+
+test('calcium channel blocker adherence', async ({ page }) => {
+  await page.goto(
+    '/exploredata?mls=1.medicare_cardiovascular-3.00&group1=All&dt1=ccb_adherence'
+  )
+  await page.getByText('Race and Ethnicity:').click()
+  await page.locator('.MuiBackdrop-root').click()
+  await page
+    .locator('#rate-map')
+    .getByRole('heading', { name: 'Population adherent to' })
+    .click()
+  await page.getByLabel('open the topic info modal').click()
+  await page.getByLabel('close topic info modal').click()
+  await page.getByText('Demographic', { exact: true }).nth(2).click()
+  await page.getByText('Off').nth(1).click()
+  await page.locator('#menu- div').first().click()
+  await page
+    .locator('#rate-chart')
+    .getByRole('heading', { name: 'Population adherent to' })
+    .click()
+  await page.getByRole('heading', { name: 'Adherent beneficiary' }).click()
+  await page.getByRole('heading', { name: 'Breakdown summary for' }).click()
+  await page.getByText('Share this report:').click()
+  await page
+    .getByText('Adherence to calcium channel blockers', { exact: true })
+    .click()
+  await page.getByRole('heading', { name: 'What data are missing?' }).click()
+  await page.getByText('Do you have information that').click()
+})


### PR DESCRIPTION
# Description and Motivation
Closes #2583

## Has this been tested? How?

Using vscode terminal.

<img width="924" alt="ccb-adherence" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/14945785/c05fe60b-7458-43b0-b2af-1176f935e44e">


## Types of changes

(leave all that apply)


- New content or feature


## New frontend preview link is below in the Netlify comment 😎
