### PR TITLE
Update GitHub Actions to Node 20 version

### DIFF
--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -188,15 +188,15 @@ jobs:
           -var 'exporter_image_digest=${{ needs.build-exporter.outputs.image-digest }}' \
           -var 'frontend_image_digest=${{ needs.build-frontend.outputs.image-digest }}'
           data_server_url=$(terraform output data_server_url)
-          echo "data_server_url=$data_server_url" >> $GITHUB_OUTPUT
+          echo "data_server_url=$data_server_url" >> "$GITHUB_OUTPUT"
           ingestion_url=$(terraform output ingestion_url)
-          echo "ingestion_url=$ingestion_url" >> $GITHUB_OUTPUT
+          echo "ingestion_url=$ingestion_url" >> "$GITHUB_OUTPUT"
           gcs_to_bq_url=$(terraform output gcs_to_bq_url)
-          echo "gcs_to_bq_url=$gcs_to_bq_url" >> $GITHUB_OUTPUT
+          echo "gcs_to_bq_url=$gcs_to_bq_url" >> "$GITHUB_OUTPUT"
           exporter_url=$(terraform output exporter_url)
-          echo "exporter_url=$exporter_url" >> $GITHUB_OUTPUT
+          echo "exporter_url=$exporter_url" >> "$GITHUB_OUTPUT"
           frontend_url=$(terraform output frontend_url)
-          echo "frontend_url=$frontend_url" >> $GITHUB_OUTPUT
+          echo "frontend_url=$frontend_url" >> "$GITHUB_OUTPUT"
       - name: Airflow Environment Variables
         id: airflow-environment-variables
         continue-on-error: true

--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -18,15 +18,15 @@ jobs:
       image-digest: ${{ steps.ingestion.outputs.image-digest }}
     steps:
       - name: Check Out Code from infra-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: infra-test
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: ingestion
@@ -43,15 +43,15 @@ jobs:
       image-digest: ${{ steps.gcstobq.outputs.image-digest }}
     steps:
       - name: Check Out Code from infra-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: infra-test
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: gcstobq
@@ -68,15 +68,15 @@ jobs:
       image-digest: ${{ steps.exporter.outputs.image-digest }}
     steps:
       - name: Check Out Code from infra-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: infra-test
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: exporter
@@ -93,15 +93,15 @@ jobs:
       image-digest: ${{ steps.serving.outputs.image-digest }}
     steps:
       - name: Check Out Code from infra-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: infra-test
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: serving
@@ -118,16 +118,16 @@ jobs:
       image-digest: ${{ steps.frontend.outputs.image-digest }}
     steps:
       - name: Check Out Code from main
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # don't update dev.healthequitytracker.org frontend with push to infra-test branch
           ref: main
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: frontend
@@ -147,19 +147,19 @@ jobs:
 
     steps:
       - name: Check Out Code from infra-test
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: infra-test
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         # Disable wrapper to enable access to terraform output.
         with:
           terraform_wrapper: false
@@ -213,6 +213,6 @@ jobs:
         run: |
           ./upload-dags.sh
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8

--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -172,15 +172,15 @@ jobs:
           -var 'exporter_image_digest=${{ needs.build-exporter.outputs.image-digest }}' \
           -var 'frontend_image_digest=${{ needs.build-frontend.outputs.image-digest }}'
           data_server_url=$(terraform output data_server_url)
-          echo "data_server_url=$data_server_url" >> $GITHUB_OUTPUT
+          echo "data_server_url=$data_server_url" >> "$GITHUB_OUTPUT"
           ingestion_url=$(terraform output ingestion_url)
-          echo "ingestion_url=$ingestion_url" >> $GITHUB_OUTPUT
+          echo "ingestion_url=$ingestion_url" >> "$GITHUB_OUTPUT"
           gcs_to_bq_url=$(terraform output gcs_to_bq_url)
-          echo "gcs_to_bq_url=$gcs_to_bq_url" >> $GITHUB_OUTPUT
+          echo "gcs_to_bq_url=$gcs_to_bq_url" >> "$GITHUB_OUTPUT"
           exporter_url=$(terraform output exporter_url)
-          echo "exporter_url=$exporter_url" >> $GITHUB_OUTPUT
+          echo "exporter_url=$exporter_url" >> "$GITHUB_OUTPUT"
           frontend_url=$(terraform output frontend_url)
