### PR TITLE
Makes new meth components

### DIFF
--- a/frontend/src/pages/Methodology/methodologyComponents/CategoryTopicLinks.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/CategoryTopicLinks.tsx
@@ -1,0 +1,25 @@
+import { type DropdownVarId } from '../../../data/config/MetricConfig'
+import { DROPDOWN_TOPIC_MAP } from '../../../utils/MadLibs'
+
+interface CategoryTopicLinksProps {
+  dropdownIds: DropdownVarId[]
+}
+
+export default function CategoryTopicLinks(props: CategoryTopicLinksProps) {
+  return (
+    <ul className='list-none pb-8'>
+      {props.dropdownIds.map((dropdownId) => {
+        return (
+          <li key={dropdownId} className='font-sansTitle font-medium'>
+            <a
+              className='no-underline'
+              href={`/exploredata?mls=1.${dropdownId}-3.00&group1=All`}
+            >
+              {DROPDOWN_TOPIC_MAP[dropdownId]}
+            </a>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}

--- a/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
@@ -1,0 +1,72 @@
+import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Paper,
+} from '@mui/material'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import React, { useState } from 'react'
+import { useIsBreakpointAndUp } from '../../../utils/hooks/useIsBreakpointAndUp'
+import { type DataTypeConfig } from '../../../data/config/MetricConfig'
+import InfoCitations from '../../../reports/ui/InfoCitations'
+import HetTerm from '../../../styles/HetComponents/HetTerm'
+
+interface KeyTermsProps {
+  datatypeConfigs: DataTypeConfig[]
+  hashId?: string
+}
+
+export default function KeyTerms(props: KeyTermsProps) {
+  const isMd = useIsBreakpointAndUp('md')
+
+  const [expanded, setExpanded] = useState(isMd)
+
+  const handleAccordionToggle = (
+    event: React.SyntheticEvent,
+    newExpanded: boolean
+  ) => {
+    setExpanded(newExpanded)
+  }
+
+  return (
+    <div id={props.hashId} className='mt-8 w-full'>
+      <Paper>
+        <Accordion expanded={expanded} onChange={handleAccordionToggle}>
+          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+            <h3 className='m-0 p-0'>Key Terms</h3>
+          </AccordionSummary>
+
+          <AccordionDetails>
+            {props.datatypeConfigs.map((config) => {
+              return (
+                <div className='m-2 mb-8' key={config.dataTypeId}>
+                  <HetTerm>{config.fullDisplayName}</HetTerm>
+                  <p className='mb-1 text-small font-medium'>
+                    Measurement Definition
+                  </p>
+                  <p className='m-0 self-start pt-1 text-small text-altBlack'>
+                    {config.definition?.text}
+                  </p>
+                  <InfoCitations citations={config.definition?.citations} />
+                  {config?.description && (
+                    <>
+                      <p className='mb-1 text-small font-medium'>
+                        Clinical Importance
+                      </p>
+                      <p className='m-0 self-start pt-1 text-small text-altBlack'>
+                        {config.description.text}
+                      </p>
+                      <InfoCitations
+                        citations={config.description?.citations}
+                      />
+                    </>
+                  )}
+                </div>
+              )
+            })}
+          </AccordionDetails>
+        </Accordion>
+      </Paper>
+    </div>
+  )
+}


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- makes new <KeyTermsAccordion> component that is basically the same as <KeyTerms> but it accepts an array of config objects to render out the needed topic definition / descriptions
- makes new <CategoryTopicLinks> component that accepts an array of DropdownVarIds (which are already created for the MadLib), and renders out the dynamic list of linked HET reports for the current page's category topics

## Has this been tested? How?

tests passing

## Screenshots (if appropriate)


<img width="481" alt="Screenshot 2024-01-25 at 10 02 08 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/91c9429f-f621-4244-b905-877e646d8d43">
<img width="481" alt="Screenshot 2024-01-25 at 10 02 12 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/57337472-8ef5-4b6d-9fc7-fae9f78d9042">
<img width="481" alt="Screenshot 2024-01-25 at 10 02 56 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/b117b04b-11f7-49e5-8fe9-2ccd81757ec8">



## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
