### PR TITLE
More dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,39 @@ updates:
     directory: "frontend/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-frontend:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2
   - package-ecosystem: "npm"
     directory: "frontend_server/"
     schedule:
       interval: "weekly"
-    open-pull-requests-limit: 0 # TODO: re-enable dependbot for frontend_server once we have test coverage #3152
+    groups:
+      minor-frontend-server:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 0 # TODO: re-enable by increasing limit once we have test coverage #3152
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-gh-actions:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2
   - package-ecosystem: "pip"
     directory: "python/"
     schedule:
       interval: "weekly"
+    groups:
+      minor-python:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 2


### PR DESCRIPTION
- groups PRs within each service that are only minor or patch updates
- limits each service's number of open bot PRs to 2