### PR TITLE
Fix: Use Population Percentage Instead of Raw Population Counts

### DIFF
--- a/python/datasources/cdc_wisqars_youth.py
+++ b/python/datasources/cdc_wisqars_youth.py
@@ -1,3 +1,30 @@
+"""
+This documentation outlines the procedure for acquiring gun violence data for the general
+population from the CDC WISQARS database. The data, once downloaded, is stored locally in
+the `data/cdc_wisqars` directory for further processing and analysis.
+
+Instructions for Downloading Data:
+1. Access the WISQARS website at https://wisqars.cdc.gov/reports/.
+2. Select `Fatal` as the injury outcome.
+3. Specify the data years of interest, from `2018-2021 by Single Race`.
+4. Set geography to `United States`.
+5. Choose `All Intents` for the intent.
+6. Under mechanism, opt for `Firearm`.
+7. For youth demographics, select `Custom Age Range: <1 to 17`, `Both Sexes`, `All Races`.
+8. For youth demographics, select `Custom Age Range: 18 to 25`, `Both Sexes`, `All Races`.
+9. Decide on the report layout based on your requirements:
+   - For youth-national-all: `Intent`, `None`, `None`, `None`
+   - For youth-national-race: `Intent`, `Race`, `Ethnicity`, `None`
+   - For youth-state-all: `Intent`, `State`, `None`, `None`
+   - For youth-state-race: `Intent`, `State`, `Race`, `Ethnicity`
+
+Notes:
+- There is no county-level data.
+- Race data is provided only for fatal data outcomes and covers the period from 2018-2021.
+
+Last Updated: 4/23
+"""
+
 import pandas as pd
 
 from datasources.data_source import DataSource
@@ -23,41 +50,6 @@ from ingestion.dataset_utils import (
     generate_time_df_with_cols_and_types,
 )
 from ingestion.merge_utils import merge_state_ids
-
-"""
-Data Source: CDC WISQARS Youth (data on gun violence)
-
-Description:
-- The data on gun violence by youth and race is downloaded from the CDC WISQARS database.
-- The downloaded data is stored locally in our data/cdc_wisqars directory for subsequent use.
-
-Instructions for Downloading Data:
-1. Visit the WISQARS website: https://wisqars.cdc.gov/reports/
-2. Select the injury outcome:
-    - `Fatal`
-3. Select the year and race options:
-    - `2018-2021 by Single Race`
-4. Select the desired data years:
-    - `2018-2021`
-5. Select the geography:
-    - `United States`
-6. Select the intent:
-    - `All Intents`
-7. Select the mechanism:
-    - `Firearm`
-8. Select the demographic selections:
-   - `Custom Age Range: <1 to Unknown`, `Both Sexes`, `All Races`
-5. Select appropriate report layout:
-   - For youth-national-all: `Intent`, `None`, `None`, `None`
-   - For youth-national-race: `Intent`, `Race`, `Ethnicity`, `None`
-   - For youth-state-all: `Intent`, `State`, `None`, `None`
-   - For youth-state-race: `Intent`, `State`, `Race`, `Ethnicity`
-Notes:
-- There is no county-level data.
-- Race data is only available for fatal data and is available from 2018-2021.
-
-Last Updated: 2/24
-"""
 
 CATEGORIES_LIST = [std_col.GUN_DEATHS_YOUNG_ADULTS_PREFIX, std_col.GUN_DEATHS_YOUTH_PREFIX]
 ESTIMATED_TOTALS_MAP = generate_cols_map(CATEGORIES_LIST, std_col.RAW_SUFFIX)
@@ -131,9 +123,9 @@ class CDCWisqarsYouthData(DataSource):
 
         for col in ESTIMATED_TOTALS_MAP.values():
             pop_col = (
-                std_col.GUN_DEATHS_YOUNG_ADULTS_POPULATION
+                std_col.GUN_DEATHS_YOUNG_ADULTS_POP_PCT
                 if col == std_col.GUN_DEATHS_YOUNG_ADULTS_PREFIX
-                else std_col.GUN_DEATHS_YOUTH_POPULATION
+                else std_col.GUN_DEATHS_YOUTH_POP_PCT
             )
             df = generate_pct_rel_inequity_col(df, PCT_SHARE_MAP[col], pop_col, PCT_REL_INEQUITY_MAP[col])
 

