### PR TITLE
Add Feature Flag for Community Safety Category 

### DIFF
--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -16,6 +16,7 @@ import {
 } from '../data/config/MetricConfigPhrma'
 import { SDOH_CATEGORY_DROPDOWNIDS } from '../data/config/MetricConfigSDOH'
 import { SHOW_PHRMA_MENTAL_HEALTH } from '../data/providers/PhrmaProvider'
+import { SHOW_GUN_VIOLENCE } from '../data/providers/GunViolenceProvider'
 import { GEORGIA_FIPS, USA_FIPS } from '../data/utils/ConstantsGeography'
 import { FIPS_MAP } from '../data/utils/FipsData'
 
@@ -194,8 +195,7 @@ const CATEGORIES_LIST: Category[] = [
   {
     title: 'Behavioral Health',
     definition: '',
-    options:
-      BEHAVIORAL_HEALTH_CATEGORY_DROPDOWNIDS as unknown as DropdownVarId[],
+    options: BEHAVIORAL_HEALTH_CATEGORY_DROPDOWNIDS as unknown as DropdownVarId[],
   },
   {
     title: 'Political Determinants of Health',
@@ -220,12 +220,15 @@ const CATEGORIES_LIST: Category[] = [
     definition: '',
     options: COVID_CATEGORY_DROPDOWNIDS as unknown as DropdownVarId[],
   },
-  {
-    title: 'Community Safety',
-    definition: '',
-    options: COMMUNITY_SAFETY_DROPDOWNIDS as unknown as DropdownVarId[],
-  }
-]
+  ...(SHOW_GUN_VIOLENCE ? [
+    {
+      title: 'Community Safety',
+      definition: '',
+      options: COMMUNITY_SAFETY_DROPDOWNIDS as unknown as DropdownVarId[],
+    }
+  ] : [])
+];
+
 
 const MADLIB_LIST: MadLib[] = [
   {


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
This pull request addresses a previously missed feature flag for the 'Community Safety' category, ensuring its visibility is controlled by the existing feature flag for gun violence, SHOW_GUN_VIOLENCE.

The 'Community Safety' category was inadvertently included without considering the conditionality of its visibility. By adding the appropriate check for SHOW_GUN_VIOLENCE, this PR ensures that the 'Community Safety' category is displayed only on dev. 

This update aligns the visibility of the 'Community Safety' category with our existing feature flagging system, enhancing the consistency and manageability of our codebase.

## Has this been tested? How?
I tested the updated codebase using manual verification.

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
