### PR TITLE
Cleans up 100k formatting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,7 @@
 		"editor.defaultFormatter": "biomejs.biome"
 	},
 	"[typescript]": {
-		"editor.defaultFormatter": "biomejs.biome"
+		"editor.defaultFormatter": "vscode.typescript-language-features"
 	},
 	"[typescriptreact]": {
 		"editor.defaultFormatter": "vscode.typescript-language-features"

--- a/frontend/src/cards/ui/AltTableView.tsx
+++ b/frontend/src/cards/ui/AltTableView.tsx
@@ -12,7 +12,7 @@ import WarningRoundedIcon from '@mui/icons-material/WarningRounded'
 import { ArrowDropDown, ArrowDropUp } from '@mui/icons-material'
 import { useRef } from 'react'
 import AnimateHeight from 'react-animate-height'
-import { type MetricConfig } from '../../data/config/MetricConfig'
+import { formatFieldValue, isPctType, type MetricConfig } from '../../data/config/MetricConfig'
 import { type DemographicType } from '../../data/query/Breakdowns'
 import {
   type DemographicGroup,
@@ -146,11 +146,7 @@ export default function AltTableView(props: AltTableViewProps) {
 
                         const appendPct =
                           key.includes('with unknown ') ||
-                          [
-                            'pct_relative_inequity',
-                            'pct_share',
-                            'pct_rate',
-                          ].includes(props.knownMetricConfig.type)
+                          isPctType(props.knownMetricConfig.type)
                         return (
                           <TableCell
                             key={key}
@@ -170,8 +166,11 @@ export default function AltTableView(props: AltTableViewProps) {
                               </>
                             ) : (
                               <>
-                                {isTimePeriod ? row[key] : Math.round(row[key])}
-                                {!isTimePeriod && appendPct ? '%' : ''}
+                                {isTimePeriod ? row[key] : formatFieldValue(
+                                  props.knownMetricConfig.type,
+                                  row[key],
+                                  !appendPct
+                                )}
                               </>
                             )}
                           </TableCell>

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -36,6 +36,7 @@ import {
 } from './mapGlobals'
 import ClickableLegendHeader from './ClickableLegendHeader'
 import {
+  LegendNumberFormat,
   setupLegendScaleSpec,
   setupNonZeroContinuousPctLegend,
   setupNonZeroDiscreteLegend,
@@ -76,6 +77,7 @@ interface LegendProps {
 
 export function Legend(props: LegendProps) {
   const isCawp = CAWP_METRICS.includes(props.metric.metricId)
+  const isLowRate100k = props.metric.metricId === 'gun_violence_legal_intervention_per_100k'
   const zeroData = props.data?.filter((row) => row[props.metric.metricId] === 0)
   const nonZeroData = props.data?.filter(
     (row) => row[props.metric.metricId] > 0
@@ -127,6 +129,8 @@ export function Legend(props: LegendProps) {
       isPct ? '%' : ''
     }' + '${overallPhrase}'`
 
+    const legendFormatterType: LegendNumberFormat = isPct ? 'pct' : isLowRate100k ? 'preventM' : 'truncateWithK'
+
     const legendList: LegendType[] = []
 
     // MAKE NON-ZERO LEGEND ITEMS ALWAYS FOR PHRMA ADHERENCE, OR IF NEEDED FOR OTHER REPORTS
@@ -140,7 +144,7 @@ export function Legend(props: LegendProps) {
     } else if (uniqueNonZeroValueCount > 0) {
       const nonZeroLegend = setupNonZeroDiscreteLegend(
         legendBucketLabel,
-        isPct,
+        legendFormatterType,
         props.stackingDirection,
         props.columns
       )

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -77,7 +77,6 @@ interface LegendProps {
 
 export function Legend(props: LegendProps) {
   const isCawp = CAWP_METRICS.includes(props.metric.metricId)
-  const isLowRate100k = props.metric.metricId === 'gun_violence_legal_intervention_per_100k'
   const zeroData = props.data?.filter((row) => row[props.metric.metricId] === 0)
   const nonZeroData = props.data?.filter(
     (row) => row[props.metric.metricId] > 0
@@ -129,8 +128,7 @@ export function Legend(props: LegendProps) {
       isPct ? '%' : ''
     }' + '${overallPhrase}'`
 
-    const legendFormatterType: LegendNumberFormat = isPct ? 'pct' : isLowRate100k ? 'preventM' : 'truncateWithK'
-
+    const legendFormatterType: LegendNumberFormat = isPct ? 'pct'  : 'truncateWithK'
     const legendList: LegendType[] = []
 
     // MAKE NON-ZERO LEGEND ITEMS ALWAYS FOR PHRMA ADHERENCE, OR IF NEEDED FOR OTHER REPORTS

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -10,7 +10,7 @@ import { type FieldRange } from '../data/utils/DatasetTypes'
 import { type View, type Legend as LegendType, type Scale } from 'vega'
 import { type GeographicBreakdown } from '../data/query/Breakdowns'
 import { CAWP_METRICS } from '../data/providers/CawpProvider'
-import { LESS_THAN_1 } from '../data/utils/Constants'
+import { LESS_THAN_POINT_1 } from '../data/utils/Constants'
 import {
   COLOR_SCALE,
   DATASET_VALUES,
@@ -199,7 +199,7 @@ export function Legend(props: LegendProps) {
               zero:
                 isCawp || props.isPhrmaAdherence
                   ? ZERO_BUCKET_LABEL
-                  : LESS_THAN_1,
+                  : LESS_THAN_POINT_1,
             },
           ],
         },

--- a/frontend/src/charts/SimpleHorizontalBarChart.tsx
+++ b/frontend/src/charts/SimpleHorizontalBarChart.tsx
@@ -277,6 +277,7 @@ interface SimpleHorizontalBarChartProps {
 }
 
 export function SimpleHorizontalBarChart(props: SimpleHorizontalBarChartProps) {
+
   const [ref, width] = useResponsiveWidth()
 
   const altLabelMetrics = [...CAWP_METRICS, ...HIV_METRICS]

--- a/frontend/src/charts/TableChart.tsx
+++ b/frontend/src/charts/TableChart.tsx
@@ -35,7 +35,7 @@ import { type CountColsMap, NO_DATA_MESSAGE } from './mapGlobals'
 import Units from './Units'
 import HetUnitLabel from '../styles/HetComponents/HetUnitLabel'
 import { het } from '../styles/DesignTokens'
-import { LESS_THAN_1 } from '../data/utils/Constants'
+import { LESS_THAN_POINT_1 } from '../data/utils/Constants'
 
 export const MAX_NUM_ROWS_WITHOUT_PAGINATION = 20
 
@@ -184,7 +184,7 @@ export function TableChart(props: TableChartProps) {
               key={`data-${index}`}
               style={row.index % 2 === 0 ? cellStyle : altCellStyle}
             >
-              {(cell.value < 1 && cell.value > 0 && index === 1) ? LESS_THAN_1 : cell.render('Cell')}
+              {(cell.value < .1 && cell.value > 0 && index === 1) ? LESS_THAN_POINT_1 : cell.render('Cell')}
               <Units column={index} metric={props.metrics} />
               {index === 1 && numeratorCount && denominatorCount ? (
                 <HetUnitLabel>

--- a/frontend/src/charts/legendHelperFunctions.ts
+++ b/frontend/src/charts/legendHelperFunctions.ts
@@ -67,18 +67,28 @@ export function setupUnknownsLegend(width: number, isPct?: boolean): Legend {
   return unknownsLegend
 }
 
+export type LegendNumberFormat = 'truncateWithK' | 'preventM' | 'pct'
 /* To make the discrete style legend where each color bucket is its own distinct shape */
 export function setupNonZeroDiscreteLegend(
   legendBucketLabel: string,
-  isPct: boolean,
+  legendNumberFormat: LegendNumberFormat,
   stackingDirection: StackingDirection,
   columns: number
+
 ): Legend {
+
+  const formatterMap: Record<LegendNumberFormat, string> = {
+    truncateWithK: ',.2r', // simplify large 100k legend breakpoints: e.g. 8,123 -> 8.1k
+    preventM: ',.2r', // ensure values well below 1 dont render with m like 100m - 200m
+    pct: 'd', // pct style
+
+  }
+
   return {
     fill: COLOR_SCALE,
     symbolType: LEGEND_SYMBOL_TYPE,
     size: DOT_SIZE_SCALE,
-    format: isPct ? 'd' : ',.2s', // simplify large 100k legend breakpoints: e.g. 8,123 -> 8.1k
+    format: formatterMap[legendNumberFormat],
     direction: stackingDirection,
     columns,
     columnPadding: 20,

--- a/frontend/src/charts/legendHelperFunctions.ts
+++ b/frontend/src/charts/legendHelperFunctions.ts
@@ -67,6 +67,12 @@ export function setupUnknownsLegend(width: number, isPct?: boolean): Legend {
   return unknownsLegend
 }
 
+export const formatterMap: Record<LegendNumberFormat, string> = {
+  truncateWithK: ',.2s', // simplify large 100k legend breakpoints: e.g. 8,123 -> 8.1k
+  preventM: ',.2r', // ensure values well below 1 dont render with m like 100m - 200m
+  pct: 'd', // pct style
+}
+
 export type LegendNumberFormat = 'truncateWithK' | 'preventM' | 'pct'
 /* To make the discrete style legend where each color bucket is its own distinct shape */
 export function setupNonZeroDiscreteLegend(
@@ -77,12 +83,7 @@ export function setupNonZeroDiscreteLegend(
 
 ): Legend {
 
-  const formatterMap: Record<LegendNumberFormat, string> = {
-    truncateWithK: ',.2r', // simplify large 100k legend breakpoints: e.g. 8,123 -> 8.1k
-    preventM: ',.2r', // ensure values well below 1 dont render with m like 100m - 200m
-    pct: 'd', // pct style
 
-  }
 
   return {
     fill: COLOR_SCALE,

--- a/frontend/src/charts/mapHelperFunctions.test.ts
+++ b/frontend/src/charts/mapHelperFunctions.test.ts
@@ -6,6 +6,7 @@ import {
   addCountsTooltipInfo,
   buildTooltipTemplate,
   createBarLabel,
+  formatPreventZero100k,
   getCawpMapGroupDenominatorLabel,
   getCawpMapGroupNumeratorLabel,
   getCountyAddOn,
@@ -360,3 +361,4 @@ describe('Test createBarLabel()', () => {
     expect(result).toEqual('datum.asthma_per_100k__DISPLAY_true + " per 100k"')
   })
 })
+

--- a/frontend/src/charts/mapHelperFunctions.ts
+++ b/frontend/src/charts/mapHelperFunctions.ts
@@ -32,6 +32,7 @@ import {
   type CountColsMap,
 } from './mapGlobals'
 import { het } from '../styles/DesignTokens'
+import { formatterMap, LegendNumberFormat } from './legendHelperFunctions'
 
 /*
 
@@ -119,8 +120,15 @@ export function formatPreventZero100k(
   metricType: MetricType,
   metricId: MetricId
 ) {
+
+  const isPct = isPctType(metricType)
+  const isLowRate100k = metricId === 'gun_violence_legal_intervention_per_100k'
+  const legendFormatterType: LegendNumberFormat = isPct ? 'pct' : isLowRate100k ? 'preventM' : 'truncateWithK'
+  const d3Format = formatterMap[legendFormatterType]
+
+
   if (metricType === 'per100k') {
-    return `if (datum.${metricId} > 0, format(datum.${metricId}, '0.1r'), '${LESS_THAN_POINT_1}') + ' per 100k'`
+    return `if (datum.${metricId} > 0, format(datum.${metricId}, '${d3Format}'), '${LESS_THAN_POINT_1}') + ' per 100k'`
   }
   if (isPctType(metricType)) {
     return `format(datum.${metricId}, ',') + '%'`

--- a/frontend/src/charts/mapHelperFunctions.ts
+++ b/frontend/src/charts/mapHelperFunctions.ts
@@ -9,6 +9,7 @@ import {
   ALL,
   RACE,
   AGE,
+  LESS_THAN_POINT_1,
 } from '../data/utils/Constants'
 import { type ScaleType, type Legend } from 'vega'
 import { type DemographicType } from '../data/query/Breakdowns'
@@ -84,17 +85,17 @@ export function addCountsTooltipInfo(
   const numeratorPhrase = isCawp
     ? getCawpMapGroupNumeratorLabel(countColsMap, activeDemographicGroup)
     : getMapGroupLabel(
-        demographicType,
-        activeDemographicGroup,
-        countColsMap?.numeratorConfig?.shortLabel ?? ''
-      )
+      demographicType,
+      activeDemographicGroup,
+      countColsMap?.numeratorConfig?.shortLabel ?? ''
+    )
   const denominatorPhrase = isCawp
     ? getCawpMapGroupDenominatorLabel(countColsMap)
     : getMapGroupLabel(
-        demographicType,
-        activeDemographicGroup,
-        countColsMap?.denominatorConfig?.shortLabel ?? ''
-      )
+      demographicType,
+      activeDemographicGroup,
+      countColsMap?.denominatorConfig?.shortLabel ?? ''
+    )
 
   if (countColsMap?.numeratorConfig) {
     tooltipPairs[`# ${numeratorPhrase}`] =
@@ -117,12 +118,12 @@ export function formatPreventZero100k(
   metricId: MetricId
 ) {
   if (metricType === 'per100k') {
-    return `if (datum.${metricId} > 0, format(datum.${metricId}, ','), '${LESS_THAN_1}') + ' per 100k'`
-  } else if (metricType === 'index') {
-    return `if (datum.${metricId} > 0, format(datum.${metricId}, ','), '${LESS_THAN_1}') + ''`
-  } else {
+    return `if (datum.${metricId} > 0, format(datum.${metricId}, '0.1r'), '${LESS_THAN_POINT_1}') + ' per 100k'`
+  }
+  if (['pct_share', 'pct_rate', 'pct_relative_inequity'].includes(metricType)) {
     return `format(datum.${metricId}, ',') + '%'`
   }
+  return `format(datum.${metricId}, ',')`
 }
 
 /*
@@ -250,9 +251,8 @@ export function makeAltText(
     : `Map showing ${filename}`
 
   if (!fips.isCounty() && !overrideShapeWithCircle) {
-    altText += `: including data from ${
-      data.length
-    } ${fips.getPluralChildFipsTypeDisplayName()}`
+    altText += `: including data from ${data.length
+      } ${fips.getPluralChildFipsTypeDisplayName()}`
   }
 
   return altText
@@ -267,22 +267,22 @@ export function getProjection(
 ) {
   return overrideShapeWithCircle
     ? {
-        name: CIRCLE_PROJECTION,
-        type: 'albersUsa',
-        scale: 1100,
-        translate: [{ signal: 'width / 2' }, { signal: 'height / 2' }],
-      }
+      name: CIRCLE_PROJECTION,
+      type: 'albersUsa',
+      scale: 1100,
+      translate: [{ signal: 'width / 2' }, { signal: 'height / 2' }],
+    }
     : {
-        name: US_PROJECTION,
-        type:
-          fips.isTerritory() || fips.getParentFips().isTerritory()
-            ? 'albers'
-            : 'albersUsa',
-        fit: { signal: "data('" + GEO_DATASET + "')" },
-        size: {
-          signal: '[' + width + ', ' + width * heightWidthRatio + ']',
-        },
-      }
+      name: US_PROJECTION,
+      type:
+        fips.isTerritory() || fips.getParentFips().isTerritory()
+          ? 'albers'
+          : 'albersUsa',
+      fit: { signal: "data('" + GEO_DATASET + "')" },
+      size: {
+        signal: '[' + width + ', ' + width * heightWidthRatio + ']',
+      },
+    }
 }
 
 /*
@@ -386,7 +386,7 @@ export function getHighestLowestGroupsByFips(
       fipsToGroup[fips] = {
         highest: generateSubtitle(
           /* activeDemographicGroup: */ ascendingGroups[
-            ascendingGroups.length - 1
+          ascendingGroups.length - 1
           ],
           /* demographicType:  */ demographicType,
           metricId

--- a/frontend/src/charts/mapHelperFunctions.ts
+++ b/frontend/src/charts/mapHelperFunctions.ts
@@ -121,8 +121,7 @@ export function formatPreventZero100k(
 ) {
 
   const isPct = isPctType(metricType)
-  const isLowRate100k = metricId === 'gun_violence_legal_intervention_per_100k'
-  const legendFormatterType: LegendNumberFormat = isPct ? 'pct' : isLowRate100k ? 'preventM' : 'truncateWithK'
+  const legendFormatterType: LegendNumberFormat = isPct ? 'pct' : 'truncateWithK'
   const d3Format = formatterMap[legendFormatterType]
 
 

--- a/frontend/src/charts/mapHelperFunctions.ts
+++ b/frontend/src/charts/mapHelperFunctions.ts
@@ -1,4 +1,4 @@
-import { type MetricId, type MetricType } from '../data/config/MetricConfig'
+import { isPctType, type MetricId, type MetricType } from '../data/config/MetricConfig'
 import { type Fips } from '../data/utils/Fips'
 import { type FieldRange, type Row } from '../data/utils/DatasetTypes'
 import { generateSubtitle } from './utils'
@@ -112,6 +112,8 @@ export function addCountsTooltipInfo(
 
 /*
  formatted tooltip hover 100k values that round to zero should display as <1, otherwise should get pretty commas
+ percent types get a single decimal place and the %
+ every else gets passed through with commas for thousands
 */
 export function formatPreventZero100k(
   metricType: MetricType,
@@ -120,7 +122,7 @@ export function formatPreventZero100k(
   if (metricType === 'per100k') {
     return `if (datum.${metricId} > 0, format(datum.${metricId}, '0.1r'), '${LESS_THAN_POINT_1}') + ' per 100k'`
   }
-  if (['pct_share', 'pct_rate', 'pct_relative_inequity'].includes(metricType)) {
+  if (isPctType(metricType)) {
     return `format(datum.${metricId}, ',') + '%'`
   }
   return `format(datum.${metricId}, ',')`

--- a/frontend/src/charts/mapHelperFunctions.ts
+++ b/frontend/src/charts/mapHelperFunctions.ts
@@ -4,7 +4,6 @@ import { type FieldRange, type Row } from '../data/utils/DatasetTypes'
 import { generateSubtitle } from './utils'
 import {
   type DemographicGroup,
-  LESS_THAN_1,
   raceNameToCodeMap,
   ALL,
   RACE,
@@ -128,7 +127,7 @@ export function formatPreventZero100k(
 
 
   if (metricType === 'per100k') {
-    return `if (datum.${metricId} > 0, format(datum.${metricId}, '${d3Format}'), '${LESS_THAN_POINT_1}') + ' per 100k'`
+    return `if (datum.${metricId} >= .1, format(datum.${metricId}, '${d3Format}'), '${LESS_THAN_POINT_1}') + ' per 100k'`
   }
   if (isPctType(metricType)) {
     return `format(datum.${metricId}, ',') + '%'`

--- a/frontend/src/charts/trendsChart/TrendsTooltip.tsx
+++ b/frontend/src/charts/trendsChart/TrendsTooltip.tsx
@@ -52,7 +52,7 @@ export function TrendsTooltip({
       UNIT: isSkinny ? '' : ' per 100k',
       width: getWidthHundredK,
       translate_x: (d: TimeSeries) => 0,
-      formatter: F.num,
+      formatter: F.num100k,
     },
     [TYPES.PCT_RATE]: {
       UNIT: '',
@@ -76,7 +76,7 @@ export function TrendsTooltip({
       UNIT: '',
       width: getWidthHundredK,
       translate_x: (d: TimeSeries) => 0,
-      formatter: F.num,
+      formatter: F.num100k,
     },
   }
 

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -175,7 +175,8 @@ const FORMATTERS = {
   dateFromString_YYYY: (str: string) => str && utcFormat('%Y')(new Date(str)),
   dateFromString_MM_YYYY: (str: string) =>
     str && utcFormat('%B %Y')(new Date(str)),
-  num: format('.1~f'),
+  num: format('.2~f'),
+  num100k: (d: number) => d < 1 ? format('.2~f')(d) : d < 10 ? format('.1~f')(d) : format('.0~f')(d),
   plusNum: (d: number) => `${d > 0 ? '+' : ''}${format('.1~f')(d)}`, // add "+" only to positive numbers (not 0)
   capitalize: (d: string) => (d ? d[0]?.toUpperCase() + d.slice(1) : ''),
 }

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -176,7 +176,7 @@ const FORMATTERS = {
   dateFromString_MM_YYYY: (str: string) =>
     str && utcFormat('%B %Y')(new Date(str)),
   num: format('.2~f'),
-  num100k: (d: number) => d < 1 ? format('.2~f')(d) : d < 10 ? format('.1~f')(d) : format('.0~f')(d),
+  num100k: (d: number) => d < 10 ? format('.1~f')(d) : format('.0~f')(d), // show single decimal if less than 10, remove trailling zeros
   plusNum: (d: number) => `${d > 0 ? '+' : ''}${format('.1~f')(d)}`, // add "+" only to positive numbers (not 0)
   capitalize: (d: string) => (d ? d[0]?.toUpperCase() + d.slice(1) : ''),
 }

--- a/frontend/src/charts/utils.ts
+++ b/frontend/src/charts/utils.ts
@@ -94,11 +94,10 @@ export function generateChartTitle(
   fips: Fips,
   demographicType?: DemographicType
 ): string {
-  return `${chartTitle}${
-    demographicType
-      ? ` with unknown ${DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType]}`
-      : ''
-  } in ${fips.getSentenceDisplayName()}`
+  return `${chartTitle}${demographicType
+    ? ` with unknown ${DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType]}`
+    : ''
+    } in ${fips.getSentenceDisplayName()}`
 }
 
 export function generateSubtitle(
@@ -164,10 +163,10 @@ export function getAltGroupLabel(
   demographicType: DemographicType
 ) {
   if (CAWP_METRICS.includes(metricId)) {
-      return getWomenRaceLabel(group)
+    return getWomenRaceLabel(group)
   }
   if (GUN_VIOLENCE_YOUTH_METRICS.includes(metricId)) {
-      return `${group} (0-25)`
+    return `${group} (0-25)`
   }
   if (group === ALL && demographicType === AGE) {
     if (metricId.includes('prep')) {
@@ -186,4 +185,15 @@ export function getAltGroupLabel(
 export function removeLastS(inputString: string) {
   // Use a regular expression to replace the last "s" with an empty string
   return inputString.replace(/s$/, '')
+}
+
+
+// Returns an options object for toLocaleString() that will round larger 100k numbers to whole numbers, but allow 1 decimal place for numbers under 10 and 2 decimal places for numbers under 1
+export const getFormatterPer100k = (value: number) => {
+  const numDecimalPlaces = value < 1 ? 2 : value < 10 ? 1 : 0
+  return {
+    minimumFractionDigits: numDecimalPlaces,
+    maximumFractionDigits: numDecimalPlaces
+  }
+
 }

--- a/frontend/src/charts/utils.ts
+++ b/frontend/src/charts/utils.ts
@@ -190,7 +190,7 @@ export function removeLastS(inputString: string) {
 
 // Returns an options object for toLocaleString() that will round larger 100k numbers to whole numbers, but allow 1 decimal place for numbers under 10 and 2 decimal places for numbers under 1
 export const getFormatterPer100k = (value: number) => {
-  const numDecimalPlaces = value < 1 ? 2 : value < 10 ? 1 : 0
+  const numDecimalPlaces = value < 10 ? 1 : 0
   return {
     minimumFractionDigits: numDecimalPlaces,
     maximumFractionDigits: numDecimalPlaces

--- a/frontend/src/data/config/MetricConfig.test.ts
+++ b/frontend/src/data/config/MetricConfig.test.ts
@@ -21,6 +21,7 @@ describe('Test Metric Config Functions', () => {
     expect(formatFieldValue('pct_share', 3, false)).toBe('3.0%')
     expect(formatFieldValue('per100k', 30_000, false)).toBe('30,000')
     expect(formatFieldValue('per100k', 0, false)).toBe('< 0.1')
+    expect(formatFieldValue('per100k', 3.33, false)).toBe('3.3')
   })
 
   test('Test buildTopicsString(): Topics without sub DataTypes', () => {

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -68,6 +68,7 @@ import {
   GUN_VIOLENCE_YOUTH_METRICS,
 } from './MetricConfigSDOH'
 import { DROPDOWN_TOPIC_MAP, type CategoryTypeId } from '../../utils/MadLibs'
+import { getFormatterPer100k } from '../../charts/utils'
 
 const dropdownVarIds = [
   ...CHRONIC_DISEASE_CATEGORY_DROPDOWNIDS,
@@ -229,7 +230,7 @@ export function formatFieldValue(
   const formatOptions =
     metricType === 'pct_share' || metricType === 'age_adjusted_ratio'
       ? { minimumFractionDigits: 1 }
-      : { maximumFractionDigits: 0 }
+      : getFormatterPer100k(value)
   const formattedValue: string =
     typeof value === 'number'
       ? value.toLocaleString('en', formatOptions)

--- a/frontend/src/data/config/MetricConfig.ts
+++ b/frontend/src/data/config/MetricConfig.ts
@@ -2,7 +2,7 @@
 // so ALL related topic data is contained in a single object
 
 import { type ColorScheme } from 'vega'
-import { LESS_THAN_1, LESS_THAN_POINT_1 } from '../utils/Constants'
+import { LESS_THAN_POINT_1 } from '../utils/Constants'
 import {
   DEPRESSION_METRICS,
   type BehavioralHealthMetricId,

--- a/frontend/src/data/utils/Constants.ts
+++ b/frontend/src/data/utils/Constants.ts
@@ -4,7 +4,6 @@ Arrays to sort through distinct groupings
 Converts to types for TS checking
 */
 
-export const LESS_THAN_1 = '< 1'
 export const LESS_THAN_POINT_1 = '< 0.1'
 
 // DEMOGRAPHIC BREAKDOWN CATEGORY TERMS

--- a/frontend/src/reports/ui/LifelineAlert.tsx
+++ b/frontend/src/reports/ui/LifelineAlert.tsx
@@ -8,7 +8,7 @@ export const LIFELINE_IDS: DataTypeId[] = ['suicide', 'gun_violence_suicide']
 export default function LifelineAlert() {
   return (
     <HetNotice
-      className='m-2 mt-0 border border-secondaryMain text-left text-small'
+      className='mx-2 mt-4 mb-2 lg:mb-4 lg:mt-4 lg:ml-2 border border-secondaryMain text-left text-small'
       icon={<PhoneIcon color='primary' />}
       title='988 Suicide & Crisis Lifeline'
       kind='text-only'


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- part of #3020 
- attempts to unify the rounding/formatting strategy across all of the cards. this should really be done on the backend (e.g., whatever we put in bigquery is exactly what we want shown on the frontend) but that'll be for future refactoring
- very large 100k values get truncated with `k` in the legend and map hover tooltip `33k`
- 100k values larger than 10 get displayed as whole numbers in other cards `32`
- 100k values less between .1 and 10 get displayed with a single decimal place `3.1`
- 100k values between zero and .1 are (should be?) displayed as `< 0.1 per 100k`

## Has this been tested? How?

- [x] tests passing
- [x] unit tests added for util functions used

## Screenshots (if appropriate)

<img width="620" alt="Screenshot 2024-03-22 at 10 00 17 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/3ffe6198-cad9-4a56-85aa-48692cf2f496">
<img width="620" alt="Screenshot 2024-03-22 at 10 08 18 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/eb92dc77-0ce3-4094-aba4-c586b656c565">
<img width="620" alt="Screenshot 2024-03-22 at 10 36 57 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/c0522aa2-40fc-439d-a66a-2ecbdc1e0819">
<img width="1402" alt="Screenshot 2024-03-22 at 12 22 31 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/e5193741-5384-4d54-9499-25f952559fb1">
<img width="1402" alt="Screenshot 2024-03-22 at 12 22 49 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/00a8459c-dba5-4758-9b8c-94ef1d11db73">
<img width="1160" alt="Screenshot 2024-03-22 at 12 23 21 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/6a4f5ec0-4c3c-4724-871b-d5e6676f3f6d">
<img width="1160" alt="Screenshot 2024-03-22 at 12 30 48 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/bd4e3b17-139b-4761-92ea-dfb2351496bb">
<img width="605" alt="Screenshot 2024-03-22 at 12 34 20 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/41567007/b329f9f1-7e3d-4616-a898-f90691b83268">


## Types of changes

(leave all that apply)

- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
