### PR TITLE
Updates external links

### DIFF
--- a/frontend/playwright-tests/externalUrls.spec.ts
+++ b/frontend/playwright-tests/externalUrls.spec.ts
@@ -16,7 +16,11 @@ const knownFlakyUrls = [
     "https://www.apha.org/topics-and-issues/communicable-disease/coronavirus/equity",
     "https://www.policylink.org/health-equity-resources",
     "https://www.uihi.org/resources/best-practices-for-american-indian-and-alaska-native-data-collection/",
-    "https://www.atsdr.cdc.gov/placeandhealth/svi/documentation/pdf/SVI2018Documentation_01192022_1.pdf"
+    "https://www.atsdr.cdc.gov/placeandhealth/svi/documentation/pdf/SVI2018Documentation_01192022_1.pdf",
+    "https://www.naccho.org/programs/public-health-infrastructure/health-equity",
+    "https://www.naccho.org/programs/public-health-infrastructure/performance-improvement/community-health-assessment/mapp",
+    "https://pubmed.ncbi.nlm.nih.gov/21563622/"
+
 
 ]
 
@@ -26,7 +30,7 @@ test.describe.configure({ mode: 'parallel' });
 test(`Fetch First 100 Blog Posts`, async ({ page }) => {
     const url = "https://hetblog.dreamhosters.com/wp-json/wp/v2/posts?_embed&per_page=100"
     const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-    if (response?.status() !== 200) console.log(url, response?.status());
+    if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
 });
 
 
@@ -34,7 +38,7 @@ for (const url of Object.values(urlMap)) {
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`${url}`, async ({ page }) => {
         const response = await page.goto(url, { waitUntil: "domcontentloaded" });
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -42,7 +46,7 @@ for (const url of RESOURCES.resources.filter(resource => resource.url).map(fello
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`Resource Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -50,7 +54,7 @@ for (const url of PDOH_RESOURCES.resources.filter(resource => resource.url).map(
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`PDOH_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -58,7 +62,7 @@ for (const url of EQUITY_INDEX_RESOURCES.resources.filter(resource => resource.u
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`EQUITY_INDEX_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -66,7 +70,7 @@ for (const url of ECONOMIC_EQUITY_RESOURCES.resources.filter(resource => resourc
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`ECONOMIC_EQUITY_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -74,7 +78,7 @@ for (const url of AIAN_RESOURCES.resources.filter(resource => resource.url).map(
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`AIAN_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -82,7 +86,7 @@ for (const url of API_RESOURCES.resources.filter(resource => resource.url).map(f
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`API_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -90,7 +94,7 @@ for (const url of HISP_RESOURCES.resources.filter(resource => resource.url).map(
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`HISP_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 
@@ -98,19 +102,19 @@ for (const url of MENTAL_HEALTH_RESOURCES.resources.filter(resource => resource.
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`MENTAL_HEALTH_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }
 for (const url of COVID_RESOURCES.resources.filter(resource => resource.url).map(fellow => fellow.url)) {
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`COVID_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 } for (const url of COVID_VACCINATION_RESOURCES.resources.filter(resource => resource.url).map(fellow => fellow.url)) {
     if (!url || knownFlakyUrls.includes(url)) continue
     test(`COVID_VACCINATION_RESOURCES Page: ${url}`, async ({ page }) => {
         const response = await page.goto(url);
-        if (response?.status() !== 200) console.log(url, response?.status());
+        if (response?.status() !== 200) console.log("\n🙀", url, response?.status(), "\n");
     });
 }

--- a/frontend/src/pages/Methodology/methodologyContent/ResourcesData.ts
+++ b/frontend/src/pages/Methodology/methodologyContent/ResourcesData.ts
@@ -274,16 +274,8 @@ export const COVID_VACCINATION_RESOURCES: ResourceGroup = {
       url: 'https://www.tfah.org/report-details/trust-and-access-to-covid-19-vaccine-within-communities-of-color/',
     },
     {
-      name: 'CDC - Johnson & Johnson’s Janssen COVID-19 Vaccine Overview and Safety',
-      url: 'https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/janssen.html',
-    },
-    {
-      name: 'CDC - Pfizer-BioNTech COVID-19 Vaccine Overview and Safety',
-      url: 'https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Pfizer-BioNTech.html',
-    },
-    {
-      name: 'CDC - Moderna COVID-19 Vaccine Overview and Safety',
-      url: 'https://www.cdc.gov/coronavirus/2019-ncov/vaccines/different-vaccines/Moderna.html',
+      name: 'CDC - U.S. COVID-19 Vaccine Product Information',
+      url: 'https://www.cdc.gov/vaccines/covid-19/info-by-product/',
     },
     {
       name: 'APM Research: Death & Vaccination Statistics',

--- a/frontend/src/utils/externalUrls.ts
+++ b/frontend/src/utils/externalUrls.ts
@@ -29,7 +29,6 @@ export type LinkName =
   | 'doi2'
   | 'doi3'
   | 'cawp'
-  | 'propublica'
   | 'repJohnLewisTweet'
   | 'deniedVoting'
   | 'aafp'
@@ -90,7 +89,7 @@ export const urlMap: Record<LinkName, string> = {
   kffCovid: 'https://www.kff.org/state-category/covid-19/',
   cdcVaxCounty:
     'https://data.cdc.gov/Vaccinations/COVID-19-Vaccinations-in-the-United-States-County/8xkx-amqh',
-  amr: 'https://www.americashealthrankings.org/explore/annual/measure/Overall_a/state/ALL',
+  amr: 'https://www.americashealthrankings.org/explore/measures',
   amrMethodology:
     'https://www.americashealthrankings.org/about/methodology/data-sources-and-measures',
   cdcCovidRestricted:
@@ -100,8 +99,6 @@ export const urlMap: Record<LinkName, string> = {
   doi2: 'https://doi.org/10.1111/j.1540-5907.2011.00512.x',
   doi3: 'https://doi.org/10.1146/annurev.polisci.11.053106.123839',
   cawp: 'https://cawpdata.rutgers.edu/',
-  propublica:
-    'https://www.propublica.org/datastore/api/propublica-congress-api',
   senateMENA:
     'https://www.hsgac.senate.gov/media/majority-media/peters-urges-omb-to-include-middle-east-north-africa-category-in-federal-standards-for-gathering-data-on-race-and-ethnicity',
   unitedStatesIo: 'https://theunitedstates.io/',


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

our external links checker run on a weekly chron job failed. this PR
- removes some no longer used links
- moves known flakies into the list
- better logging for non-200 responses. it wont fail the test run, but will log out issues

## Has this been tested? How?

passes locally with `npm run url`


## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