-          echo "frontend_url=$frontend_url" >> $GITHUB_OUTPUT
+          echo "frontend_url=$frontend_url" >> "$GITHUB_OUTPUT"
       - name: Airflow Environment Variables
         id: airflow-environment-variables
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -14,13 +14,13 @@ jobs:
       image-digest: ${{ steps.ingestion.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: ingestion
@@ -37,13 +37,13 @@ jobs:
       image-digest: ${{ steps.gcstobq.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: gcstobq
@@ -60,13 +60,13 @@ jobs:
       image-digest: ${{ steps.exporter.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: exporter
@@ -83,13 +83,13 @@ jobs:
       image-digest: ${{ steps.serving.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: serving
@@ -106,13 +106,13 @@ jobs:
       image-digest: ${{ steps.frontend.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: frontend
@@ -132,17 +132,17 @@ jobs:
 
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         # Disable wrapper to enable access to terraform output.
         with:
           terraform_wrapper: false
@@ -199,7 +199,7 @@ jobs:
         run: |
           ./upload-dags.sh
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Run Python E2E Tests

--- a/.github/workflows/destroyTest.yml
+++ b/.github/workflows/destroyTest.yml
@@ -12,13 +12,13 @@ jobs:
       image-digest: ${{ steps.ingestion.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: ingestion
@@ -35,13 +35,13 @@ jobs:
       image-digest: ${{ steps.gcstobq.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: gcstobq
@@ -58,13 +58,13 @@ jobs:
       image-digest: ${{ steps.exporter.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: exporter
@@ -81,13 +81,13 @@ jobs:
       image-digest: ${{ steps.serving.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: serving
@@ -104,13 +104,13 @@ jobs:
       image-digest: ${{ steps.frontend.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - id: frontend
@@ -130,17 +130,17 @@ jobs:
 
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         # Disable wrapper to enable access to terraform output.
         with:
           terraform_wrapper: false
@@ -168,4 +168,3 @@ jobs:
           -var 'data_server_image_digest=${{ needs.build-data-server.outputs.image-digest }}' \
           -var 'exporter_image_digest=${{ needs.build-exporter.outputs.image-digest }}' \
           -var 'frontend_image_digest=${{ needs.build-frontend.outputs.image-digest }}'
-

--- a/.github/workflows/e2eScheduled.yml
+++ b/.github/workflows/e2eScheduled.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json

--- a/.github/workflows/e2eStaging.yml
+++ b/.github/workflows/e2eStaging.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json
@@ -32,7 +32,7 @@ jobs:
       - name: Runs playwright E2E_STAGING
         run: npm run e2e-staging
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -23,7 +23,7 @@ jobs:
     name: Builds frontend
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json
@@ -40,7 +40,7 @@ jobs:
     name: Runs frontend unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json
@@ -73,7 +73,7 @@ jobs:
     if: github.event_name == 'pull_request'
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json
@@ -89,7 +89,7 @@ jobs:
         env:
           E2E_BASE_URL: 'https://deploy-preview-${{env.GITHUB_PR_NUMBER}}--${{env.NETLIFY_SITE_NAME}}.netlify.app'
       # store test run reports if they fail
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ failure() }}
         with:
           name: playwright-report

--- a/.github/workflows/runMyPy.yml
+++ b/.github/workflows/runMyPy.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set Up Python 3.8
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
           cache: 'pip'

--- a/.github/workflows/runPytest.yml
+++ b/.github/workflows/runPytest.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
 

--- a/.github/workflows/runSuperLinter.yml
+++ b/.github/workflows/runSuperLinter.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
         # Lint changed files of these langauges using Super Linter shared action
       - name: Lint Code Base
-        uses: super-linter/super-linter@v6.0.0
+        uses: super-linter/super-linter/slim@v6.0.0
         env:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/runSuperLinter.yml
+++ b/.github/workflows/runSuperLinter.yml
@@ -13,13 +13,13 @@ jobs:
       statuses: write
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files
           fetch-depth: 0
         # Lint changed files of these langauges using Super Linter shared action
       - name: Lint Code Base
-        uses: github/super-linter/slim@v5
+        uses: super-linter/super-linter@v6.0.0
         env:
           DEFAULT_BRANCH: main
           VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/urlsScheduled.yml
+++ b/.github/workflows/urlsScheduled.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: frontend/package.json


### PR DESCRIPTION
# Description and Motivation

This PR updates the following actions to the latest major version:

- actions/checkout (v3 -> v4)
- google-github-actions/auth (v1 -> v2)
- google-github-actions/setup-gcloud (v1 -> v2)
- hashicorp/setup-terraform (v2 -> v3)
- actions/setup-python (v4 -> v5)
- actions/upload-artifact (v3 -> v4)
- super-linter/super-linter (v5 -> v6)

Closes https://github.com/SatcherInstitute/health-equity-tracker/issues/2877.

## Has this been tested? How?

CI runs in my fork.

## Screenshots (if appropriate)

## Types of changes

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
