### PR TITLE
Fix handling of LifeLine alert and "empty" demographic rows on table

### DIFF
--- a/frontend/playwright-tests/asthma.ci.spec.ts
+++ b/frontend/playwright-tests/asthma.ci.spec.ts
@@ -17,7 +17,9 @@ test('Asthma', async ({ page }) => {
     .locator('#rate-chart')
     .getByRole('heading', { name: 'Asthma in the United States' })
     .click()
-  await page.getByRole('heading', { name: 'Share of all asthma cases' }).click()
+  await page
+    .getByRole('heading', { name: 'Share of all adult asthma cases' })
+    .click()
   await page
     .getByRole('heading', { name: 'Population vs. distribution' })
     .click()

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -159,8 +159,6 @@ export function TableChart(props: TableChartProps) {
     const denominatorLabel =
       props.countColsMap.denominatorConfig?.shortLabel ?? ''
     prepareRow(row)
-    console.log(row)
-
     if (row.cells.slice(1).every((cell) => cell.value == null)) {
       // skip a row if the only non-null item is the demographic group
       return <></>

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -159,6 +159,12 @@ export function TableChart(props: TableChartProps) {
     const denominatorLabel =
       props.countColsMap.denominatorConfig?.shortLabel ?? ''
     prepareRow(row)
+    console.log(row)
+
+    if (row.cells.slice(1).every((cell) => cell.value == null)) {
+      // skip a row if the only non-null item is the demographic group
+      return <></>
+    }
     return (
       <TableRow {...row.getRowProps()}>
         {row.cells.map((cell, index) =>

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -21,6 +21,7 @@ import {
   type ChronicDiseaseMetricId,
   COPD_METRICS,
   CHRONIC_DISEASE_CATEGORY_DROPDOWNIDS,
+  ChronicDiseaseDataTypeId,
 } from './MetricConfigChronicDisease'
 import {
   COVID_CATEGORY_DROPDOWNIDS,
@@ -91,6 +92,7 @@ export type AgeAdjustedDataTypeId =
 // IDs for the sub-data types (if any) for theDropDownId
 export type DataTypeId =
   | DropdownVarId
+  | ChronicDiseaseDataTypeId
   | CovidCategoryDataTypeId
   | HivCategoryDataTypeId
   | BehavioralHealthDataTypeId

--- a/frontend/src/data/config/MetricConfigBehavioralHealth.ts
+++ b/frontend/src/data/config/MetricConfigBehavioralHealth.ts
@@ -51,16 +51,17 @@ export const DEPRESSION_METRICS: DataTypeConfig[] = [
       ],
     },
     surveyCollectedData: true,
-    dataTableTitle: 'Breakdown summary for depression cases',
+    dataTableTitle: 'Breakdown summary for depression',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of total depression cases',
+        chartTitle: 'Share of total adult depression cases',
         metricId: 'depression_pct_share',
-        columnTitleHeader: 'Share of total depression cases',
+        columnTitleHeader: 'Share of total adult depression cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
-          chartTitle: 'Population vs. distribution of total depression cases',
+          chartTitle:
+            'Population vs. distribution of total adult depression cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -103,14 +104,14 @@ export const EXCESSIVE_DRINKING_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Breakdown summary for excessive drinking cases',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of all excessive drinking cases',
+        chartTitle: 'Share of all adult excessive drinking cases',
         metricId: 'excessive_drinking_pct_share',
-        columnTitleHeader: 'Share of all excessive drinking cases',
+        columnTitleHeader: 'Share of all adult excessive drinking cases',
         shortLabel: '% of all cases',
         type: 'pct_share',
         populationComparisonMetric: {
           chartTitle:
-            'Population vs. distribution of total excessive drinking cases',
+            'Population vs. distribution of total adult excessive drinking cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -155,14 +156,14 @@ export const SUBSTANCE_MISUSE_METRICS: DataTypeConfig[] = [
       'Breakdown summary for opioid and other non-medical drug use',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of total non-medical drug use',
+        chartTitle: 'Share of total adult non-medical drug use',
         metricId: 'non_medical_drug_use_pct_share',
-        columnTitleHeader: 'Share of total non-medical drug use',
+        columnTitleHeader: 'Share of total adult non-medical drug use',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
           chartTitle:
-            'Population vs. distribution of total non-medical drug use',
+            'Population vs. distribution of total adult non-medical drug use',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -202,17 +203,17 @@ export const FREQUENT_MENTAL_DISTRESS_METRICS: DataTypeConfig[] = [
       ],
     },
     surveyCollectedData: true,
-    dataTableTitle: 'Breakdown summary for frequent mental distress cases',
+    dataTableTitle: 'Breakdown summary for frequent mental distress',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of all frequent mental distress cases',
+        chartTitle: 'Share of all adult frequent mental distress cases',
         metricId: 'frequent_mental_distress_pct_share',
-        columnTitleHeader: 'Share of all frequent mental distress cases',
+        columnTitleHeader: 'Share of all adult frequent mental distress cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
           chartTitle:
-            'Population vs. distribution of total frequent mental distress cases',
+            'Population vs. distribution of total adult frequent mental distress cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,

--- a/frontend/src/data/config/MetricConfigChronicDisease.ts
+++ b/frontend/src/data/config/MetricConfigChronicDisease.ts
@@ -58,13 +58,13 @@ export const ASTHMA_METRICS: DataTypeConfig[] = [
         type: 'per100k',
       },
       pct_share: {
-        chartTitle: 'Share of all asthma cases',
+        chartTitle: 'Share of all adult asthma cases',
         metricId: 'asthma_pct_share',
-        columnTitleHeader: 'Share of all asthma cases',
+        columnTitleHeader: 'Share of all adult asthma cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
-          chartTitle: 'Population vs. distribution of total asthma cases',
+          chartTitle: 'Population vs. distribution of total adult asthma cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -109,12 +109,13 @@ export const CARDIOVASCULAR_DISEASES_METRICS: DataTypeConfig[] = [
       pct_share: {
         chartTitle: 'Share of all cases of cardiovascular diseases',
         metricId: 'cardiovascular_diseases_pct_share',
-        columnTitleHeader: 'Share of all cases of cardiovascular diseases',
+        columnTitleHeader:
+          'Share of all adult cases of cardiovascular diseases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
           chartTitle:
-            'Population vs. distribution of total cases of cardiovascular diseases',
+            'Population vs. distribution of total adult cases of cardiovascular diseases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -159,12 +160,12 @@ export const CHRONIC_KIDNEY_DISEASE_METRICS: DataTypeConfig[] = [
       pct_share: {
         chartTitle: 'Share of all chronic kidney disease cases',
         metricId: 'chronic_kidney_disease_pct_share',
-        columnTitleHeader: 'Share of all chronic kidney disease cases',
+        columnTitleHeader: 'Share of all adult chronic kidney disease cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
           chartTitle:
-            'Population vs. distribution of total cases of chronic kidney disease',
+            'Population vs. distribution of total adult cases of chronic kidney disease',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -193,13 +194,14 @@ export const DIABETES_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Breakdown summary for diabetes',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of total diabetes cases',
+        chartTitle: 'Share of total adult diabetes cases',
         metricId: 'diabetes_pct_share',
-        columnTitleHeader: 'Share of total diabetes cases',
+        columnTitleHeader: 'Share of total adult diabetes cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
-          chartTitle: 'Population vs. distribution of total diabetes cases',
+          chartTitle:
+            'Population vs. distribution of total adult diabetes cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,
@@ -241,13 +243,13 @@ export const COPD_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Breakdown summary for COPD',
     metrics: {
       pct_share: {
-        chartTitle: 'Share of total COPD cases',
+        chartTitle: 'Share of total adult COPD cases',
         metricId: 'copd_pct_share',
-        columnTitleHeader: 'Share of total COPD cases',
+        columnTitleHeader: 'Share of total adult COPD cases',
         shortLabel: '% of cases',
         type: 'pct_share',
         populationComparisonMetric: {
-          chartTitle: 'Population vs. distribution of total COPD cases',
+          chartTitle: 'Population vs. distribution of total adult COPD cases',
           metricId: 'ahr_population_pct',
           columnTitleHeader: populationPctTitle,
           shortLabel: populationPctShortLabel,

--- a/frontend/src/data/config/MetricConfigChronicDisease.ts
+++ b/frontend/src/data/config/MetricConfigChronicDisease.ts
@@ -13,6 +13,9 @@ export const CHRONIC_DISEASE_CATEGORY_DROPDOWNIDS = [
   'diabetes',
 ] as const
 
+export type ChronicDiseaseDataTypeId =
+  (typeof CHRONIC_DISEASE_CATEGORY_DROPDOWNIDS)[number]
+
 export type ChronicDiseaseMetricId =
   | 'ahr_population_pct'
   | 'asthma_pct_share'

--- a/frontend/src/data/config/MetricConfigSDOH.ts
+++ b/frontend/src/data/config/MetricConfigSDOH.ts
@@ -216,7 +216,7 @@ export const CARE_AVOIDANCE_METRICS: DataTypeConfig[] = [
       pct_share: {
         chartTitle: 'Share of all care avoidance due to cost',
         metricId: 'avoided_care_pct_share',
-        columnTitleHeader: 'Share of all care avoidance due to cost',
+        columnTitleHeader: 'Share of all care avoidance due to cost for adults',
         shortLabel: '% of avoidances',
         type: 'pct_share',
         populationComparisonMetric: {

--- a/frontend/src/data/config/MetricConfigSDOH.ts
+++ b/frontend/src/data/config/MetricConfigSDOH.ts
@@ -24,6 +24,10 @@ export type SDOHDataTypeId =
   | 'gun_violence_injuries'
   | 'gun_violence_suicide'
   | 'gun_violence_legal_intervention'
+  | 'poverty'
+  | 'health_insurance'
+  | 'preventable_hospitalizations'
+  | 'avoided_care'
 
 export type SDOHMetricId =
   | 'ahr_population_pct'

--- a/frontend/src/data/providers/AcsConditionProvider.ts
+++ b/frontend/src/data/providers/AcsConditionProvider.ts
@@ -36,7 +36,6 @@ class AcsConditionProvider extends VariableProvider {
     _dataTypeId?: DataTypeId,
     timeView?: TimeView
   ): DatasetId | undefined {
-    console.log({ breakdowns }, { _dataTypeId }, { timeView })
     if (timeView === 'historical') {
       if (breakdowns.geography === 'national') {
         if (breakdowns.hasOnlyRace())

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -31,6 +31,7 @@ import {
   type DataTypeConfig,
   METRIC_CONFIG,
   isDropdownVarId,
+  DataTypeId,
 } from '../../data/config/MetricConfig'
 import { INCARCERATION_IDS } from '../../data/providers/IncarcerationProvider'
 import useScrollPosition from '../../utils/hooks/useScrollPosition'
@@ -41,6 +42,12 @@ import useDeprecatedParamRedirects from '../../utils/hooks/useDeprecatedParamRed
 import MadLibUI from './MadLibUI'
 import { ALL } from '../../data/utils/Constants'
 import TopicInfoModal from './TopicInfoModal'
+import { LIFELINE_IDS } from '../../reports/ui/LifelineAlert'
+import { useAtom, useAtomValue } from 'jotai'
+import {
+  selectedDataTypeConfig1Atom,
+  selectedDataTypeConfig2Atom,
+} from '../../utils/sharedSettingsState'
 
 const Onboarding = lazy(async () => await import('./Onboarding'))
 
@@ -52,10 +59,19 @@ interface ExploreDataPageProps {
 
 function ExploreDataPage(props: ExploreDataPageProps) {
   const location: any = useLocation()
-  const [showStickyLifeline, setShowStickyLifeline] = useState(false)
   const [showAnnouncementBanner, setShowAnnouncementBanner] = useState(false)
   const [showIncarceratedChildrenAlert, setShowIncarceratedChildrenAlert] =
     useState(false)
+
+  const dtId1: DataTypeId | undefined = useAtomValue(
+    selectedDataTypeConfig1Atom
+  )?.dataTypeId
+  const dtId2: DataTypeId | undefined = useAtomValue(
+    selectedDataTypeConfig2Atom
+  )?.dataTypeId
+  const showStickyLifeline = LIFELINE_IDS.some(
+    (id) => id === dtId1 || id === dtId2
+  )
 
   // Set up initial mad lib values based on defaults and query params, redirecting from deprecated ones
   const params = useDeprecatedParamRedirects()
@@ -261,13 +277,6 @@ function ExploreDataPage(props: ExploreDataPageProps) {
   useEffect(() => {
     // A11y - create then delete an invisible alert that the report mode has changed
     srSpeak(`Now viewing report: ${getMadLibPhraseText(madLib)}`)
-
-    // hide/display the sticky suicide lifeline link based on selected condition
-    setShowStickyLifeline(
-      getSelectedConditions(madLib)?.some(
-        (condition: DataTypeConfig) => condition?.dataTypeId === 'suicide'
-      )
-    )
     setShowAnnouncementBanner(
       getSelectedConditions(madLib)?.some(
         (condition: DataTypeConfig) =>

--- a/frontend/src/reports/ui/LifelineAlert.tsx
+++ b/frontend/src/reports/ui/LifelineAlert.tsx
@@ -1,8 +1,11 @@
 import PhoneIcon from '@mui/icons-material/Phone'
 import { urlMap } from '../../utils/externalUrls'
 import HetNotice from '../../styles/HetComponents/HetNotice'
+import { DataTypeId } from '../../data/config/MetricConfig'
 
-function LifelineAlert() {
+export const LIFELINE_IDS: DataTypeId[] = ['suicide', 'gun_violence_suicide']
+
+export default function LifelineAlert() {
   return (
     <HetNotice
       className='m-2 mt-0 border border-secondaryMain text-left text-small'
@@ -21,5 +24,3 @@ function LifelineAlert() {
     </HetNotice>
   )
 }
-
-export default LifelineAlert

--- a/frontend/src/utils/Logger.ts
+++ b/frontend/src/utils/Logger.ts
@@ -19,7 +19,6 @@ class Logger {
       if (context) {
         logInfo.push(context)
       }
-      // console.log(...logInfo);
     }
   }
 
@@ -32,11 +31,6 @@ class Logger {
     const consoleFn = this.getConsoleFn(severity)
     if (this.enableConsoleLogging) {
       consoleFn('Error Reported', error, error.stack, severity, context)
-    }
-
-    if (this.enableServerLogging && !import.meta.env.PROD) {
-      // TODO: implement server logging
-      console.log('TODO: implement server logging')
     }
   }
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

fixes #2963 

- updates metric configs with labels indicated share of adults for AHR topics
- prevents "empty" rows from rendering on DataTable
- started working on fixing typing for DataTypeId but it's not done yet, will finish in another pr, right now ts is treating them as strings
- uses Jotai to figure out the selected daa type
- renders LifeLine alerts for Suicide and Gun Suidide DataTypeIds as report or compare report
- no need to use state for this. need to also use similar lookup for the voter announcement from #2968 
- cleans up some unused logs

## Has this been tested? How?

both topics work to show the alert as expected

## Screenshots (if appropriate)

<img width="943" alt="Screenshot 2024-03-07 at 11 55 27 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/b087d90c-d3c6-476e-9f4b-c5cc39a5bc6d">



## Types of changes

(leave all that apply)


- bug fix

## New frontend preview link is below in the Netlify comment 😎
