### PR TITLE
Fixes the mobile overflow issue for the `ClickableLegendHeader`

### DIFF
--- a/frontend/src/charts/ClickableLegendHeader.tsx
+++ b/frontend/src/charts/ClickableLegendHeader.tsx
@@ -22,22 +22,25 @@ export default function ClickableLegendHeader(
     props.dataTypeConfig.fullDisplayName
 
   return (
-    <Tooltip
-      arrow={true}
-      placement='top'
-      title={`Click for more info on ${topicName}`}
-    >
-      <Button
-        onClick={() => {
-          setTopicInfoModalIsOpen(true)
-        }}
-        className='grid h-full w-full place-content-center'
+    <div className='w-full'>
+      <Tooltip
+        arrow={true}
+        placement='top'
+        title={`Click for more info on ${topicName}`}
       >
-        <span className='inline-flex items-center break-words text-start text-smallest leading-lhSomeMoreSpace text-black'>
-          <InfoOutlinedIcon className='mb-[-1px] mr-1 p-[3px]' />
-          {props.legendTitle}
-        </span>
-      </Button>
-    </Tooltip>
+        <Button
+          onClick={() => {
+            setTopicInfoModalIsOpen(true)
+          }}
+          className='grid h-full w-full place-content-center'
+        >
+          <span className='inline-flex items-center break-words text-start text-smallest leading-lhSomeMoreSpace text-black'>
+            <InfoOutlinedIcon className='mb-[-1px] mr-1 p-[3px]' />
+            {props.legendTitle}
+          </span>
+        </Button>
+      </Tooltip>
+    </div>
+
   )
 }

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -307,12 +307,10 @@ export function Legend(props: LegendProps) {
           {props.legendTitle}
         </span>
       ) : (
-        <div>
-          <ClickableLegendHeader
-            legendTitle={props.legendTitle}
-            dataTypeConfig={props.dataTypeConfig}
-          />
-        </div>
+        <ClickableLegendHeader
+          legendTitle={props.legendTitle}
+          dataTypeConfig={props.dataTypeConfig}
+        />
 
       )}
 

--- a/frontend/src/charts/Legend.tsx
+++ b/frontend/src/charts/Legend.tsx
@@ -307,10 +307,13 @@ export function Legend(props: LegendProps) {
           {props.legendTitle}
         </span>
       ) : (
-        <ClickableLegendHeader
-          legendTitle={props.legendTitle}
-          dataTypeConfig={props.dataTypeConfig}
-        />
+        <div>
+          <ClickableLegendHeader
+            legendTitle={props.legendTitle}
+            dataTypeConfig={props.dataTypeConfig}
+          />
+        </div>
+
       )}
 
       {spec && (


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high-level items. use keywords (eg "closes #144" or "fixes #4323") -->
This PR fixes #3473, where the `ClickableLegendHeader` was spilling out of its parent container on mobile devices. The problem was resolved by wrapping the `ClickableLegendHeader` component in a `div`.

## Has this been tested? How?
I ran localhost:3000 on the phone and tested the changes. 

## Screenshots (if appropriate)

- Mobile localhost after the fix:![IMG_0283](https://github.com/user-attachments/assets/dde719df-af61-44da-ab13-a30ba377b35a)
- Prod mobile: ![IMG_0282](https://github.com/user-attachments/assets/26b379de-1e92-4192-bd03-99901dcf091f)

## Types of changes

(leave all that apply)

- Bug fix
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
