### PR TITLE
Removes deprecated time-series flags

### DIFF
--- a/frontend/playwright-tests/ami.ci.spec.ts
+++ b/frontend/playwright-tests/ami.ci.spec.ts
@@ -6,10 +6,9 @@ test('PHRMA: Medicare AMI', async ({ page }) => {
   await page.getByRole('heading', { name: 'Ages 85+, Medicare' }).click();
   await page.getByLabel('Legend for rate map').getByRole('img').click();
   await page.locator('li').filter({ hasText: 'Total Medicare Population:' }).click();
-  const page1Promise = page.waitForEvent('popup');
   await page.locator('#rate-chart').getByText('Medication Utilization and Disease Rates in the Medicare Population (data from 2020)').click();
-  const page1 = await page1Promise;
-  await page.getByRole('note').click();
+  await page.locator('#unknown-demographic-map').getByRole('note').click();
+  await page.getByRole('button', { name: 'Population vs. distribution' }).click();
   await page.getByLabel('Comparison bar chart showing').getByRole('img').click();
   await page.getByRole('heading', { name: 'Breakdown summary for acute' }).click();
   await page.getByRole('figure', { name: 'Breakdown summary for acute' }).locator('h4').click();

--- a/frontend/playwright-tests/drinking.nightly.spec.ts
+++ b/frontend/playwright-tests/drinking.nightly.spec.ts
@@ -12,6 +12,13 @@ test('Excessive Drinking Flow', async ({ page }) => {
   await page
     .getByText('See the states/territories with the highest and lowest rates.')
     .click()
+  await page.getByRole('heading', { name: 'Highest:' }).click();
+  await page.getByRole('heading', { name: 'Lowest:' }).click();
+  await page.getByRole('heading', { name: 'National overall:' }).click();
+  await page.locator('#highest-lowest-geos').getByText('Excessive drinking cases').click();
+  await page.getByText('Consider the possible impact').click();
+  await page.getByLabel('hide lists of states/').click();
+  await page.getByRole('button', { name: 'Unknown demographic map' }).click();
   await page
     .getByRole('heading', {
       name: 'Share of all excessive drinking cases with unknown race and ethnicity in the United States',

--- a/frontend/playwright-tests/non_medical_drug_use.nightly.spec.ts
+++ b/frontend/playwright-tests/non_medical_drug_use.nightly.spec.ts
@@ -28,7 +28,7 @@ test('Non Medical Drug Use', async ({ page }) => {
       name: 'Graph unavailable: Population vs. distribution of total non-medical drug use in the United States',
     })
     .click()
-  await page.getByText('Our data sources do not have').click()
+  await page.getByText('Our data sources do not have Population vs. distribution of total non-medical').click()
   await page
     .getByRole('heading', {
       name: 'Breakdown summary for opioid and other non-medical drug use in the United States',

--- a/frontend/src/cards/ui/SourcesInfo.tsx
+++ b/frontend/src/cards/ui/SourcesInfo.tsx
@@ -1,3 +1,4 @@
+import { type DataSourceId } from '../../data/config/MetadataMap'
 import { DATA_CATALOG_PAGE_LINK } from '../../utils/internalRoutes'
 import {
   LinkWithStickyParams,
@@ -6,14 +7,15 @@ import {
 import { type DataSourceInfo, insertPunctuation } from './SourcesHelpers'
 
 interface SourcesInfoProps {
-  dataSourceMap: Record<string, DataSourceInfo>
+  dataSourceMap: Record<DataSourceId, DataSourceInfo>
 }
 
 export default function SourcesInfo(props: SourcesInfoProps) {
+  const dataSourceIds = Object.keys(props.dataSourceMap) as DataSourceId[]
   return (
     <p>
       Sources:{' '}
-      {Object.keys(props.dataSourceMap).map((dataSourceId, idx) => (
+      {dataSourceIds.map((dataSourceId, idx) => (
         <span key={dataSourceId}>
           <LinkWithStickyParams
             target='_blank'

--- a/frontend/src/data/config/MetadataMap.ts
+++ b/frontend/src/data/config/MetadataMap.ts
@@ -34,7 +34,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
     data_source_link:
       'https://data.cdc.gov/Case-Surveillance/COVID-19-Case-Surveillance-Restricted-Access-Detai/mbd7-r32t',
     geographic_level: 'National, State, County',
-    time_period_range: 'January 2020 - Current',
+    time_period_range: 'January 2020 - current',
     demographic_granularity: 'Race/ethnicity, age, sex',
     update_frequency: 'Monthly',
     description:
@@ -102,6 +102,8 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'acs_condition-by_sex_national_current',
     ],
     downloadable: true,
+    time_period_range:
+      'Population: 2009 - current, Health Topics: 2012 - current',
   },
   decia_2010_territory_population: {
     id: 'decia_2010_territory_population',
@@ -120,6 +122,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'decia_2010_territory_population-by_age_territory_state_level',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   decia_2020_territory_population: {
     id: 'decia_2020_territory_population',
@@ -141,6 +144,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'decia_2020_territory_population-by_age_territory_county_level',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   census_pop_estimates: {
     id: 'census_pop_estimates',
@@ -155,6 +159,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'Population percentage estimates by race/ethnicity, age, and sex to the county level provided by the U.S Census Bureau. We use the single year estimates from 2019.',
     dataset_ids: ['census_pop_estimates-race_and_ethnicity'],
     downloadable: true,
+    time_period_range: null,
   },
   cdc_svi_county: {
     id: 'cdc_svi_county',
@@ -169,6 +174,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'Every community must prepare for and respond to hazardous events, whether a natural disaster like a tornado or a disease outbreak, or an anthropogenic event such as a harmful chemical spill. The degree to which a community exhibits certain social conditions, including high poverty, low percentage of vehicle access, or crowded households, may affect that community’s ability to prevent human suffering and financial loss in the event of disaster. These factors describe a community’s social vulnerability.',
     dataset_ids: ['cdc_svi_county-age'],
     downloadable: true,
+    time_period_range: null,
   },
   cdc_vaccination_county: {
     id: 'cdc_vaccination_county',
@@ -183,6 +189,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'Overall US COVID-19 Vaccine administration and vaccine equity data at county level Data represents all vaccine partners including jurisdictional partner clinics, retail pharmacies, long-term care facilities, dialysis centers, Federal Emergency Management Agency and Health Resources and Services Administration partner sites, and federal entity facilities.',
     dataset_ids: ['cdc_vaccination_county-alls_county'],
     downloadable: true,
+    time_period_range: null,
   },
   cdc_vaccination_national: {
     id: 'cdc_vaccination_national',
@@ -202,6 +209,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'cdc_vaccination_national-sex_processed',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   cdc_atlas: {
     id: 'cdc_atlas',
@@ -240,6 +248,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'cdc_hiv_data-black_women_state_historical',
     ],
     downloadable: true,
+    time_period_range: '2008 - current',
   },
   kff_vaccination: {
     id: 'kff_vaccination',
@@ -256,6 +265,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'kff_vaccination-alls_state',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   ahr: {
     id: 'ahr',
@@ -277,6 +287,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'ahr_data-sex_state',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   bjs: {
     id: 'bjs',
@@ -297,6 +308,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'bjs_incarceration_data-sex_state',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   vera: {
     id: 'vera',
@@ -314,6 +326,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'vera_incarceration_county-by_age_county_time_series',
     ],
     downloadable: true,
+    time_period_range: '1985 - 2016',
   },
   cawp: {
     id: 'cawp',
@@ -322,7 +335,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
     data_source_link: 'https://cawpdata.rutgers.edu/',
     geographic_level: 'National, State',
     time_period_range:
-      'U.S. Congress: 1915 - Current, State Legislatures: 1983 - Current',
+      'U.S. Congress: 1915 - current, State Legislatures: 1983 - current',
     demographic_granularity: 'Race/ethnicity',
     update_frequency: 'Monthly',
     description:
@@ -348,6 +361,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'Total members of the United States Congress (Senate and House of Representatives including Delegates) both nationally and by state/territory. This dataset is viewable and downloadable in the CAWP datasets.',
     dataset_ids: ['the_unitedstates_project'],
     downloadable: false,
+    time_period_range: null,
   },
   geo_context: {
     id: 'geo_context',
@@ -367,6 +381,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'geo_context-national',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   phrma: {
     id: 'phrma',
@@ -402,6 +417,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
     downloadable_blurb:
       'Disease rates and medication adherence percentages for multiple HIV, mental health, and cardiovascular conditions within the Medicare beneficiary population.',
     downloadable_data_dictionary: true,
+    time_period_range: null,
   },
   covid_tracking_project: {
     id: 'covid_tracking_project',
@@ -420,6 +436,7 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'covid_tracking_project-tests_by_race_state',
     ],
     downloadable: true,
+    time_period_range: null,
   },
   geographies_source: {
     id: 'geographies_source',
@@ -434,5 +451,6 @@ export const dataSourceMetadataMap: Record<DataSourceId, DataSourceMetadata> = {
       'This dataset contains the geographic boundaries for the United States, states, territories, counties, and county-equivalents.',
     dataset_ids: [],
     downloadable: false,
+    time_period_range: null,
   },
 }

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -179,7 +179,6 @@ export interface DataTypeConfig {
     sub_population_count?: MetricConfig
   }
   surveyCollectedData?: boolean
-  timeSeriesData?: boolean
   dataTableTitle: string
   mapConfig: MapConfig
   categoryId?: CategoryTypeId

--- a/frontend/src/data/config/MetricConfigCovidCategory.ts
+++ b/frontend/src/data/config/MetricConfigCovidCategory.ts
@@ -63,7 +63,6 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'COVID-19 has had a disproportionate impact on certain populations, including older adults, people of color, people with disabilities, and people living in poverty. Studying COVID-19 in regard to health equity can help us to understand why these disparities exist and how to address them.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for COVID-19 cases',
     metrics: {
       pct_share: {
@@ -112,7 +111,6 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'COVID-19 has had a disproportionate impact on certain populations, including older adults, people of color, people with disabilities, and people living in poverty. Studying COVID-19 in regard to health equity can help us to understand why these disparities exist and how to address them.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for COVID-19 deaths',
     metrics: {
       pct_share: {
@@ -168,7 +166,6 @@ export const COVID_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'COVID-19 has had a disproportionate impact on certain populations, including older adults, people of color, people with disabilities, and people living in poverty. Studying COVID-19 in regard to health equity can help us to understand why these disparities exist and how to address them.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for COVID-19 hospitalizations',
     metrics: {
       pct_share: {

--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -82,7 +82,6 @@ export const HIV_CARE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'Access to quality HIV care is essential for ensuring that people living with HIV can live long and healthy lives. However, not everyone with HIV has access to quality care. Studying HIV care in regard to health equity can help us to understand why these disparities exist and how to improve access to quality care for all people living with HIV.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for linkage to HIV care',
     metrics: {
       pct_share: {
@@ -133,7 +132,6 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV prevalence',
     metrics: {
       pct_share: {
@@ -180,7 +178,6 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV diagnoses',
     metrics: {
       pct_share: {
@@ -226,7 +223,6 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV deaths',
     metrics: {
       pct_share: {
@@ -283,7 +279,6 @@ export const HIV_STIGMA_METRICS: DataTypeConfig[] = [
     description: {
       text: 'HIV stigma often intersects with other forms of stigma and discrimination, such as racism, homophobia, and sexism. Studying HIV stigma can shed light on broader issues of social injustice and inequality.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV stigma',
     metrics: {
       index: {
@@ -324,7 +319,6 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV prevalence for Black (NH) women',
     metrics: {
       pct_share: {
@@ -373,7 +367,6 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
     },
-    timeSeriesData: true,
     dataTableTitle:
       'Breakdown summary for new HIV diagnoses for Black (NH) women',
     metrics: {
@@ -424,7 +417,6 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
     description: {
       text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for HIV deaths for Black (NH) women',
     metrics: {
       pct_share: {
@@ -477,7 +469,6 @@ export const HIV_PREP_METRICS: DataTypeConfig[] = [
     description: {
       text: 'HIV PrEP is a medication that can help to prevent HIV infection. PrEP is highly effective when taken as prescribed. Studying HIV PrEP in regard to health equity can help us to understand why certain populations are more likely to use PrEP and why others are less likely to use it.',
     },
-    timeSeriesData: true,
     dataTableTitle: 'Breakdown summary for PrEP coverage',
     metrics: {
       pct_share: {

--- a/frontend/src/data/config/MetricConfigPDOH.ts
+++ b/frontend/src/data/config/MetricConfigPDOH.ts
@@ -102,7 +102,6 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
     },
     fullDisplayName: 'Women in US Congress',
     surveyCollectedData: true,
-    timeSeriesData: true,
     definition: {
       text: `Individuals identifying as women who have served in the Congress of the United States, including members of the U.S. Senate and members, territorial delegates, and resident commissioners of the U.S. House of Representatives. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
     },
@@ -162,7 +161,6 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
     dataTypeShortLabel: 'State legislatures', // DATA TOGGLE
     fullDisplayName: 'Women in state legislatures', // TABLE TITLE,
     surveyCollectedData: true,
-    timeSeriesData: true,
     definition: {
       text: `Individuals identifying as women currently serving in their state or territory’s legislature. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
     },
@@ -230,7 +228,6 @@ export const INCARCERATION_METRICS: DataTypeConfig[] = [
     fullDisplayName: 'People in prison',
     fullDisplayNameInline: 'people in prison',
     surveyCollectedData: true,
-    timeSeriesData: true,
     definition: {
       text: `Individuals of any age, including children, under the jurisdiction of an adult prison facility. ‘Age’ reports at the national level include only the subset of this jurisdictional population who have been sentenced to one year or more, which accounted for 97% of the total U.S. prison population in 2020. For all national reports, this rate includes both state and federal prisons. For state number of people incarcerated under the jurisdiction of a state prison system on charges arising from a criminal case in that specific county, which are not available in every state. The county of court commitment is generally where a person was convicted; it is not necessarily the person’s county of residence, and may not even be the county where the crime was committed, but nevertheless is likely to be both.  AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Prisons are longer-term facilities run by the state or the federal government that typically hold felons and persons with sentences of more than one year. Definitions may vary by state.`,
     },
@@ -286,7 +283,6 @@ export const INCARCERATION_METRICS: DataTypeConfig[] = [
     fullDisplayName: 'People in jail',
     fullDisplayNameInline: 'people in jail',
     surveyCollectedData: true,
-    timeSeriesData: true,
     definition: {
       text: `Individuals of any age, including children, confined in a local, adult jail facility. AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Jails are locally operated short-term facilities that hold inmates awaiting trial or sentencing or both, and inmates sentenced to a term of less than one year, typically misdemeanants. Definitions may vary by state.`,
     },

--- a/frontend/src/data/config/MetricConfigSDOH.ts
+++ b/frontend/src/data/config/MetricConfigSDOH.ts
@@ -55,7 +55,6 @@ export const UNINSURANCE_METRICS: DataTypeConfig[] = [
       text: 'Health insurance is important for ensuring that people have access to quality healthcare. People of color and people with low incomes are less likely to have health insurance. Studying health insurance can help us understand why these disparities exist and how to address them.',
     },
     dataTableTitle: 'Breakdown summary for uninsured people',
-    timeSeriesData: true,
     metrics: {
       pct_rate: {
         metricId: 'uninsured_pct_rate',
@@ -116,7 +115,6 @@ export const POVERTY_METRICS: DataTypeConfig[] = [
       text: 'Poverty is a major determinant of health. People who are poor are more likely to experience a number of health problems, including chronic diseases, mental illness, and substance use disorders. Studying poverty can help us understand why these disparities exist and how to address them.',
     },
     dataTableTitle: 'Breakdown summary for people below the poverty line',
-    timeSeriesData: true,
     metrics: {
       pct_rate: {
         metricId: 'poverty_pct_rate',

--- a/frontend/src/data/utils/DatasetTypes.ts
+++ b/frontend/src/data/utils/DatasetTypes.ts
@@ -17,7 +17,7 @@ export interface DataSourceMetadata {
   readonly downloadable: boolean
   readonly downloadable_blurb?: string
   readonly downloadable_data_dictionary?: boolean
-  readonly time_period_range?: string
+  readonly time_period_range: string | null
 }
 
 // Datasets contain data with specified breakdowns

--- a/frontend/src/reports/CompareReport.tsx
+++ b/frontend/src/reports/CompareReport.tsx
@@ -157,8 +157,6 @@ export default function CompareReport(props: CompareReportProps) {
     return <></>
   }
 
-  const showTrendCardRow =
-    dataTypeConfig1?.timeSeriesData ?? dataTypeConfig2?.timeSeriesData
   const showAgeAdjustCardRow =
     dataTypeConfig1?.metrics?.age_adjusted_ratio?.ageAdjusted ??
     dataTypeConfig2?.metrics?.age_adjusted_ratio?.ageAdjusted
@@ -232,32 +230,30 @@ export default function CompareReport(props: CompareReportProps) {
             />
 
             {/* SIDE-BY-SIDE RATE TREND CARDS */}
-            {showTrendCardRow && (
-              <RowOfTwoOptionalMetrics
-                trackerMode={props.trackerMode}
-                id='rates-over-time'
-                dataTypeConfig1={dataTypeConfig1}
-                dataTypeConfig2={dataTypeConfig2}
-                fips1={props.fips1}
-                fips2={props.fips2}
-                headerScrollMargin={props.headerScrollMargin}
-                createCard={(
-                  dataTypeConfig: DataTypeConfig,
-                  fips: Fips,
-                  unusedUpdateFips: (fips: Fips) => void,
-                  unusedDropdown: any,
-                  isCompareCard: boolean | undefined
-                ) => (
-                  <RateTrendsChartCard
-                    dataTypeConfig={dataTypeConfig}
-                    demographicType={demographicType}
-                    fips={fips}
-                    isCompareCard={isCompareCard}
-                    reportTitle={props.reportTitle}
-                  />
-                )}
-              />
-            )}
+            <RowOfTwoOptionalMetrics
+              trackerMode={props.trackerMode}
+              id='rates-over-time'
+              dataTypeConfig1={dataTypeConfig1}
+              dataTypeConfig2={dataTypeConfig2}
+              fips1={props.fips1}
+              fips2={props.fips2}
+              headerScrollMargin={props.headerScrollMargin}
+              createCard={(
+                dataTypeConfig: DataTypeConfig,
+                fips: Fips,
+                unusedUpdateFips: (fips: Fips) => void,
+                unusedDropdown: any,
+                isCompareCard: boolean | undefined
+              ) => (
+                <RateTrendsChartCard
+                  dataTypeConfig={dataTypeConfig}
+                  demographicType={demographicType}
+                  fips={fips}
+                  isCompareCard={isCompareCard}
+                  reportTitle={props.reportTitle}
+                />
+              )}
+            />
 
             {/* SIDE-BY-SIDE 100K BAR GRAPH CARDS */}
 
@@ -314,32 +310,30 @@ export default function CompareReport(props: CompareReportProps) {
 
             {/* SIDE-BY-SIDE SHARE INEQUITY TREND CARDS */}
 
-            {showTrendCardRow && (
-              <RowOfTwoOptionalMetrics
-                trackerMode={props.trackerMode}
-                id='inequities-over-time'
-                dataTypeConfig1={dataTypeConfig1}
-                dataTypeConfig2={dataTypeConfig2}
-                fips1={props.fips1}
-                fips2={props.fips2}
-                headerScrollMargin={props.headerScrollMargin}
-                createCard={(
-                  dataTypeConfig: DataTypeConfig,
-                  fips: Fips,
-                  unusedUpdateFips: (fips: Fips) => void,
-                  unusedDropdown: any,
-                  isCompareCard: boolean | undefined
-                ) => (
-                  <ShareTrendsChartCard
-                    dataTypeConfig={dataTypeConfig}
-                    demographicType={demographicType}
-                    fips={fips}
-                    isCompareCard={isCompareCard}
-                    reportTitle={props.reportTitle}
-                  />
-                )}
-              />
-            )}
+            <RowOfTwoOptionalMetrics
+              trackerMode={props.trackerMode}
+              id='inequities-over-time'
+              dataTypeConfig1={dataTypeConfig1}
+              dataTypeConfig2={dataTypeConfig2}
+              fips1={props.fips1}
+              fips2={props.fips2}
+              headerScrollMargin={props.headerScrollMargin}
+              createCard={(
+                dataTypeConfig: DataTypeConfig,
+                fips: Fips,
+                unusedUpdateFips: (fips: Fips) => void,
+                unusedDropdown: any,
+                isCompareCard: boolean | undefined
+              ) => (
+                <ShareTrendsChartCard
+                  dataTypeConfig={dataTypeConfig}
+                  demographicType={demographicType}
+                  fips={fips}
+                  isCompareCard={isCompareCard}
+                  reportTitle={props.reportTitle}
+                />
+              )}
+            />
 
             {/* SIDE-BY-SIDE DISPARITY BAR GRAPH (COMPARE TO POPULATION) CARDS */}
             <RowOfTwoOptionalMetrics

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -33,7 +33,6 @@ import ShareButtons, { SHARE_LABEL } from './ui/ShareButtons'
 import Sidebar from '../pages/ui/Sidebar'
 import { type MadLibId } from '../utils/MadLibs'
 import ModeSelectorBoxMobile from './ui/ModeSelectorBoxMobile'
-import { INCARCERATION_IDS } from '../data/providers/IncarcerationProvider'
 import { useAtom } from 'jotai'
 import { selectedDataTypeConfig1Atom } from '../utils/sharedSettingsState'
 import { getAllDemographicOptions } from './reportUtils'
@@ -123,10 +122,6 @@ export function Report(props: ReportProps) {
     'covid_hospitalizations',
   ].includes(props.dropdownVarId)
 
-  // we only have time-series data for incarceration at the county-level
-  const hideNonCountyBJSTimeCards =
-    !props.fips.isCounty() && INCARCERATION_IDS.includes(props.dropdownVarId)
-
   const shareMetricConfig =
     dataTypeConfig?.metrics.pct_share_unknown ??
     dataTypeConfig?.metrics.pct_share
@@ -180,14 +175,12 @@ export function Report(props: ReportProps) {
                   className='w-full scroll-m-0 md:scroll-mt-24'
                   id='rates-over-time'
                 >
-                  {!hideNonCountyBJSTimeCards && (
-                    <RateTrendsChartCard
-                      dataTypeConfig={dataTypeConfig}
-                      demographicType={demographicType}
-                      fips={props.fips}
-                      reportTitle={props.reportTitle}
-                    />
-                  )}
+                  <RateTrendsChartCard
+                    dataTypeConfig={dataTypeConfig}
+                    demographicType={demographicType}
+                    fips={props.fips}
+                    reportTitle={props.reportTitle}
+                  />
                 </div>
 
                 {/* 100K BAR CHART CARD */}
@@ -239,14 +232,12 @@ export function Report(props: ReportProps) {
                   className='w-full scroll-m-0 md:scroll-mt-24'
                 >
                   <LazyLoad offset={600} height={750} once>
-                    {!hideNonCountyBJSTimeCards && (
-                      <ShareTrendsChartCard
-                        dataTypeConfig={dataTypeConfig}
-                        demographicType={demographicType}
-                        fips={props.fips}
-                        reportTitle={props.reportTitle}
-                      />
-                    )}
+                    <ShareTrendsChartCard
+                      dataTypeConfig={dataTypeConfig}
+                      demographicType={demographicType}
+                      fips={props.fips}
+                      reportTitle={props.reportTitle}
+                    />
                   </LazyLoad>
                 </div>
 

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -178,21 +178,16 @@ export function Report(props: ReportProps) {
                 <div
                   tabIndex={-1}
                   className='w-full scroll-m-0 md:scroll-mt-24'
-                  id={
-                    dataTypeConfig.timeSeriesData
-                      ? 'rates-over-time'
-                      : undefined
-                  }
+                  id='rates-over-time'
                 >
-                  {dataTypeConfig.timeSeriesData &&
-                    !hideNonCountyBJSTimeCards && (
-                      <RateTrendsChartCard
-                        dataTypeConfig={dataTypeConfig}
-                        demographicType={demographicType}
-                        fips={props.fips}
-                        reportTitle={props.reportTitle}
-                      />
-                    )}
+                  {!hideNonCountyBJSTimeCards && (
+                    <RateTrendsChartCard
+                      dataTypeConfig={dataTypeConfig}
+                      demographicType={demographicType}
+                      fips={props.fips}
+                      reportTitle={props.reportTitle}
+                    />
+                  )}
                 </div>
 
                 {/* 100K BAR CHART CARD */}
@@ -240,23 +235,18 @@ export function Report(props: ReportProps) {
                 {/* SHARE TRENDS LINE CHART CARD */}
                 <div
                   tabIndex={-1}
-                  id={
-                    dataTypeConfig.timeSeriesData
-                      ? 'inequities-over-time'
-                      : undefined
-                  }
+                  id='inequities-over-time'
                   className='w-full scroll-m-0 md:scroll-mt-24'
                 >
                   <LazyLoad offset={600} height={750} once>
-                    {dataTypeConfig.timeSeriesData &&
-                      !hideNonCountyBJSTimeCards && (
-                        <ShareTrendsChartCard
-                          dataTypeConfig={dataTypeConfig}
-                          demographicType={demographicType}
-                          fips={props.fips}
-                          reportTitle={props.reportTitle}
-                        />
-                      )}
+                    {!hideNonCountyBJSTimeCards && (
+                      <ShareTrendsChartCard
+                        dataTypeConfig={dataTypeConfig}
+                        demographicType={demographicType}
+                        fips={props.fips}
+                        reportTitle={props.reportTitle}
+                      />
+                    )}
                   </LazyLoad>
                 </div>
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- closes #2930 (no longer really needed to handle time-series data sources, and we provide helpful missing data boxes when time data isn't available)
- closes #2852
- adjusts data source field `time_period_range` to either be null or to reflect the source's time range

## Has this been tested? How?

tests updated and passing

## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
