### PR TITLE
Splits ACS CONDITION into `_historical` and `_current` tables

### DIFF
--- a/python/datasources/acs_population.py
+++ b/python/datasources/acs_population.py
@@ -565,7 +565,6 @@ class ACSPopulationIngester:
         """Alternative format where race categories include Hispanic/Latino.
         Totals are also included because summing over the column will give a
         larger number than the actual total."""
-
         by_hispanic = df.copy()
         group_by_cols = self.base_group_by_cols.copy()
         group_by_cols.append(std_col.HISPANIC_COL)

--- a/python/tests/data/acs_condition/golden_data/race_county.csv
+++ b/python/tests/data/acs_condition/golden_data/race_county.csv
@@ -1,10 +1,10 @@
-state_fips,state_name,race_category_id,county_name,county_fips,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity
-17,Illinois,AIAN,Fayette County,17051,0.0,0.0,0.0,0.3,0.0,0.3,-100.0,-100.0
-17,Illinois,ASIAN,Fayette County,17051,0.0,11.0,0.0,0.6,0.4,0.6,-100.0,-33.3
-17,Illinois,HISP,Fayette County,17051,0.0,0.0,0.0,1.0,0.0,1.0,-100.0,-100.0
-17,Illinois,BLACK,Fayette County,17051,0.0,65.0,0.0,0.4,1.7,0.4,-100.0,325.0
-17,Illinois,NHPI,Fayette County,17051,0.0,0.0,0.0,0.1,0.0,0.1,-100.0,-100.0
-17,Illinois,WHITE,Fayette County,17051,8.0,17.0,100.0,98.1,97.2,98.1,1.9,-0.9
-17,Illinois,OTHER_STANDARD,Fayette County,17051,0.0,0.0,0.0,0.1,0.0,0.1,-100.0,-100.0
-17,Illinois,MULTI,Fayette County,17051,0.0,36.0,0.0,0.4,0.8,0.4,-100.0,100.0
-17,Illinois,ALL,Fayette County,17051,8.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0
+state_fips,state_name,race_category_id,county_name,county_fips,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity,uninsured_estimated_total,uninsured_pop_estimated_total,poverty_estimated_total,poverty_pop_estimated_total
+17,Illinois,AIAN,Fayette County,17051,0.0,0.0,0.0,0.3,0.0,0.3,-100.0,-100.0,0.0,68.0,0.0,68.0
+17,Illinois,ASIAN,Fayette County,17051,0.0,11.0,0.0,0.6,0.4,0.6,-100.0,-33.3,0.0,116.0,13.0,116.0
+17,Illinois,HISP,Fayette County,17051,0.0,0.0,0.0,1.0,0.0,1.0,-100.0,-100.0,0.0,195.0,0.0,195.0
+17,Illinois,BLACK,Fayette County,17051,0.0,65.0,0.0,0.4,1.7,0.4,-100.0,325.0,0.0,88.0,57.0,88.0
+17,Illinois,NHPI,Fayette County,17051,0.0,0.0,0.0,0.1,0.0,0.1,-100.0,-100.0,0.0,28.0,0.0,28.0
+17,Illinois,WHITE,Fayette County,17051,8.0,17.0,100.0,98.1,97.2,98.1,1.9,-0.9,1644.0,19562.0,3325.0,19469.0
+17,Illinois,OTHER_STANDARD,Fayette County,17051,0.0,0.0,0.0,0.1,0.0,0.1,-100.0,-100.0,0.0,13.0,0.0,13.0
+17,Illinois,MULTI,Fayette County,17051,0.0,36.0,0.0,0.4,0.8,0.4,-100.0,100.0,0.0,73.0,26.0,73.0
+17,Illinois,ALL,Fayette County,17051,8.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0,1644.0,19948.0,3421.0,19855.0

