### PR TITLE
Fixes time-charts bug on mobile

### DIFF
--- a/frontend/playwright-tests/health_insurance.ci.spec.ts
+++ b/frontend/playwright-tests/health_insurance.ci.spec.ts
@@ -45,10 +45,9 @@ test('Health Insurance Flow', async ({ page }) => {
       name: 'Relative inequity for uninsurance in the United States',
     })
     .click()
-  await page
-    .locator('#inequities-over-time')
-    .getByLabel('Clear demographic filters')
-    .click()
+  await page.getByRole('heading', { name: 'Relative inequity for' }).click();
+  await page.locator('#inequities-over-time').getByLabel('Highlight groups with lowest').click();
+  await page.locator('#inequities-over-time').getByLabel('Clear demographic filters').click();
   await page.getByText('Expand inequities over time').click()
   await page
     .locator('#inequities-over-time')

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -32,7 +32,7 @@ import { HIV_METRICS } from '../data/providers/HivProvider'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import ChartTitle from './ChartTitle'
 import { type ElementHashIdHiddenOnScreenshot } from '../utils/hooks/useDownloadCardImage'
-import { het } from '../styles/DesignTokens'
+import UnknownPctRateGradient from './UnknownPctRateGradient'
 
 /* minimize layout shift */
 const PRELOAD_HEIGHT = 668