--- a/python/datasources/cdc_wisqars_youth.py
+++ b/python/datasources/cdc_wisqars_youth.py
@@ -1,5 +1,5 @@
 """
-This documentation outlines the procedure for acquiring gun violence data for the general
+This documentation outlines the procedure for acquiring gun violence data for the youth/young adult
 population from the CDC WISQARS database. The data, once downloaded, is stored locally in
 the `data/cdc_wisqars` directory for further processing and analysis.
 

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_historical.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_historical.csv
@@ -1,37 +1,37 @@
 time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k
-2018,United States,00,American Indian and Alaska Native (NH),-100.0,,1.2,,28.56,
-2018,United States,00,Asian (NH),-100.0,-100.0,1.2,2.4,4.23,1.03
-2018,United States,00,Black or African American (NH),-100.0,-100.0,43.3,36.0,60.86,6.03
-2018,United States,00,Hispanic or Latino,-100.0,-100.0,16.5,15.3,15.0,1.0
-2018,United States,00,Two or more races (NH),-100.0,-100.0,1.6,2.4,10.9,1.26
+2018,United States,00,American Indian and Alaska Native (NH),50.0,,1.2,,28.56,
+2018,United States,00,Asian (NH),-77.4,-54.7,1.2,2.4,4.23,1.03
+2018,United States,00,Black or African American (NH),216.1,162.8,43.3,36.0,60.86,6.03
+2018,United States,00,Hispanic or Latino,-34.5,-39.3,16.5,15.3,15.0,1.0
+2018,United States,00,Two or more races (NH),-63.6,-45.5,1.6,2.4,10.9,1.26
 2018,United States,00,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,United States,00,White (NH),-100.0,-100.0,36.2,43.9,13.62,2.0
-2019,United States,00,American Indian and Alaska Native (NH),-100.0,-100.0,1.1,1.4,25.59,3.82
-2019,United States,00,Asian (NH),-100.0,-100.0,1.5,1.5,5.18,0.67
-2019,United States,00,Black or African American (NH),-100.0,-100.0,45.9,39.6,65.43,6.69
-2019,United States,00,Hispanic or Latino,-100.0,-100.0,15.4,16.1,14.0,1.0
-2019,United States,00,Two or more races (NH),-100.0,-100.0,1.9,2.4,11.98,1.24
+2018,United States,00,White (NH),-28.0,-12.7,36.2,43.9,13.62,2.0
+2019,United States,00,American Indian and Alaska Native (NH),37.5,75.0,1.1,1.4,25.59,3.82
+2019,United States,00,Asian (NH),-72.2,-72.2,1.5,1.5,5.18,0.67
+2019,United States,00,Black or African American (NH),235.0,189.1,45.9,39.6,65.43,6.69
+2019,United States,00,Hispanic or Latino,-39.4,-36.6,15.4,16.1,14.0,1.0
+2019,United States,00,Two or more races (NH),-57.8,-46.7,1.9,2.4,11.98,1.24
 2019,United States,00,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,United States,00,White (NH),-100.0,-100.0,34.3,39.0,13.04,1.81
-2020,United States,00,American Indian and Alaska Native (NH),-100.0,-100.0,1.2,1.6,37.79,5.96
-2020,United States,00,Asian (NH),-100.0,-100.0,1.3,1.2,5.84,0.65
-2020,United States,00,Black or African American (NH),-100.0,-100.0,49.3,42.7,92.04,9.37
-2020,United States,00,Hispanic or Latino,-100.0,-100.0,16.0,16.6,18.0,2.0
-2020,United States,00,Two or more races (NH),-100.0,-100.0,1.7,2.0,13.68,1.29
+2019,United States,00,White (NH),-31.3,-21.8,34.3,39.0,13.04,1.81
+2020,United States,00,American Indian and Alaska Native (NH),50.0,100.0,1.2,1.6,37.79,5.96
+2020,United States,00,Asian (NH),-75.9,-77.8,1.3,1.2,5.84,0.65
+2020,United States,00,Black or African American (NH),259.9,211.7,49.3,42.7,92.04,9.37
+2020,United States,00,Hispanic or Latino,-37.5,-35.2,16.0,16.6,18.0,2.0
+2020,United States,00,Two or more races (NH),-63.0,-56.5,1.7,2.0,13.68,1.29
 2020,United States,00,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,United States,00,White (NH),-100.0,-100.0,30.5,36.0,15.09,2.18
-2021,United States,00,American Indian and Alaska Native (NH),-100.0,-100.0,1.1,1.0,35.88,4.37
-2021,United States,00,Asian (NH),-100.0,-100.0,1.4,1.4,6.68,0.9
-2021,United States,00,Black or African American (NH),-100.0,-100.0,48.8,46.6,96.78,11.81
-2021,United States,00,Hispanic or Latino,-100.0,-100.0,17.1,16.3,20.0,2.0
-2021,United States,00,Two or more races (NH),-100.0,-100.0,2.1,2.4,17.5,1.77
-2021,United States,00,Native Hawaiian and Pacific Islander (NH),-100.0,,0.2,,30.61,
-2021,United States,00,White (NH),-100.0,-100.0,29.3,32.2,15.31,2.28
+2020,United States,00,White (NH),-38.6,-27.6,30.5,36.0,15.09,2.18
+2021,United States,00,American Indian and Alaska Native (NH),37.5,25.0,1.1,1.0,35.88,4.37
+2021,United States,00,Asian (NH),-74.1,-74.1,1.4,1.4,6.68,0.9
+2021,United States,00,Black or African American (NH),253.6,237.7,48.8,46.6,96.78,11.81
+2021,United States,00,Hispanic or Latino,-33.5,-36.6,17.1,16.3,20.0,2.0
+2021,United States,00,Two or more races (NH),-55.3,-48.9,2.1,2.4,17.5,1.77
+2021,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,30.61,
+2021,United States,00,White (NH),-40.7,-34.8,29.3,32.2,15.31,2.28
 2018,United States,00,Unknown race,,,,,,
 2019,United States,00,Unknown race,,,,,,
 2020,United States,00,Unknown race,,,,,,
 2021,United States,00,Unknown race,,,,,,
-2021,United States,00,All,-100.0,-100.0,100.0,100.0,27.73,3.52
-2020,United States,00,All,-100.0,-100.0,100.0,100.0,26.36,3.07
-2019,United States,00,All,-100.0,-100.0,100.0,100.0,20.45,2.37
-2018,United States,00,All,-100.0,-100.0,100.0,100.0,20.35,2.36
+2021,United States,00,All,0.0,0.0,100.0,100.0,27.73,3.52
+2020,United States,00,All,0.0,0.0,100.0,100.0,26.36,3.07
+2019,United States,00,All,0.0,0.0,100.0,100.0,20.45,2.37
+2018,United States,00,All,0.0,0.0,100.0,100.0,20.35,2.36

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_historical.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_historical.csv
@@ -1,11 +1,11 @@
 time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k
 2018,Alabama,01,American Indian and Alaska Native (NH),,,,,,
 2018,Alabama,01,Asian (NH),,,,,,
-2018,Alabama,01,Black or African American (NH),-100.0,,65.3,,80.76,
+2018,Alabama,01,Black or African American (NH),125.2,,65.3,,80.76,
 2018,Alabama,01,Hispanic or Latino,,,,,,
 2018,Alabama,01,Two or more races (NH),,,,,,
 2018,Alabama,01,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Alabama,01,White (NH),-100.0,-100.0,34.7,100.0,22.7,4.27
+2018,Alabama,01,White (NH),-40.1,72.7,34.7,100.0,22.7,4.27
 2018,Alaska,02,American Indian and Alaska Native (NH),,,,,,
 2018,Alaska,02,Asian (NH),,,,,,
 2018,Alaska,02,Black or African American (NH),,,,,,
@@ -15,32 +15,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Alaska,02,White (NH),,,,,,
 2018,Arizona,04,American Indian and Alaska Native (NH),,,,,,
 2018,Arizona,04,Asian (NH),,,,,,
-2018,Arizona,04,Black or African American (NH),-100.0,,17.3,,65.77,
-2018,Arizona,04,Hispanic or Latino,-100.0,,45.5,,22.0,
+2018,Arizona,04,Black or African American (NH),253.1,,17.3,,65.77,
+2018,Arizona,04,Hispanic or Latino,2.2,,45.5,,22.0,
 2018,Arizona,04,Two or more races (NH),,,,,,
 2018,Arizona,04,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Arizona,04,White (NH),-100.0,,37.2,,17.43,
+2018,Arizona,04,White (NH),-3.6,,37.2,,17.43,
 2018,Arkansas,05,American Indian and Alaska Native (NH),,,,,,
 2018,Arkansas,05,Asian (NH),,,,,,
-2018,Arkansas,05,Black or African American (NH),-100.0,,52.7,,81.25,
+2018,Arkansas,05,Black or African American (NH),194.4,,52.7,,81.25,
 2018,Arkansas,05,Hispanic or Latino,,,,,,
 2018,Arkansas,05,Two or more races (NH),,,,,,
 2018,Arkansas,05,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Arkansas,05,White (NH),-100.0,,47.3,,20.9,
+2018,Arkansas,05,White (NH),-24.8,,47.3,,20.9,
 2018,California,06,American Indian and Alaska Native (NH),,,,,,
 2018,California,06,Asian (NH),,,,,,
-2018,California,06,Black or African American (NH),-100.0,,22.5,,42.21,
-2018,California,06,Hispanic or Latino,-100.0,-100.0,53.4,63.8,12.0,1.0
-2018,California,06,Two or more races (NH),-100.0,,4.8,,14.14,
+2018,California,06,Black or African American (NH),350.0,,22.5,,42.21,
+2018,California,06,Hispanic or Latino,3.7,23.9,53.4,63.8,12.0,1.0
+2018,California,06,Two or more races (NH),-5.9,,4.8,,14.14,
 2018,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,California,06,White (NH),-100.0,-100.0,19.3,36.2,7.52,1.1
+2018,California,06,White (NH),-23.7,43.1,19.3,36.2,7.52,1.1
 2018,Colorado,08,American Indian and Alaska Native (NH),,,,,,
 2018,Colorado,08,Asian (NH),,,,,,
-2018,Colorado,08,Black or African American (NH),-100.0,,16.8,,77.5,
-2018,Colorado,08,Hispanic or Latino,-100.0,,29.8,,23.0,
+2018,Colorado,08,Black or African American (NH),290.7,,16.8,,77.5,
+2018,Colorado,08,Hispanic or Latino,-5.4,,29.8,,23.0,
 2018,Colorado,08,Two or more races (NH),,,,,,
 2018,Colorado,08,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Colorado,08,White (NH),-100.0,-100.0,53.4,100.0,19.02,3.12
+2018,Colorado,08,White (NH),-4.3,79.2,53.4,100.0,19.02,3.12
 2018,Connecticut,09,American Indian and Alaska Native (NH),,,,,,
 2018,Connecticut,09,Asian (NH),,,,,,
 2018,Connecticut,09,Black or African American (NH),,,,,,
@@ -57,25 +57,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Delaware,10,White (NH),,,,,,
 2018,District of Columbia,11,American Indian and Alaska Native (NH),,,,,,
 2018,District of Columbia,11,Asian (NH),,,,,,
-2018,District of Columbia,11,Black or African American (NH),-99.9,,100.0,,127.94,
+2018,District of Columbia,11,Black or African American (NH),83.2,,100.0,,127.94,
 2018,District of Columbia,11,Hispanic or Latino,,,,,,
 2018,District of Columbia,11,Two or more races (NH),,,,,,
 2018,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),,,,,,
 2018,District of Columbia,11,White (NH),,,,,,
 2018,Florida,12,American Indian and Alaska Native (NH),,,,,,
 2018,Florida,12,Asian (NH),,,,,,
-2018,Florida,12,Black or African American (NH),-100.0,-100.0,49.6,32.9,50.15,3.28
-2018,Florida,12,Hispanic or Latino,-100.0,-100.0,18.8,24.7,13.0,2.0
+2018,Florida,12,Black or African American (NH),145.5,62.9,49.6,32.9,50.15,3.28
+2018,Florida,12,Hispanic or Latino,-38.8,-19.5,18.8,24.7,13.0,2.0
 2018,Florida,12,Two or more races (NH),,,,,,
 2018,Florida,12,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Florida,12,White (NH),-100.0,-100.0,31.5,42.4,14.41,2.01
+2018,Florida,12,White (NH),-25.5,0.2,31.5,42.4,14.41,2.01
 2018,Georgia,13,American Indian and Alaska Native (NH),,,,,,
 2018,Georgia,13,Asian (NH),,,,,,
-2018,Georgia,13,Black or African American (NH),-100.0,-100.0,69.9,63.2,47.99,5.7
+2018,Georgia,13,Black or African American (NH),108.7,88.7,69.9,63.2,47.99,5.7
 2018,Georgia,13,Hispanic or Latino,,,,,,
 2018,Georgia,13,Two or more races (NH),,,,,,
 2018,Georgia,13,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Georgia,13,White (NH),-100.0,-100.0,30.1,36.8,15.76,2.56
+2018,Georgia,13,White (NH),-31.1,-15.8,30.1,36.8,15.76,2.56
 2018,Hawaii,15,American Indian and Alaska Native (NH),,,,,,
 2018,Hawaii,15,Asian (NH),,,,,,
 2018,Hawaii,15,Black or African American (NH),,,,,,
@@ -89,49 +89,49 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Idaho,16,Hispanic or Latino,,,,,,
 2018,Idaho,16,Two or more races (NH),,,,,,
 2018,Idaho,16,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Idaho,16,White (NH),-100.0,,100.0,,26.26,
+2018,Idaho,16,White (NH),33.5,,100.0,,26.26,
 2018,Illinois,17,American Indian and Alaska Native (NH),,,,,,
 2018,Illinois,17,Asian (NH),,,,,,
-2018,Illinois,17,Black or African American (NH),-100.0,-100.0,70.0,100.0,101.97,13.91
-2018,Illinois,17,Hispanic or Latino,-100.0,,13.6,,15.0,
+2018,Illinois,17,Black or African American (NH),357.5,553.6,70.0,100.0,101.97,13.91
+2018,Illinois,17,Hispanic or Latino,-44.5,,13.6,,15.0,
 2018,Illinois,17,Two or more races (NH),,,,,,
 2018,Illinois,17,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Illinois,17,White (NH),-100.0,,16.4,,7.33,
+2018,Illinois,17,White (NH),-67.9,,16.4,,7.33,
 2018,Indiana,18,American Indian and Alaska Native (NH),,,,,,
 2018,Indiana,18,Asian (NH),,,,,,
-2018,Indiana,18,Black or African American (NH),-100.0,-100.0,49.2,52.0,107.81,14.64
+2018,Indiana,18,Black or African American (NH),335.4,360.2,49.2,52.0,107.81,14.64
 2018,Indiana,18,Hispanic or Latino,,,,,,
 2018,Indiana,18,Two or more races (NH),,,,,,
 2018,Indiana,18,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Indiana,18,White (NH),-100.0,-100.0,50.8,48.0,16.51,2.17
+2018,Indiana,18,White (NH),-27.9,-31.9,50.8,48.0,16.51,2.17
 2018,Iowa,19,American Indian and Alaska Native (NH),,,,,,
 2018,Iowa,19,Asian (NH),,,,,,
 2018,Iowa,19,Black or African American (NH),,,,,,
 2018,Iowa,19,Hispanic or Latino,,,,,,
 2018,Iowa,19,Two or more races (NH),,,,,,
 2018,Iowa,19,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Iowa,19,White (NH),-100.0,,100.0,,13.01,
+2018,Iowa,19,White (NH),30.0,,100.0,,13.01,
 2018,Kansas,20,American Indian and Alaska Native (NH),,,,,,
 2018,Kansas,20,Asian (NH),,,,,,
 2018,Kansas,20,Black or African American (NH),,,,,,
 2018,Kansas,20,Hispanic or Latino,,,,,,
 2018,Kansas,20,Two or more races (NH),,,,,,
 2018,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Kansas,20,White (NH),-100.0,,100.0,,16.92,
+2018,Kansas,20,White (NH),51.3,,100.0,,16.92,
 2018,Kentucky,21,American Indian and Alaska Native (NH),,,,,,
 2018,Kentucky,21,Asian (NH),,,,,,
-2018,Kentucky,21,Black or African American (NH),-100.0,,35.0,,70.52,
+2018,Kentucky,21,Black or African American (NH),284.6,,35.0,,70.52,
 2018,Kentucky,21,Hispanic or Latino,,,,,,
 2018,Kentucky,21,Two or more races (NH),,,,,,
 2018,Kentucky,21,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Kentucky,21,White (NH),-100.0,,65.0,,17.54,
+2018,Kentucky,21,White (NH),-16.8,,65.0,,17.54,
 2018,Louisiana,22,American Indian and Alaska Native (NH),,,,,,
 2018,Louisiana,22,Asian (NH),,,,,,
-2018,Louisiana,22,Black or African American (NH),-100.0,-100.0,73.1,60.4,82.61,7.95
+2018,Louisiana,22,Black or African American (NH),99.2,64.6,73.1,60.4,82.61,7.95
 2018,Louisiana,22,Hispanic or Latino,,,,,,
 2018,Louisiana,22,Two or more races (NH),,,,,,
 2018,Louisiana,22,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Louisiana,22,White (NH),-100.0,-100.0,26.9,39.6,22.46,3.75
+2018,Louisiana,22,White (NH),-47.2,-22.2,26.9,39.6,22.46,3.75
 2018,Maine,23,American Indian and Alaska Native (NH),,,,,,
 2018,Maine,23,Asian (NH),,,,,,
 2018,Maine,23,Black or African American (NH),,,,,,
@@ -141,11 +141,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Maine,23,White (NH),,,,,,
 2018,Maryland,24,American Indian and Alaska Native (NH),,,,,,
 2018,Maryland,24,Asian (NH),,,,,,
-2018,Maryland,24,Black or African American (NH),-100.0,,79.7,,53.3,
+2018,Maryland,24,Black or African American (NH),158.8,,79.7,,53.3,
 2018,Maryland,24,Hispanic or Latino,,,,,,
 2018,Maryland,24,Two or more races (NH),,,,,,
 2018,Maryland,24,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Maryland,24,White (NH),-100.0,,20.3,,9.57,
+2018,Maryland,24,White (NH),-51.3,,20.3,,9.57,
 2018,Massachusetts,25,American Indian and Alaska Native (NH),,,,,,
 2018,Massachusetts,25,Asian (NH),,,,,,
 2018,Massachusetts,25,Black or African American (NH),,,,,,
@@ -155,32 +155,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Massachusetts,25,White (NH),,,,,,
 2018,Michigan,26,American Indian and Alaska Native (NH),,,,,,
 2018,Michigan,26,Asian (NH),,,,,,
-2018,Michigan,26,Black or African American (NH),-100.0,-100.0,57.3,46.7,73.4,6.08
+2018,Michigan,26,Black or African American (NH),258.1,191.9,57.3,46.7,73.4,6.08
 2018,Michigan,26,Hispanic or Latino,,,,,,
 2018,Michigan,26,Two or more races (NH),,,,,,
 2018,Michigan,26,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Michigan,26,White (NH),-100.0,-100.0,42.7,53.3,12.4,1.67
+2018,Michigan,26,White (NH),-35.9,-20.0,42.7,53.3,12.4,1.67
 2018,Minnesota,27,American Indian and Alaska Native (NH),,,,,,
 2018,Minnesota,27,Asian (NH),,,,,,
 2018,Minnesota,27,Black or African American (NH),,,,,,
 2018,Minnesota,27,Hispanic or Latino,,,,,,
 2018,Minnesota,27,Two or more races (NH),,,,,,
 2018,Minnesota,27,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Minnesota,27,White (NH),-100.0,,100.0,,10.45,
+2018,Minnesota,27,White (NH),47.1,,100.0,,10.45,
 2018,Mississippi,28,American Indian and Alaska Native (NH),,,,,,
 2018,Mississippi,28,Asian (NH),,,,,,
-2018,Mississippi,28,Black or African American (NH),-100.0,-100.0,70.4,100.0,70.59,8.46
+2018,Mississippi,28,Black or African American (NH),68.4,139.2,70.4,100.0,70.59,8.46
 2018,Mississippi,28,Hispanic or Latino,,,,,,
 2018,Mississippi,28,Two or more races (NH),,,,,,
 2018,Mississippi,28,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Mississippi,28,White (NH),-100.0,,29.6,,25.63,
+2018,Mississippi,28,White (NH),-40.0,,29.6,,25.63,
 2018,Missouri,29,American Indian and Alaska Native (NH),,,,,,
 2018,Missouri,29,Asian (NH),,,,,,
-2018,Missouri,29,Black or African American (NH),-100.0,-100.0,59.2,45.3,135.62,15.61
+2018,Missouri,29,Black or African American (NH),338.5,235.6,59.2,45.3,135.62,15.61
 2018,Missouri,29,Hispanic or Latino,,,,,,
 2018,Missouri,29,Two or more races (NH),,,,,,
 2018,Missouri,29,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Missouri,29,White (NH),-100.0,-100.0,40.8,54.7,17.47,3.51
+2018,Missouri,29,White (NH),-43.6,-24.4,40.8,54.7,17.47,3.51
 2018,Montana,30,American Indian and Alaska Native (NH),,,,,,
 2018,Montana,30,Asian (NH),,,,,,
 2018,Montana,30,Black or African American (NH),,,,,,
@@ -197,11 +197,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Nebraska,31,White (NH),,,,,,
 2018,Nevada,32,American Indian and Alaska Native (NH),,,,,,
 2018,Nevada,32,Asian (NH),,,,,,
-2018,Nevada,32,Black or African American (NH),-100.0,,29.7,,70.82,
-2018,Nevada,32,Hispanic or Latino,-100.0,,35.1,,23.0,
+2018,Nevada,32,Black or African American (NH),188.3,,29.7,,70.82,
+2018,Nevada,32,Hispanic or Latino,-14.2,,35.1,,23.0,
 2018,Nevada,32,Two or more races (NH),,,,,,
 2018,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Nevada,32,White (NH),-100.0,,35.1,,24.63,
+2018,Nevada,32,White (NH),1.4,,35.1,,24.63,
 2018,New Hampshire,33,American Indian and Alaska Native (NH),,,,,,
 2018,New Hampshire,33,Asian (NH),,,,,,
 2018,New Hampshire,33,Black or African American (NH),,,,,,
@@ -211,7 +211,7 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,New Hampshire,33,White (NH),,,,,,
 2018,New Jersey,34,American Indian and Alaska Native (NH),,,,,,
 2018,New Jersey,34,Asian (NH),,,,,,
-2018,New Jersey,34,Black or African American (NH),-100.0,,100.0,,35.93,
+2018,New Jersey,34,Black or African American (NH),646.3,,100.0,,35.93,
 2018,New Jersey,34,Hispanic or Latino,,,,,,
 2018,New Jersey,34,Two or more races (NH),,,,,,
 2018,New Jersey,34,Native Hawaiian and Pacific Islander (NH),,,,,,
@@ -219,24 +219,24 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,New Mexico,35,American Indian and Alaska Native (NH),,,,,,
 2018,New Mexico,35,Asian (NH),,,,,,
 2018,New Mexico,35,Black or African American (NH),,,,,,
-2018,New Mexico,35,Hispanic or Latino,-100.0,,71.2,,40.0,
+2018,New Mexico,35,Hispanic or Latino,15.6,,71.2,,40.0,
 2018,New Mexico,35,Two or more races (NH),,,,,,
 2018,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,New Mexico,35,White (NH),-100.0,,28.8,,34.88,
+2018,New Mexico,35,White (NH),24.7,,28.8,,34.88,
 2018,New York,36,American Indian and Alaska Native (NH),,,,,,
 2018,New York,36,Asian (NH),,,,,,
-2018,New York,36,Black or African American (NH),-100.0,,51.4,,22.95,
-2018,New York,36,Hispanic or Latino,-100.0,,16.4,,5.0,
+2018,New York,36,Black or African American (NH),247.3,,51.4,,22.95,
+2018,New York,36,Hispanic or Latino,-32.8,,16.4,,5.0,
 2018,New York,36,Two or more races (NH),,,,,,
 2018,New York,36,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,New York,36,White (NH),-100.0,,32.2,,4.43,
+2018,New York,36,White (NH),-33.2,,32.2,,4.43,
 2018,North Carolina,37,American Indian and Alaska Native (NH),,,,,,
 2018,North Carolina,37,Asian (NH),,,,,,
-2018,North Carolina,37,Black or African American (NH),-100.0,-100.0,61.1,48.1,48.82,5.02
+2018,North Carolina,37,Black or African American (NH),171.6,113.8,61.1,48.1,48.82,5.02
 2018,North Carolina,37,Hispanic or Latino,,,,,,
 2018,North Carolina,37,Two or more races (NH),,,,,,
 2018,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,North Carolina,37,White (NH),-100.0,-100.0,38.9,51.9,13.4,2.34
+2018,North Carolina,37,White (NH),-25.0,0.0,38.9,51.9,13.4,2.34
 2018,North Dakota,38,American Indian and Alaska Native (NH),,,,,,
 2018,North Dakota,38,Asian (NH),,,,,,
 2018,North Dakota,38,Black or African American (NH),,,,,,
@@ -246,32 +246,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,North Dakota,38,White (NH),,,,,,
 2018,Ohio,39,American Indian and Alaska Native (NH),,,,,,
 2018,Ohio,39,Asian (NH),,,,,,
-2018,Ohio,39,Black or African American (NH),-100.0,-100.0,50.2,44.4,76.03,8.17
+2018,Ohio,39,Black or African American (NH),232.5,194.0,50.2,44.4,76.03,8.17
 2018,Ohio,39,Hispanic or Latino,,,,,,
 2018,Ohio,39,Two or more races (NH),,,,,,
 2018,Ohio,39,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Ohio,39,White (NH),-100.0,-100.0,49.8,55.6,15.05,2.18
+2018,Ohio,39,White (NH),-29.7,-21.5,49.8,55.6,15.05,2.18
 2018,Oklahoma,40,American Indian and Alaska Native (NH),,,,,,
 2018,Oklahoma,40,Asian (NH),,,,,,
-2018,Oklahoma,40,Black or African American (NH),-100.0,,35.5,,54.51,
+2018,Oklahoma,40,Black or African American (NH),361.0,,35.5,,54.51,
 2018,Oklahoma,40,Hispanic or Latino,,,,,,
 2018,Oklahoma,40,Two or more races (NH),,,,,,
 2018,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Oklahoma,40,White (NH),-100.0,,64.5,,16.35,
+2018,Oklahoma,40,White (NH),23.6,,64.5,,16.35,
 2018,Oregon,41,American Indian and Alaska Native (NH),,,,,,
 2018,Oregon,41,Asian (NH),,,,,,
 2018,Oregon,41,Black or African American (NH),,,,,,
 2018,Oregon,41,Hispanic or Latino,,,,,,
 2018,Oregon,41,Two or more races (NH),,,,,,
 2018,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Oregon,41,White (NH),-100.0,,100.0,,16.25,
+2018,Oregon,41,White (NH),57.7,,100.0,,16.25,
 2018,Pennsylvania,42,American Indian and Alaska Native (NH),,,,,,
 2018,Pennsylvania,42,Asian (NH),,,,,,
-2018,Pennsylvania,42,Black or African American (NH),-100.0,-100.0,49.8,100.0,84.74,8.16
-2018,Pennsylvania,42,Hispanic or Latino,-100.0,,9.3,,21.0,
+2018,Pennsylvania,42,Black or African American (NH),286.0,675.2,49.8,100.0,84.74,8.16
+2018,Pennsylvania,42,Hispanic or Latino,-26.8,,9.3,,21.0,
 2018,Pennsylvania,42,Two or more races (NH),,,,,,
 2018,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Pennsylvania,42,White (NH),-100.0,,40.9,,13.37,
+2018,Pennsylvania,42,White (NH),-38.2,,40.9,,13.37,
 2018,Rhode Island,44,American Indian and Alaska Native (NH),,,,,,
 2018,Rhode Island,44,Asian (NH),,,,,,
 2018,Rhode Island,44,Black or African American (NH),,,,,,
@@ -281,11 +281,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Rhode Island,44,White (NH),,,,,,
 2018,South Carolina,45,American Indian and Alaska Native (NH),,,,,,
 2018,South Carolina,45,Asian (NH),,,,,,
-2018,South Carolina,45,Black or African American (NH),-100.0,-100.0,56.2,100.0,60.41,8.86
+2018,South Carolina,45,Black or African American (NH),90.5,239.0,56.2,100.0,60.41,8.86
 2018,South Carolina,45,Hispanic or Latino,,,,,,
 2018,South Carolina,45,Two or more races (NH),,,,,,
 2018,South Carolina,45,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,South Carolina,45,White (NH),-100.0,,43.8,,24.98,
+2018,South Carolina,45,White (NH),-19.8,,43.8,,24.98,
 2018,South Dakota,46,American Indian and Alaska Native (NH),,,,,,
 2018,South Dakota,46,Asian (NH),,,,,,
 2018,South Dakota,46,Black or African American (NH),,,,,,
@@ -295,25 +295,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,South Dakota,46,White (NH),,,,,,
 2018,Tennessee,47,American Indian and Alaska Native (NH),,,,,,
 2018,Tennessee,47,Asian (NH),,,,,,
-2018,Tennessee,47,Black or African American (NH),-100.0,-100.0,62.8,46.3,103.14,8.72
+2018,Tennessee,47,Black or African American (NH),230.5,143.7,62.8,46.3,103.14,8.72
 2018,Tennessee,47,Hispanic or Latino,,,,,,
 2018,Tennessee,47,Two or more races (NH),,,,,,
 2018,Tennessee,47,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Tennessee,47,White (NH),-100.0,-100.0,37.2,53.7,18.37,2.95
+2018,Tennessee,47,White (NH),-42.8,-17.4,37.2,53.7,18.37,2.95
 2018,Texas,48,American Indian and Alaska Native (NH),,,,,,
 2018,Texas,48,Asian (NH),,,,,,
-2018,Texas,48,Black or African American (NH),-100.0,-100.0,33.1,19.1,47.27,3.86
-2018,Texas,48,Hispanic or Latino,-100.0,-100.0,36.8,44.4,15.0,2.0
+2018,Texas,48,Black or African American (NH),178.2,60.5,33.1,19.1,47.27,3.86
+2018,Texas,48,Hispanic or Latino,-25.1,-9.6,36.8,44.4,15.0,2.0
 2018,Texas,48,Two or more races (NH),,,,,,
 2018,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Texas,48,White (NH),-100.0,-100.0,30.1,36.5,16.45,2.81
+2018,Texas,48,White (NH),-4.1,16.2,30.1,36.5,16.45,2.81
 2018,Utah,49,American Indian and Alaska Native (NH),,,,,,
 2018,Utah,49,Asian (NH),,,,,,
 2018,Utah,49,Black or African American (NH),,,,,,
 2018,Utah,49,Hispanic or Latino,,,,,,
 2018,Utah,49,Two or more races (NH),,,,,,
 2018,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Utah,49,White (NH),-100.0,,100.0,,14.54,
+2018,Utah,49,White (NH),35.3,,100.0,,14.54,
 2018,Vermont,50,American Indian and Alaska Native (NH),,,,,,
 2018,Vermont,50,Asian (NH),,,,,,
 2018,Vermont,50,Black or African American (NH),,,,,,
@@ -323,32 +323,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Vermont,50,White (NH),,,,,,
 2018,Virginia,51,American Indian and Alaska Native (NH),,,,,,
 2018,Virginia,51,Asian (NH),,,,,,
-2018,Virginia,51,Black or African American (NH),-100.0,,53.5,,54.18,
+2018,Virginia,51,Black or African American (NH),168.8,,53.5,,54.18,
 2018,Virginia,51,Hispanic or Latino,,,,,,
 2018,Virginia,51,Two or more races (NH),,,,,,
 2018,Virginia,51,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Virginia,51,White (NH),-100.0,-100.0,46.5,100.0,17.5,2.11
+2018,Virginia,51,White (NH),-12.8,87.6,46.5,100.0,17.5,2.11
 2018,Washington,53,American Indian and Alaska Native (NH),,,,,,
 2018,Washington,53,Asian (NH),,,,,,
 2018,Washington,53,Black or African American (NH),,,,,,
-2018,Washington,53,Hispanic or Latino,-100.0,,29.6,,23.0,
+2018,Washington,53,Hispanic or Latino,35.8,,29.6,,23.0,
 2018,Washington,53,Two or more races (NH),,,,,,
 2018,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Washington,53,White (NH),-100.0,,70.4,,16.65,
+2018,Washington,53,White (NH),26.8,,70.4,,16.65,
 2018,West Virginia,54,American Indian and Alaska Native (NH),,,,,,
 2018,West Virginia,54,Asian (NH),,,,,,
 2018,West Virginia,54,Black or African American (NH),,,,,,
 2018,West Virginia,54,Hispanic or Latino,,,,,,
 2018,West Virginia,54,Two or more races (NH),,,,,,
 2018,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,West Virginia,54,White (NH),-100.0,,100.0,,20.23,
+2018,West Virginia,54,White (NH),12.6,,100.0,,20.23,
 2018,Wisconsin,55,American Indian and Alaska Native (NH),,,,,,
 2018,Wisconsin,55,Asian (NH),,,,,,
-2018,Wisconsin,55,Black or African American (NH),-100.0,,41.8,,75.35,
+2018,Wisconsin,55,Black or African American (NH),369.7,,41.8,,75.35,
 2018,Wisconsin,55,Hispanic or Latino,,,,,,
 2018,Wisconsin,55,Two or more races (NH),,,,,,
 2018,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,,,,,
-2018,Wisconsin,55,White (NH),-100.0,,58.2,,11.17,
+2018,Wisconsin,55,White (NH),-16.3,,58.2,,11.17,
 2018,Wyoming,56,American Indian and Alaska Native (NH),,,,,,
 2018,Wyoming,56,Asian (NH),,,,,,
 2018,Wyoming,56,Black or African American (NH),,,,,,
@@ -358,11 +358,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2018,Wyoming,56,White (NH),,,,,,
 2019,Alabama,01,American Indian and Alaska Native (NH),,,,,,
 2019,Alabama,01,Asian (NH),,,,,,
-2019,Alabama,01,Black or African American (NH),-100.0,,67.0,,80.03,
+2019,Alabama,01,Black or African American (NH),131.8,,67.0,,80.03,
 2019,Alabama,01,Hispanic or Latino,,,,,,
 2019,Alabama,01,Two or more races (NH),,,,,,
 2019,Alabama,01,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Alabama,01,White (NH),-100.0,,33.0,,20.5,
+2019,Alabama,01,White (NH),-42.7,,33.0,,20.5,
 2019,Alaska,02,American Indian and Alaska Native (NH),,,,,,
 2019,Alaska,02,Asian (NH),,,,,,
 2019,Alaska,02,Black or African American (NH),,,,,,
@@ -373,31 +373,31 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Arizona,04,American Indian and Alaska Native (NH),,,,,,
 2019,Arizona,04,Asian (NH),,,,,,
 2019,Arizona,04,Black or African American (NH),,,,,,
-2019,Arizona,04,Hispanic or Latino,-100.0,,55.3,,22.0,
+2019,Arizona,04,Hispanic or Latino,23.7,,55.3,,22.0,
 2019,Arizona,04,Two or more races (NH),,,,,,
 2019,Arizona,04,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Arizona,04,White (NH),-100.0,,44.7,,17.64,
+2019,Arizona,04,White (NH),16.7,,44.7,,17.64,
 2019,Arkansas,05,American Indian and Alaska Native (NH),,,,,,
 2019,Arkansas,05,Asian (NH),,,,,,
-2019,Arkansas,05,Black or African American (NH),-100.0,,45.9,,84.05,
+2019,Arkansas,05,Black or African American (NH),157.9,,45.9,,84.05,
 2019,Arkansas,05,Hispanic or Latino,,,,,,
 2019,Arkansas,05,Two or more races (NH),,,,,,
 2019,Arkansas,05,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Arkansas,05,White (NH),-100.0,,54.1,,28.31,
+2019,Arkansas,05,White (NH),-13.6,,54.1,,28.31,
 2019,California,06,American Indian and Alaska Native (NH),,,,,,
 2019,California,06,Asian (NH),,,,,,
-2019,California,06,Black or African American (NH),-100.0,,25.0,,44.05,
-2019,California,06,Hispanic or Latino,-100.0,-100.0,55.5,100.0,12.0,1.0
+2019,California,06,Black or African American (NH),400.0,,25.0,,44.05,
+2019,California,06,Hispanic or Latino,7.8,94.2,55.5,100.0,12.0,1.0
 2019,California,06,Two or more races (NH),,,,,,
 2019,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,California,06,White (NH),-100.0,,19.5,,7.09,
+2019,California,06,White (NH),-22.0,,19.5,,7.09,
 2019,Colorado,08,American Indian and Alaska Native (NH),,,,,,
 2019,Colorado,08,Asian (NH),,,,,,
 2019,Colorado,08,Black or African American (NH),,,,,,
-2019,Colorado,08,Hispanic or Latino,-100.0,,29.0,,18.0,
+2019,Colorado,08,Hispanic or Latino,-8.2,,29.0,,18.0,
 2019,Colorado,08,Two or more races (NH),,,,,,
 2019,Colorado,08,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Colorado,08,White (NH),-100.0,,71.0,,20.73,
+2019,Colorado,08,White (NH),27.9,,71.0,,20.73,
 2019,Connecticut,09,American Indian and Alaska Native (NH),,,,,,
 2019,Connecticut,09,Asian (NH),,,,,,
 2019,Connecticut,09,Black or African American (NH),,,,,,
@@ -414,25 +414,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Delaware,10,White (NH),,,,,,
 2019,District of Columbia,11,American Indian and Alaska Native (NH),,,,,,
 2019,District of Columbia,11,Asian (NH),,,,,,
-2019,District of Columbia,11,Black or African American (NH),-99.9,,100.0,,165.05,
+2019,District of Columbia,11,Black or African American (NH),88.0,,100.0,,165.05,
 2019,District of Columbia,11,Hispanic or Latino,,,,,,
 2019,District of Columbia,11,Two or more races (NH),,,,,,
 2019,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),,,,,,
 2019,District of Columbia,11,White (NH),,,,,,
 2019,Florida,12,American Indian and Alaska Native (NH),,,,,,
 2019,Florida,12,Asian (NH),,,,,,
-2019,Florida,12,Black or African American (NH),-100.0,-100.0,54.4,60.0,57.07,5.29
-2019,Florida,12,Hispanic or Latino,-100.0,,16.9,,12.0,
+2019,Florida,12,Black or African American (NH),170.6,198.5,54.4,60.0,57.07,5.29
+2019,Florida,12,Hispanic or Latino,-45.7,,16.9,,12.0,
 2019,Florida,12,Two or more races (NH),,,,,,
 2019,Florida,12,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Florida,12,White (NH),-100.0,-100.0,28.6,40.0,13.56,1.69
+2019,Florida,12,White (NH),-31.9,-4.8,28.6,40.0,13.56,1.69
 2019,Georgia,13,American Indian and Alaska Native (NH),,,,,,
 2019,Georgia,13,Asian (NH),,,,,,
-2019,Georgia,13,Black or African American (NH),-100.0,-100.0,73.9,58.5,57.33,4.51
+2019,Georgia,13,Black or African American (NH),119.9,74.1,73.9,58.5,57.33,4.51
 2019,Georgia,13,Hispanic or Latino,,,,,,
 2019,Georgia,13,Two or more races (NH),,,,,,
 2019,Georgia,13,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Georgia,13,White (NH),-100.0,-100.0,26.1,41.5,15.35,2.5
+2019,Georgia,13,White (NH),-39.6,-3.9,26.1,41.5,15.35,2.5
 2019,Hawaii,15,American Indian and Alaska Native (NH),,,,,,
 2019,Hawaii,15,Asian (NH),,,,,,
 2019,Hawaii,15,Black or African American (NH),,,,,,
@@ -446,49 +446,49 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Idaho,16,Hispanic or Latino,,,,,,
 2019,Idaho,16,Two or more races (NH),,,,,,
 2019,Idaho,16,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Idaho,16,White (NH),-100.0,,100.0,,22.43,
+2019,Idaho,16,White (NH),33.9,,100.0,,22.43,
 2019,Illinois,17,American Indian and Alaska Native (NH),,,,,,
 2019,Illinois,17,Asian (NH),,,,,,
-2019,Illinois,17,Black or African American (NH),-100.0,-100.0,70.9,100.0,103.78,14.83
-2019,Illinois,17,Hispanic or Latino,-100.0,,14.4,,15.0,
+2019,Illinois,17,Black or African American (NH),363.4,553.6,70.9,100.0,103.78,14.83
+2019,Illinois,17,Hispanic or Latino,-41.5,,14.4,,15.0,
 2019,Illinois,17,Two or more races (NH),,,,,,
 2019,Illinois,17,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Illinois,17,White (NH),-100.0,,14.7,,6.5,
+2019,Illinois,17,White (NH),-71.1,,14.7,,6.5,
 2019,Indiana,18,American Indian and Alaska Native (NH),,,,,,
 2019,Indiana,18,Asian (NH),,,,,,
-2019,Indiana,18,Black or African American (NH),-100.0,-99.9,56.0,100.0,126.57,13.46
+2019,Indiana,18,Black or African American (NH),391.2,777.2,56.0,100.0,126.57,13.46
 2019,Indiana,18,Hispanic or Latino,,,,,,
 2019,Indiana,18,Two or more races (NH),,,,,,
 2019,Indiana,18,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Indiana,18,White (NH),-100.0,,44.0,,14.82,
+2019,Indiana,18,White (NH),-37.1,,44.0,,14.82,
 2019,Iowa,19,American Indian and Alaska Native (NH),,,,,,
 2019,Iowa,19,Asian (NH),,,,,,
 2019,Iowa,19,Black or African American (NH),,,,,,
 2019,Iowa,19,Hispanic or Latino,,,,,,
 2019,Iowa,19,Two or more races (NH),,,,,,
 2019,Iowa,19,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Iowa,19,White (NH),-100.0,,100.0,,13.51,
+2019,Iowa,19,White (NH),30.7,,100.0,,13.51,
 2019,Kansas,20,American Indian and Alaska Native (NH),,,,,,
 2019,Kansas,20,Asian (NH),,,,,,
 2019,Kansas,20,Black or African American (NH),,,,,,
 2019,Kansas,20,Hispanic or Latino,,,,,,
 2019,Kansas,20,Two or more races (NH),,,,,,
 2019,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Kansas,20,White (NH),-100.0,,100.0,,19.81,
+2019,Kansas,20,White (NH),51.7,,100.0,,19.81,
 2019,Kentucky,21,American Indian and Alaska Native (NH),,,,,,
 2019,Kentucky,21,Asian (NH),,,,,,
-2019,Kentucky,21,Black or African American (NH),-99.9,,46.8,,86.57,
+2019,Kentucky,21,Black or African American (NH),408.7,,46.8,,86.57,
 2019,Kentucky,21,Hispanic or Latino,,,,,,
 2019,Kentucky,21,Two or more races (NH),,,,,,
 2019,Kentucky,21,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Kentucky,21,White (NH),-100.0,,53.2,,13.19,
+2019,Kentucky,21,White (NH),-31.6,,53.2,,13.19,
 2019,Louisiana,22,American Indian and Alaska Native (NH),,,,,,
 2019,Louisiana,22,Asian (NH),,,,,,
-2019,Louisiana,22,Black or African American (NH),-100.0,-100.0,74.0,100.0,82.02,9.3
+2019,Louisiana,22,Black or African American (NH),102.7,174.0,74.0,100.0,82.02,9.3
 2019,Louisiana,22,Hispanic or Latino,,,,,,
 2019,Louisiana,22,Two or more races (NH),,,,,,
 2019,Louisiana,22,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Louisiana,22,White (NH),-100.0,,26.0,,21.18,
+2019,Louisiana,22,White (NH),-48.7,,26.0,,21.18,
 2019,Maine,23,American Indian and Alaska Native (NH),,,,,,
 2019,Maine,23,Asian (NH),,,,,,
 2019,Maine,23,Black or African American (NH),,,,,,
@@ -498,7 +498,7 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Maine,23,White (NH),,,,,,
 2019,Maryland,24,American Indian and Alaska Native (NH),,,,,,
 2019,Maryland,24,Asian (NH),,,,,,
-2019,Maryland,24,Black or African American (NH),-100.0,,100.0,,77.28,
+2019,Maryland,24,Black or African American (NH),225.7,,100.0,,77.28,
 2019,Maryland,24,Hispanic or Latino,,,,,,
 2019,Maryland,24,Two or more races (NH),,,,,,
 2019,Maryland,24,Native Hawaiian and Pacific Islander (NH),,,,,,
@@ -512,32 +512,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Massachusetts,25,White (NH),,,,,,
 2019,Michigan,26,American Indian and Alaska Native (NH),,,,,,
 2019,Michigan,26,Asian (NH),,,,,,
-2019,Michigan,26,Black or African American (NH),-100.0,-100.0,66.7,100.0,74.75,6.41
+2019,Michigan,26,Black or African American (NH),316.9,525.0,66.7,100.0,74.75,6.41
 2019,Michigan,26,Hispanic or Latino,,,,,,
 2019,Michigan,26,Two or more races (NH),,,,,,
 2019,Michigan,26,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Michigan,26,White (NH),-100.0,,33.3,,8.32,
+2019,Michigan,26,White (NH),-49.8,,33.3,,8.32,
 2019,Minnesota,27,American Indian and Alaska Native (NH),,,,,,
 2019,Minnesota,27,Asian (NH),,,,,,
-2019,Minnesota,27,Black or African American (NH),-100.0,,39.7,,53.75,
+2019,Minnesota,27,Black or African American (NH),285.4,,39.7,,53.75,
 2019,Minnesota,27,Hispanic or Latino,,,,,,
 2019,Minnesota,27,Two or more races (NH),,,,,,
 2019,Minnesota,27,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Minnesota,27,White (NH),-100.0,,60.3,,9.15,
+2019,Minnesota,27,White (NH),-10.7,,60.3,,9.15,
 2019,Mississippi,28,American Indian and Alaska Native (NH),,,,,,
 2019,Mississippi,28,Asian (NH),,,,,,
-2019,Mississippi,28,Black or African American (NH),-100.0,,72.5,,74.44,
+2019,Mississippi,28,Black or African American (NH),74.3,,72.5,,74.44,
 2019,Mississippi,28,Hispanic or Latino,,,,,,
 2019,Mississippi,28,Two or more races (NH),,,,,,
 2019,Mississippi,28,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Mississippi,28,White (NH),-100.0,,27.5,,24.01,
+2019,Mississippi,28,White (NH),-44.1,,27.5,,24.01,
 2019,Missouri,29,American Indian and Alaska Native (NH),,,,,,
 2019,Missouri,29,Asian (NH),,,,,,
-2019,Missouri,29,Black or African American (NH),-100.0,-99.9,57.6,100.0,157.16,22.68
+2019,Missouri,29,Black or African American (NH),326.7,640.7,57.6,100.0,157.16,22.68
 2019,Missouri,29,Hispanic or Latino,,,,,,
 2019,Missouri,29,Two or more races (NH),,,,,,
 2019,Missouri,29,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Missouri,29,White (NH),-100.0,,42.4,,21.19,
+2019,Missouri,29,White (NH),-41.2,,42.4,,21.19,
 2019,Montana,30,American Indian and Alaska Native (NH),,,,,,
 2019,Montana,30,Asian (NH),,,,,,
 2019,Montana,30,Black or African American (NH),,,,,,
@@ -551,14 +551,14 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Nebraska,31,Hispanic or Latino,,,,,,
 2019,Nebraska,31,Two or more races (NH),,,,,,
 2019,Nebraska,31,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Nebraska,31,White (NH),-100.0,,100.0,,13.46,
+2019,Nebraska,31,White (NH),47.9,,100.0,,13.46,
 2019,Nevada,32,American Indian and Alaska Native (NH),,,,,,
 2019,Nevada,32,Asian (NH),,,,,,
 2019,Nevada,32,Black or African American (NH),,,,,,
 2019,Nevada,32,Hispanic or Latino,,,,,,
 2019,Nevada,32,Two or more races (NH),,,,,,
 2019,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Nevada,32,White (NH),-100.0,,100.0,,28.6,
+2019,Nevada,32,White (NH),193.3,,100.0,,28.6,
 2019,New Hampshire,33,American Indian and Alaska Native (NH),,,,,,
 2019,New Hampshire,33,Asian (NH),,,,,,
 2019,New Hampshire,33,Black or African American (NH),,,,,,
@@ -568,7 +568,7 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,New Hampshire,33,White (NH),,,,,,
 2019,New Jersey,34,American Indian and Alaska Native (NH),,,,,,
 2019,New Jersey,34,Asian (NH),,,,,,
-2019,New Jersey,34,Black or African American (NH),-100.0,,100.0,,38.36,
+2019,New Jersey,34,Black or African American (NH),651.9,,100.0,,38.36,
 2019,New Jersey,34,Hispanic or Latino,,,,,,
 2019,New Jersey,34,Two or more races (NH),,,,,,
 2019,New Jersey,34,Native Hawaiian and Pacific Islander (NH),,,,,,
@@ -576,24 +576,24 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,New Mexico,35,American Indian and Alaska Native (NH),,,,,,
 2019,New Mexico,35,Asian (NH),,,,,,
 2019,New Mexico,35,Black or African American (NH),,,,,,
-2019,New Mexico,35,Hispanic or Latino,-100.0,,100.0,,34.0,
+2019,New Mexico,35,Hispanic or Latino,62.1,,100.0,,34.0,
 2019,New Mexico,35,Two or more races (NH),,,,,,
 2019,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,,,,,
 2019,New Mexico,35,White (NH),,,,,,
 2019,New York,36,American Indian and Alaska Native (NH),,,,,,
 2019,New York,36,Asian (NH),,,,,,
-2019,New York,36,Black or African American (NH),-100.0,,63.8,,21.17,
+2019,New York,36,Black or African American (NH),334.0,,63.8,,21.17,
 2019,New York,36,Hispanic or Latino,,,,,,
 2019,New York,36,Two or more races (NH),,,,,,
 2019,New York,36,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,New York,36,White (NH),-100.0,,36.2,,3.65,
+2019,New York,36,White (NH),-24.4,,36.2,,3.65,
 2019,North Carolina,37,American Indian and Alaska Native (NH),,,,,,
 2019,North Carolina,37,Asian (NH),,,,,,
-2019,North Carolina,37,Black or African American (NH),-100.0,-100.0,62.9,100.0,57.85,6.38
+2019,North Carolina,37,Black or African American (NH),180.8,346.4,62.9,100.0,57.85,6.38
 2019,North Carolina,37,Hispanic or Latino,,,,,,
 2019,North Carolina,37,Two or more races (NH),,,,,,
 2019,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,North Carolina,37,White (NH),-100.0,,37.1,,14.48,
+2019,North Carolina,37,White (NH),-27.8,,37.1,,14.48,
 2019,North Dakota,38,American Indian and Alaska Native (NH),,,,,,
 2019,North Dakota,38,Asian (NH),,,,,,
 2019,North Dakota,38,Black or African American (NH),,,,,,
@@ -603,32 +603,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,North Dakota,38,White (NH),,,,,,
 2019,Ohio,39,American Indian and Alaska Native (NH),,,,,,
 2019,Ohio,39,Asian (NH),,,,,,
-2019,Ohio,39,Black or African American (NH),-100.0,-100.0,56.6,47.7,87.79,7.92
+2019,Ohio,39,Black or African American (NH),272.4,213.8,56.6,47.7,87.79,7.92
 2019,Ohio,39,Hispanic or Latino,,,,,,
 2019,Ohio,39,Two or more races (NH),,,,,,
 2019,Ohio,39,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Ohio,39,White (NH),-100.0,-100.0,43.4,52.3,13.3,1.87
+2019,Ohio,39,White (NH),-38.4,-25.7,43.4,52.3,13.3,1.87
 2019,Oklahoma,40,American Indian and Alaska Native (NH),,,,,,
 2019,Oklahoma,40,Asian (NH),,,,,,
-2019,Oklahoma,40,Black or African American (NH),-99.9,,42.4,,90.63,
+2019,Oklahoma,40,Black or African American (NH),457.9,,42.4,,90.63,
 2019,Oklahoma,40,Hispanic or Latino,,,,,,
 2019,Oklahoma,40,Two or more races (NH),,,,,,
 2019,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Oklahoma,40,White (NH),-100.0,-100.0,57.6,100.0,20.17,5.26
+2019,Oklahoma,40,White (NH),11.2,93.1,57.6,100.0,20.17,5.26
 2019,Oregon,41,American Indian and Alaska Native (NH),,,,,,
 2019,Oregon,41,Asian (NH),,,,,,
 2019,Oregon,41,Black or African American (NH),,,,,,
 2019,Oregon,41,Hispanic or Latino,,,,,,
 2019,Oregon,41,Two or more races (NH),,,,,,
 2019,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Oregon,41,White (NH),-100.0,,100.0,,20.47,
+2019,Oregon,41,White (NH),58.5,,100.0,,20.47,
 2019,Pennsylvania,42,American Indian and Alaska Native (NH),,,,,,
 2019,Pennsylvania,42,Asian (NH),,,,,,
-2019,Pennsylvania,42,Black or African American (NH),-100.0,-100.0,55.6,51.2,83.07,6.45
-2019,Pennsylvania,42,Hispanic or Latino,-100.0,,9.3,,18.0,
+2019,Pennsylvania,42,Black or African American (NH),331.0,296.9,55.6,51.2,83.07,6.45
+2019,Pennsylvania,42,Hispanic or Latino,-28.5,,9.3,,18.0,
 2019,Pennsylvania,42,Two or more races (NH),,,,,,
 2019,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Pennsylvania,42,White (NH),-100.0,-100.0,35.0,48.8,10.0,1.21
+2019,Pennsylvania,42,White (NH),-46.7,-25.7,35.0,48.8,10.0,1.21
 2019,Rhode Island,44,American Indian and Alaska Native (NH),,,,,,
 2019,Rhode Island,44,Asian (NH),,,,,,
 2019,Rhode Island,44,Black or African American (NH),,,,,,
@@ -638,11 +638,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Rhode Island,44,White (NH),,,,,,
 2019,South Carolina,45,American Indian and Alaska Native (NH),,,,,,
 2019,South Carolina,45,Asian (NH),,,,,,
-2019,South Carolina,45,Black or African American (NH),-100.0,,69.6,,88.36,
+2019,South Carolina,45,Black or African American (NH),137.5,,69.6,,88.36,
 2019,South Carolina,45,Hispanic or Latino,,,,,,
 2019,South Carolina,45,Two or more races (NH),,,,,,
 2019,South Carolina,45,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,South Carolina,45,White (NH),-100.0,-100.0,30.4,100.0,20.13,4.13
+2019,South Carolina,45,White (NH),-44.1,83.8,30.4,100.0,20.13,4.13
 2019,South Dakota,46,American Indian and Alaska Native (NH),,,,,,
 2019,South Dakota,46,Asian (NH),,,,,,
 2019,South Dakota,46,Black or African American (NH),,,,,,
@@ -652,25 +652,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,South Dakota,46,White (NH),,,,,,
 2019,Tennessee,47,American Indian and Alaska Native (NH),,,,,,
 2019,Tennessee,47,Asian (NH),,,,,,
-2019,Tennessee,47,Black or African American (NH),-100.0,-100.0,58.4,48.8,82.99,7.35
+2019,Tennessee,47,Black or African American (NH),209.0,158.2,58.4,48.8,82.99,7.35
 2019,Tennessee,47,Hispanic or Latino,,,,,,
 2019,Tennessee,47,Two or more races (NH),,,,,,
 2019,Tennessee,47,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Tennessee,47,White (NH),-100.0,-100.0,41.6,51.2,17.43,2.25
+2019,Tennessee,47,White (NH),-35.7,-20.9,41.6,51.2,17.43,2.25
 2019,Texas,48,American Indian and Alaska Native (NH),,,,,,
 2019,Texas,48,Asian (NH),,,,,,
-2019,Texas,48,Black or African American (NH),-100.0,-100.0,32.0,29.6,49.34,6.74
-2019,Texas,48,Hispanic or Latino,-100.0,-100.0,36.2,31.0,16.0,2.0
+2019,Texas,48,Black or African American (NH),166.7,146.7,32.0,29.6,49.34,6.74
+2019,Texas,48,Hispanic or Latino,-26.4,-37.0,36.2,31.0,16.0,2.0
 2019,Texas,48,Two or more races (NH),,,,,,
 2019,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Texas,48,White (NH),-100.0,-100.0,31.8,39.4,18.8,3.47
+2019,Texas,48,White (NH),2.3,26.7,31.8,39.4,18.8,3.47
 2019,Utah,49,American Indian and Alaska Native (NH),,,,,,
 2019,Utah,49,Asian (NH),,,,,,
 2019,Utah,49,Black or African American (NH),,,,,,
 2019,Utah,49,Hispanic or Latino,,,,,,
 2019,Utah,49,Two or more races (NH),,,,,,
 2019,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Utah,49,White (NH),-100.0,,100.0,,17.22,
+2019,Utah,49,White (NH),36.1,,100.0,,17.22,
 2019,Vermont,50,American Indian and Alaska Native (NH),,,,,,
 2019,Vermont,50,Asian (NH),,,,,,
 2019,Vermont,50,Black or African American (NH),,,,,,
@@ -680,32 +680,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Vermont,50,White (NH),,,,,,
 2019,Virginia,51,American Indian and Alaska Native (NH),,,,,,
 2019,Virginia,51,Asian (NH),,,,,,
-2019,Virginia,51,Black or African American (NH),-100.0,-100.0,56.6,100.0,51.53,7.01
+2019,Virginia,51,Black or African American (NH),184.4,402.5,56.6,100.0,51.53,7.01
 2019,Virginia,51,Hispanic or Latino,,,,,,
 2019,Virginia,51,Two or more races (NH),,,,,,
 2019,Virginia,51,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Virginia,51,White (NH),-100.0,,43.4,,14.59,
+2019,Virginia,51,White (NH),-17.8,,43.4,,14.59,
 2019,Washington,53,American Indian and Alaska Native (NH),,,,,,
 2019,Washington,53,Asian (NH),,,,,,
 2019,Washington,53,Black or African American (NH),,,,,,
-2019,Washington,53,Hispanic or Latino,-100.0,,28.2,,16.0,
+2019,Washington,53,Hispanic or Latino,28.2,,28.2,,16.0,
 2019,Washington,53,Two or more races (NH),,,,,,
 2019,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Washington,53,White (NH),-100.0,,71.8,,12.44,
+2019,Washington,53,White (NH),30.8,,71.8,,12.44,
 2019,West Virginia,54,American Indian and Alaska Native (NH),,,,,,
 2019,West Virginia,54,Asian (NH),,,,,,
 2019,West Virginia,54,Black or African American (NH),,,,,,
 2019,West Virginia,54,Hispanic or Latino,,,,,,
 2019,West Virginia,54,Two or more races (NH),,,,,,
 2019,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,West Virginia,54,White (NH),-100.0,,100.0,,20.5,
+2019,West Virginia,54,White (NH),12.9,,100.0,,20.5,
 2019,Wisconsin,55,American Indian and Alaska Native (NH),,,,,,
 2019,Wisconsin,55,Asian (NH),,,,,,
-2019,Wisconsin,55,Black or African American (NH),-100.0,,39.4,,56.74,
+2019,Wisconsin,55,Black or African American (NH),342.7,,39.4,,56.74,
 2019,Wisconsin,55,Hispanic or Latino,,,,,,
 2019,Wisconsin,55,Two or more races (NH),,,,,,
 2019,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Wisconsin,55,White (NH),-100.0,,60.6,,9.19,
+2019,Wisconsin,55,White (NH),-12.6,,60.6,,9.19,
 2019,Wyoming,56,American Indian and Alaska Native (NH),,,,,,
 2019,Wyoming,56,Asian (NH),,,,,,
 2019,Wyoming,56,Black or African American (NH),,,,,,
@@ -715,11 +715,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2019,Wyoming,56,White (NH),,,,,,
 2020,Alabama,01,American Indian and Alaska Native (NH),,,,,,
 2020,Alabama,01,Asian (NH),,,,,,
-2020,Alabama,01,Black or African American (NH),-100.0,,68.7,,107.61,
+2020,Alabama,01,Black or African American (NH),137.7,,68.7,,107.61,
 2020,Alabama,01,Hispanic or Latino,,,,,,
 2020,Alabama,01,Two or more races (NH),,,,,,
 2020,Alabama,01,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Alabama,01,White (NH),-100.0,,31.3,,25.29,
+2020,Alabama,01,White (NH),-45.5,,31.3,,25.29,
 2020,Alaska,02,American Indian and Alaska Native (NH),,,,,,
 2020,Alaska,02,Asian (NH),,,,,,
 2020,Alaska,02,Black or African American (NH),,,,,,
@@ -729,67 +729,67 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Alaska,02,White (NH),,,,,,
 2020,Arizona,04,American Indian and Alaska Native (NH),,,,,,
 2020,Arizona,04,Asian (NH),,,,,,
-2020,Arizona,04,Black or African American (NH),-100.0,,19.4,,76.96,
-2020,Arizona,04,Hispanic or Latino,-100.0,,41.9,,21.0,
+2020,Arizona,04,Black or African American (NH),280.4,,19.4,,76.96,
+2020,Arizona,04,Hispanic or Latino,-6.7,,41.9,,21.0,
 2020,Arizona,04,Two or more races (NH),,,,,,
 2020,Arizona,04,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Arizona,04,White (NH),-100.0,,38.8,,19.28,
+2020,Arizona,04,White (NH),2.4,,38.8,,19.28,
 2020,Arkansas,05,American Indian and Alaska Native (NH),,,,,,
 2020,Arkansas,05,Asian (NH),,,,,,
-2020,Arkansas,05,Black or African American (NH),-100.0,-99.9,56.5,100.0,120.92,19.16
+2020,Arkansas,05,Black or African American (NH),217.4,461.8,56.5,100.0,120.92,19.16
 2020,Arkansas,05,Hispanic or Latino,,,,,,
 2020,Arkansas,05,Two or more races (NH),,,,,,
 2020,Arkansas,05,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Arkansas,05,White (NH),-100.0,,43.5,,26.43,
+2020,Arkansas,05,White (NH),-30.2,,43.5,,26.43,
 2020,California,06,American Indian and Alaska Native (NH),,,,,,
-2020,California,06,Asian (NH),-100.0,,3.5,,3.95,
-2020,California,06,Black or African American (NH),-100.0,-100.0,25.2,24.6,64.5,6.73
-2020,California,06,Hispanic or Latino,-100.0,-100.0,51.5,52.5,15.0,1.0
-2020,California,06,Two or more races (NH),-100.0,,4.8,,17.78,
+2020,California,06,Asian (NH),-72.2,,3.5,,3.95,
+2020,California,06,Black or African American (NH),404.0,392.0,25.2,24.6,64.5,6.73
+2020,California,06,Hispanic or Latino,-0.4,1.5,51.5,52.5,15.0,1.0
+2020,California,06,Two or more races (NH),-9.4,,4.8,,17.78,
 2020,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,California,06,White (NH),-100.0,-100.0,15.0,23.0,7.89,1.27
+2020,California,06,White (NH),-39.5,-7.3,15.0,23.0,7.89,1.27
 2020,Colorado,08,American Indian and Alaska Native (NH),,,,,,
 2020,Colorado,08,Asian (NH),,,,,,
-2020,Colorado,08,Black or African American (NH),-100.0,,17.0,,87.66,
-2020,Colorado,08,Hispanic or Latino,-100.0,,29.8,,25.0,
+2020,Colorado,08,Black or African American (NH),295.3,,17.0,,87.66,
+2020,Colorado,08,Hispanic or Latino,-6.3,,29.8,,25.0,
 2020,Colorado,08,Two or more races (NH),,,,,,
 2020,Colorado,08,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Colorado,08,White (NH),-100.0,-100.0,53.2,100.0,20.88,3.16
+2020,Colorado,08,White (NH),-3.6,81.2,53.2,100.0,20.88,3.16
 2020,Connecticut,09,American Indian and Alaska Native (NH),,,,,,
 2020,Connecticut,09,Asian (NH),,,,,,
-2020,Connecticut,09,Black or African American (NH),-99.9,,100.0,,57.16,
+2020,Connecticut,09,Black or African American (NH),762.1,,100.0,,57.16,
 2020,Connecticut,09,Hispanic or Latino,,,,,,
 2020,Connecticut,09,Two or more races (NH),,,,,,
 2020,Connecticut,09,Native Hawaiian and Pacific Islander (NH),,,,,,
 2020,Connecticut,09,White (NH),,,,,,
 2020,Delaware,10,American Indian and Alaska Native (NH),,,,,,
 2020,Delaware,10,Asian (NH),,,,,,
-2020,Delaware,10,Black or African American (NH),-99.8,,100.0,,101.99,
+2020,Delaware,10,Black or African American (NH),292.2,,100.0,,101.99,
 2020,Delaware,10,Hispanic or Latino,,,,,,
 2020,Delaware,10,Two or more races (NH),,,,,,
 2020,Delaware,10,Native Hawaiian and Pacific Islander (NH),,,,,,
 2020,Delaware,10,White (NH),,,,,,
 2020,District of Columbia,11,American Indian and Alaska Native (NH),,,,,,
 2020,District of Columbia,11,Asian (NH),,,,,,
-2020,District of Columbia,11,Black or African American (NH),-99.8,,100.0,,178.18,
+2020,District of Columbia,11,Black or African American (NH),91.6,,100.0,,178.18,
 2020,District of Columbia,11,Hispanic or Latino,,,,,,
 2020,District of Columbia,11,Two or more races (NH),,,,,,
 2020,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),,,,,,
 2020,District of Columbia,11,White (NH),,,,,,
 2020,Florida,12,American Indian and Alaska Native (NH),,,,,,
 2020,Florida,12,Asian (NH),,,,,,
-2020,Florida,12,Black or African American (NH),-100.0,-100.0,56.9,40.5,76.42,5.73
-2020,Florida,12,Hispanic or Latino,-100.0,-100.0,14.9,22.3,13.0,2.0
+2020,Florida,12,Black or African American (NH),184.5,102.5,56.9,40.5,76.42,5.73
+2020,Florida,12,Hispanic or Latino,-52.5,-29.0,14.9,22.3,13.0,2.0
 2020,Florida,12,Two or more races (NH),,,,,,
 2020,Florida,12,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Florida,12,White (NH),-100.0,-100.0,28.2,37.2,17.01,2.52
+2020,Florida,12,White (NH),-32.4,-10.8,28.2,37.2,17.01,2.52
 2020,Georgia,13,American Indian and Alaska Native (NH),,,,,,
 2020,Georgia,13,Asian (NH),,,,,,
-2020,Georgia,13,Black or African American (NH),-100.0,-100.0,74.8,71.7,71.21,7.73
+2020,Georgia,13,Black or African American (NH),122.0,112.8,74.8,71.7,71.21,7.73
 2020,Georgia,13,Hispanic or Latino,,,,,,
 2020,Georgia,13,Two or more races (NH),,,,,,
 2020,Georgia,13,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Georgia,13,White (NH),-100.0,-100.0,25.2,28.3,18.18,2.4
+2020,Georgia,13,White (NH),-41.1,-33.9,25.2,28.3,18.18,2.4
 2020,Hawaii,15,American Indian and Alaska Native (NH),,,,,,
 2020,Hawaii,15,Asian (NH),,,,,,
 2020,Hawaii,15,Black or African American (NH),,,,,,
@@ -803,49 +803,49 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Idaho,16,Hispanic or Latino,,,,,,
 2020,Idaho,16,Two or more races (NH),,,,,,
 2020,Idaho,16,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Idaho,16,White (NH),-100.0,,100.0,,22.15,
+2020,Idaho,16,White (NH),34.2,,100.0,,22.15,
 2020,Illinois,17,American Indian and Alaska Native (NH),,,,,,
 2020,Illinois,17,Asian (NH),,,,,,
-2020,Illinois,17,Black or African American (NH),-100.0,-100.0,71.8,75.0,145.68,14.4
-2020,Illinois,17,Hispanic or Latino,-100.0,-100.0,15.9,25.0,22.0,3.0
+2020,Illinois,17,Black or African American (NH),369.3,390.2,71.8,75.0,145.68,14.4
+2020,Illinois,17,Hispanic or Latino,-35.6,1.2,15.9,25.0,22.0,3.0
 2020,Illinois,17,Two or more races (NH),,,,,,
 2020,Illinois,17,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Illinois,17,White (NH),-100.0,,12.3,,7.48,
+2020,Illinois,17,White (NH),-75.7,,12.3,,7.48,
 2020,Indiana,18,American Indian and Alaska Native (NH),,,,,,
 2020,Indiana,18,Asian (NH),,,,,,
-2020,Indiana,18,Black or African American (NH),-100.0,-100.0,56.3,46.8,183.92,15.94
+2020,Indiana,18,Black or African American (NH),393.9,310.5,56.3,46.8,183.92,15.94
 2020,Indiana,18,Hispanic or Latino,,,,,,
 2020,Indiana,18,Two or more races (NH),,,,,,
 2020,Indiana,18,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Indiana,18,White (NH),-100.0,-100.0,43.7,53.2,21.33,2.97
+2020,Indiana,18,White (NH),-37.2,-23.6,43.7,53.2,21.33,2.97
 2020,Iowa,19,American Indian and Alaska Native (NH),,,,,,
 2020,Iowa,19,Asian (NH),,,,,,
 2020,Iowa,19,Black or African American (NH),,,,,,
 2020,Iowa,19,Hispanic or Latino,,,,,,
 2020,Iowa,19,Two or more races (NH),,,,,,
 2020,Iowa,19,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Iowa,19,White (NH),-100.0,,100.0,,12.2,
+2020,Iowa,19,White (NH),31.2,,100.0,,12.2,
 2020,Kansas,20,American Indian and Alaska Native (NH),,,,,,
 2020,Kansas,20,Asian (NH),,,,,,
-2020,Kansas,20,Black or African American (NH),-100.0,,20.8,,93.66,
-2020,Kansas,20,Hispanic or Latino,-100.0,,25.7,,48.0,
+2020,Kansas,20,Black or African American (NH),241.0,,20.8,,93.66,
+2020,Kansas,20,Hispanic or Latino,35.3,,25.7,,48.0,
 2020,Kansas,20,Two or more races (NH),,,,,,
 2020,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Kansas,20,White (NH),-100.0,,53.5,,24.01,
+2020,Kansas,20,White (NH),-18.6,,53.5,,24.01,
 2020,Kentucky,21,American Indian and Alaska Native (NH),,,,,,
 2020,Kentucky,21,Asian (NH),,,,,,
-2020,Kentucky,21,Black or African American (NH),-100.0,-100.0,45.5,45.1,139.3,24.41
+2020,Kentucky,21,Black or African American (NH),394.6,390.2,45.5,45.1,139.3,24.41
 2020,Kentucky,21,Hispanic or Latino,,,,,,
 2020,Kentucky,21,Two or more races (NH),,,,,,
 2020,Kentucky,21,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Kentucky,21,White (NH),-100.0,-100.0,54.5,54.9,22.47,3.54
+2020,Kentucky,21,White (NH),-29.7,-29.2,54.5,54.9,22.47,3.54
 2020,Louisiana,22,American Indian and Alaska Native (NH),,,,,,
 2020,Louisiana,22,Asian (NH),,,,,,
-2020,Louisiana,22,Black or African American (NH),-100.0,-100.0,87.2,100.0,148.12,13.28
+2020,Louisiana,22,Black or African American (NH),139.6,174.7,87.2,100.0,148.12,13.28
 2020,Louisiana,22,Hispanic or Latino,,,,,,
 2020,Louisiana,22,Two or more races (NH),,,,,,
 2020,Louisiana,22,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Louisiana,22,White (NH),-100.0,,12.8,,15.92,
+2020,Louisiana,22,White (NH),-74.7,,12.8,,15.92,
 2020,Maine,23,American Indian and Alaska Native (NH),,,,,,
 2020,Maine,23,Asian (NH),,,,,,
 2020,Maine,23,Black or African American (NH),,,,,,
@@ -855,53 +855,53 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Maine,23,White (NH),,,,,,
 2020,Maryland,24,American Indian and Alaska Native (NH),,,,,,
 2020,Maryland,24,Asian (NH),,,,,,
-2020,Maryland,24,Black or African American (NH),-100.0,,88.7,,88.78,
+2020,Maryland,24,Black or African American (NH),189.9,,88.7,,88.78,
 2020,Maryland,24,Hispanic or Latino,,,,,,
 2020,Maryland,24,Two or more races (NH),,,,,,
 2020,Maryland,24,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Maryland,24,White (NH),-100.0,,11.3,,8.03,
+2020,Maryland,24,White (NH),-72.2,,11.3,,8.03,
 2020,Massachusetts,25,American Indian and Alaska Native (NH),,,,,,
 2020,Massachusetts,25,Asian (NH),,,,,,
-2020,Massachusetts,25,Black or African American (NH),-99.9,,100.0,,40.28,
+2020,Massachusetts,25,Black or African American (NH),1023.6,,100.0,,40.28,
 2020,Massachusetts,25,Hispanic or Latino,,,,,,
 2020,Massachusetts,25,Two or more races (NH),,,,,,
 2020,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),,,,,,
 2020,Massachusetts,25,White (NH),,,,,,
 2020,Michigan,26,American Indian and Alaska Native (NH),,,,,,
 2020,Michigan,26,Asian (NH),,,,,,
-2020,Michigan,26,Black or African American (NH),-100.0,-100.0,66.0,100.0,106.59,10.3
+2020,Michigan,26,Black or African American (NH),312.5,525.0,66.0,100.0,106.59,10.3
 2020,Michigan,26,Hispanic or Latino,,,,,,
 2020,Michigan,26,Two or more races (NH),,,,,,
 2020,Michigan,26,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Michigan,26,White (NH),-100.0,,34.0,,12.01,
+2020,Michigan,26,White (NH),-48.6,,34.0,,12.01,
 2020,Minnesota,27,American Indian and Alaska Native (NH),,,,,,
 2020,Minnesota,27,Asian (NH),,,,,,
-2020,Minnesota,27,Black or African American (NH),-100.0,,48.4,,63.33,
+2020,Minnesota,27,Black or African American (NH),361.0,,48.4,,63.33,
 2020,Minnesota,27,Hispanic or Latino,,,,,,
 2020,Minnesota,27,Two or more races (NH),,,,,,
 2020,Minnesota,27,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Minnesota,27,White (NH),-100.0,,51.6,,7.82,
+2020,Minnesota,27,White (NH),-23.2,,51.6,,7.82,
 2020,Mississippi,28,American Indian and Alaska Native (NH),,,,,,
 2020,Mississippi,28,Asian (NH),,,,,,
-2020,Mississippi,28,Black or African American (NH),-100.0,-100.0,79.4,100.0,101.03,11.69
+2020,Mississippi,28,Black or African American (NH),90.9,140.4,79.4,100.0,101.03,11.69
 2020,Mississippi,28,Hispanic or Latino,,,,,,
 2020,Mississippi,28,Two or more races (NH),,,,,,
 2020,Mississippi,28,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Mississippi,28,White (NH),-100.0,,20.6,,22.08,
+2020,Mississippi,28,White (NH),-58.0,,20.6,,22.08,
 2020,Missouri,29,American Indian and Alaska Native (NH),,,,,,
 2020,Missouri,29,Asian (NH),,,,,,
-2020,Missouri,29,Black or African American (NH),-100.0,-100.0,59.2,61.1,194.62,23.52
+2020,Missouri,29,Black or African American (NH),341.8,356.0,59.2,61.1,194.62,23.52
 2020,Missouri,29,Hispanic or Latino,,,,,,
 2020,Missouri,29,Two or more races (NH),,,,,,
 2020,Missouri,29,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Missouri,29,White (NH),-100.0,-100.0,40.8,38.9,24.1,2.8
+2020,Missouri,29,White (NH),-43.3,-45.9,40.8,38.9,24.1,2.8
 2020,Montana,30,American Indian and Alaska Native (NH),,,,,,
 2020,Montana,30,Asian (NH),,,,,,
 2020,Montana,30,Black or African American (NH),,,,,,
 2020,Montana,30,Hispanic or Latino,,,,,,
 2020,Montana,30,Two or more races (NH),,,,,,
 2020,Montana,30,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Montana,30,White (NH),-99.9,,100.0,,36.53,
+2020,Montana,30,White (NH),29.0,,100.0,,36.53,
 2020,Nebraska,31,American Indian and Alaska Native (NH),,,,,,
 2020,Nebraska,31,Asian (NH),,,,,,
 2020,Nebraska,31,Black or African American (NH),,,,,,
@@ -911,11 +911,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Nebraska,31,White (NH),,,,,,
 2020,Nevada,32,American Indian and Alaska Native (NH),,,,,,
 2020,Nevada,32,Asian (NH),,,,,,
-2020,Nevada,32,Black or African American (NH),-99.9,,42.9,,68.74,
+2020,Nevada,32,Black or African American (NH),300.9,,42.9,,68.74,
 2020,Nevada,32,Hispanic or Latino,,,,,,
 2020,Nevada,32,Two or more races (NH),,,,,,
 2020,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Nevada,32,White (NH),-100.0,,57.1,,27.52,
+2020,Nevada,32,White (NH),70.4,,57.1,,27.52,
 2020,New Hampshire,33,American Indian and Alaska Native (NH),,,,,,
 2020,New Hampshire,33,Asian (NH),,,,,,
 2020,New Hampshire,33,Black or African American (NH),,,,,,
@@ -925,7 +925,7 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,New Hampshire,33,White (NH),,,,,,
 2020,New Jersey,34,American Indian and Alaska Native (NH),,,,,,
 2020,New Jersey,34,Asian (NH),,,,,,
-2020,New Jersey,34,Black or African American (NH),-100.0,,100.0,,46.99,
+2020,New Jersey,34,Black or African American (NH),646.3,,100.0,,46.99,
 2020,New Jersey,34,Hispanic or Latino,,,,,,
 2020,New Jersey,34,Two or more races (NH),,,,,,
 2020,New Jersey,34,Native Hawaiian and Pacific Islander (NH),,,,,,
@@ -933,24 +933,24 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,New Mexico,35,American Indian and Alaska Native (NH),,,,,,
 2020,New Mexico,35,Asian (NH),,,,,,
 2020,New Mexico,35,Black or African American (NH),,,,,,
-2020,New Mexico,35,Hispanic or Latino,-100.0,,100.0,,37.0,
+2020,New Mexico,35,Hispanic or Latino,62.1,,100.0,,37.0,
 2020,New Mexico,35,Two or more races (NH),,,,,,
 2020,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,,,,,
 2020,New Mexico,35,White (NH),,,,,,
 2020,New York,36,American Indian and Alaska Native (NH),,,,,,
 2020,New York,36,Asian (NH),,,,,,
-2020,New York,36,Black or African American (NH),-100.0,,62.8,,44.28,
-2020,New York,36,Hispanic or Latino,-100.0,,15.2,,8.0,
+2020,New York,36,Black or African American (NH),327.2,,62.8,,44.28,
+2020,New York,36,Hispanic or Latino,-38.7,,15.2,,8.0,
 2020,New York,36,Two or more races (NH),,,,,,
 2020,New York,36,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,New York,36,White (NH),-100.0,,22.0,,4.66,
+2020,New York,36,White (NH),-53.8,,22.0,,4.66,
 2020,North Carolina,37,American Indian and Alaska Native (NH),,,,,,
 2020,North Carolina,37,Asian (NH),,,,,,
-2020,North Carolina,37,Black or African American (NH),-100.0,-100.0,61.1,53.8,74.44,9.67
+2020,North Carolina,37,Black or African American (NH),172.8,140.2,61.1,53.8,74.44,9.67
 2020,North Carolina,37,Hispanic or Latino,,,,,,
 2020,North Carolina,37,Two or more races (NH),,,,,,
 2020,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,North Carolina,37,White (NH),-100.0,-100.0,38.9,46.2,20.0,3.65
+2020,North Carolina,37,White (NH),-23.9,-9.6,38.9,46.2,20.0,3.65
 2020,North Dakota,38,American Indian and Alaska Native (NH),,,,,,
 2020,North Dakota,38,Asian (NH),,,,,,
 2020,North Dakota,38,Black or African American (NH),,,,,,
@@ -960,32 +960,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,North Dakota,38,White (NH),,,,,,
 2020,Ohio,39,American Indian and Alaska Native (NH),,,,,,
 2020,Ohio,39,Asian (NH),,,,,,
-2020,Ohio,39,Black or African American (NH),-100.0,-100.0,65.8,61.1,140.93,14.52
+2020,Ohio,39,Black or African American (NH),332.9,302.0,65.8,61.1,140.93,14.52
 2020,Ohio,39,Hispanic or Latino,,,,,,
 2020,Ohio,39,Two or more races (NH),,,,,,
 2020,Ohio,39,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Ohio,39,White (NH),-100.0,-100.0,34.2,38.9,14.41,2.01
+2020,Ohio,39,White (NH),-51.1,-44.4,34.2,38.9,14.41,2.01
 2020,Oklahoma,40,American Indian and Alaska Native (NH),,,,,,
 2020,Oklahoma,40,Asian (NH),,,,,,
-2020,Oklahoma,40,Black or African American (NH),-100.0,,28.6,,82.41,
+2020,Oklahoma,40,Black or African American (NH),276.3,,28.6,,82.41,
 2020,Oklahoma,40,Hispanic or Latino,,,,,,
 2020,Oklahoma,40,Two or more races (NH),,,,,,
 2020,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Oklahoma,40,White (NH),-100.0,,71.4,,33.54,
+2020,Oklahoma,40,White (NH),38.6,,71.4,,33.54,
 2020,Oregon,41,American Indian and Alaska Native (NH),,,,,,
 2020,Oregon,41,Asian (NH),,,,,,
 2020,Oregon,41,Black or African American (NH),,,,,,
-2020,Oregon,41,Hispanic or Latino,-100.0,,33.3,,26.0,
+2020,Oregon,41,Hispanic or Latino,46.7,,33.3,,26.0,
 2020,Oregon,41,Two or more races (NH),,,,,,
 2020,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Oregon,41,White (NH),-100.0,,66.7,,16.45,
+2020,Oregon,41,White (NH),6.4,,66.7,,16.45,
 2020,Pennsylvania,42,American Indian and Alaska Native (NH),,,,,,
 2020,Pennsylvania,42,Asian (NH),,,,,,
-2020,Pennsylvania,42,Black or African American (NH),-100.0,-100.0,64.7,59.7,131.86,12.33
-2020,Pennsylvania,42,Hispanic or Latino,-100.0,,8.7,,21.0,
+2020,Pennsylvania,42,Black or African American (NH),401.6,362.8,64.7,59.7,131.86,12.33
+2020,Pennsylvania,42,Hispanic or Latino,-34.6,,8.7,,21.0,
 2020,Pennsylvania,42,Two or more races (NH),,,,,,
 2020,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Pennsylvania,42,White (NH),-100.0,-100.0,26.6,40.3,10.32,1.65
+2020,Pennsylvania,42,White (NH),-59.2,-38.2,26.6,40.3,10.32,1.65
 2020,Rhode Island,44,American Indian and Alaska Native (NH),,,,,,
 2020,Rhode Island,44,Asian (NH),,,,,,
 2020,Rhode Island,44,Black or African American (NH),,,,,,
@@ -995,11 +995,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Rhode Island,44,White (NH),,,,,,
 2020,South Carolina,45,American Indian and Alaska Native (NH),,,,,,
 2020,South Carolina,45,Asian (NH),,,,,,
-2020,South Carolina,45,Black or African American (NH),-100.0,-100.0,66.8,63.5,105.8,12.3
+2020,South Carolina,45,Black or African American (NH),128.8,117.5,66.8,63.5,105.8,12.3
 2020,South Carolina,45,Hispanic or Latino,,,,,,
 2020,South Carolina,45,Two or more races (NH),,,,,,
 2020,South Carolina,45,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,South Carolina,45,White (NH),-100.0,-100.0,33.2,36.5,26.94,3.81
+2020,South Carolina,45,White (NH),-38.7,-32.7,33.2,36.5,26.94,3.81
 2020,South Dakota,46,American Indian and Alaska Native (NH),,,,,,
 2020,South Dakota,46,Asian (NH),,,,,,
 2020,South Dakota,46,Black or African American (NH),,,,,,
@@ -1009,25 +1009,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,South Dakota,46,White (NH),,,,,,
 2020,Tennessee,47,American Indian and Alaska Native (NH),,,,,,
 2020,Tennessee,47,Asian (NH),,,,,,
-2020,Tennessee,47,Black or African American (NH),-100.0,-100.0,66.0,65.6,117.04,14.45
+2020,Tennessee,47,Black or African American (NH),249.2,247.1,66.0,65.6,117.04,14.45
 2020,Tennessee,47,Hispanic or Latino,,,,,,
 2020,Tennessee,47,Two or more races (NH),,,,,,
 2020,Tennessee,47,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Tennessee,47,White (NH),-100.0,-100.0,34.0,34.4,17.54,2.22
+2020,Tennessee,47,White (NH),-47.2,-46.6,34.0,34.4,17.54,2.22
 2020,Texas,48,American Indian and Alaska Native (NH),,,,,,
 2020,Texas,48,Asian (NH),,,,,,
-2020,Texas,48,Black or African American (NH),-100.0,-100.0,34.2,24.1,70.11,6.73
-2020,Texas,48,Hispanic or Latino,-100.0,-100.0,36.6,39.1,21.0,3.0
+2020,Texas,48,Black or African American (NH),182.6,99.2,34.2,24.1,70.11,6.73
+2020,Texas,48,Hispanic or Latino,-25.8,-20.7,36.6,39.1,21.0,3.0
 2020,Texas,48,Two or more races (NH),,,,,,
 2020,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Texas,48,White (NH),-100.0,-100.0,29.2,36.8,23.07,4.03
+2020,Texas,48,White (NH),-5.2,19.5,29.2,36.8,23.07,4.03
 2020,Utah,49,American Indian and Alaska Native (NH),,,,,,
 2020,Utah,49,Asian (NH),,,,,,
 2020,Utah,49,Black or African American (NH),,,,,,
-2020,Utah,49,Hispanic or Latino,-100.0,,33.8,,33.0,
+2020,Utah,49,Hispanic or Latino,85.7,,33.8,,33.0,
 2020,Utah,49,Two or more races (NH),,,,,,
 2020,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Utah,49,White (NH),-100.0,,66.2,,14.46,
+2020,Utah,49,White (NH),-9.4,,66.2,,14.46,
 2020,Vermont,50,American Indian and Alaska Native (NH),,,,,,
 2020,Vermont,50,Asian (NH),,,,,,
 2020,Vermont,50,Black or African American (NH),,,,,,
@@ -1037,32 +1037,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Vermont,50,White (NH),,,,,,
 2020,Virginia,51,American Indian and Alaska Native (NH),,,,,,
 2020,Virginia,51,Asian (NH),,,,,,
-2020,Virginia,51,Black or African American (NH),-100.0,-100.0,64.1,55.0,74.82,8.75
+2020,Virginia,51,Black or African American (NH),222.1,176.4,64.1,55.0,74.82,8.75
 2020,Virginia,51,Hispanic or Latino,,,,,,
 2020,Virginia,51,Two or more races (NH),,,,,,
 2020,Virginia,51,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Virginia,51,White (NH),-100.0,-100.0,35.9,45.0,15.37,2.71
+2020,Virginia,51,White (NH),-31.5,-14.1,35.9,45.0,15.37,2.71
 2020,Washington,53,American Indian and Alaska Native (NH),,,,,,
 2020,Washington,53,Asian (NH),,,,,,
-2020,Washington,53,Black or African American (NH),-100.0,,18.0,,65.68,
-2020,Washington,53,Hispanic or Latino,-100.0,,27.1,,25.0,
+2020,Washington,53,Black or African American (NH),318.6,,18.0,,65.68,
+2020,Washington,53,Hispanic or Latino,22.1,,27.1,,25.0,
 2020,Washington,53,Two or more races (NH),,,,,,
 2020,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Washington,53,White (NH),-100.0,,54.9,,16.58,
+2020,Washington,53,White (NH),0.9,,54.9,,16.58,
 2020,West Virginia,54,American Indian and Alaska Native (NH),,,,,,
 2020,West Virginia,54,Asian (NH),,,,,,
 2020,West Virginia,54,Black or African American (NH),,,,,,
 2020,West Virginia,54,Hispanic or Latino,,,,,,
 2020,West Virginia,54,Two or more races (NH),,,,,,
 2020,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,West Virginia,54,White (NH),-100.0,,100.0,,22.11,
+2020,West Virginia,54,White (NH),13.3,,100.0,,22.11,
 2020,Wisconsin,55,American Indian and Alaska Native (NH),,,,,,
 2020,Wisconsin,55,Asian (NH),,,,,,
-2020,Wisconsin,55,Black or African American (NH),-100.0,,49.6,,115.54,
+2020,Wisconsin,55,Black or African American (NH),457.3,,49.6,,115.54,
 2020,Wisconsin,55,Hispanic or Latino,,,,,,
 2020,Wisconsin,55,Two or more races (NH),,,,,,
 2020,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Wisconsin,55,White (NH),-100.0,,50.4,,12.31,
+2020,Wisconsin,55,White (NH),-27.1,,50.4,,12.31,
 2020,Wyoming,56,American Indian and Alaska Native (NH),,,,,,
 2020,Wyoming,56,Asian (NH),,,,,,
 2020,Wyoming,56,Black or African American (NH),,,,,,
@@ -1072,11 +1072,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2020,Wyoming,56,White (NH),,,,,,
 2021,Alabama,01,American Indian and Alaska Native (NH),,,,,,
 2021,Alabama,01,Asian (NH),,,,,,
-2021,Alabama,01,Black or African American (NH),-100.0,-100.0,79.0,67.5,126.74,16.03
+2021,Alabama,01,Black or African American (NH),173.4,133.6,79.0,67.5,126.74,16.03
 2021,Alabama,01,Hispanic or Latino,,,,,,
 2021,Alabama,01,Two or more races (NH),,,,,,
 2021,Alabama,01,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Alabama,01,White (NH),-100.0,-100.0,21.0,32.5,17.15,3.9
+2021,Alabama,01,White (NH),-63.2,-43.1,21.0,32.5,17.15,3.9
 2021,Alaska,02,American Indian and Alaska Native (NH),,,,,,
 2021,Alaska,02,Asian (NH),,,,,,
 2021,Alaska,02,Black or African American (NH),,,,,,
@@ -1086,67 +1086,67 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Alaska,02,White (NH),,,,,,
 2021,Arizona,04,American Indian and Alaska Native (NH),,,,,,
 2021,Arizona,04,Asian (NH),,,,,,
-2021,Arizona,04,Black or African American (NH),-100.0,,18.0,,80.93,
-2021,Arizona,04,Hispanic or Latino,-100.0,-100.0,45.9,100.0,26.0,4.0
+2021,Arizona,04,Black or African American (NH),246.2,,18.0,,80.93,
+2021,Arizona,04,Hispanic or Latino,2.0,122.2,45.9,100.0,26.0,4.0
 2021,Arizona,04,Two or more races (NH),,,,,,
 2021,Arizona,04,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Arizona,04,White (NH),-100.0,,36.1,,20.39,
+2021,Arizona,04,White (NH),-4.0,,36.1,,20.39,
 2021,Arkansas,05,American Indian and Alaska Native (NH),,,,,,
 2021,Arkansas,05,Asian (NH),,,,,,
-2021,Arkansas,05,Black or African American (NH),-100.0,,58.9,,126.85,
+2021,Arkansas,05,Black or African American (NH),232.8,,58.9,,126.85,
 2021,Arkansas,05,Hispanic or Latino,,,,,,
 2021,Arkansas,05,Two or more races (NH),,,,,,
 2021,Arkansas,05,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Arkansas,05,White (NH),-100.0,,41.1,,24.85,
+2021,Arkansas,05,White (NH),-33.7,,41.1,,24.85,
 2021,California,06,American Indian and Alaska Native (NH),,,,,,
-2021,California,06,Asian (NH),-100.0,,4.1,,4.99,
-2021,California,06,Black or African American (NH),-100.0,-100.0,29.2,29.9,80.64,7.31
-2021,California,06,Hispanic or Latino,-100.0,-100.0,51.8,70.1,16.0,2.0
+2021,California,06,Asian (NH),-67.7,,4.1,,4.99,
+2021,California,06,Black or African American (NH),484.0,498.0,29.2,29.9,80.64,7.31
+2021,California,06,Hispanic or Latino,0.0,35.3,51.8,70.1,16.0,2.0
 2021,California,06,Two or more races (NH),,,,,,
 2021,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,California,06,White (NH),-100.0,,14.8,,8.44,
+2021,California,06,White (NH),-39.3,,14.8,,8.44,
 2021,Colorado,08,American Indian and Alaska Native (NH),,,,,,
 2021,Colorado,08,Asian (NH),,,,,,
 2021,Colorado,08,Black or African American (NH),,,,,,
-2021,Colorado,08,Hispanic or Latino,-100.0,,44.3,,35.0,
+2021,Colorado,08,Hispanic or Latino,38.4,,44.3,,35.0,
 2021,Colorado,08,Two or more races (NH),,,,,,
 2021,Colorado,08,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Colorado,08,White (NH),-100.0,,55.7,,21.79,
+2021,Colorado,08,White (NH),1.5,,55.7,,21.79,
 2021,Connecticut,09,American Indian and Alaska Native (NH),,,,,,
 2021,Connecticut,09,Asian (NH),,,,,,
-2021,Connecticut,09,Black or African American (NH),-99.9,,100.0,,70.58,
+2021,Connecticut,09,Black or African American (NH),754.7,,100.0,,70.58,
 2021,Connecticut,09,Hispanic or Latino,,,,,,
 2021,Connecticut,09,Two or more races (NH),,,,,,
 2021,Connecticut,09,Native Hawaiian and Pacific Islander (NH),,,,,,
 2021,Connecticut,09,White (NH),,,,,,
 2021,Delaware,10,American Indian and Alaska Native (NH),,,,,,
 2021,Delaware,10,Asian (NH),,,,,,
-2021,Delaware,10,Black or African American (NH),-99.8,,100.0,,121.23,
+2021,Delaware,10,Black or African American (NH),290.6,,100.0,,121.23,
 2021,Delaware,10,Hispanic or Latino,,,,,,
 2021,Delaware,10,Two or more races (NH),,,,,,
 2021,Delaware,10,Native Hawaiian and Pacific Islander (NH),,,,,,
 2021,Delaware,10,White (NH),,,,,,
 2021,District of Columbia,11,American Indian and Alaska Native (NH),,,,,,
 2021,District of Columbia,11,Asian (NH),,,,,,
-2021,District of Columbia,11,Black or African American (NH),-99.8,,100.0,,144.34,
+2021,District of Columbia,11,Black or African American (NH),92.7,,100.0,,144.34,
 2021,District of Columbia,11,Hispanic or Latino,,,,,,
 2021,District of Columbia,11,Two or more races (NH),,,,,,
 2021,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),,,,,,
 2021,District of Columbia,11,White (NH),,,,,,
 2021,Florida,12,American Indian and Alaska Native (NH),,,,,,
 2021,Florida,12,Asian (NH),,,,,,
-2021,Florida,12,Black or African American (NH),-100.0,-100.0,55.2,63.2,70.08,7.04
-2021,Florida,12,Hispanic or Latino,-100.0,,16.6,,13.0,
+2021,Florida,12,Black or African American (NH),177.4,217.6,55.2,63.2,70.08,7.04
+2021,Florida,12,Hispanic or Latino,-47.3,,16.6,,13.0,
 2021,Florida,12,Two or more races (NH),,,,,,
 2021,Florida,12,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Florida,12,White (NH),-100.0,-100.0,28.2,36.8,15.98,1.96
+2021,Florida,12,White (NH),-32.2,-11.5,28.2,36.8,15.98,1.96
 2021,Georgia,13,American Indian and Alaska Native (NH),,,,,,
 2021,Georgia,13,Asian (NH),,,,,,
-2021,Georgia,13,Black or African American (NH),-100.0,-100.0,70.1,68.0,75.9,9.96
-2021,Georgia,13,Hispanic or Latino,-100.0,,7.1,,21.0,
+2021,Georgia,13,Black or African American (NH),107.4,101.2,70.1,68.0,75.9,9.96
+2021,Georgia,13,Hispanic or Latino,-53.3,,7.1,,21.0,
 2021,Georgia,13,Two or more races (NH),,,,,,
 2021,Georgia,13,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Georgia,13,White (NH),-100.0,-100.0,22.8,32.0,18.7,3.74
+2021,Georgia,13,White (NH),-46.2,-24.5,22.8,32.0,18.7,3.74
 2021,Hawaii,15,American Indian and Alaska Native (NH),,,,,,
 2021,Hawaii,15,Asian (NH),,,,,,
 2021,Hawaii,15,Black or African American (NH),,,,,,
@@ -1160,49 +1160,49 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Idaho,16,Hispanic or Latino,,,,,,
 2021,Idaho,16,Two or more races (NH),,,,,,
 2021,Idaho,16,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Idaho,16,White (NH),-100.0,,100.0,,18.85,
+2021,Idaho,16,White (NH),34.8,,100.0,,18.85,
 2021,Illinois,17,American Indian and Alaska Native (NH),,,,,,
 2021,Illinois,17,Asian (NH),,,,,,
-2021,Illinois,17,Black or African American (NH),-100.0,-100.0,71.7,79.6,166.8,20.98
-2021,Illinois,17,Hispanic or Latino,-100.0,,16.0,,24.0,
+2021,Illinois,17,Black or African American (NH),368.6,420.3,71.7,79.6,166.8,20.98
+2021,Illinois,17,Hispanic or Latino,-35.5,,16.0,,24.0,
 2021,Illinois,17,Two or more races (NH),,,,,,
 2021,Illinois,17,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Illinois,17,White (NH),-100.0,-100.0,12.3,20.4,8.51,1.63
+2021,Illinois,17,White (NH),-75.6,-59.6,12.3,20.4,8.51,1.63
 2021,Indiana,18,American Indian and Alaska Native (NH),,,,,,
 2021,Indiana,18,Asian (NH),,,,,,
-2021,Indiana,18,Black or African American (NH),-100.0,,52.4,,162.46,
+2021,Indiana,18,Black or African American (NH),355.7,,52.4,,162.46,
 2021,Indiana,18,Hispanic or Latino,,,,,,
 2021,Indiana,18,Two or more races (NH),,,,,,
 2021,Indiana,18,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Indiana,18,White (NH),-100.0,-100.0,47.6,100.0,22.11,3.28
+2021,Indiana,18,White (NH),-31.2,44.5,47.6,100.0,22.11,3.28
 2021,Iowa,19,American Indian and Alaska Native (NH),,,,,,
 2021,Iowa,19,Asian (NH),,,,,,
 2021,Iowa,19,Black or African American (NH),,,,,,
 2021,Iowa,19,Hispanic or Latino,,,,,,
 2021,Iowa,19,Two or more races (NH),,,,,,
 2021,Iowa,19,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Iowa,19,White (NH),-100.0,,100.0,,12.57,
+2021,Iowa,19,White (NH),31.9,,100.0,,12.57,
 2021,Kansas,20,American Indian and Alaska Native (NH),,,,,,
 2021,Kansas,20,Asian (NH),,,,,,
 2021,Kansas,20,Black or African American (NH),,,,,,
-2021,Kansas,20,Hispanic or Latino,-100.0,,30.4,,38.0,
+2021,Kansas,20,Hispanic or Latino,58.3,,30.4,,38.0,
 2021,Kansas,20,Two or more races (NH),,,,,,
 2021,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Kansas,20,White (NH),-100.0,,69.6,,21.41,
+2021,Kansas,20,White (NH),6.3,,69.6,,21.41,
 2021,Kentucky,21,American Indian and Alaska Native (NH),,,,,,
 2021,Kentucky,21,Asian (NH),,,,,,
-2021,Kentucky,21,Black or African American (NH),-100.0,-99.9,46.1,54.2,152.9,27.54
+2021,Kentucky,21,Black or African American (NH),395.7,482.8,46.1,54.2,152.9,27.54
 2021,Kentucky,21,Hispanic or Latino,,,,,,
 2021,Kentucky,21,Two or more races (NH),,,,,,
 2021,Kentucky,21,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Kentucky,21,White (NH),-100.0,-100.0,53.9,45.8,24.08,2.81
+2021,Kentucky,21,White (NH),-30.2,-40.7,53.9,45.8,24.08,2.81
 2021,Louisiana,22,American Indian and Alaska Native (NH),,,,,,
 2021,Louisiana,22,Asian (NH),,,,,,
-2021,Louisiana,22,Black or African American (NH),-100.0,-100.0,83.0,79.8,148.93,22.16
+2021,Louisiana,22,Black or African American (NH),129.3,120.4,83.0,79.8,148.93,22.16
 2021,Louisiana,22,Hispanic or Latino,,,,,,
 2021,Louisiana,22,Two or more races (NH),,,,,,
 2021,Louisiana,22,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Louisiana,22,White (NH),-100.0,-100.0,17.0,20.2,22.2,4.04
+2021,Louisiana,22,White (NH),-66.2,-59.8,17.0,20.2,22.2,4.04
 2021,Maine,23,American Indian and Alaska Native (NH),,,,,,
 2021,Maine,23,Asian (NH),,,,,,
 2021,Maine,23,Black or African American (NH),,,,,,
@@ -1212,11 +1212,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Maine,23,White (NH),,,,,,
 2021,Maryland,24,American Indian and Alaska Native (NH),,,,,,
 2021,Maryland,24,Asian (NH),,,,,,
-2021,Maryland,24,Black or African American (NH),-100.0,-100.0,87.2,100.0,85.01,5.27
+2021,Maryland,24,Black or African American (NH),185.0,226.8,87.2,100.0,85.01,5.27
 2021,Maryland,24,Hispanic or Latino,,,,,,
 2021,Maryland,24,Two or more races (NH),,,,,,
 2021,Maryland,24,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Maryland,24,White (NH),-100.0,,12.8,,8.86,
+2021,Maryland,24,White (NH),-68.2,,12.8,,8.86,
 2021,Massachusetts,25,American Indian and Alaska Native (NH),,,,,,
 2021,Massachusetts,25,Asian (NH),,,,,,
 2021,Massachusetts,25,Black or African American (NH),,,,,,
@@ -1226,53 +1226,53 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Massachusetts,25,White (NH),,,,,,
 2021,Michigan,26,American Indian and Alaska Native (NH),,,,,,
 2021,Michigan,26,Asian (NH),,,,,,
-2021,Michigan,26,Black or African American (NH),-100.0,-100.0,67.8,46.4,116.6,7.49
+2021,Michigan,26,Black or African American (NH),321.1,188.2,67.8,46.4,116.6,7.49
 2021,Michigan,26,Hispanic or Latino,,,,,,
 2021,Michigan,26,Two or more races (NH),,,,,,
 2021,Michigan,26,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Michigan,26,White (NH),-100.0,-100.0,32.2,53.6,11.97,2.11
+2021,Michigan,26,White (NH),-51.1,-18.7,32.2,53.6,11.97,2.11
 2021,Minnesota,27,American Indian and Alaska Native (NH),,,,,,
 2021,Minnesota,27,Asian (NH),,,,,,
-2021,Minnesota,27,Black or African American (NH),-100.0,,51.3,,82.37,
+2021,Minnesota,27,Black or African American (NH),384.0,,51.3,,82.37,
 2021,Minnesota,27,Hispanic or Latino,,,,,,
 2021,Minnesota,27,Two or more races (NH),,,,,,
 2021,Minnesota,27,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Minnesota,27,White (NH),-100.0,,48.7,,9.35,
+2021,Minnesota,27,White (NH),-27.1,,48.7,,9.35,
 2021,Mississippi,28,American Indian and Alaska Native (NH),,,,,,
 2021,Mississippi,28,Asian (NH),,,,,,
-2021,Mississippi,28,Black or African American (NH),-100.0,-100.0,81.3,100.0,132.21,17.07
+2021,Mississippi,28,Black or African American (NH),96.4,141.5,81.3,100.0,132.21,17.07
 2021,Mississippi,28,Hispanic or Latino,,,,,,
 2021,Mississippi,28,Two or more races (NH),,,,,,
 2021,Mississippi,28,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Mississippi,28,White (NH),-100.0,,18.7,,25.23,
+2021,Mississippi,28,White (NH),-61.8,,18.7,,25.23,
 2021,Missouri,29,American Indian and Alaska Native (NH),,,,,,
 2021,Missouri,29,Asian (NH),,,,,,
-2021,Missouri,29,Black or African American (NH),-100.0,-100.0,54.6,54.9,163.46,24.3
+2021,Missouri,29,Black or African American (NH),307.5,309.7,54.6,54.9,163.46,24.3
 2021,Missouri,29,Hispanic or Latino,,,,,,
 2021,Missouri,29,Two or more races (NH),,,,,,
 2021,Missouri,29,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Missouri,29,White (NH),-100.0,-100.0,45.4,45.1,24.06,3.73
+2021,Missouri,29,White (NH),-36.7,-37.1,45.4,45.1,24.06,3.73
 2021,Montana,30,American Indian and Alaska Native (NH),,,,,,
 2021,Montana,30,Asian (NH),,,,,,
 2021,Montana,30,Black or African American (NH),,,,,,
 2021,Montana,30,Hispanic or Latino,,,,,,
 2021,Montana,30,Two or more races (NH),,,,,,
 2021,Montana,30,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Montana,30,White (NH),-99.9,,100.0,,38.09,
+2021,Montana,30,White (NH),29.2,,100.0,,38.09,
 2021,Nebraska,31,American Indian and Alaska Native (NH),,,,,,
 2021,Nebraska,31,Asian (NH),,,,,,
 2021,Nebraska,31,Black or African American (NH),,,,,,
 2021,Nebraska,31,Hispanic or Latino,,,,,,
 2021,Nebraska,31,Two or more races (NH),,,,,,
 2021,Nebraska,31,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Nebraska,31,White (NH),-100.0,,100.0,,13.48,
+2021,Nebraska,31,White (NH),49.5,,100.0,,13.48,
 2021,Nevada,32,American Indian and Alaska Native (NH),,,,,,
 2021,Nevada,32,Asian (NH),,,,,,
-2021,Nevada,32,Black or African American (NH),-99.9,,38.9,,120.86,
-2021,Nevada,32,Hispanic or Latino,-100.0,,31.6,,25.0,
+2021,Nevada,32,Black or African American (NH),256.9,,38.9,,120.86,
+2021,Nevada,32,Hispanic or Latino,-23.5,,31.6,,25.0,
 2021,Nevada,32,Two or more races (NH),,,,,,
 2021,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Nevada,32,White (NH),-100.0,,29.5,,27.86,
+2021,Nevada,32,White (NH),-10.6,,29.5,,27.86,
 2021,New Hampshire,33,American Indian and Alaska Native (NH),,,,,,
 2021,New Hampshire,33,Asian (NH),,,,,,
 2021,New Hampshire,33,Black or African American (NH),,,,,,
@@ -1282,7 +1282,7 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,New Hampshire,33,White (NH),,,,,,
 2021,New Jersey,34,American Indian and Alaska Native (NH),,,,,,
 2021,New Jersey,34,Asian (NH),,,,,,
-2021,New Jersey,34,Black or African American (NH),-100.0,,100.0,,45.42,
+2021,New Jersey,34,Black or African American (NH),651.9,,100.0,,45.42,
 2021,New Jersey,34,Hispanic or Latino,,,,,,
 2021,New Jersey,34,Two or more races (NH),,,,,,
 2021,New Jersey,34,Native Hawaiian and Pacific Islander (NH),,,,,,
@@ -1290,24 +1290,24 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,New Mexico,35,American Indian and Alaska Native (NH),,,,,,
 2021,New Mexico,35,Asian (NH),,,,,,
 2021,New Mexico,35,Black or African American (NH),,,,,,
-2021,New Mexico,35,Hispanic or Latino,-100.0,,100.0,,52.0,
+2021,New Mexico,35,Hispanic or Latino,61.8,,100.0,,52.0,
 2021,New Mexico,35,Two or more races (NH),,,,,,
 2021,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,,,,,
 2021,New Mexico,35,White (NH),,,,,,
 2021,New York,36,American Indian and Alaska Native (NH),,,,,,
 2021,New York,36,Asian (NH),,,,,,
-2021,New York,36,Black or African American (NH),-100.0,-100.0,66.3,100.0,40.21,4.98
-2021,New York,36,Hispanic or Latino,-100.0,,17.9,,7.0,
+2021,New York,36,Black or African American (NH),354.1,584.9,66.3,100.0,40.21,4.98
+2021,New York,36,Hispanic or Latino,-28.1,,17.9,,7.0,
 2021,New York,36,Two or more races (NH),,,,,,
 2021,New York,36,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,New York,36,White (NH),-100.0,,15.8,,2.84,
+2021,New York,36,White (NH),-66.7,,15.8,,2.84,
 2021,North Carolina,37,American Indian and Alaska Native (NH),,,,,,
 2021,North Carolina,37,Asian (NH),,,,,,
-2021,North Carolina,37,Black or African American (NH),-100.0,-100.0,58.5,69.7,83.93,13.37
-2021,North Carolina,37,Hispanic or Latino,-100.0,,9.0,,23.0,
+2021,North Carolina,37,Black or African American (NH),161.2,211.2,58.5,69.7,83.93,13.37
+2021,North Carolina,37,Hispanic or Latino,-48.3,,9.0,,23.0,
 2021,North Carolina,37,Two or more races (NH),,,,,,
 2021,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,North Carolina,37,White (NH),-100.0,-100.0,32.4,30.3,19.44,2.57
+2021,North Carolina,37,White (NH),-36.1,-40.2,32.4,30.3,19.44,2.57
 2021,North Dakota,38,American Indian and Alaska Native (NH),,,,,,
 2021,North Dakota,38,Asian (NH),,,,,,
 2021,North Dakota,38,Black or African American (NH),,,,,,
@@ -1317,32 +1317,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,North Dakota,38,White (NH),,,,,,
 2021,Ohio,39,American Indian and Alaska Native (NH),,,,,,
 2021,Ohio,39,Asian (NH),,,,,,
-2021,Ohio,39,Black or African American (NH),-100.0,-100.0,61.3,68.8,131.17,18.8
+2021,Ohio,39,Black or African American (NH),300.7,349.7,61.3,68.8,131.17,18.8
 2021,Ohio,39,Hispanic or Latino,,,,,,
 2021,Ohio,39,Two or more races (NH),,,,,,
 2021,Ohio,39,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Ohio,39,White (NH),-100.0,-100.0,38.7,31.2,16.18,1.87
+2021,Ohio,39,White (NH),-44.5,-55.2,38.7,31.2,16.18,1.87
 2021,Oklahoma,40,American Indian and Alaska Native (NH),,,,,,
 2021,Oklahoma,40,Asian (NH),,,,,,
-2021,Oklahoma,40,Black or African American (NH),-100.0,,34.8,,80.07,
+2021,Oklahoma,40,Black or African American (NH),351.9,,34.8,,80.07,
 2021,Oklahoma,40,Hispanic or Latino,,,,,,
 2021,Oklahoma,40,Two or more races (NH),,,,,,
 2021,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Oklahoma,40,White (NH),-100.0,,65.2,,24.15,
+2021,Oklahoma,40,White (NH),27.3,,65.2,,24.15,
 2021,Oregon,41,American Indian and Alaska Native (NH),,,,,,
 2021,Oregon,41,Asian (NH),,,,,,
 2021,Oregon,41,Black or African American (NH),,,,,,
-2021,Oregon,41,Hispanic or Latino,-100.0,,30.9,,25.0,
+2021,Oregon,41,Hispanic or Latino,34.9,,30.9,,25.0,
 2021,Oregon,41,Two or more races (NH),,,,,,
 2021,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Oregon,41,White (NH),-100.0,,69.1,,17.79,
+2021,Oregon,41,White (NH),10.7,,69.1,,17.79,
 2021,Pennsylvania,42,American Indian and Alaska Native (NH),,,,,,
 2021,Pennsylvania,42,Asian (NH),,,,,,
-2021,Pennsylvania,42,Black or African American (NH),-100.0,-100.0,63.9,60.6,133.19,17.42
-2021,Pennsylvania,42,Hispanic or Latino,-100.0,,9.2,,22.0,
+2021,Pennsylvania,42,Black or African American (NH),395.3,369.8,63.9,60.6,133.19,17.42
+2021,Pennsylvania,42,Hispanic or Latino,-32.8,,9.2,,22.0,
 2021,Pennsylvania,42,Two or more races (NH),,,,,,
 2021,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Pennsylvania,42,White (NH),-100.0,-100.0,26.9,39.4,10.64,2.25
+2021,Pennsylvania,42,White (NH),-58.5,-39.2,26.9,39.4,10.64,2.25
 2021,Rhode Island,44,American Indian and Alaska Native (NH),,,,,,
 2021,Rhode Island,44,Asian (NH),,,,,,
 2021,Rhode Island,44,Black or African American (NH),,,,,,
@@ -1352,11 +1352,11 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Rhode Island,44,White (NH),,,,,,
 2021,South Carolina,45,American Indian and Alaska Native (NH),,,,,,
 2021,South Carolina,45,Asian (NH),,,,,,
-2021,South Carolina,45,Black or African American (NH),-100.0,-100.0,70.0,67.2,105.22,13.29
+2021,South Carolina,45,Black or African American (NH),141.4,131.7,70.0,67.2,105.22,13.29
 2021,South Carolina,45,Hispanic or Latino,,,,,,
 2021,South Carolina,45,Two or more races (NH),,,,,,
 2021,South Carolina,45,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,South Carolina,45,White (NH),-100.0,-100.0,30.0,32.8,22.7,3.48
+2021,South Carolina,45,White (NH),-44.4,-39.3,30.0,32.8,22.7,3.48
 2021,South Dakota,46,American Indian and Alaska Native (NH),,,,,,
 2021,South Dakota,46,Asian (NH),,,,,,
 2021,South Dakota,46,Black or African American (NH),,,,,,
@@ -1366,25 +1366,25 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,South Dakota,46,White (NH),,,,,,
 2021,Tennessee,47,American Indian and Alaska Native (NH),,,,,,
 2021,Tennessee,47,Asian (NH),,,,,,
-2021,Tennessee,47,Black or African American (NH),-100.0,-100.0,64.7,70.7,126.42,20.08
+2021,Tennessee,47,Black or African American (NH),246.0,278.1,64.7,70.7,126.42,20.08
 2021,Tennessee,47,Hispanic or Latino,,,,,,
 2021,Tennessee,47,Two or more races (NH),,,,,,
 2021,Tennessee,47,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Tennessee,47,White (NH),-100.0,-100.0,35.3,29.3,19.74,2.43
+2021,Tennessee,47,White (NH),-45.0,-54.4,35.3,29.3,19.74,2.43
 2021,Texas,48,American Indian and Alaska Native (NH),,,,,,
-2021,Texas,48,Asian (NH),-100.0,,2.5,,16.63,
-2021,Texas,48,Black or African American (NH),-100.0,-100.0,35.6,30.6,82.46,8.53
-2021,Texas,48,Hispanic or Latino,-100.0,-100.0,34.7,41.6,22.0,3.0
+2021,Texas,48,Asian (NH),-47.9,,2.5,,16.63,
+2021,Texas,48,Black or African American (NH),191.8,150.8,35.6,30.6,82.46,8.53
+2021,Texas,48,Hispanic or Latino,-29.5,-15.4,34.7,41.6,22.0,3.0
 2021,Texas,48,Two or more races (NH),,,,,,
 2021,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Texas,48,White (NH),-100.0,-100.0,27.2,27.8,24.39,3.1
+2021,Texas,48,White (NH),-11.1,-9.2,27.2,27.8,24.39,3.1
 2021,Utah,49,American Indian and Alaska Native (NH),,,,,,
 2021,Utah,49,Asian (NH),,,,,,
 2021,Utah,49,Black or African American (NH),,,,,,
 2021,Utah,49,Hispanic or Latino,,,,,,
 2021,Utah,49,Two or more races (NH),,,,,,
 2021,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Utah,49,White (NH),-100.0,,100.0,,16.26,
+2021,Utah,49,White (NH),37.7,,100.0,,16.26,
 2021,Vermont,50,American Indian and Alaska Native (NH),,,,,,
 2021,Vermont,50,Asian (NH),,,,,,
 2021,Vermont,50,Black or African American (NH),,,,,,
@@ -1394,32 +1394,32 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,Vermont,50,White (NH),,,,,,
 2021,Virginia,51,American Indian and Alaska Native (NH),,,,,,
 2021,Virginia,51,Asian (NH),,,,,,
-2021,Virginia,51,Black or African American (NH),-100.0,-100.0,65.4,63.3,81.88,10.14
+2021,Virginia,51,Black or African American (NH),228.6,218.1,65.4,63.3,81.88,10.14
 2021,Virginia,51,Hispanic or Latino,,,,,,
 2021,Virginia,51,Two or more races (NH),,,,,,
 2021,Virginia,51,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Virginia,51,White (NH),-100.0,-100.0,34.6,36.7,15.88,2.25
+2021,Virginia,51,White (NH),-33.3,-29.3,34.6,36.7,15.88,2.25
 2021,Washington,53,American Indian and Alaska Native (NH),,,,,,
 2021,Washington,53,Asian (NH),,,,,,
 2021,Washington,53,Black or African American (NH),,,,,,
-2021,Washington,53,Hispanic or Latino,-100.0,,26.9,,17.0,
+2021,Washington,53,Hispanic or Latino,19.6,,26.9,,17.0,
 2021,Washington,53,Two or more races (NH),,,,,,
 2021,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Washington,53,White (NH),-100.0,-100.0,73.1,100.0,15.73,2.66
+2021,Washington,53,White (NH),35.9,85.9,73.1,100.0,15.73,2.66
 2021,West Virginia,54,American Indian and Alaska Native (NH),,,,,,
 2021,West Virginia,54,Asian (NH),,,,,,
 2021,West Virginia,54,Black or African American (NH),,,,,,
 2021,West Virginia,54,Hispanic or Latino,,,,,,
 2021,West Virginia,54,Two or more races (NH),,,,,,
 2021,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,West Virginia,54,White (NH),-100.0,,100.0,,17.57,
+2021,West Virginia,54,White (NH),13.6,,100.0,,17.57,
 2021,Wisconsin,55,American Indian and Alaska Native (NH),,,,,,
 2021,Wisconsin,55,Asian (NH),,,,,,
-2021,Wisconsin,55,Black or African American (NH),-100.0,-99.9,55.1,100.0,156.53,23.87
+2021,Wisconsin,55,Black or African American (NH),519.1,1023.6,55.1,100.0,156.53,23.87
 2021,Wisconsin,55,Hispanic or Latino,,,,,,
 2021,Wisconsin,55,Two or more races (NH),,,,,,
 2021,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Wisconsin,55,White (NH),-100.0,,44.9,,13.19,
+2021,Wisconsin,55,White (NH),-34.8,,44.9,,13.19,
 2021,Wyoming,56,American Indian and Alaska Native (NH),,,,,,
 2021,Wyoming,56,Asian (NH),,,,,,
 2021,Wyoming,56,Black or African American (NH),,,,,,
@@ -1471,207 +1471,207 @@ time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct
 2021,California,06,Unknown race,,,,,,
 2021,Minnesota,27,Unknown race,,,,,,
 2021,Virginia,51,Unknown race,,,,,,
-2021,Alabama,01,All,-100.0,-100.0,100.0,100.0,50.64,7.22
-2021,Alaska,02,All,-99.9,-99.9,100.0,100.0,58.14,
-2021,Arizona,04,All,-100.0,-100.0,100.0,100.0,28.45,3.53
-2021,Arkansas,05,All,-100.0,-100.0,100.0,100.0,43.0,4.83
-2021,California,06,All,-100.0,-100.0,100.0,100.0,16.64,1.65
-2021,Colorado,08,All,-100.0,-100.0,100.0,100.0,28.5,3.78
-2021,Connecticut,09,All,-100.0,-100.0,100.0,100.0,14.29,
-2021,Delaware,10,All,-100.0,-100.0,100.0,100.0,47.23,
-2021,District of Columbia,11,All,-99.9,-99.9,100.0,100.0,60.31,
-2021,Florida,12,All,-100.0,-100.0,100.0,100.0,26.12,2.87
-2021,Georgia,13,All,-100.0,-100.0,100.0,100.0,39.17,5.31
-2021,Hawaii,15,All,-100.0,-100.0,100.0,100.0,,
-2021,Idaho,16,All,-100.0,-100.0,100.0,100.0,19.16,
-2021,Illinois,17,All,-100.0,-100.0,100.0,100.0,36.63,4.64
-2021,Indiana,18,All,-100.0,-100.0,100.0,100.0,37.34,4.03
-2021,Iowa,19,All,-100.0,-100.0,100.0,100.0,14.04,
-2021,Kansas,20,All,-100.0,-100.0,100.0,100.0,29.2,5.97
-2021,Kentucky,21,All,-100.0,-100.0,100.0,100.0,38.07,5.32
-2021,Louisiana,22,All,-100.0,-100.0,100.0,100.0,69.76,10.25
-2021,Maine,23,All,-100.0,-100.0,100.0,100.0,,
-2021,Maryland,24,All,-100.0,-100.0,100.0,100.0,34.65,2.64
-2021,Massachusetts,25,All,-100.0,-100.0,100.0,100.0,5.25,
-2021,Michigan,26,All,-100.0,-100.0,100.0,100.0,28.25,2.97
-2021,Minnesota,27,All,-100.0,-100.0,100.0,100.0,17.43,1.67
-2021,Mississippi,28,All,-100.0,-100.0,100.0,100.0,69.35,9.96
-2021,Missouri,29,All,-100.0,-100.0,100.0,100.0,40.55,6.28
-2021,Montana,30,All,-100.0,-100.0,100.0,100.0,42.09,
-2021,Nebraska,31,All,-100.0,-100.0,100.0,100.0,15.67,
-2021,Nevada,32,All,-100.0,-100.0,100.0,100.0,36.23,
-2021,New Hampshire,33,All,-100.0,-100.0,100.0,100.0,,
-2021,New Jersey,34,All,-100.0,-100.0,100.0,100.0,11.18,1.24
-2021,New Mexico,35,All,-100.0,-100.0,100.0,100.0,45.55,5.07
-2021,New York,36,All,-100.0,-100.0,100.0,100.0,10.32,1.26
-2021,North Carolina,37,All,-100.0,-100.0,100.0,100.0,35.24,5.17
-2021,North Dakota,38,All,-99.9,-99.9,100.0,100.0,,
-2021,Ohio,39,All,-100.0,-100.0,100.0,100.0,32.32,4.68
-2021,Oklahoma,40,All,-100.0,-100.0,100.0,100.0,31.21,4.99
-2021,Oregon,41,All,-100.0,-100.0,100.0,100.0,21.09,
-2021,Pennsylvania,42,All,-100.0,-100.0,100.0,100.0,28.13,4.15
-2021,Rhode Island,44,All,-100.0,-100.0,100.0,100.0,,
-2021,South Carolina,45,All,-100.0,-100.0,100.0,100.0,45.85,6.36
-2021,South Dakota,46,All,-100.0,-100.0,100.0,100.0,29.7,
-2021,Tennessee,47,All,-100.0,-100.0,100.0,100.0,41.98,5.58
-2021,Texas,48,All,-100.0,-100.0,100.0,100.0,30.63,3.48
-2021,Utah,49,All,-100.0,-100.0,100.0,100.0,18.27,
-2021,Vermont,50,All,-99.9,-99.9,100.0,100.0,,
-2021,Virginia,51,All,-100.0,-100.0,100.0,100.0,29.69,4.03
-2021,Washington,53,All,-100.0,-100.0,100.0,100.0,18.34,2.69
-2021,West Virginia,54,All,-100.0,-100.0,100.0,100.0,20.66,
-2021,Wisconsin,55,All,-100.0,-100.0,100.0,100.0,26.17,3.69
-2021,Wyoming,56,All,-99.9,-99.9,100.0,100.0,,
-2020,Alabama,01,All,-100.0,-100.0,100.0,100.0,49.95,3.38
-2020,Alaska,02,All,-99.9,-99.9,100.0,100.0,46.41,
-2020,Arizona,04,All,-100.0,-100.0,100.0,100.0,25.2,3.4
-2020,Arkansas,05,All,-100.0,-100.0,100.0,100.0,42.37,6.39
-2020,California,06,All,-100.0,-100.0,100.0,100.0,15.17,1.6
-2020,Colorado,08,All,-100.0,-100.0,100.0,100.0,24.55,4.2
-2020,Connecticut,09,All,-100.0,-100.0,100.0,100.0,10.4,
-2020,Delaware,10,All,-100.0,-100.0,100.0,100.0,34.84,
-2020,District of Columbia,11,All,-99.9,-99.9,100.0,100.0,71.97,
-2020,Florida,12,All,-100.0,-100.0,100.0,100.0,27.22,3.08
-2020,Georgia,13,All,-100.0,-100.0,100.0,100.0,35.44,3.87
-2020,Hawaii,15,All,-100.0,-100.0,100.0,100.0,,
-2020,Idaho,16,All,-100.0,-100.0,100.0,100.0,23.38,
-2020,Illinois,17,All,-100.0,-100.0,100.0,100.0,32.71,3.57
-2020,Indiana,18,All,-100.0,-100.0,100.0,100.0,38.44,4.27
-2020,Iowa,19,All,-100.0,-100.0,100.0,100.0,16.62,
-2020,Kansas,20,All,-100.0,-100.0,100.0,100.0,33.48,4.78
-2020,Kentucky,21,All,-100.0,-100.0,100.0,100.0,34.79,5.29
-2020,Louisiana,22,All,-100.0,-100.0,100.0,100.0,66.1,6.39
-2020,Maine,23,All,-100.0,-100.0,100.0,100.0,,
-2020,Maryland,24,All,-100.0,-100.0,100.0,100.0,34.72,1.89
-2020,Massachusetts,25,All,-100.0,-100.0,100.0,100.0,8.6,
-2020,Michigan,26,All,-100.0,-100.0,100.0,100.0,26.66,2.89
-2020,Minnesota,27,All,-100.0,-100.0,100.0,100.0,13.91,2.11
-2020,Mississippi,28,All,-100.0,-100.0,100.0,100.0,55.14,7.15
-2020,Missouri,29,All,-100.0,-100.0,100.0,100.0,46.94,5.39
-2020,Montana,30,All,-100.0,-100.0,100.0,100.0,36.67,
-2020,Nebraska,31,All,-100.0,-100.0,100.0,100.0,13.9,
-2020,Nevada,32,All,-100.0,-100.0,100.0,100.0,27.11,3.57
-2020,New Hampshire,33,All,-100.0,-100.0,100.0,100.0,,
-2020,New Jersey,34,All,-100.0,-100.0,100.0,100.0,11.15,
-2020,New Mexico,35,All,-100.0,-100.0,100.0,100.0,36.14,5.19
-2020,New York,36,All,-100.0,-100.0,100.0,100.0,11.23,0.76
-2020,North Carolina,37,All,-100.0,-100.0,100.0,100.0,31.79,4.73
-2020,North Dakota,38,All,-99.9,-99.9,100.0,100.0,,
-2020,Ohio,39,All,-100.0,-100.0,100.0,100.0,32.18,3.69
-2020,Oklahoma,40,All,-100.0,-100.0,100.0,100.0,35.99,4.16
-2020,Oregon,41,All,-100.0,-100.0,100.0,100.0,19.31,
-2020,Pennsylvania,42,All,-100.0,-100.0,100.0,100.0,27.47,3.04
-2020,Rhode Island,44,All,-100.0,-100.0,100.0,100.0,,
-2020,South Carolina,45,All,-100.0,-100.0,100.0,100.0,48.4,5.92
-2020,South Dakota,46,All,-100.0,-100.0,100.0,100.0,25.78,
-2020,Tennessee,47,All,-100.0,-100.0,100.0,100.0,38.29,4.54
-2020,Texas,48,All,-100.0,-100.0,100.0,100.0,27.51,3.5
-2020,Utah,49,All,-100.0,-100.0,100.0,100.0,18.79,3.27
-2020,Vermont,50,All,-99.9,-99.9,100.0,100.0,,
-2020,Virginia,51,All,-100.0,-100.0,100.0,100.0,28.01,3.53
-2020,Washington,53,All,-100.0,-100.0,100.0,100.0,20.56,1.65
-2020,West Virginia,54,All,-100.0,-100.0,100.0,100.0,22.99,
-2020,Wisconsin,55,All,-100.0,-100.0,100.0,100.0,19.65,2.72
-2020,Wyoming,56,All,-99.9,-99.9,100.0,100.0,,
-2019,Alabama,01,All,-100.0,-100.0,100.0,100.0,38.15,3.95
-2019,Alaska,02,All,-99.9,-99.9,100.0,100.0,42.54,
-2019,Arizona,04,All,-100.0,-100.0,100.0,100.0,22.4,2.13
-2019,Arkansas,05,All,-100.0,-100.0,100.0,100.0,36.68,3.28
-2019,California,06,All,-100.0,-100.0,100.0,100.0,11.59,1.25
-2019,Colorado,08,All,-100.0,-100.0,100.0,100.0,21.67,3.42
-2019,Connecticut,09,All,-100.0,-100.0,100.0,100.0,6.45,
-2019,Delaware,10,All,-100.0,-100.0,100.0,100.0,,
-2019,District of Columbia,11,All,-99.9,-99.9,100.0,100.0,68.32,
-2019,Florida,12,All,-100.0,-100.0,100.0,100.0,21.79,2.22
-2019,Georgia,13,All,-100.0,-100.0,100.0,100.0,29.4,3.11
-2019,Hawaii,15,All,-100.0,-100.0,100.0,100.0,,
-2019,Idaho,16,All,-100.0,-100.0,100.0,100.0,20.6,
-2019,Illinois,17,All,-100.0,-100.0,100.0,100.0,24.16,3.51
-2019,Indiana,18,All,-100.0,-100.0,100.0,100.0,26.93,3.06
-2019,Iowa,19,All,-100.0,-100.0,100.0,100.0,13.17,
-2019,Kansas,20,All,-100.0,-100.0,100.0,100.0,22.53,3.56
-2019,Kentucky,21,All,-100.0,-100.0,100.0,100.0,21.63,3.09
-2019,Louisiana,22,All,-100.0,-100.0,100.0,100.0,44.36,5.14
-2019,Maine,23,All,-100.0,-100.0,100.0,100.0,,
-2019,Maryland,24,All,-100.0,-100.0,100.0,100.0,29.05,1.79
-2019,Massachusetts,25,All,-100.0,-100.0,100.0,100.0,6.06,
-2019,Michigan,26,All,-100.0,-100.0,100.0,100.0,19.22,2.15
-2019,Minnesota,27,All,-100.0,-100.0,100.0,100.0,12.77,1.61
-2019,Mississippi,28,All,-100.0,-100.0,100.0,100.0,45.35,5.14
-2019,Missouri,29,All,-100.0,-100.0,100.0,100.0,39.43,5.17
-2019,Montana,30,All,-100.0,-100.0,100.0,100.0,24.94,
-2019,Nebraska,31,All,-100.0,-100.0,100.0,100.0,16.72,
-2019,Nevada,32,All,-100.0,-100.0,100.0,100.0,24.12,
-2019,New Hampshire,33,All,-100.0,-100.0,100.0,100.0,,
-2019,New Jersey,34,All,-100.0,-100.0,100.0,100.0,8.18,
-2019,New Mexico,35,All,-100.0,-100.0,100.0,100.0,36.86,5.24
-2019,New York,36,All,-100.0,-100.0,100.0,100.0,6.37,0.69
-2019,North Carolina,37,All,-100.0,-100.0,100.0,100.0,24.78,2.43
-2019,North Dakota,38,All,-99.9,-99.9,100.0,100.0,,
-2019,Ohio,39,All,-100.0,-100.0,100.0,100.0,23.93,2.75
-2019,Oklahoma,40,All,-100.0,-100.0,100.0,100.0,25.53,4.19
-2019,Oregon,41,All,-100.0,-100.0,100.0,100.0,17.84,
-2019,Pennsylvania,42,All,-100.0,-100.0,100.0,100.0,20.43,2.05
-2019,Rhode Island,44,All,-100.0,-100.0,100.0,100.0,,
-2019,South Carolina,45,All,-100.0,-100.0,100.0,100.0,40.33,4.31
-2019,South Dakota,46,All,-100.0,-100.0,100.0,100.0,24.22,
-2019,Tennessee,47,All,-100.0,-100.0,100.0,100.0,30.64,3.04
-2019,Texas,48,All,-100.0,-100.0,100.0,100.0,20.9,2.85
-2019,Utah,49,All,-100.0,-100.0,100.0,100.0,17.39,
-2019,Vermont,50,All,-99.9,-99.9,100.0,100.0,,
-2019,Virginia,51,All,-100.0,-100.0,100.0,100.0,21.18,2.25
-2019,Washington,53,All,-100.0,-100.0,100.0,100.0,15.19,1.63
-2019,West Virginia,54,All,-100.0,-100.0,100.0,100.0,22.71,
-2019,Wisconsin,55,All,-100.0,-100.0,100.0,100.0,14.74,1.81
-2019,Wyoming,56,All,-99.9,-99.9,100.0,100.0,,
-2018,Alabama,01,All,-100.0,-100.0,100.0,100.0,39.83,4.3
-2018,Alaska,02,All,-99.9,-99.9,100.0,100.0,42.81,
-2018,Arizona,04,All,-100.0,-100.0,100.0,100.0,23.54,2.56
-2018,Arkansas,05,All,-100.0,-100.0,100.0,100.0,30.86,3.27
-2018,California,06,All,-100.0,-100.0,100.0,100.0,12.31,1.2
-2018,Colorado,08,All,-100.0,-100.0,100.0,100.0,23.55,3.4
-2018,Connecticut,09,All,-100.0,-100.0,100.0,100.0,,
-2018,Delaware,10,All,-100.0,-100.0,100.0,100.0,28.18,
-2018,District of Columbia,11,All,-99.9,-99.9,100.0,100.0,53.81,
-2018,Florida,12,All,-100.0,-100.0,100.0,100.0,21.21,2.2
-2018,Georgia,13,All,-100.0,-100.0,100.0,100.0,26.67,3.11
-2018,Hawaii,15,All,-100.0,-100.0,100.0,100.0,,
-2018,Idaho,16,All,-100.0,-100.0,100.0,100.0,27.33,
-2018,Illinois,17,All,-100.0,-100.0,100.0,100.0,24.34,2.98
-2018,Indiana,18,All,-100.0,-100.0,100.0,100.0,25.56,3.43
-2018,Iowa,19,All,-100.0,-100.0,100.0,100.0,12.56,
-2018,Kansas,20,All,-100.0,-100.0,100.0,100.0,24.07,
-2018,Kentucky,21,All,-100.0,-100.0,100.0,100.0,22.58,2.88
-2018,Louisiana,22,All,-100.0,-100.0,100.0,100.0,43.95,4.83
-2018,Maine,23,All,-100.0,-100.0,100.0,100.0,,
-2018,Maryland,24,All,-100.0,-100.0,100.0,100.0,23.87,2.09
-2018,Massachusetts,25,All,-100.0,-100.0,100.0,100.0,6.02,
-2018,Michigan,26,All,-100.0,-100.0,100.0,100.0,21.37,2.31
-2018,Minnesota,27,All,-100.0,-100.0,100.0,100.0,13.74,
-2018,Mississippi,28,All,-100.0,-100.0,100.0,100.0,45.04,4.95
-2018,Missouri,29,All,-100.0,-100.0,100.0,100.0,33.7,5.29
-2018,Montana,30,All,-100.0,-100.0,100.0,100.0,18.6,
-2018,Nebraska,31,All,-100.0,-100.0,100.0,100.0,12.94,
-2018,Nevada,32,All,-100.0,-100.0,100.0,100.0,27.16,3.19
-2018,New Hampshire,33,All,-100.0,-100.0,100.0,100.0,,
-2018,New Jersey,34,All,-100.0,-100.0,100.0,100.0,8.99,
-2018,New Mexico,35,All,-100.0,-100.0,100.0,100.0,39.29,
-2018,New York,36,All,-100.0,-100.0,100.0,100.0,7.63,0.81
-2018,North Carolina,37,All,-100.0,-100.0,100.0,100.0,22.01,2.69
-2018,North Dakota,38,All,-99.9,-99.9,100.0,100.0,,
-2018,Ohio,39,All,-100.0,-100.0,100.0,100.0,23.36,2.89
-2018,Oklahoma,40,All,-100.0,-100.0,100.0,100.0,19.08,3.45
-2018,Oregon,41,All,-100.0,-100.0,100.0,100.0,15.41,2.76
-2018,Pennsylvania,42,All,-100.0,-100.0,100.0,100.0,23.4,2.07
-2018,Rhode Island,44,All,-100.0,-100.0,100.0,100.0,,
-2018,South Carolina,45,All,-100.0,-100.0,100.0,100.0,34.86,3.88
-2018,South Dakota,46,All,-100.0,-100.0,100.0,100.0,28.31,
-2018,Tennessee,47,All,-100.0,-100.0,100.0,100.0,35.71,4.24
-2018,Texas,48,All,-100.0,-100.0,100.0,100.0,19.37,2.52
-2018,Utah,49,All,-100.0,-100.0,100.0,100.0,15.52,3.01
-2018,Vermont,50,All,-99.9,-99.9,100.0,100.0,,
-2018,Virginia,51,All,-100.0,-100.0,100.0,100.0,24.04,2.51
-2018,Washington,53,All,-100.0,-100.0,100.0,100.0,17.95,2.05
-2018,West Virginia,54,All,-100.0,-100.0,100.0,100.0,21.31,
-2018,Wisconsin,55,All,-100.0,-100.0,100.0,100.0,16.68,
-2018,Wyoming,56,All,-99.9,-99.9,100.0,100.0,36.49,
+2021,Alabama,01,All,0.0,0.0,100.0,100.0,50.64,7.22
+2021,Alaska,02,All,0.0,0.0,100.0,100.0,58.14,
+2021,Arizona,04,All,0.0,0.0,100.0,100.0,28.45,3.53
+2021,Arkansas,05,All,0.0,0.0,100.0,100.0,43.0,4.83
+2021,California,06,All,0.0,0.0,100.0,100.0,16.64,1.65
+2021,Colorado,08,All,0.0,0.0,100.0,100.0,28.5,3.78
+2021,Connecticut,09,All,0.0,0.0,100.0,100.0,14.29,
+2021,Delaware,10,All,0.0,0.0,100.0,100.0,47.23,
+2021,District of Columbia,11,All,0.0,0.0,100.0,100.0,60.31,
+2021,Florida,12,All,0.0,0.0,100.0,100.0,26.12,2.87
+2021,Georgia,13,All,0.0,0.0,100.0,100.0,39.17,5.31
+2021,Hawaii,15,All,0.0,0.0,100.0,100.0,,
+2021,Idaho,16,All,0.0,0.0,100.0,100.0,19.16,
+2021,Illinois,17,All,0.0,0.0,100.0,100.0,36.63,4.64
+2021,Indiana,18,All,0.0,0.0,100.0,100.0,37.34,4.03
+2021,Iowa,19,All,0.0,0.0,100.0,100.0,14.04,
+2021,Kansas,20,All,0.0,0.0,100.0,100.0,29.2,5.97
+2021,Kentucky,21,All,0.0,0.0,100.0,100.0,38.07,5.32
+2021,Louisiana,22,All,0.0,0.0,100.0,100.0,69.76,10.25
+2021,Maine,23,All,0.0,0.0,100.0,100.0,,
+2021,Maryland,24,All,0.0,0.0,100.0,100.0,34.65,2.64
+2021,Massachusetts,25,All,0.0,0.0,100.0,100.0,5.25,
+2021,Michigan,26,All,0.0,0.0,100.0,100.0,28.25,2.97
+2021,Minnesota,27,All,0.0,0.0,100.0,100.0,17.43,1.67
+2021,Mississippi,28,All,0.0,0.0,100.0,100.0,69.35,9.96
+2021,Missouri,29,All,0.0,0.0,100.0,100.0,40.55,6.28
+2021,Montana,30,All,0.0,0.0,100.0,100.0,42.09,
+2021,Nebraska,31,All,0.0,0.0,100.0,100.0,15.67,
+2021,Nevada,32,All,0.0,0.0,100.0,100.0,36.23,
+2021,New Hampshire,33,All,0.0,0.0,100.0,100.0,,
+2021,New Jersey,34,All,0.0,0.0,100.0,100.0,11.18,1.24
+2021,New Mexico,35,All,0.0,0.0,100.0,100.0,45.55,5.07
+2021,New York,36,All,0.0,0.0,100.0,100.0,10.32,1.26
+2021,North Carolina,37,All,0.0,0.0,100.0,100.0,35.24,5.17
+2021,North Dakota,38,All,0.0,0.0,100.0,100.0,,
+2021,Ohio,39,All,0.0,0.0,100.0,100.0,32.32,4.68
+2021,Oklahoma,40,All,0.0,0.0,100.0,100.0,31.21,4.99
+2021,Oregon,41,All,0.0,0.0,100.0,100.0,21.09,
+2021,Pennsylvania,42,All,0.0,0.0,100.0,100.0,28.13,4.15
+2021,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
+2021,South Carolina,45,All,0.0,0.0,100.0,100.0,45.85,6.36
+2021,South Dakota,46,All,0.0,0.0,100.0,100.0,29.7,
+2021,Tennessee,47,All,0.0,0.0,100.0,100.0,41.98,5.58
+2021,Texas,48,All,0.0,0.0,100.0,100.0,30.63,3.48
+2021,Utah,49,All,0.0,0.0,100.0,100.0,18.27,
+2021,Vermont,50,All,0.0,0.0,100.0,100.0,,
+2021,Virginia,51,All,0.0,0.0,100.0,100.0,29.69,4.03
+2021,Washington,53,All,0.0,0.0,100.0,100.0,18.34,2.69
+2021,West Virginia,54,All,0.0,0.0,100.0,100.0,20.66,
+2021,Wisconsin,55,All,0.0,0.0,100.0,100.0,26.17,3.69
+2021,Wyoming,56,All,0.0,0.0,100.0,100.0,,
+2020,Alabama,01,All,0.0,0.0,100.0,100.0,49.95,3.38
+2020,Alaska,02,All,0.0,0.0,100.0,100.0,46.41,
+2020,Arizona,04,All,0.0,0.0,100.0,100.0,25.2,3.4
+2020,Arkansas,05,All,0.0,0.0,100.0,100.0,42.37,6.39
+2020,California,06,All,0.0,0.0,100.0,100.0,15.17,1.6
+2020,Colorado,08,All,0.0,0.0,100.0,100.0,24.55,4.2
+2020,Connecticut,09,All,0.0,0.0,100.0,100.0,10.4,
+2020,Delaware,10,All,0.0,0.0,100.0,100.0,34.84,
+2020,District of Columbia,11,All,0.0,0.0,100.0,100.0,71.97,
+2020,Florida,12,All,0.0,0.0,100.0,100.0,27.22,3.08
+2020,Georgia,13,All,0.0,0.0,100.0,100.0,35.44,3.87
+2020,Hawaii,15,All,0.0,0.0,100.0,100.0,,
+2020,Idaho,16,All,0.0,0.0,100.0,100.0,23.38,
+2020,Illinois,17,All,0.0,0.0,100.0,100.0,32.71,3.57
+2020,Indiana,18,All,0.0,0.0,100.0,100.0,38.44,4.27
+2020,Iowa,19,All,0.0,0.0,100.0,100.0,16.62,
+2020,Kansas,20,All,0.0,0.0,100.0,100.0,33.48,4.78
+2020,Kentucky,21,All,0.0,0.0,100.0,100.0,34.79,5.29
+2020,Louisiana,22,All,0.0,0.0,100.0,100.0,66.1,6.39
+2020,Maine,23,All,0.0,0.0,100.0,100.0,,
+2020,Maryland,24,All,0.0,0.0,100.0,100.0,34.72,1.89
+2020,Massachusetts,25,All,0.0,0.0,100.0,100.0,8.6,
+2020,Michigan,26,All,0.0,0.0,100.0,100.0,26.66,2.89
+2020,Minnesota,27,All,0.0,0.0,100.0,100.0,13.91,2.11
+2020,Mississippi,28,All,0.0,0.0,100.0,100.0,55.14,7.15
+2020,Missouri,29,All,0.0,0.0,100.0,100.0,46.94,5.39
+2020,Montana,30,All,0.0,0.0,100.0,100.0,36.67,
+2020,Nebraska,31,All,0.0,0.0,100.0,100.0,13.9,
+2020,Nevada,32,All,0.0,0.0,100.0,100.0,27.11,3.57
+2020,New Hampshire,33,All,0.0,0.0,100.0,100.0,,
+2020,New Jersey,34,All,0.0,0.0,100.0,100.0,11.15,
+2020,New Mexico,35,All,0.0,0.0,100.0,100.0,36.14,5.19
+2020,New York,36,All,0.0,0.0,100.0,100.0,11.23,0.76
+2020,North Carolina,37,All,0.0,0.0,100.0,100.0,31.79,4.73
+2020,North Dakota,38,All,0.0,0.0,100.0,100.0,,
+2020,Ohio,39,All,0.0,0.0,100.0,100.0,32.18,3.69
+2020,Oklahoma,40,All,0.0,0.0,100.0,100.0,35.99,4.16
+2020,Oregon,41,All,0.0,0.0,100.0,100.0,19.31,
+2020,Pennsylvania,42,All,0.0,0.0,100.0,100.0,27.47,3.04
+2020,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
+2020,South Carolina,45,All,0.0,0.0,100.0,100.0,48.4,5.92
+2020,South Dakota,46,All,0.0,0.0,100.0,100.0,25.78,
+2020,Tennessee,47,All,0.0,0.0,100.0,100.0,38.29,4.54
+2020,Texas,48,All,0.0,0.0,100.0,100.0,27.51,3.5
+2020,Utah,49,All,0.0,0.0,100.0,100.0,18.79,3.27
+2020,Vermont,50,All,0.0,0.0,100.0,100.0,,
+2020,Virginia,51,All,0.0,0.0,100.0,100.0,28.01,3.53
+2020,Washington,53,All,0.0,0.0,100.0,100.0,20.56,1.65
+2020,West Virginia,54,All,0.0,0.0,100.0,100.0,22.99,
+2020,Wisconsin,55,All,0.0,0.0,100.0,100.0,19.65,2.72
+2020,Wyoming,56,All,0.0,0.0,100.0,100.0,,
+2019,Alabama,01,All,0.0,0.0,100.0,100.0,38.15,3.95
+2019,Alaska,02,All,0.0,0.0,100.0,100.0,42.54,
+2019,Arizona,04,All,0.0,0.0,100.0,100.0,22.4,2.13
+2019,Arkansas,05,All,0.0,0.0,100.0,100.0,36.68,3.28
+2019,California,06,All,0.0,0.0,100.0,100.0,11.59,1.25
+2019,Colorado,08,All,0.0,0.0,100.0,100.0,21.67,3.42
+2019,Connecticut,09,All,0.0,0.0,100.0,100.0,6.45,
+2019,Delaware,10,All,0.0,0.0,100.0,100.0,,
+2019,District of Columbia,11,All,0.0,0.0,100.0,100.0,68.32,
+2019,Florida,12,All,0.0,0.0,100.0,100.0,21.79,2.22
+2019,Georgia,13,All,0.0,0.0,100.0,100.0,29.4,3.11
+2019,Hawaii,15,All,0.0,0.0,100.0,100.0,,
+2019,Idaho,16,All,0.0,0.0,100.0,100.0,20.6,
+2019,Illinois,17,All,0.0,0.0,100.0,100.0,24.16,3.51
+2019,Indiana,18,All,0.0,0.0,100.0,100.0,26.93,3.06
+2019,Iowa,19,All,0.0,0.0,100.0,100.0,13.17,
+2019,Kansas,20,All,0.0,0.0,100.0,100.0,22.53,3.56
+2019,Kentucky,21,All,0.0,0.0,100.0,100.0,21.63,3.09
+2019,Louisiana,22,All,0.0,0.0,100.0,100.0,44.36,5.14
+2019,Maine,23,All,0.0,0.0,100.0,100.0,,
+2019,Maryland,24,All,0.0,0.0,100.0,100.0,29.05,1.79
+2019,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.06,
+2019,Michigan,26,All,0.0,0.0,100.0,100.0,19.22,2.15
+2019,Minnesota,27,All,0.0,0.0,100.0,100.0,12.77,1.61
+2019,Mississippi,28,All,0.0,0.0,100.0,100.0,45.35,5.14
+2019,Missouri,29,All,0.0,0.0,100.0,100.0,39.43,5.17
+2019,Montana,30,All,0.0,0.0,100.0,100.0,24.94,
+2019,Nebraska,31,All,0.0,0.0,100.0,100.0,16.72,
+2019,Nevada,32,All,0.0,0.0,100.0,100.0,24.12,
+2019,New Hampshire,33,All,0.0,0.0,100.0,100.0,,
+2019,New Jersey,34,All,0.0,0.0,100.0,100.0,8.18,
+2019,New Mexico,35,All,0.0,0.0,100.0,100.0,36.86,5.24
+2019,New York,36,All,0.0,0.0,100.0,100.0,6.37,0.69
+2019,North Carolina,37,All,0.0,0.0,100.0,100.0,24.78,2.43
+2019,North Dakota,38,All,0.0,0.0,100.0,100.0,,
+2019,Ohio,39,All,0.0,0.0,100.0,100.0,23.93,2.75
+2019,Oklahoma,40,All,0.0,0.0,100.0,100.0,25.53,4.19
+2019,Oregon,41,All,0.0,0.0,100.0,100.0,17.84,
+2019,Pennsylvania,42,All,0.0,0.0,100.0,100.0,20.43,2.05
+2019,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
+2019,South Carolina,45,All,0.0,0.0,100.0,100.0,40.33,4.31
+2019,South Dakota,46,All,0.0,0.0,100.0,100.0,24.22,
+2019,Tennessee,47,All,0.0,0.0,100.0,100.0,30.64,3.04
+2019,Texas,48,All,0.0,0.0,100.0,100.0,20.9,2.85
+2019,Utah,49,All,0.0,0.0,100.0,100.0,17.39,
+2019,Vermont,50,All,0.0,0.0,100.0,100.0,,
+2019,Virginia,51,All,0.0,0.0,100.0,100.0,21.18,2.25
+2019,Washington,53,All,0.0,0.0,100.0,100.0,15.19,1.63
+2019,West Virginia,54,All,0.0,0.0,100.0,100.0,22.71,
+2019,Wisconsin,55,All,0.0,0.0,100.0,100.0,14.74,1.81
+2019,Wyoming,56,All,0.0,0.0,100.0,100.0,,
+2018,Alabama,01,All,0.0,0.0,100.0,100.0,39.83,4.3
+2018,Alaska,02,All,0.0,0.0,100.0,100.0,42.81,
+2018,Arizona,04,All,0.0,0.0,100.0,100.0,23.54,2.56
+2018,Arkansas,05,All,0.0,0.0,100.0,100.0,30.86,3.27
+2018,California,06,All,0.0,0.0,100.0,100.0,12.31,1.2
+2018,Colorado,08,All,0.0,0.0,100.0,100.0,23.55,3.4
+2018,Connecticut,09,All,0.0,0.0,100.0,100.0,,
+2018,Delaware,10,All,0.0,0.0,100.0,100.0,28.18,
+2018,District of Columbia,11,All,0.0,0.0,100.0,100.0,53.81,
+2018,Florida,12,All,0.0,0.0,100.0,100.0,21.21,2.2
+2018,Georgia,13,All,0.0,0.0,100.0,100.0,26.67,3.11
+2018,Hawaii,15,All,0.0,0.0,100.0,100.0,,
+2018,Idaho,16,All,0.0,0.0,100.0,100.0,27.33,
+2018,Illinois,17,All,0.0,0.0,100.0,100.0,24.34,2.98
+2018,Indiana,18,All,0.0,0.0,100.0,100.0,25.56,3.43
+2018,Iowa,19,All,0.0,0.0,100.0,100.0,12.56,
+2018,Kansas,20,All,0.0,0.0,100.0,100.0,24.07,
+2018,Kentucky,21,All,0.0,0.0,100.0,100.0,22.58,2.88
+2018,Louisiana,22,All,0.0,0.0,100.0,100.0,43.95,4.83
+2018,Maine,23,All,0.0,0.0,100.0,100.0,,
+2018,Maryland,24,All,0.0,0.0,100.0,100.0,23.87,2.09
+2018,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.02,
+2018,Michigan,26,All,0.0,0.0,100.0,100.0,21.37,2.31
+2018,Minnesota,27,All,0.0,0.0,100.0,100.0,13.74,
+2018,Mississippi,28,All,0.0,0.0,100.0,100.0,45.04,4.95
+2018,Missouri,29,All,0.0,0.0,100.0,100.0,33.7,5.29
+2018,Montana,30,All,0.0,0.0,100.0,100.0,18.6,
+2018,Nebraska,31,All,0.0,0.0,100.0,100.0,12.94,
+2018,Nevada,32,All,0.0,0.0,100.0,100.0,27.16,3.19
+2018,New Hampshire,33,All,0.0,0.0,100.0,100.0,,
+2018,New Jersey,34,All,0.0,0.0,100.0,100.0,8.99,
+2018,New Mexico,35,All,0.0,0.0,100.0,100.0,39.29,
+2018,New York,36,All,0.0,0.0,100.0,100.0,7.63,0.81
+2018,North Carolina,37,All,0.0,0.0,100.0,100.0,22.01,2.69
+2018,North Dakota,38,All,0.0,0.0,100.0,100.0,,
+2018,Ohio,39,All,0.0,0.0,100.0,100.0,23.36,2.89
+2018,Oklahoma,40,All,0.0,0.0,100.0,100.0,19.08,3.45
+2018,Oregon,41,All,0.0,0.0,100.0,100.0,15.41,2.76
+2018,Pennsylvania,42,All,0.0,0.0,100.0,100.0,23.4,2.07
+2018,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
+2018,South Carolina,45,All,0.0,0.0,100.0,100.0,34.86,3.88
+2018,South Dakota,46,All,0.0,0.0,100.0,100.0,28.31,
+2018,Tennessee,47,All,0.0,0.0,100.0,100.0,35.71,4.24
+2018,Texas,48,All,0.0,0.0,100.0,100.0,19.37,2.52
+2018,Utah,49,All,0.0,0.0,100.0,100.0,15.52,3.01
+2018,Vermont,50,All,0.0,0.0,100.0,100.0,,
+2018,Virginia,51,All,0.0,0.0,100.0,100.0,24.04,2.51
+2018,Washington,53,All,0.0,0.0,100.0,100.0,17.95,2.05
+2018,West Virginia,54,All,0.0,0.0,100.0,100.0,21.31,
+2018,Wisconsin,55,All,0.0,0.0,100.0,100.0,16.68,
+2018,Wyoming,56,All,0.0,0.0,100.0,100.0,36.49,


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- [ ] Fixes #3185 (uses population percent to calculate the percent relative inequity instead of the raw population count.
- [ ] Updates and moves docstring to the top of the file. 

## Has this been tested? How?
Manually tested.  

## Screenshots (if appropriate)

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