--- a/python/tests/data/acs_condition/golden_data/sex_county.csv
+++ b/python/tests/data/acs_condition/golden_data/sex_county.csv
@@ -1,4 +1,4 @@
-state_fips,state_name,sex,county_name,county_fips,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity
-17,Illinois,Female,Fayette County,17051,6.0,17.0,38.4,50.3,49.1,50.4,-23.7,-2.6
-17,Illinois,Male,Fayette County,17051,10.0,18.0,61.6,49.7,50.9,49.6,23.9,2.6
-17,Illinois,All,Fayette County,17051,8.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0
+state_fips,state_name,sex,county_name,county_fips,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity,uninsured_estimated_total,uninsured_pop_estimated_total,poverty_estimated_total,poverty_pop_estimated_total
+17,Illinois,Female,Fayette County,17051,6.0,17.0,38.4,50.3,49.1,50.4,-23.7,-2.6,631.0,10035.0,1680.0,10008.0
+17,Illinois,Male,Fayette County,17051,10.0,18.0,61.6,49.7,50.9,49.6,23.9,2.6,1013.0,9913.0,1741.0,9847.0
+17,Illinois,All,Fayette County,17051,8.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0,1644.0,19948.0,3421.0,19855.0

--- a/python/tests/data/acs_condition/golden_data/sex_national.csv
+++ b/python/tests/data/acs_condition/golden_data/sex_national.csv
@@ -1,4 +1,4 @@
-state_fips,state_name,sex,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity
-00,United States,Female,7.0,30.0,44.5,52.2,55.5,52.1,-14.8,6.5
-00,United States,Male,10.0,26.0,55.5,47.8,44.5,47.9,16.1,-7.1
-00,United States,All,8.0,28.0,100.0,100.0,100.0,100.0,0.0,0.0
+state_fips,state_name,sex,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity,uninsured_estimated_total,uninsured_pop_estimated_total,poverty_estimated_total,poverty_pop_estimated_total
+00,United States,Female,7.0,30.0,44.5,52.2,55.5,52.1,-14.8,6.5,299999.0,4226870.0,1246770.0,4193722.0
+00,United States,Male,10.0,26.0,55.5,47.8,44.5,47.9,16.1,-7.1,373654.0,3863871.0,998310.0,3850088.0
+00,United States,All,8.0,28.0,100.0,100.0,100.0,100.0,0.0,0.0,673653.0,8090741.0,2245080.0,8043810.0

--- a/python/tests/data/acs_condition/golden_data/sex_state.csv
+++ b/python/tests/data/acs_condition/golden_data/sex_state.csv
@@ -1,7 +1,7 @@
-state_fips,state_name,sex,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity
-01,Alabama,Female,9.0,18.0,46.7,52.0,57.0,51.8,-10.2,10.0
-01,Alabama,Male,11.0,15.0,53.3,48.0,43.0,48.2,11.0,-10.8
-72,Puerto Rico,Female,5.0,46.0,39.9,52.6,54.7,52.6,-24.1,4.0
-72,Puerto Rico,Male,8.0,42.0,60.1,47.4,45.3,47.4,26.8,-4.4
-01,Alabama,All,10.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0
-72,Puerto Rico,All,7.0,44.0,100.0,100.0,100.0,100.0,0.0,0.0
+state_fips,state_name,sex,uninsured_pct_rate,poverty_pct_rate,uninsured_pct_share,uninsured_population_pct,poverty_pct_share,poverty_population_pct,uninsured_pct_relative_inequity,poverty_pct_relative_inequity,uninsured_estimated_total,uninsured_pop_estimated_total,poverty_estimated_total,poverty_pop_estimated_total
+01,Alabama,Female,9.0,18.0,46.7,52.0,57.0,51.8,-10.2,10.0,213825.0,2494140.0,453810.0,2464351.0
+01,Alabama,Male,11.0,15.0,53.3,48.0,43.0,48.2,11.0,-10.8,244001.0,2303075.0,342179.0,2289937.0
+72,Puerto Rico,Female,5.0,46.0,39.9,52.6,54.7,52.6,-24.1,4.0,86174.0,1732730.0,792960.0,1729371.0
+72,Puerto Rico,Male,8.0,42.0,60.1,47.4,45.3,47.4,26.8,-4.4,129653.0,1560796.0,656131.0,1560151.0
+01,Alabama,All,10.0,17.0,100.0,100.0,100.0,100.0,0.0,0.0,457826.0,4797215.0,795989.0,4754288.0
+72,Puerto Rico,All,7.0,44.0,100.0,100.0,100.0,100.0,0.0,0.0,215827.0,3293526.0,1449091.0,3289522.0

