### PR TITLE
Adds E2E for CAWP state leg

### DIFF
--- a/frontend/playwright-tests/cawp.nightly.spec.ts
+++ b/frontend/playwright-tests/cawp.nightly.spec.ts
@@ -1,6 +1,6 @@
 import { test } from '@playwright/test'
 
-test('CAWP: CAWP National Congress Flow', async ({ page }) => {
+test('CAWP: Congress', async ({ page }) => {
   await page.goto(
     '/exploredata?mls=1.women_in_gov-3.00&group1=All'
   )
@@ -70,3 +70,40 @@ test('CAWP: CAWP National Congress Flow', async ({ page }) => {
   await page.getByText('Percentages reported for Women in state legislatures cannot be summed, as these ').click();
 
 })
+
+
+test('CAWP: State Legislature', async ({ page }) => {
+  await page.goto('/exploredata?mls=1.women_in_gov-3.00&group1=All');
+  await page.getByRole('button', { name: 'US Congress', exact: true }).click();
+  await page.getByRole('button', { name: 'State legislatures' }).click();
+  await page.getByLabel('Race and Ethnicity:').click();
+  await page.getByRole('button', { name: 'Black or African American' }).click();
+  await page.locator('#rate-map').getByRole('heading', { name: 'Percentage of state' }).click();
+  await page.getByRole('heading', { name: 'Black or African American' }).click();
+  await page.getByLabel('Click for more info on Women').click();
+  await page.getByRole('heading', { name: 'Women in state legislatures' }).click();
+  await page.getByText('Women in state legislaturesMeasurement Definition: Individuals identifying as').click();
+  await page.getByLabel('close topic info modal').click();
+  await page.getByRole('heading', { name: 'Rates of women in state' }).click();
+  await page.getByText('% women in state legislature →').click();
+  await page.getByLabel('View the share of Women in').click();
+  await page.getByText('Missing and unknown data').click();
+  await page.locator('#rate-chart').getByRole('heading', { name: 'Percentage of state' }).click();
+  await page.getByRole('heading', { name: 'Percent share of women state' }).click();
+  await page.getByRole('button', { name: 'Inequities over time' }).click();
+  await page.locator('#inequities-over-time').getByLabel('Include Latinas and Hispanic').click();
+  await page.locator('#inequities-over-time').getByLabel('Include Latinas and Hispanic').click();
+  await page.getByText('This graph visualizes the').click();
+  await page.getByRole('heading', { name: 'Population vs. distribution' }).click();
+  await page.getByText('Percentages reported for').click();
+  await page.getByRole('heading', { name: 'Breakdown summary for Women' }).click();
+  await page.getByRole('columnheader', { name: 'Race and Ethnicity' }).click();
+  await page.getByRole('columnheader', { name: 'Percentage of women state' }).click();
+  await page.getByRole('columnheader', { name: 'Percent share of women state' }).click();
+  await page.getByRole('columnheader', { name: 'Total population share (all' }).click();
+  await page.getByText('Share this report:').click();
+  await page.getByText('Political Determinants of').click();
+  await page.getByRole('combobox', { name: 'Demographic Race/ethnicity' }).click();
+  await page.getByLabel('Age unavailable for Women in').click();
+  await page.getByLabel('Sex unavailable for Women in').click();
+});


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- closes #2576 
- Adds another test within the existing CAWP test file
- Targets text, alerts, and UI elements that are unique to these types of reports (women in politics)

## Has this been tested? How?

passes locally and against prod

## Screenshots (if appropriate)

<img width="878" alt="Screenshot 2024-01-17 at 8 42 47 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/b654ccff-43e8-463a-83c5-6535f735801c">


## Types of changes

(leave all that apply)

- chore

## New frontend preview link is below in the Netlify comment 😎
