### PR TITLE
Announcement banner for voter participation report

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -22,12 +22,21 @@
   }
   ul {
 <<<<<<< HEAD
+<<<<<<< HEAD
     /* list-style: none;
     padding: 0;
     margin: 0; */
 =======
     margin: 0;
 >>>>>>> 8238f099 (Wordpress styling updates (#2941))
+=======
+    margin: 0;
+=======
+    /* list-style: none;
+    padding: 0;
+    margin: 0; */
+>>>>>>> 8a6964ea (styling)
+>>>>>>> 09071846 (styling)
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,9 +21,13 @@
     background: theme('colors.white');
   }
   ul {
+<<<<<<< HEAD
     /* list-style: none;
     padding: 0;
     margin: 0; */
+=======
+    margin: 0;
+>>>>>>> 8238f099 (Wordpress styling updates (#2941))
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,9 +21,9 @@
     background: theme('colors.white');
   }
   ul {
-    list-style: none;
+    /* list-style: none;
     padding: 0;
-    margin: 0;
+    margin: 0; */
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -21,22 +21,7 @@
     background: theme('colors.white');
   }
   ul {
-<<<<<<< HEAD
-<<<<<<< HEAD
-    /* list-style: none;
-    padding: 0;
-    margin: 0; */
-=======
     margin: 0;
->>>>>>> 8238f099 (Wordpress styling updates (#2941))
-=======
-    margin: 0;
-=======
-    /* list-style: none;
-    padding: 0;
-    margin: 0; */
->>>>>>> 8a6964ea (styling)
->>>>>>> 09071846 (styling)
   }
 }
 

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -53,6 +53,7 @@ interface ExploreDataPageProps {
 function ExploreDataPage(props: ExploreDataPageProps) {
   const location: any = useLocation()
   const [showStickyLifeline, setShowStickyLifeline] = useState(false)
+  const [showAnnouncementBanner, setShowAnnouncementBanner] = useState(false)
   const [showIncarceratedChildrenAlert, setShowIncarceratedChildrenAlert] =
     useState(false)
 
@@ -267,6 +268,12 @@ function ExploreDataPage(props: ExploreDataPageProps) {
         (condition: DataTypeConfig) => condition?.dataTypeId === 'suicide'
       )
     )
+    setShowAnnouncementBanner(
+      getSelectedConditions(madLib)?.some(
+        (condition: DataTypeConfig) =>
+          condition?.dataTypeId === 'voter_participation'
+      )
+    )
 
     setShowIncarceratedChildrenAlert(
       getSelectedConditions(madLib)?.some((condition: DataTypeConfig) =>
@@ -278,7 +285,12 @@ function ExploreDataPage(props: ExploreDataPageProps) {
   const headerScrollMargin = useHeaderScrollMargin(
     'madlib-container',
     isSticking,
-    [madLib, showIncarceratedChildrenAlert, showStickyLifeline]
+    [
+      madLib,
+      showIncarceratedChildrenAlert,
+      showStickyLifeline,
+      showAnnouncementBanner,
+    ]
   )
 
   return (
@@ -328,6 +340,7 @@ function ExploreDataPage(props: ExploreDataPageProps) {
               selectedConditions={getSelectedConditions(madLib)}
               showLifeLineAlert={showStickyLifeline}
               showIncarceratedChildrenAlert={showIncarceratedChildrenAlert}
+              showAnnouncementBanner={showAnnouncementBanner}
               setMadLib={setMadLibWithParam}
               isScrolledToTop={!isSticking}
               headerScrollMargin={headerScrollMargin}

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -21,6 +21,7 @@ import { type ScrollableHashId } from '../utils/hooks/useStepObserver'
 import WhatDataAreMissing from './WhatDataAreMissing'
 import HetLinkButton from '../styles/HetComponents/HetLinkButton'
 import { DATA_CATALOG_PAGE_LINK } from '../utils/internalRoutes'
+import AnnouncementBanner from './ui/AnnouncementBanner'
 
 export const SINGLE_COLUMN_WIDTH = 12
 
@@ -32,6 +33,7 @@ interface ReportProviderProps {
   showLifeLineAlert: boolean
   setMadLib: (madLib: MadLib) => void
   showIncarceratedChildrenAlert: boolean
+  showAnnouncementBanner: boolean
   isScrolledToTop: boolean
   headerScrollMargin: number
   isMobile: boolean
@@ -171,6 +173,7 @@ function ReportProvider(props: ReportProviderProps) {
         }`}
       >
         {props.showLifeLineAlert && <LifelineAlert />}
+        {props.showAnnouncementBanner && <AnnouncementBanner />}
         {props.showIncarceratedChildrenAlert && false && (
           <IncarceratedChildrenLongAlert />
         )}

--- a/frontend/src/reports/ui/AnnouncementBanner.tsx
+++ b/frontend/src/reports/ui/AnnouncementBanner.tsx
@@ -1,0 +1,31 @@
+import LightbulbIcon from '@mui/icons-material/Lightbulb'
+import HetNotice from '../../styles/HetComponents/HetNotice'
+import HetLinkButton from '../../styles/HetComponents/HetLinkButton'
+import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
+import { Button } from 'react-scroll'
+import { IconButton } from '@mui/material'
+
+function AnnouncementBanner() {
+  return (
+    <HetNotice
+      className='m-2 mt-0 border border-secondaryMain text-left text-small'
+      icon={<LightbulbIcon color='primary' />}
+      title='Did You Know?'
+      kind='text-only'
+    >
+      <p>
+        Historical data reveals that women in government positions significantly
+        contribute to higher rates of inclusivity and equitable power
+        distribution, fostering a more representative democracy.
+      </p>
+      <IconButton
+        href={'/exploredata?mls=1.women_in_gov-3.00&group1=All'}
+        className='mx-0 my-2 px-0 text-left text-text'
+      >
+        Explore the Women in Government Data →
+      </IconButton>
+    </HetNotice>
+  )
+}
+
+export default AnnouncementBanner


### PR DESCRIPTION
# Description and Motivation
With election season among us, it was suggested by our marketing strategist that adding a CTA to our voter participation page would be a good idea to help users learn more about political determinants of health.

## Has this been tested? How?
tests passing

## Screenshots (if appropriate)
<img width="1438" alt="Screenshot 2024-03-06 at 1 24 45 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/67879386/d9351db7-ff64-4414-ae08-434569c689ec">
<img width="296" alt="Screenshot 2024-03-06 at 1 23 00 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/67879386/a1b1d93c-fe30-45dc-add2-0cedbbb3d850">

## Types of changes
- New content or feature
## New frontend preview link is below in the Netlify comment 😎
