### PR TITLE
Moves type-checking from pre-commit to `dev` command in watch mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         entry: npx biome check --apply --files-ignore-unknown=true --no-errors-on-unmatched --changed
         language: system
         types: [text]
-  # WARN IF THERE ARE TOO MANY FILES IN ONE COMMIT
+  # WARN IF TOO MANY FILES IN ONE COMMIT
   - repo: local
     hooks:
       - id: check-file-count

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,16 +28,8 @@ repos:
   - repo: local
     hooks:
       - id: local-biome-check
-        name: ☕️ ts/json format + lint with biome
+        name: 🦕 ts/json format + lint with biome
         entry: npx biome check --apply --files-ignore-unknown=true --no-errors-on-unmatched --changed
-        language: system
-        types: [text]
-  # TYPECHECK WITH TSC
-  - repo: local
-    hooks:
-      - id: local-tsc-check
-        name: 🦕 typechecking
-        entry: bash -c 'npm run tsc --prefix frontend/'
         language: system
         types: [text]
   # WARN IF THERE ARE TOO MANY FILES IN ONE COMMIT

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -97,7 +97,7 @@
 		"build:staging": "env-cmd -f .env.staging npm run build",
 		"build": "tsc && vite build",
 		"cspell": "cspell '../**/*.{ts,tsx,css,md,py}' --no-progress --no-must-find-files --gitignore",
-		"dev": "env-cmd -f .env.development npm run start -- --host",
+		"dev": "env-cmd -f .env.development npm run start -- --host & npm run tsc:watch",
 		"e2e-staging": "npx playwright install chromium && cross-env E2E_BASE_URL=https://dev.healthequitytracker.org npx playwright test --project=E2E_NIGHTLY --workers 5",
 		"e2e-prod": "npx playwright install chromium && cross-env E2E_BASE_URL=https://healthequitytracker.org npx playwright test --project=E2E_NIGHTLY --workers 5",
 		"e2e": "npx playwright install chromium && npx playwright test --project=E2E_NIGHTLY --workers 2",
@@ -110,7 +110,7 @@
 		"test:coverage": "vitest run --coverage",
 		"test:watch": "vitest watch",
 		"test": "vitest run",
-		"tsc": "npx tsc --noEmit",
+		"tsc:watch": "npx tsc --watch",
 		"url": "npx playwright install chromium && npx playwright test --project=URL"
 	},
 	"engines": {


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

Due to some issues with running tsc on windows machines, and the type checking step being fairly slow, i have moved things around a bit:

- removes the tsc step from the precommit yaml
- appends a call to `tsc -w` into the `npm run dev` command, allowing incremental build type checks to report out in the terminal that's running the dev server. this will help users to see their errors as they occur. we also need to make sure devs are using good tooling like VSCODE with typescript checking enabled

## Screenshots (if appropriate)

<img width="748" alt="Screenshot 2024-03-06 at 5 54 53 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/afff42d9-cd5a-43f3-bc6a-980129c50a91">


## Types of changes

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
