### PR TITLE
Remove Redundant Filtering of `COMMUNITY_SAFETY_DROPDOWNIDS` in MadLibs

### DIFF
--- a/frontend/src/utils/MadLibs.ts
+++ b/frontend/src/utils/MadLibs.ts
@@ -225,14 +225,12 @@ const CATEGORIES_LIST: Category[] = [
     definition: '',
     options: COVID_CATEGORY_DROPDOWNIDS as unknown as DropdownVarId[],
   },
-  ...(SHOW_GUN_VIOLENCE ? [
-    {
-      title: 'Community Safety',
-      definition: '',
-      options: COMMUNITY_SAFETY_DROPDOWNIDS as unknown as DropdownVarId[],
-    }
-  ] : [])
-];
+  {
+    title: 'Community Safety',
+    definition: '',
+    options: COMMUNITY_SAFETY_DROPDOWNIDS as unknown as DropdownVarId[],
+  }
+]
 
 
 const MADLIB_LIST: MadLib[] = [


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
`MetricConfigCommunitySafety.tsx` already filters out `gun_violence` and `gun_deaths_black_men` based on the `SHOW_GUN_VIOLENCE` flag, so the additional filtering in MadLibs is unnecessary.

## Has this been tested? How?

## Screenshots (if appropriate)
`MetricConfigCommunitySafety.tsx`: <img width="830" alt="Screenshot 2024-06-21 at 10 42 26 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/b01bd3b6-f501-4b48-a984-3f2d63c3d262">

Double filtering in `MadLibs.ts`: 
<img width="600" alt="Screenshot 2024-06-21 at 10 44 44 AM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/8080363c-e0d1-42e8-b9ed-049996a7a67b">

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