--- a/python/tests/datasources/test_acs_condition.py
+++ b/python/tests/datasources/test_acs_condition.py
@@ -260,14 +260,14 @@ def testWriteToBqAppend2022(
     assert mock_fips.call_count == 9 + 3
 
     assert mock_bq.call_count == 9
-    assert mock_bq.call_args_list[0].args[2] == 'by_race_national_time_series'
-    assert mock_bq.call_args_list[1].args[2] == 'by_age_national_time_series'
-    assert mock_bq.call_args_list[2].args[2] == 'by_sex_national_time_series'
+    assert mock_bq.call_args_list[0].args[2] == 'by_race_national_historical'
+    assert mock_bq.call_args_list[1].args[2] == 'by_age_national_historical'
+    assert mock_bq.call_args_list[2].args[2] == 'by_sex_national_historical'
 
-    assert mock_bq.call_args_list[3].args[2] == 'by_race_state_time_series'
-    assert mock_bq.call_args_list[4].args[2] == 'by_age_state_time_series'
-    assert mock_bq.call_args_list[5].args[2] == 'by_sex_state_time_series'
+    assert mock_bq.call_args_list[3].args[2] == 'by_race_state_historical'
+    assert mock_bq.call_args_list[4].args[2] == 'by_age_state_historical'
+    assert mock_bq.call_args_list[5].args[2] == 'by_sex_state_historical'
 
-    assert mock_bq.call_args_list[6].args[2] == 'by_race_county_time_series'
-    assert mock_bq.call_args_list[7].args[2] == 'by_age_county_time_series'
-    assert mock_bq.call_args_list[8].args[2] == 'by_sex_county_time_series'
+    assert mock_bq.call_args_list[6].args[2] == 'by_race_county_historical'
+    assert mock_bq.call_args_list[7].args[2] == 'by_age_county_historical'
+    assert mock_bq.call_args_list[8].args[2] == 'by_sex_county_historical'

--- a/python/tests/datasources/test_acs_condition.py
+++ b/python/tests/datasources/test_acs_condition.py
@@ -18,10 +18,10 @@ from test_utils import (
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_DIR = os.path.join(THIS_DIR, os.pardir, 'data', 'acs_condition')
 
-GOLDEN_DATA_2022_NATIONAL_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_national.csv')
-GOLDEN_DATA_2022_STATE_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_state.csv')
-GOLDEN_DATA_2022_COUNTY_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_county.csv')
-GOLDEN_DATA_2022_COUNTY_RACE = os.path.join(TEST_DIR, 'golden_data', 'race_county.csv')
+GOLDEN_BASE_TABLE_NATIONAL_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_national.csv')
+GOLDEN_BASE_TABLE_STATE_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_state.csv')
+GOLDEN_BASE_TABLE_COUNTY_SEX = os.path.join(TEST_DIR, 'golden_data', 'sex_county.csv')
+GOLDEN_BASE_TABLE_COUNTY_RACE = os.path.join(TEST_DIR, 'golden_data', 'race_county.csv')
 
 
 # NOT USING SHARED POPULATION MOCKS BECAUSE THESE ARE THE CACHED ACS_CONDITION TABLES,
@@ -42,7 +42,7 @@ acsCondition.year = '2022'
     side_effect=_load_public_dataset_from_bigquery_as_df,
 )
 @mock.patch('ingestion.gcs_to_bq_util.load_values_as_df', side_effect=_get_by_race_as_df)
-def testSexNational2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
+def testSexNationalBaseTable(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     df = acsCondition.get_raw_data(
         'sex', 'national', get_acs_metadata_as_json(2022), ACS_ITEMS_2022_AND_LATER, 'some-bucket'
     )
@@ -54,7 +54,7 @@ def testSexNational2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
         HEALTH_INSURANCE_RACE_TO_CONCEPT_TITLE,
     )
 
-    expected_df = pd.read_csv(GOLDEN_DATA_2022_NATIONAL_SEX, dtype={'state_fips': str})
+    expected_df = pd.read_csv(GOLDEN_BASE_TABLE_NATIONAL_SEX, dtype={'state_fips': str})
     cols = list(expected_df.columns)
     assert_frame_equal(
         df.sort_values(cols).reset_index(drop=True),
@@ -68,7 +68,7 @@ def testSexNational2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     side_effect=_load_public_dataset_from_bigquery_as_df,
 )
 @mock.patch('ingestion.gcs_to_bq_util.load_values_as_df', side_effect=_get_by_race_as_df)
-def testSexState2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
+def testSexStateBaseTable(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     df = acsCondition.get_raw_data(
         'sex', 'state', get_acs_metadata_as_json(2022), ACS_ITEMS_2022_AND_LATER, 'some-bucket'
     )
@@ -80,7 +80,7 @@ def testSexState2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
         HEALTH_INSURANCE_RACE_TO_CONCEPT_TITLE,
     )
 
-    expected_df = pd.read_csv(GOLDEN_DATA_2022_STATE_SEX, dtype={'state_fips': str})
+    expected_df = pd.read_csv(GOLDEN_BASE_TABLE_STATE_SEX, dtype={'state_fips': str})
     cols = list(expected_df.columns)
     assert_frame_equal(
         df.sort_values(cols).reset_index(drop=True),
@@ -94,7 +94,7 @@ def testSexState2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     side_effect=_load_public_dataset_from_bigquery_as_df,
 )
 @mock.patch('ingestion.gcs_to_bq_util.load_values_as_df', side_effect=_get_by_race_as_df)
-def testSexCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
+def testSexCountyBaseTable(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     df = acsCondition.get_raw_data(
         'sex', 'county', get_acs_metadata_as_json(2022), ACS_ITEMS_2022_AND_LATER, 'some-bucket'
     )
@@ -106,7 +106,7 @@ def testSexCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
         HEALTH_INSURANCE_RACE_TO_CONCEPT_TITLE,
     )
 
-    expected_df = pd.read_csv(GOLDEN_DATA_2022_COUNTY_SEX, dtype={'state_fips': str, 'county_fips': str})
+    expected_df = pd.read_csv(GOLDEN_BASE_TABLE_COUNTY_SEX, dtype={'state_fips': str, 'county_fips': str})
     cols = list(expected_df.columns)
     assert_frame_equal(
         df.sort_values(cols).reset_index(drop=True),
@@ -120,7 +120,7 @@ def testSexCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     side_effect=_load_public_dataset_from_bigquery_as_df,
 )
 @mock.patch('ingestion.gcs_to_bq_util.load_values_as_df', side_effect=_get_by_race_as_df)
-def testRaceCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
+def testRaceCountyBaseTable(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     df = acsCondition.get_raw_data(
         'race', 'county', get_acs_metadata_as_json(2022), ACS_ITEMS_2022_AND_LATER, 'some-bucket'
     )
@@ -132,7 +132,7 @@ def testRaceCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
         HEALTH_INSURANCE_RACE_TO_CONCEPT_TITLE,
     )
 
-    expected_df = pd.read_csv(GOLDEN_DATA_2022_COUNTY_RACE, dtype={'state_fips': str, 'county_fips': str})
+    expected_df = pd.read_csv(GOLDEN_BASE_TABLE_COUNTY_RACE, dtype={'state_fips': str, 'county_fips': str})
     cols = list(expected_df.columns)
     assert_frame_equal(
         df.sort_values(cols).reset_index(drop=True),
@@ -148,7 +148,7 @@ def testRaceCounty2022(mock_acs: mock.MagicMock, mock_fips: mock.MagicMock):
     side_effect=_load_public_dataset_from_bigquery_as_df,
 )
 @mock.patch('ingestion.gcs_to_bq_util.add_df_to_bq', return_value=None)
-def testWriteToBqOverwriteFirstYear2012(
+def testWriteToBqOverwriteEarliestYear(
     mock_bq: mock.MagicMock,
     mock_fips: mock.MagicMock,
     mock_acs: mock.MagicMock,
@@ -157,9 +157,13 @@ def testWriteToBqOverwriteFirstYear2012(
     acsCondition2012 = AcsCondition()
     acsCondition2012.write_to_bq('dataset', 'gcs_bucket', year='2012')
 
-    # The earliest year should OVERWRITE and create brand new BQ tables
     for call in mock_bq.call_args_list:
+        # This earliest year should OVERWRITE and create brand new BQ tables
         assert call[1]['overwrite'] is True
+        # Column names should match between the shipped df and the BQ types object
+        df_cols = sorted(call[0][0].columns)
+        bq_types_cols = sorted(call[1]["column_types"].keys())
+        assert df_cols == bq_types_cols
 
 
 @mock.patch('ingestion.census.fetch_acs_metadata', return_value=get_acs_metadata_as_json(2022))
@@ -178,9 +182,26 @@ def testWriteToBqAppend2022(
     acsCondition2022 = AcsCondition()
     acsCondition2022.write_to_bq('dataset', 'gcs_bucket', year='2022')
 
-    # Every subsequent year should APPEND its yearly data onto the existing BQ tables
-    for call in mock_bq.call_args_list:
-        assert call[1]['overwrite'] is False
+    # Non-earliest year like this should APPEND its TIME_SERIES yearly data onto the existing BQ tables
+    # This most current year should also generate a CURRENT table with an undefined overwrite arg
+    assert mock_bq.call_args_list[0][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[1][1]
+    assert mock_bq.call_args_list[2][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[3][1]
+    assert mock_bq.call_args_list[4][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[5][1]
+    assert mock_bq.call_args_list[6][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[7][1]
+    assert mock_bq.call_args_list[8][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[9][1]
+    assert mock_bq.call_args_list[10][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[11][1]
+    assert mock_bq.call_args_list[12][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[13][1]
+    assert mock_bq.call_args_list[14][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[15][1]
+    assert mock_bq.call_args_list[16][1]['overwrite'] is False
+    assert "overwrite" not in mock_bq.call_args_list[17][1]
 
     assert mock_json.call_count == 1
 
@@ -259,15 +280,32 @@ def testWriteToBqAppend2022(
     # One state name call for each run, and then 1 county name for each county run
     assert mock_fips.call_count == 9 + 3
 
-    assert mock_bq.call_count == 9
+    # One call for each table write to BQ
+    assert mock_bq.call_count == 18
+
     assert mock_bq.call_args_list[0].args[2] == 'by_race_national_historical'
-    assert mock_bq.call_args_list[1].args[2] == 'by_age_national_historical'
-    assert mock_bq.call_args_list[2].args[2] == 'by_sex_national_historical'
+    assert mock_bq.call_args_list[1].args[2] == 'by_race_national_current'
 
-    assert mock_bq.call_args_list[3].args[2] == 'by_race_state_historical'
-    assert mock_bq.call_args_list[4].args[2] == 'by_age_state_historical'
-    assert mock_bq.call_args_list[5].args[2] == 'by_sex_state_historical'
+    assert mock_bq.call_args_list[2].args[2] == 'by_age_national_historical'
+    assert mock_bq.call_args_list[3].args[2] == 'by_age_national_current'
 
-    assert mock_bq.call_args_list[6].args[2] == 'by_race_county_historical'
-    assert mock_bq.call_args_list[7].args[2] == 'by_age_county_historical'
-    assert mock_bq.call_args_list[8].args[2] == 'by_sex_county_historical'
+    assert mock_bq.call_args_list[4].args[2] == 'by_sex_national_historical'
+    assert mock_bq.call_args_list[5].args[2] == 'by_sex_national_current'
+
+    assert mock_bq.call_args_list[6].args[2] == 'by_race_state_historical'
+    assert mock_bq.call_args_list[7].args[2] == 'by_race_state_current'
+
+    assert mock_bq.call_args_list[8].args[2] == 'by_age_state_historical'
+    assert mock_bq.call_args_list[9].args[2] == 'by_age_state_current'
+
+    assert mock_bq.call_args_list[10].args[2] == 'by_sex_state_historical'
+    assert mock_bq.call_args_list[11].args[2] == 'by_sex_state_current'
+
+    assert mock_bq.call_args_list[12].args[2] == 'by_race_county_historical'
+    assert mock_bq.call_args_list[13].args[2] == 'by_race_county_current'
+
+    assert mock_bq.call_args_list[14].args[2] == 'by_age_county_historical'
+    assert mock_bq.call_args_list[15].args[2] == 'by_age_county_current'
+
+    assert mock_bq.call_args_list[16].args[2] == 'by_sex_county_historical'
+    assert mock_bq.call_args_list[17].args[2] == 'by_sex_county_current'


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- completes split table setup of #2361 for acs condition
- N count numerators and denominators are added to `_current` tables for later use on the frontend

## Has this been tested? How?

- [x] tests updated and passing
- [x] runs on infra test

## Screenshots (if appropriate)

<img width="1576" alt="Screenshot 2024-02-20 at 7 46 50 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/e0063f2b-fbe0-4029-8690-8c9f1789f219">
<img width="1576" alt="Screenshot 2024-02-20 at 7 48 15 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/718615f5-76c0-4bda-bf8e-41f80ea211c8">


## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
