### PR TITLE
Adds nightly e2e for asthma

### DIFF
--- a/frontend/playwright-tests/asthma.ci.spec.ts
+++ b/frontend/playwright-tests/asthma.ci.spec.ts
@@ -1,0 +1,30 @@
+import { test } from '@playwright/test'
+
+test('Asthma', async ({ page }) => {
+  await page.goto('/exploredata?mls=1.asthma-3.00&group1=All')
+  await page.getByText('Race and Ethnicity:').click()
+  await page.locator('.MuiBackdrop-root').click()
+  await page
+    .locator('#rate-map')
+    .getByRole('heading', { name: 'Asthma in the United States' })
+    .click()
+  await page.getByLabel('open the topic info modal').click()
+  await page.getByLabel('close topic info modal').click()
+  await page.getByText('Demographic').nth(2).click()
+  await page.getByText('Off').nth(1).click()
+  await page.locator('#menu- div').first().click()
+  await page
+    .locator('#rate-chart')
+    .getByRole('heading', { name: 'Asthma in the United States' })
+    .click()
+  await page.getByRole('heading', { name: 'Share of all asthma cases' }).click()
+  await page
+    .getByRole('heading', { name: 'Population vs. distribution' })
+    .click()
+  await page
+    .getByRole('heading', { name: 'Breakdown summary for asthma' })
+    .click()
+  await page.getByText('Share this report:').click()
+  await page.getByText('Asthma cases', { exact: true }).click()
+  await page.getByText('Do you have information that').click()
+})


### PR DESCRIPTION
# Description and Motivation
Closes #2571

## Has this been tested? How?

Yes. Using vscode terminal

<img width="939" alt="asthma" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/14945785/1ee6a732-56d7-4a5a-9f09-fce875d391bc">


## Types of changes

(leave all that apply)


- New content or feature


## New frontend preview link is below in the Netlify comment 😎
