### PR TITLE
Updates codebase to Python 3.9

### DIFF
--- a/.github/linters/mypy.ini
+++ b/.github/linters/mypy.ini
@@ -1,6 +1,6 @@
 # Global options
 [mypy]
-python_version = 3.8
+python_version = 3.9
 
 # Per-module options. These 3rd-party libraries don't export type hints, so suppress errors from them.
 [mypy-airflow.*]

--- a/.github/workflows/deployBackendToInfraTest.yml
+++ b/.github/workflows/deployBackendToInfraTest.yml
@@ -3,7 +3,6 @@ name: Deploy Backend to Infra Test
 # TODO: Currently this deploys ALL of the microservices including the frontend and data server
 # TODO: ideally we should reduce this to the minimum services needed for backend
 
-
 on:
   push:
     branches: [infra-test]
@@ -143,7 +142,14 @@ jobs:
     if: github.repository == 'SatcherInstitute/health-equity-tracker'
     name: (infra-test) Terraform / Airflow Configs
     runs-on: ubuntu-latest
-    needs: [build-ingestion, build-gcs-to-bq, build-exporter, build-data-server, build-frontend]
+    needs:
+      [
+        build-ingestion,
+        build-gcs-to-bq,
+        build-exporter,
+        build-data-server,
+        build-frontend,
+      ]
 
     steps:
       - name: Check Out Code from infra-test
@@ -215,4 +221,4 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9

--- a/.github/workflows/deployToTest.yml
+++ b/.github/workflows/deployToTest.yml
@@ -128,7 +128,14 @@ jobs:
     if: github.repository == 'SatcherInstitute/health-equity-tracker'
     name: Deploy to Test Environment
     runs-on: ubuntu-latest
-    needs: [build-ingestion, build-gcs-to-bq, build-exporter, build-data-server, build-frontend]
+    needs:
+      [
+        build-ingestion,
+        build-gcs-to-bq,
+        build-exporter,
+        build-data-server,
+        build-frontend,
+      ]
 
     steps:
       - name: Check Out Code
@@ -201,7 +208,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Run Python E2E Tests
         run: |
           pip install -r e2e_tests/requirements.txt

--- a/.github/workflows/runMyPy.yml
+++ b/.github/workflows/runMyPy.yml
@@ -25,10 +25,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Up Python 3.8
+      - name: Set Up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
           cache: 'pip'
 
       - name: Install Dependencies

--- a/.github/workflows/runPytest.yml
+++ b/.github/workflows/runPytest.yml
@@ -23,29 +23,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Set up Python 3.8
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.8
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip setuptools
-        pip install pytest
-        pip install -r requirements/tests.txt
-        pip install python/ingestion python/data_server python/datasources
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          pip install pytest
+          pip install -r requirements/tests.txt
+          pip install python/ingestion python/data_server python/datasources
 
-    - name: Test python packages with pytest
-      working-directory: ./python
-      run: pytest
+      - name: Test python packages with pytest
+        working-directory: ./python
+        run: pytest
 
-    - name: Test data_server service with pytest
-      working-directory: ./data_server
-      run: pytest
+      - name: Test data_server service with pytest
+        working-directory: ./data_server
+        run: pytest
 
