### PR TITLE
Fixed issue with GraphQL AHR ingestion DAG not creating state-level tables in BigQuery

### DIFF
--- a/airflow/dags/graphql_ahr.py
+++ b/airflow/dags/graphql_ahr.py
@@ -21,7 +21,7 @@ graphql_ahr_bq_payload_age_national = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='age', geographic='national'
 )
 graphql_ahr_bq_operator_age_national = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_age_national', graphql_ahr_bq_payload_age_national, data_ingestion_dag
+    'graphql_ahr_to_bq_age_national', graphql_ahr_bq_payload_age_national, data_ingestion_dag
 )
 
 # AGE STATE
@@ -29,7 +29,7 @@ graphql_ahr_bq_payload_age_state = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='age', geographic='state'
 )
 graphql_ahr_bq_operator_age_state = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_age_state', graphql_ahr_bq_payload_age_national, data_ingestion_dag
+    'graphql_ahr_to_bq_age_state', graphql_ahr_bq_payload_age_state, data_ingestion_dag
 )
 
 # RACE NATIONAL
@@ -37,7 +37,7 @@ graphql_ahr_bq_payload_race_national = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='race_and_ethnicity', geographic='national'
 )
 graphql_ahr_bq_operator_race_national = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_race_national', graphql_ahr_bq_payload_race_national, data_ingestion_dag
+    'graphql_ahr_to_bq_race_national', graphql_ahr_bq_payload_race_national, data_ingestion_dag
 )
 
 # RACE STATE
@@ -45,7 +45,7 @@ graphql_ahr_bq_payload_race_state = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='race_and_ethnicity', geographic='state'
 )
 graphql_ahr_bq_operator_race_state = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_race_state', graphql_ahr_bq_payload_race_national, data_ingestion_dag
+    'graphql_ahr_to_bq_race_state', graphql_ahr_bq_payload_race_state, data_ingestion_dag
 )
 
 # SEX NATIONAL
@@ -53,7 +53,7 @@ graphql_ahr_bq_payload_sex_national = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='sex', geographic='national'
 )
 graphql_ahr_bq_operator_sex_national = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_sex_national', graphql_ahr_bq_payload_sex_national, data_ingestion_dag
+    'graphql_ahr_to_bq_sex_national', graphql_ahr_bq_payload_sex_national, data_ingestion_dag
 )
 
 # SEX STATE
@@ -61,7 +61,7 @@ graphql_ahr_bq_payload_sex_state = util.generate_bq_payload(
     _GRAPHQL_AHR_WORKFLOW_ID, _GRAPHQL_AHR_DATASET_NAME, demographic='sex', geographic='state'
 )
 graphql_ahr_bq_operator_sex_state = util.create_bq_ingest_operator(
-    'graph_ahr_to_bq_sex_state', graphql_ahr_bq_payload_sex_national, data_ingestion_dag
+    'graphql_ahr_to_bq_sex_state', graphql_ahr_bq_payload_sex_state, data_ingestion_dag
 )
 
 # EXPORTERS

--- a/run_gcs_to_bq/test_run_gcs_to_bq.py
+++ b/run_gcs_to_bq/test_run_gcs_to_bq.py
@@ -11,7 +11,7 @@ def client():
 
 
 def test_ingest_bucket_to_bq_no_json(client):
-    response = client.post('/')
+    response = client.post('/', content_type='application/json')
     assert response.status_code == 400
 
 

--- a/run_gcs_to_bq/test_run_gcs_to_bq.py
+++ b/run_gcs_to_bq/test_run_gcs_to_bq.py
@@ -1,3 +1,5 @@
+# pylint: disable=no-member
+
 import pytest
 from unittest import mock
 import main

--- a/run_ingestion/test_run_ingestion.py
+++ b/run_ingestion/test_run_ingestion.py
@@ -12,7 +12,7 @@ def client():
 
 
 def test_ingest_data_no_json(client):
-    response = client.post('/')
+    response = client.post('/', content_type='application/json')
     assert response.status_code == HTTPStatus.BAD_REQUEST
 
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high-level items. use keywords (eg "closes #144" or "fixes #4323") -->
This PR fixes the issue where incorrect payloads were being passed, preventing the state tables from being created in BigQuery.

## Has this been tested? How?
Tested changes on infra-test

## Screenshots (if appropriate)
<img width="574" alt="Screenshot 2024-06-26 at 6 00 06 PM" src="https://github.com/SatcherInstitute/health-equity-tracker/assets/72993442/093aeaf5-5566-42f9-a44a-8611c391be65">

## Types of changes

(leave all that apply)
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
