### PR TITLE
Moves spell check action out of the Frontend CI action

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -36,8 +36,8 @@ jobs:
           NODE_OPTIONS: '--max_old_space_size=4096'
         run: npm run build:deploy_preview
 
-  frontend_unit_tests_cspell:
-    name: Runs spellcheck and unit tests
+  frontend_unit_tests:
+    name: Runs frontend unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -48,8 +48,6 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: Install dependencies
         run: npm ci
-      - name: Run cspell spellcheck
-        run: npm run cspell
       - name: Run Jest unit tests
         run: npm test
 

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - name: Waiting for Netlify Preview
         uses: josephduffy/wait-for-netlify-action@v1
-        id: wait-for-netflify-preview
+        id: wait-for-netlify-preview
         with:
           site_name: ${{env.NETLIFY_SITE_NAME}}
           max_timeout: 90

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,4 +11,4 @@ jobs:
       - uses: streetsidesoftware/cspell-action@v5
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          config: '../../cspell.config.json'
+          config: 'cspell.config.json'

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,14 @@
+name: 'Check spelling on changed files'
+on: # rebuild any PRs and main branch changes
+  pull_request:
+  push:
+
+jobs:
+  spellcheck: # run the action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: streetsidesoftware/cspell-action@v5
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          config: '../../cspell.config.json'


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

This should make it so that the spell checker is run against all changed files, not only frontend files (because previously the check was only run on frontend ci action), using our shared cspell config file

## Has this been tested? How?

it caught a spelling error copied over from the GitHub Action sample usage script



## Types of changes

(leave all that apply)

-  chore

## New frontend preview link is below in the Netlify comment 😎