@@ -207,56 +207,7 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
             ) : (
               <>
                 {/* ensure we don't render two of these in compare mode */}
-                {!props.isCompareCard && (
-                  <svg
-                    height='0'
-                    version='1.1'
-                    xmlns='http://www.w3.org/2000/svg'
-                  >
-                    <linearGradient id='gradient'>
-                      <stop
-                        style={{ stopColor: het.unknownMapMost }}
-                        offset='0%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMid }}
-                        offset='20%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMost }}
-                        offset='30%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMid }}
-                        offset='40%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMost }}
-                        offset='50%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMid }}
-                        offset='60%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMost }}
-                        offset='70%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMid }}
-                        offset='80%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMost }}
-                        offset='90%'
-                      />
-                      <stop
-                        style={{ stopColor: het.unknownMapMid }}
-                        offset='100%'
-                      />
-                    </linearGradient>
-                  </svg>
-                )}
+                {!props.isCompareCard && <UnknownPctRateGradient />}
                 <TrendsChart
                   data={nestedRatesData}
                   chartTitle={getTitleText()}

--- a/frontend/src/cards/UnknownPctRateGradient.tsx
+++ b/frontend/src/cards/UnknownPctRateGradient.tsx
@@ -1,0 +1,20 @@
+import { het } from '../styles/DesignTokens'
+
+export default function UnknownPctRateGradient() {
+  return (
+    <svg height='0' version='1.1' xmlns='http://www.w3.org/2000/svg'>
+      <linearGradient id='gradient'>
+        <stop style={{ stopColor: het.unknownMapMost }} offset='0%' />
+        <stop style={{ stopColor: het.unknownMapMid }} offset='20%' />
+        <stop style={{ stopColor: het.unknownMapMost }} offset='30%' />
+        <stop style={{ stopColor: het.unknownMapMid }} offset='40%' />
+        <stop style={{ stopColor: het.unknownMapMost }} offset='50%' />
+        <stop style={{ stopColor: het.unknownMapMid }} offset='60%' />
+        <stop style={{ stopColor: het.unknownMapMost }} offset='70%' />
+        <stop style={{ stopColor: het.unknownMapMid }} offset='80%' />
+        <stop style={{ stopColor: het.unknownMapMost }} offset='90%' />
+        <stop style={{ stopColor: het.unknownMapMid }} offset='100%' />
+      </linearGradient>
+    </svg>
+  )
+}

--- a/frontend/src/charts/trendsChart/FilterLegend.tsx
+++ b/frontend/src/charts/trendsChart/FilterLegend.tsx
@@ -52,14 +52,14 @@ export function FilterLegend({
 
   return (
     // Legend Wrapper
-    <div className='font-sansText text-small font-normal'>
+    <div className='font-sansText text-small font-normal '>
       {/* Legend Title & Clear Button */}
       <div className='mb-5 flex	items-center text-left font-sansText font-medium'>
         <p id={legendId}>Select groups:</p>
         {/* Reset to Highest Lowest Averages */}
         <button
           aria-disabled={!selectedGroups?.length}
-          className={`ml-5 ${
+          className={`ml-5 text-altBlack  ${
             groupsAreMinMax
               ? 'cursor-not-allowed opacity-30'
               : 'cursor-pointer rounded-sm border bg-transparent px-1.5'
@@ -76,7 +76,7 @@ export function FilterLegend({
         <button
           aria-label={`Clear demographic filters`}
           aria-disabled={!selectedGroups?.length}
-          className={`ml-5 ${
+          className={`ml-5 text-altBlack ${
             !selectedGroups?.length
               ? 'cursor-not-allowed opacity-30 '
               : 'cursor-pointer rounded-sm border bg-transparent px-1.5'
@@ -110,7 +110,7 @@ export function FilterLegend({
               key={`legendItem-${group}`}
               aria-label={`Include ${group}`}
               aria-pressed={groupEnabled}
-              className='mb-1.5 mr-5 flex cursor-pointer items-center border-0 bg-transparent p-0 text-start transition-opacity	duration-300 ease-in-out'
+              className='mb-1.5 mr-5 flex cursor-pointer items-center border-0 bg-transparent p-0 text-start text-altBlack transition-opacity	duration-300 ease-in-out'
               onClick={() => {
                 handleClick(group)
               }} // send group name to parent on click

--- a/frontend/src/charts/trendsChart/FilterLegend.tsx
+++ b/frontend/src/charts/trendsChart/FilterLegend.tsx
@@ -50,6 +50,8 @@ export function FilterLegend({
   const groupsAreMinMax =
     JSON.stringify(selectedGroups) === JSON.stringify(getMinMaxGroups(data))
 
+  const noGroupsAreFiltered = selectedGroups.length === 0
+
   return (
     // Legend Wrapper
     <div className='font-sansText text-small font-normal '>
@@ -58,7 +60,7 @@ export function FilterLegend({
         <p id={legendId}>Select groups:</p>
         {/* Reset to Highest Lowest Averages */}
         <button
-          aria-disabled={!selectedGroups?.length}
+          aria-disabled={groupsAreMinMax}
           className={`ml-5 text-altBlack  ${
             groupsAreMinMax
               ? 'cursor-not-allowed opacity-30'
@@ -75,9 +77,9 @@ export function FilterLegend({
         {/* Remove Filters / Show All Button */}
         <button
           aria-label={`Clear demographic filters`}
-          aria-disabled={!selectedGroups?.length}
+          aria-disabled={noGroupsAreFiltered}
           className={`ml-5 text-altBlack ${
-            !selectedGroups?.length
+            noGroupsAreFiltered
               ? 'cursor-not-allowed opacity-30 '
               : 'cursor-pointer rounded-sm border bg-transparent px-1.5'
           }`}

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -79,12 +79,8 @@ export function TrendsChart({
   /* State Management */
   const allPossibleGroups = data.map(([group]) => group)
 
-  const isRelativeInequity = axisConfig.type === 'pct_relative_inequity'
-  const isInequityWithManyGroups =
-    isRelativeInequity && allPossibleGroups.length > 6
-
   // Manages which group filters user has applied
-  const defaultGroups = isInequityWithManyGroups ? getMinMaxGroups(data) : []
+  const defaultGroups: DemographicGroup[] = []
   const [selectedTrendGroups, setSelectedTrendGroups] =
     useState<DemographicGroup[]>(defaultGroups)
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- fixes #2854 by explicitly setting black color text on time chart legend buttons
- cleans up the logic for those buttons. However, we still need to tackle #2278
- extracts the linear gradient svg used for unknown race pct_rate on time chart into its own component
- removes deprecated hiding logic for BJS cards over time
- removes logic that defaulted pct_rel inequity chart to only showing highest/lowest groups; that was really only useful on COVID topics, but it is confusing and unhelpful for most of our new topics

## Has this been tested? How?

working on mobile

## Screenshots (if appropriate)

Correct color text on legend buttons:

![image](https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/ad940b22-4a8e-4f40-8b43-6c403c201f05)

## Types of changes

(leave all that apply)

- Bug fix
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
