### PR TITLE
Fixes broken e2es

### DIFF
--- a/frontend/playwright-tests/ami.nightly.spec.ts
+++ b/frontend/playwright-tests/ami.nightly.spec.ts
@@ -20,10 +20,6 @@ test('PHRMA: Medicare AMI', async ({ page }) => {
   await page.getByRole('heading', { name: 'Definitions:' }).click();
   await page.getByText('Medication Utilization in the').click();
   await page.getByText('Acute Myocardial Infarctions (Heart Attacks)', { exact: true }).click();
-  await page.locator('li').filter({ hasText: 'Acute Myocardial Infarctions' }).locator('b').first().click();
-  await page.getByText('Measurement Definition: The').click();
-  await page.locator('li').filter({ hasText: 'Acute Myocardial Infarctions' }).locator('b').nth(1).click();
-  await page.getByText('Clinical Importance: Heart').click();
   await page.getByRole('heading', { name: 'Medicare Administration Data' }).click();
   await page.getByText('What demographic data are').click();
   await page.getByText('Gender:').click();

--- a/frontend/playwright-tests/chronic_kidney_disease.nightly.spec.ts
+++ b/frontend/playwright-tests/chronic_kidney_disease.nightly.spec.ts
@@ -9,14 +9,9 @@ test('Chronic Kidney Disease', async ({ page }) => {
     .getByRole('heading', { name: 'Chronic kidney disease in the' })
     .click()
   await page.getByLabel('open the topic info modal').click()
-  await page
-    .locator('div')
-    .filter({
-      hasText:
-        'Cases of chronic kidney diseaseMeasurement Definition: Adults who reported',
-    })
-    .nth(1)
-    .click()
+  await page.getByRole('heading', { name: 'Cases of chronic kidney' }).click();
+  await page.getByRole('dialog').getByText('Measurement Definition:').click();
+  await page.getByText('For specific calculations and').click();
   await page.getByLabel('close topic info modal').click()
   await page.getByText('Demographic').nth(2).click()
   await page.getByText('Off').nth(1).click()

--- a/frontend/playwright-tests/copd.nightly.spec.ts
+++ b/frontend/playwright-tests/copd.nightly.spec.ts
@@ -25,6 +25,13 @@ test('COPD Flow', async ({ page }) => {
     .getByRole('heading', { name: 'Breakdown summary for COPD in' })
     .click()
   await page.getByText('Share this report:').click()
-  await page.locator('#definitionsList').getByText('COPD').click()
+
+  await page.getByRole('button', { name: 'Definitions & missing data' }).click();
+  await page.getByRole('heading', { name: 'Definitions:' }).click();
+  await page.getByText('Chronic Disease').click();
+  await page.locator('#definitionsList').getByText('COPD', { exact: true }).click();
+  await page.getByText('Measurement Definition: Adults who reported being told by a health professional').click();
+  await page.getByText('Clinical Importance: COPD is').click();
+
   await page.getByText('Do you have information that').click()
 })

--- a/frontend/playwright-tests/hiv_black_women.nightly.spec.ts
+++ b/frontend/playwright-tests/hiv_black_women.nightly.spec.ts
@@ -89,6 +89,8 @@ test('HIV Black Women: Deaths', async ({ page }) => {
   await page.getByLabel('Scroll to Top').click();
   await page.getByLabel('open the topic info modal').click();
   await page.getByRole('heading', { name: 'HIV deaths for Black women' }).click();
-  await page.getByText('HIV deaths for Black womenMeasurement Definition: Black or African-American (NH').click();
+  await page.getByRole('dialog').getByText('Measurement Definition:').click();
+  await page.getByRole('paragraph').getByText('Clinical Importance:').click();
+
   await page.getByLabel('close topic info modal').click();
 });

--- a/frontend/playwright-tests/hiv_stigma.nightly.spec.ts
+++ b/frontend/playwright-tests/hiv_stigma.nightly.spec.ts
@@ -26,7 +26,12 @@ test('HIV Stigma', async ({ page }) => {
     .click()
   await page.getByRole('heading', { name: 'Breakdown summary for HIV' }).click()
   await page.getByText('Share this report:').click()
-  await page.locator('#definitionsList').getByText('HIV stigma').click()
+  await page.getByRole('button', { name: 'Definitions & missing data' }).click();
+  await page.getByRole('heading', { name: 'Definitions:' }).click();
+  await page.getByText('HIV', { exact: true }).click();
+  await page.locator('#definitionsList').getByText('HIV stigma', { exact: true }).click();
+  await page.getByText('Measurement Definition: Self-').click();
+  await page.getByText('Clinical Importance: HIV').click();
   await page.getByRole('heading', { name: 'What data are missing?' }).click()
   await page.getByText('Do you have information that').click()
 })

--- a/frontend/playwright-tests/preventable_hospitalizations.nightly.spec.ts
+++ b/frontend/playwright-tests/preventable_hospitalizations.nightly.spec.ts
@@ -57,22 +57,22 @@ test('Preventable Hospitalizations', async ({ page }) => {
       name: 'Breakdown summary for preventable hospitalizations in the United States',
     })
     .click()
-  await page.getByRole('heading', { name: 'Definitions:' }).click()
-  await page.getByText('Social Determinants of Health').click()
-  await page
-    .locator('#definitionsList')
-    .getByText('Preventable hospitalizations')
-    .click()
-  await page.getByRole('heading', { name: 'What data are missing?' }).click()
-  await page
-    .getByText('Unfortunately there are crucial data missing in our sources.')
-    .click()
-  await page
-    .getByRole('heading', { name: 'Missing and misidentified people' })
-    .click()
-  await page
-    .getByRole('heading', { name: "Missing America's Health Rankings data" })
-    .click()
+  await page.getByRole('button', { name: 'Definitions & missing data' }).click();
+
+  await page.getByRole('heading', { name: 'Definitions:' }).click();
+  await page.getByRole('heading', { name: 'Social Determinants of' }).click();
+  await page.locator('#definitionsList').getByText('Preventable hospitalizations', { exact: true }).click();
+  await page.getByText('Measurement Definition:').click();
+  await page.getByText('Measurement Definition: Discharges following hospitalization for diabetes with').click();
+  await page.getByText('Clinical Importance:').click();
+  await page.getByText('Clinical Importance: Studying').click();
+  await page.getByRole('heading', { name: 'What data are missing?' }).click();
+  await page.getByText('Unfortunately there are').click();
+  await page.getByRole('heading', { name: 'Missing and misidentified' }).click();
+  await page.getByText('Native Hawaiian and Pacific').click();
+  await page.getByRole('heading', { name: 'Missing America\'s Health' }).click();
+  await page.getByText('Population data:').click();
+  await page.getByText('Population data: AHR does not').click();
   await page
     .getByText(
       'Do you have information that belongs on the Health Equity Tracker? We would love to hear from you!'

--- a/frontend/src/pages/ui/DataTypeDefinitionsList.tsx
+++ b/frontend/src/pages/ui/DataTypeDefinitionsList.tsx
@@ -26,11 +26,11 @@ export default function DataTypeDefinitionsList() {
         return (
           <div key={config.dataTypeId}>
             <h3>{config.fullDisplayName}</h3>
-            <b>Measurement Definition:</b> {config.definition?.text}
+            <span>Measurement Definition:</span> {config.definition?.text}
             <InfoCitations citations={config.definition?.citations} />
             {config?.description && (
               <p>
-                <b>Clinical Importance:</b> {config.description.text}
+                <span>Clinical Importance:</span> {config.description.text}
                 <InfoCitations citations={config.description?.citations} />
               </p>
             )}

--- a/frontend/src/reports/ui/DefinitionsList.tsx
+++ b/frontend/src/reports/ui/DefinitionsList.tsx
@@ -38,9 +38,11 @@ export default function DefinitionsList(
         )
 
         return (
-          <div key={category.title}>
+          <aside key={category.title} className='px-5 pb-10'>
             {/* display category name and optional category definition */}
-            <b>{category.title}</b>
+            <h4 className='m-0 pb-5  text-title font-semibold'>
+              {category.title}
+            </h4>
             {category.definition && <p>{category.definition}</p>}
 
             <ul>
@@ -51,15 +53,18 @@ export default function DefinitionsList(
                   return dataType[1].map((dataTypeConfig: DataTypeConfig) => {
                     const hasAddedInfo = Boolean(dataTypeConfig?.description)
                     return (
-                      <li key={dataTypeConfig?.fullDisplayName}>
+                      <li
+                        key={dataTypeConfig?.fullDisplayName}
+                        className='pt-1'
+                      >
                         <HetTerm>
                           {dataTypeConfig?.fullDisplayName ?? 'Data Type'}
                         </HetTerm>
-                        <ul>
+                        <ul className='list-outside list-disc pl-5'>
                           <li>
                             {hasAddedInfo && (
                               <>
-                                <b>Measurement Definition:</b>{' '}
+                                <span>Measurement Definition:</span>{' '}
                               </>
                             )}
 
@@ -70,7 +75,7 @@ export default function DefinitionsList(
                           </li>
                           {hasAddedInfo && (
                             <li>
-                              <b>Clinical Importance:</b>{' '}
+                              <span>Clinical Importance:</span>{' '}
                               {dataTypeConfig.description?.text}
                               <InfoCitations
                                 citations={
@@ -86,7 +91,7 @@ export default function DefinitionsList(
                 })
               }
             </ul>
-          </div>
+          </aside>
         )
       })}
     </div>


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

E2E tests were failing on PR merge, not sure why they aren't being caught on the e2e against the netlify deploy on PR update

- updates the e2e tests for less flaky behavior, like using the side menu to navigate playwright closer to the target area, using more specific locators, etc.
- updates some html elements and improves regression bug in layout of definitions at the bottom of the report

## Has this been tested? How?

- [x] e2es pass when run locally: `npm run e2e` 
- [x] e2es pass on CI against deploy preview
 


## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