-    - name: Test exporter service with pytest
-      working-directory: ./exporter
-      run: pytest
+      - name: Test exporter service with pytest
+        working-directory: ./exporter
+        run: pytest

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -26,6 +26,9 @@
 	"minWordLength": 3,
 	"words": [
 		"aafp",
+		"xlrd",
+		"numpy",
+		"rpc",
 		"aamc",
 		"AAMC",
 		"aapi",

--- a/data_server/Dockerfile
+++ b/data_server/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True

--- a/exporter/Dockerfile
+++ b/exporter/Dockerfile
@@ -1,6 +1,6 @@
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
 # configuration settings for python linters when run locally / pre-commit
 [tool.black]
 skip-string-normalization = true
+[tool.pytest.ini_options]
+filterwarnings = [
+    "ignore:Deprecated call to `pkg_resources\\.declare_namespace\\('.*'\\):DeprecationWarning",
+    "ignore::DeprecationWarning:google.rpc",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+[tool]
+python = "3.9"
 # configuration settings for python linters when run locally / pre-commit
 [tool.black]
 skip-string-normalization = true

--- a/python/datasources/cdc_hiv.py
+++ b/python/datasources/cdc_hiv.py
@@ -561,6 +561,9 @@ def load_atlas_df_from_data_dir(geo_level: str, breakdown: str):
             if determinant == std_col.HIV_STIGMA_INDEX:
                 df = df.drop(columns=["Cases", "population"])
 
+            # TODO: this is causing FutureWarning: not sure how to fix
+            # In a future version, the Index constructor will not infer
+            # numeric dtypes when passed object-dtype sequences (matching Series behavior)
             output_df = output_df.merge(df, how="outer")
 
     return output_df

--- a/python/datasources/cdc_hiv.py
+++ b/python/datasources/cdc_hiv.py
@@ -561,7 +561,7 @@ def load_atlas_df_from_data_dir(geo_level: str, breakdown: str):
             if determinant == std_col.HIV_STIGMA_INDEX:
                 df = df.drop(columns=["Cases", "population"])
 
-            # TODO: this is causing FutureWarning: not sure how to fix
+            # TODO: GitHub #2907 this is causing FutureWarning: not sure how to fix
             # In a future version, the Index constructor will not infer
             # numeric dtypes when passed object-dtype sequences (matching Series behavior)
             output_df = output_df.merge(df, how="outer")

--- a/python/tests/datasources/test_cdc_hiv.py
+++ b/python/tests/datasources/test_cdc_hiv.py
@@ -105,7 +105,13 @@ def test_write_to_bq_race_national(
     )
 
     assert_frame_equal(
-        race_national_current_df, expected_race_national_current_df, check_like=True
+        race_national_current_df.sort_values(by='race_and_ethnicity').reset_index(
+            drop=True
+        ),
+        expected_race_national_current_df.sort_values(
+            by='race_and_ethnicity'
+        ).reset_index(drop=True),
+        check_like=True,
     )
 
     # BY RACE NATIONAL HISTORICAL
@@ -121,8 +127,12 @@ def test_write_to_bq_race_national(
     )
 
     assert_frame_equal(
-        race_national_historical_df,
-        expected_race_national_historical_df,
+        race_national_historical_df.sort_values(
+            by=['time_period', 'race_and_ethnicity']
+        ).reset_index(drop=True),
+        expected_race_national_historical_df.sort_values(
+            by=['time_period', 'race_and_ethnicity']
+        ).reset_index(drop=True),
         check_like=True,
     )
 
@@ -158,7 +168,9 @@ def test_write_to_bq_age_national(
     )
 
     assert_frame_equal(
-        age_national_current_df, expected_age_national_current_df, check_like=True
+        age_national_current_df.sort_values(by=['age']).reset_index(drop=True),
+        expected_age_national_current_df.sort_values(by=['age']).reset_index(drop=True),
+        check_like=True,
     )
 
     (
@@ -172,8 +184,12 @@ def test_write_to_bq_age_national(
     )
 
     assert_frame_equal(
-        age_national_historical_df,
-        expected_age_national_historical_df,
+        age_national_historical_df.sort_values(by=['time_period', 'age']).reset_index(
+            drop=True
+        ),
+        expected_age_national_historical_df.sort_values(
+            by=['time_period', 'age']
+        ).reset_index(drop=True),
         check_like=True,
     )
 
@@ -202,7 +218,13 @@ def test_write_to_bq_sex_state(
     )
 
     assert_frame_equal(
-        sex_state_current_df, expected_sex_state_current_df, check_like=True
+        sex_state_current_df.sort_values(by=['sex', 'state_name']).reset_index(
+            drop=True
+        ),
+        expected_sex_state_current_df.sort_values(by=['sex', 'state_name']).reset_index(
+            drop=True
+        ),
+        check_like=True,
     )
 
     (
@@ -216,7 +238,13 @@ def test_write_to_bq_sex_state(
     )
 
     assert_frame_equal(
-        sex_state_historical_df, expected_sex_state_historical_df, check_like=True
+        sex_state_historical_df.sort_values(
+            by=['time_period', 'sex', 'state_name']
+        ).reset_index(drop=True),
+        expected_sex_state_historical_df.sort_values(
+            by=['time_period', 'sex', 'state_name']
+        ).reset_index(drop=True),
+        check_like=True,
     )
 
 
@@ -265,7 +293,13 @@ def test_write_to_bq_sex_county(
         GOLDEN_DATA["sex_county_historical"], dtype=EXP_DTYPE
     )
     assert_frame_equal(
-        sex_county_historical_df, expected_sex_county_historical_df, check_like=True
+        sex_county_historical_df.sort_values(by=['time_period', 'sex']).reset_index(
+            drop=True
+        ),
+        expected_sex_county_historical_df.sort_values(
+            by=['time_period', 'sex']
+        ).reset_index(drop=True),
+        check_like=True,
     )
 
 
@@ -299,8 +333,10 @@ def test_write_to_bq_black_women_national(
         GOLDEN_DATA["black_women_national_current"], dtype=EXP_DTYPE
     )
     assert_frame_equal(
-        black_women_national_current_df,
-        expected_black_women_national_current_df,
+        black_women_national_current_df.sort_values(by=['age']).reset_index(drop=True),
+        expected_black_women_national_current_df.sort_values(by=['age']).reset_index(
+            drop=True
+        ),
         check_like=True,
     )
 
@@ -314,7 +350,11 @@ def test_write_to_bq_black_women_national(
         GOLDEN_DATA["black_women_national_historical"], dtype=EXP_DTYPE
     )
     assert_frame_equal(
-        black_women_national_historical_df,
-        expected_black_women_national_historical_df,
+        black_women_national_historical_df.sort_values(
+            by=['time_period', 'age']
+        ).reset_index(drop=True),
+        expected_black_women_national_historical_df.sort_values(
+            by=['time_period', 'age']
+        ).reset_index(drop=True),
         check_like=True,
     )

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -84,7 +84,7 @@ markupsafe==1.1.1
     # via jinja2
 mypy-extensions==0.4.3
     # via typing-inspect
-numpy==1.19.2
+numpy==1.23.2
     # via pandas
 packaging==20.4
     # via pytest

--- a/run_gcs_to_bq/Dockerfile
+++ b/run_gcs_to_bq/Dockerfile
@@ -1,7 +1,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True

--- a/run_gcs_to_bq/requirements.txt
+++ b/run_gcs_to_bq/requirements.txt
@@ -29,7 +29,7 @@ jinja2==2.11.2            # via flask
 libcst==0.3.12            # via google-cloud-pubsub
 markupsafe==1.1.1         # via jinja2
 mypy-extensions==0.4.3    # via typing-inspect
-numpy==1.19.2             # via pandas
+numpy==1.23.2             # via pandas
 pandas==1.4.3             # via -r ../python/ingestion/requirements.in
 proto-plus==1.10.0        # via google-cloud-pubsub
 protobuf==3.13.0          # via google-api-core, googleapis-common-protos, proto-plus

--- a/run_ingestion/Dockerfile
+++ b/run_ingestion/Dockerfile
@@ -1,7 +1,7 @@
 
 # Use the official lightweight Python image.
 # https://hub.docker.com/_/python
-FROM python:3.8-slim
+FROM python:3.9-slim
 
 # Allow statements and log messages to immediately appear in the Knative logs
 ENV PYTHONUNBUFFERED True

--- a/run_ingestion/requirements.txt
+++ b/run_ingestion/requirements.txt
@@ -29,7 +29,7 @@ jinja2==2.11.2            # via flask
 libcst==0.3.10            # via google-cloud-bigquery, google-cloud-pubsub
 markupsafe==1.1.1         # via jinja2
 mypy-extensions==0.4.3    # via typing-inspect
-numpy==1.19.2             # via pandas
+numpy==1.23.2             # via pandas
 pandas==1.4.3             # via -r ../python/ingestion/requirements.in
 proto-plus==1.10.0        # via google-cloud-bigquery, google-cloud-pubsub
 protobuf==3.13.0          # via google-api-core, googleapis-common-protos, proto-plus


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

partway to #2905 
a bit of manual #1649 
 
- moves all hard coded python 3.8 → 3.9
- black formatting
- spelling
- adds sub-package warning skip to pyproject.toml
- adds a TODO note for #2907
- sort dfs before compare to ignore row order
- manual update numpy version


## Has this been tested? How?

- [x] all tests pass locally using Python 3.9 and only cause the single FutureWarning which has an issue filed
- [x] the PR builds and tests pass
- [x] pushing to infra-test works to build the various containers for the services
- [x] DAGs work as expected (tested COVID pipeline on dev)


## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
