### PR TITLE
Fixes for New Methodology Menu, Routing, Wording

### DIFF
--- a/frontend/src/pages/AboutUs/ContactUsTab.tsx
+++ b/frontend/src/pages/AboutUs/ContactUsTab.tsx
@@ -34,7 +34,7 @@ function ContactUsTab() {
               width='870'
               height='644'
               src='/img/stock/women-laughing-in-line.png'
-              className='m-10 h-auto w-9/12 max-w-xl rounded-md'
+              className='m-10 h-auto w-9/12 max-w-lg rounded-md'
               alt=''
             />
           </div>

--- a/frontend/src/pages/AboutUs/OurTeamTab.tsx
+++ b/frontend/src/pages/AboutUs/OurTeamTab.tsx
@@ -16,7 +16,7 @@ function OurTeamTab() {
         <title>Our Team - About Us - Health Equity Tracker</title>
       </Helmet>
       <h2 className='sr-only'>Our Team</h2>
-      <div className='flex w-full max-w-xl flex-col p-10'>
+      <div className='flex w-full max-w-lg flex-col p-10'>
         <div className='flex w-full justify-center'>
           <div className='w-full justify-center sm:w-10/12 md:w-6/12 xl:w-8/12'>
             <h3

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -46,7 +46,7 @@ function LandingPage() {
       </Helmet>
 
       <h2 className='sr-only'>Home Page</h2>
-      <div className='m-auto flex w-full max-w-newsPage flex-wrap justify-center'>
+      <div className='m-auto flex w-full max-w-lgXl flex-wrap justify-center'>
         <div className='flex flex-wrap items-center justify-center border-0 border-b border-solid pb-8 pt-4'>
           <div className='flex w-full flex-col items-center px-12 py-4 md:w-7/12'>
             <h3

--- a/frontend/src/pages/Methodology/methodologyComponents/MethodologyCardMenu.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/MethodologyCardMenu.tsx
@@ -28,7 +28,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
   return (
     <nav
       aria-label='methodology sections'
-      className={`flex  flex-col rounded-sm py-0 shadow-raised-tighter ${
+      className={`flex flex-col rounded-sm py-0 tracking-normal shadow-raised-tighter ${
         props.className ?? ''
       } `}
     >
@@ -36,7 +36,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link to={NEW_METHODOLOGY_PAGE_LINK} className='no-underline'>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === NEW_METHODOLOGY_PAGE_LINK}
             >
               Introduction
@@ -47,7 +47,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={NEW_AGE_ADJUSTMENT_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === NEW_AGE_ADJUSTMENT_LINK}
             >
               Age-Adjustment
@@ -58,7 +58,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={SOURCES_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === SOURCES_LINK}
             >
               Data Sources
@@ -69,7 +69,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={TOPICS_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === TOPICS_LINK}
             >
               Categories and Limitations
@@ -79,7 +79,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={BEHAVIORAL_HEALTH_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === BEHAVIORAL_HEALTH_LINK}
               option='normalBlack'
             >
@@ -90,7 +90,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={CHRONIC_DISEASE_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === CHRONIC_DISEASE_LINK}
               option='normalBlack'
             >
@@ -101,7 +101,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={COVID_19_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === COVID_19_LINK}
               option='normalBlack'
             >
@@ -112,7 +112,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={HIV_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === HIV_LINK}
               option='normalBlack'
             >
@@ -123,7 +123,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={PDOH_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === PDOH_LINK}
               option='normalBlack'
             >
@@ -134,7 +134,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={SDOH_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === SDOH_LINK}
               option='normalBlack'
             >
@@ -146,7 +146,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={DATA_METHOD_DEFINITIONS_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={
                 window.location.pathname === DATA_METHOD_DEFINITIONS_LINK
               }
@@ -158,7 +158,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={METRICS_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === METRICS_LINK}
               option='normalBlack'
             >
@@ -169,7 +169,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={CONDITION_VARIABLES_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === CONDITION_VARIABLES_LINK}
               option='normalBlack'
             >
@@ -181,7 +181,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={RACES_AND_ETHNICITIES_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === RACES_AND_ETHNICITIES_LINK}
               option='normalBlack'
             >
@@ -193,7 +193,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={RECOMMENDED_CITATION_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === RECOMMENDED_CITATION_LINK}
             >
               Recommended Citation
@@ -204,7 +204,7 @@ export default function MethodologyCardMenu(props: MethodologyCardMenuProps) {
         <li>
           <Link className='no-underline' to={GLOSSARY_LINK}>
             <HetListItemButton
-              className='mx-2 pl-2'
+              className='mx-2 pl-2 font-roboto'
               selected={window.location.pathname === GLOSSARY_LINK}
             >
               Glossary

--- a/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
@@ -39,7 +39,7 @@ export default function MethodologyPage() {
       <div className='flex w-full justify-center'>
         <h2 className='sr-only'>Methodology</h2>
 
-        <section className='m-[2%] flex max-w-xl justify-start'>
+        <section className='m-[2%] flex max-w-lgXl justify-start'>
           <div className='flex flex-col justify-items-center smMd:flex-row smMd:gap-2 md:gap-12'>
             {/* MAIN METHODOLOGY PAGES MENU */}
             <div className='min-w-fit'>

--- a/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
@@ -36,10 +36,10 @@ export default function MethodologyPage() {
         <title>Methodology - Health Equity Tracker</title>
       </Helmet>
 
-      <div className='flex justify-start'>
+      <div className='flex w-full justify-center'>
         <h2 className='sr-only'>Methodology</h2>
 
-        <section className='m-[2%] max-w-xl'>
+        <section className='m-[2%] flex max-w-xl justify-start'>
           <div className='flex flex-col justify-items-center smMd:flex-row smMd:gap-2 md:gap-12'>
             {/* MAIN METHODOLOGY PAGES MENU */}
             <div className='min-w-fit'>
@@ -50,7 +50,7 @@ export default function MethodologyPage() {
             {/* CONTENT */}
             <div className='flex flex-wrap p-1'>
               {/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}
-              <div className='px-12 lg:hidden'>
+              <div className='px-12 md:hidden'>
                 {routeConfigs.map((route, index) => {
                   const match = useRouteMatch({
                     path: route.path,
@@ -66,7 +66,7 @@ export default function MethodologyPage() {
                 })}
               </div>
 
-              <article className='flex w-full flex-col p-8 text-left lg:p-0 '>
+              <article className='flex w-full flex-col p-8 text-left md:p-0 '>
                 {/* HEADING */}
                 <h2 className='font-serif text-header font-light' id='main'>
                   {activeRoute?.label}
@@ -91,7 +91,7 @@ export default function MethodologyPage() {
             </div>
 
             {/* ON THIS PAGE SUB-MENU - DESKTOP */}
-            <div className='hidden min-w-fit lg:block'>
+            <div className='hidden min-w-fit md:block'>
               {routeConfigs.map((route, index) => {
                 const match = useRouteMatch({
                   path: route.path,

--- a/frontend/src/pages/Methodology/methodologyComponents/StripedTable.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/StripedTable.tsx
@@ -37,35 +37,34 @@ interface StripedTableProps {
   applyThickBorder?: boolean
 }
 
-const StripedTable: React.FC<StripedTableProps> = ({
-  rows,
-  columns,
-  id,
-  applyThickBorder = true,
-}) => {
+export default function StripedTable(props: StripedTableProps) {
   return (
-    <TableContainer className=' overflow-x-auto' component={Paper} id={id}>
+    <TableContainer
+      className=' overflow-x-auto'
+      component={Paper}
+      id={props.id}
+    >
       <Table aria-label='customized table' className='min-w-full'>
         <TableHead>
-          <TableRow className='bg-altGreen text-navlinkColor'>
-            {columns.map((col) => (
+          <TableRow className='bg-methodologyGreen text-navlinkColor'>
+            {props.columns.map((col) => (
               <TableCell key={col.accessor}>{col.header}</TableCell>
             ))}
           </TableRow>
         </TableHead>
         <TableBody>
-          {rows.map((row, rowIndex) => (
+          {props.rows.map((row, rowIndex) => (
             <StyledTableRow
               key={rowIndex}
               className={
-                applyThickBorder &&
-                rows.length !== 3 &&
+                props.applyThickBorder &&
+                props.rows.length !== 3 &&
                 (rowIndex + 1) % 2 === 0
-                  ? 'border-0 border-b-2 border-altGreen'
+                  ? 'border-0 border-b-2 border-methodologyGreen'
                   : ''
               }
             >
-              {columns.map((col) => (
+              {props.columns.map((col) => (
                 <TableCell
                   key={col.accessor}
                   component='td'
@@ -82,5 +81,3 @@ const StripedTable: React.FC<StripedTableProps> = ({
     </TableContainer>
   )
 }
-
-export default StripedTable

--- a/frontend/src/pages/Methodology/methodologyContent/routeConfigs.jsx
+++ b/frontend/src/pages/Methodology/methodologyContent/routeConfigs.jsx
@@ -35,7 +35,7 @@ import GlossaryLink from '../methodologySections/GlossaryLink'
 
 export const routeConfigs = [
   {
-    label: 'Methodology',
+    label: 'Methodology Introduction',
     path: NEW_METHODOLOGY_PAGE_LINK,
     component: MethodologyHomeLink,
     subLinks: [],
@@ -106,6 +106,25 @@ export const routeConfigs = [
       {
         label: 'Contact Information',
         path: '#contact-information',
+      },
+    ],
+  },
+  {
+    label: 'Categories and Limitations',
+    path: TOPICS_LINK,
+    component: TopicsLink,
+    subLinks: [
+      {
+        label: 'Categories',
+        path: '#categories',
+      },
+      {
+        label: 'Limitations',
+        path: '#limitations',
+      },
+      {
+        label: 'Missing Data',
+        path: '#missing-data',
       },
     ],
   },
@@ -286,6 +305,12 @@ export const routeConfigs = [
     ],
   },
   {
+    label: 'Data Methods',
+    path: DATA_METHOD_DEFINITIONS_LINK,
+    component: DataMethodDefinitionsLink,
+    subLinks: [],
+  },
+  {
     label: 'Metrics',
     path: METRICS_LINK,
     component: MetricsLink,
@@ -333,25 +358,7 @@ export const routeConfigs = [
       },
     ],
   },
-  {
-    label: 'Categories and Limitations',
-    path: TOPICS_LINK,
-    component: TopicsLink,
-    subLinks: [
-      {
-        label: 'Categories',
-        path: '#categories',
-      },
-      {
-        label: 'Limitations',
-        path: '#limitations',
-      },
-      {
-        label: 'Missing Data',
-        path: '#missing-data',
-      },
-    ],
-  },
+
   {
     label: 'Races and Ethnicities',
     path: RACES_AND_ETHNICITIES_LINK,
@@ -412,12 +419,6 @@ export const routeConfigs = [
         path: '#white',
       },
     ],
-  },
-  {
-    label: 'Data Methods',
-    path: DATA_METHOD_DEFINITIONS_LINK,
-    component: DataMethodDefinitionsLink,
-    subLinks: [],
   },
   {
     label: 'Recommended Citation',

--- a/frontend/src/pages/Methodology/methodologyContent/routeConfigs.jsx
+++ b/frontend/src/pages/Methodology/methodologyContent/routeConfigs.jsx
@@ -52,13 +52,10 @@ export const routeConfigs = [
         label: 'Example: HIV Deaths',
         path: '#age-adjustment-examples',
       },
-      {
-        label: 'Data Sources',
-        path: '#age-adjustment-data-sources',
-      },
+      { label: 'Explore Examples', path: '#age-adjustment-explore' },
+
       { label: 'Key Terms', path: '#age-adjustment-key-terms' },
       { label: 'Resources', path: '#age-adjustment-resources' },
-      { label: 'Explore Examples', path: '#age-adjustment-explore' },
     ],
   },
   {
@@ -225,8 +222,7 @@ export const routeConfigs = [
       },
       { label: 'PrEP Coverage', path: '#prep-coverage' },
       {
-        label:
-          'Addressing Missing and Suppressed PrEP Coverage and Prescriptions Data',
+        label: 'Missing PrEP Data',
         path: '#prep-missing-and-suppressed-data',
       },
       { label: 'Linkage to Care', path: '#linkage-to-care' },
@@ -315,7 +311,6 @@ export const routeConfigs = [
     path: METRICS_LINK,
     component: MetricsLink,
     subLinks: [
-      { label: 'Metrics', path: '#metrics' },
       { label: 'Age-adjusted ratios', path: '#age-adjusted-ratios-metrics' },
       { label: 'Total cases per 100k people', path: '#per-100k-metrics' },
       {

--- a/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
@@ -107,7 +107,10 @@ const AgeAdjustmentLink = () => {
             </a>
             .
           </p>
-          <h4 className='mt-20 font-sansText text-text font-medium'>
+          <h4
+            id='#data-sourcing'
+            className='mt-20 font-sansText text-text font-medium'
+          >
             Data Sourcing
           </h4>
           <p>
@@ -160,7 +163,10 @@ const AgeAdjustmentLink = () => {
               </ul>
             </li>
           </ol>
-          <h4 className='mt-20 font-sansText text-text font-medium'>
+          <h4
+            id='#algorithm'
+            className='mt-20 font-sansText text-text font-medium'
+          >
             Algorithm
           </h4>
           <p>
@@ -247,7 +253,10 @@ const AgeAdjustmentLink = () => {
             </li>
           </ol>
 
-          <h3 className='text-left font-serif text-smallestHeader font-light text-altBlack'>
+          <h3
+            id='#age-adjustment-examples'
+            className='text-left font-serif text-smallestHeader font-light text-altBlack'
+          >
             Age-Adjustment Example: HIV Deaths
           </h3>
           <p>

--- a/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
@@ -14,7 +14,7 @@ import LifelineAlert from '../../../reports/ui/LifelineAlert'
 import HetNotice from '../../../styles/HetComponents/HetNotice'
 import HetTerm from '../../../styles/HetComponents/HetTerm'
 
-const BehavioralHealthLink: React.FC = () => {
+export default function BehavioralHealthLink() {
   return (
     <section id='#behavioral-health'>
       <article>
@@ -176,14 +176,15 @@ const BehavioralHealthLink: React.FC = () => {
           definitionsArray={behavioralHealthDefinitionsArray}
         />
 
-        <LifelineAlert />
         <Resources
           id='#behavioral-health-resources'
           resourceGroups={[MENTAL_HEALTH_RESOURCES]}
         />
+
+        <div className='pt-5'>
+          <LifelineAlert />
+        </div>
       </article>
     </section>
   )
 }
-
-export default BehavioralHealthLink

--- a/frontend/src/pages/Methodology/methodologySections/RacesAndEthnicitiesLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/RacesAndEthnicitiesLink.tsx
@@ -174,7 +174,7 @@ const raceDefinitions: DataItem[] = [
       {
         key: 'NH',
         path: '#nh',
-        description: `Not Hispanic/Latino. To promote inclusion, we replace the source data labels 'Multiracial' with 'Two or more races,' and 'Some other' with 'Unrepresented'.`,
+        description: `Not Hispanic/Latino. To promote inclusion, we replace the source data labels ‘Multiracial’ with ‘Two or more races’, and ‘Some other’ with ‘Unrepresented’.`,
       },
       {
         key: 'Unrepresented race (NH)',

--- a/frontend/src/pages/Methodology/methodologySections/RecommendedCitationLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/RecommendedCitationLink.tsx
@@ -4,16 +4,16 @@ import { Helmet } from 'react-helmet-async'
 
 export default function RecommendedCitationLink() {
   return (
-    <section id='#recommended-citation'>
-      <article>
-        <Helmet>
-          <title>Recommended Citation - Health Equity Tracker</title>
-        </Helmet>
+    <>
+      <Helmet>
+        <title>Recommended Citation - Health Equity Tracker</title>
+      </Helmet>
+      <article id='#recommended-citation'>
         <h2 className='sr-only'>Recommended Citation</h2>
         <h3 className='font-sansTitle text-title'>
           APA (American Psychological Association) Format
         </h3>
-        <div className='w-full text-left font-sansText text-small text-altBlack'>
+        <div className='text-left font-sansText text-small text-altBlack'>
           <Card elevation={3}>
             <p className='mx-0 my-4 pl-12 pr-4 first-of-type:-indent-8'>
               {CITATION_APA}
@@ -21,6 +21,6 @@ export default function RecommendedCitationLink() {
           </Card>
         </div>
       </article>
-    </section>
+    </>
   )
 }

--- a/frontend/src/pages/Methodology/methodologySections/TopicsLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/TopicsLink.tsx
@@ -3,7 +3,7 @@ import StripedTable from '../methodologyComponents/StripedTable'
 import ConditionVariable from '../methodologyContent/ConditionVariable'
 import { missingDataArray } from '../methodologyContent/SourcesDefinitions'
 
-const TopicsLink: React.FC = () => {
+export default function TopicsLink() {
   return (
     <section id='#categories'>
       <article>
@@ -104,5 +104,3 @@ const TopicsLink: React.FC = () => {
     </section>
   )
 }
-
-export default TopicsLink

--- a/frontend/src/pages/News/NewsPage.tsx
+++ b/frontend/src/pages/News/NewsPage.tsx
@@ -81,7 +81,7 @@ export default function NewsPage(props: NewsPageProps) {
 
   return (
     <section>
-      <div className='m-auto max-w-newsPage'>
+      <div className='m-auto max-w-lgXl'>
         <div className='flex-col'>
           <Route path='/'>
             <Tabs

--- a/frontend/src/pages/TermsOfUsePage/TermsOfUsePage.tsx
+++ b/frontend/src/pages/TermsOfUsePage/TermsOfUsePage.tsx
@@ -15,7 +15,7 @@ function TermsOfUsePage() {
             Terms of Use
           </h2>
         </div>
-        <ul className='w-full max-w-xl list-none text-left md:w-3/4'>
+        <ul className='w-full max-w-lg list-none text-left md:w-3/4'>
           <li className='pb-5'>
             <h3 className='font-sansTitle text-title font-medium'>
               Privacy Policy

--- a/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/EquityTab.tsx
@@ -50,7 +50,7 @@ function EquityTab() {
         <Helmet>
           <title>What is Health Equity? - Health Equity Tracker</title>
         </Helmet>
-        <div className='m-auto flex w-full max-w-newsPage flex-wrap'>
+        <div className='m-auto flex w-full max-w-lgXl flex-wrap'>
           <div className='flex w-full items-center justify-center border-0 border-b border-solid border-borderColor'>
             <figure className='mx-auto mt-0 hidden p-2 text-left md:block md:w-1/3'>
               <LazyLoad

--- a/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/FaqTab.tsx
@@ -11,7 +11,7 @@ function FaqTab() {
         <title>FAQ - What Is Health Equity - Health Equity Tracker</title>
       </Helmet>
       <h2 className='sr-only'>Frequently Asked Questions</h2>
-      <div className='m-auto flex w-full max-w-newsPage flex-wrap'>
+      <div className='m-auto flex w-full max-w-lgXl flex-wrap'>
         <div className='border-0 border-b border-solid border-altGrey px-5 py-12 md:flex'>
           <div className='w-full md:w-1/4'>
             <h2

--- a/frontend/src/styles/DesignTokens.ts
+++ b/frontend/src/styles/DesignTokens.ts
@@ -5,6 +5,7 @@ const ThemeStandardScreenSizes = {
   smMd: '768px',
   md: '960px',
   lg: '1280px',
+  lgXl: '1440px',
   xl: '1920px',
 }
 

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -70,7 +70,6 @@ export default {
         articleLogo: '700px',
         teamHeadshot: '181px',
         teamLogo: '250px',
-        newsPage: '1440px',
         exploreDataPage: '1500px',
         exploreDataTwoColumnPage: '2500px',
         newsText: '800px',


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- make most non-explore data pages `max-w-lg`
- better naming for other widths
- use roboto for meth menu with skinny letters
- wider breakpoint for "on this page" responsiveness
- fix colors on striped table
- fix routeConfigs wording and linking


## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
