### PR TITLE
update HET social links

### DIFF
--- a/frontend/src/styles/HetComponents/HetSocialIconLinks.tsx
+++ b/frontend/src/styles/HetComponents/HetSocialIconLinks.tsx
@@ -14,8 +14,8 @@ export default function HetSocialIconLinks(props: HetSocialIconLinksProps) {
     <div className={`flex justify-center ${props.className ?? ''}`}>
       <a
         className={`mx-[7px] my-0 ${colorClass}`}
-        href={urlMap.shliLinkedIn}
-        aria-label='Satcher Health on LinkedIn'
+        href={urlMap.hetLinkedIn}
+        aria-label='Health Equity Tracker on LinkedIn'
       >
         <LinkedIn />
       </a>
@@ -28,8 +28,8 @@ export default function HetSocialIconLinks(props: HetSocialIconLinksProps) {
       </a>
       <a
         className={`mx-[7px] my-0 ${colorClass}`}
-        href={urlMap.shliYoutube}
-        aria-label='Satcher Health on YouTube'
+        href={urlMap.hetYouTubeShorts}
+        aria-label='Health Equity Tracker on YouTube Shorts'
       >
         <YouTube />
       </a>

--- a/frontend/src/utils/externalUrls.ts
+++ b/frontend/src/utils/externalUrls.ts
@@ -43,11 +43,15 @@ export type LinkName =
   | 'unitedStatesIo'
   | 'cdcTrans'
   | 'hetTikTok'
+  | 'hetYouTubeShorts'
+  | 'hetLinkedIn'
   | 'msm'
   | 'whoWomenVoting'
 
 export const urlMap: Record<LinkName, string> = {
   hetTikTok: 'https://www.tiktok.com/@healthequitytracker',
+  hetYouTubeShorts: 'https://www.youtube.com/@HealthEquityTracker/shorts',
+  hetLinkedIn: 'https://www.linkedin.com/company/healthequitytracker/',
   cdcTrans: 'https://www.cdc.gov/hiv/clinicians/transforming-health/index.html',
   veraGithub: 'https://github.com/vera-institute/incarceration-trends',
   bjsPrisoners:


### PR DESCRIPTION
# Description and Motivation
Updates the HET social links from the SHLI YouTube channel and SHLI LinkedIn to our own dedicated YouTube Shorts channel and LinkedIn page.

## Has this been tested? How?
Tests passing

## Types of changes
- New content or feature

## New frontend preview link is below in the Netlify comment 😎
