### PR TITLE
Adds console warning if .env file hasn't set the apiBaseUrl

### DIFF
--- a/frontend/src/utils/Environment.ts
+++ b/frontend/src/utils/Environment.ts
@@ -62,7 +62,7 @@ export class HetEnvironment implements Environment {
   }
 
   private getEnvVariable(nonPrefixedName: string): string | undefined {
-    const prefix = this.deployContext === 'storybook' ? 'STORYBOOK_' : 'VITE_'
+    const prefix = 'VITE_'
     return import.meta.env[prefix + nonPrefixedName]
   }
 
@@ -72,7 +72,13 @@ export class HetEnvironment implements Environment {
 
   getBaseApiUrl() {
     // If the API url isn't provided, requests are relative to current domain.
-    return this.getEnvVariable('BASE_API_URL') ?? ''
+    const apiBaseUrl = this.getEnvVariable('BASE_API_URL')
+    if (!apiBaseUrl && this.deployContext === 'development') {
+      console.warn(
+        'BASE_API_URL environment variable is not set. Did you forget to copy the .env.example into an .env.development file? See the repo README for more information.'
+      )
+    }
+    return apiBaseUrl ?? ''
   }
 
   getEnableServerLogging() {

--- a/frontend/src/utils/Environment.ts
+++ b/frontend/src/utils/Environment.ts
@@ -75,7 +75,7 @@ export class HetEnvironment implements Environment {
     const apiBaseUrl = this.getEnvVariable('BASE_API_URL')
     if (!apiBaseUrl && this.deployContext === 'development') {
       console.warn(
-        'BASE_API_URL environment variable is not set. Did you forget to copy the .env.example into an .env.development file? See the repo README for more information.'
+        '\n\n.ENV MISSING\n\n\nBASE_API_URL environment variable is not set. Did you forget to copy the .env.example into an .env.development file? See the repo README for more information.'
       )
     }
     return apiBaseUrl ?? ''


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

if a user sets up a fresh repo locally, they must copy the .env.example over into an .env.development so that the app can read in the api base url. at some point we may need to have users keeping sensitive info in the local env that we don't want to check in to GitHub publically, so that's why this set up is in place. 

This PR
- removes some deprecated logic from when Storybook was installed
- adds a console warning when the app detects that the env was not retreived and the user is running in dev mode

## Has this been tested? How?

intentionally broke the .env file and observed the warning in the console

## Screenshots (if appropriate)

<img width="726" alt="Screenshot 2024-02-27 at 9 05 09 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/c21f1514-bcd7-4cb4-ba33-c92d14fe3d42">


## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
