### PR TITLE
Better subset population labels

### DIFF
--- a/frontend/src/charts/utils.test.ts
+++ b/frontend/src/charts/utils.test.ts
@@ -1,6 +1,9 @@
 import { HIV_DISEASE_METRICS } from '../data/config/MetricConfigHivCategory'
 import { PHRMA_CARDIOVASCULAR_METRICS } from '../data/config/MetricConfigPhrma'
-import { PREVENTABLE_HOSP_METRICS, UNINSURANCE_METRICS } from '../data/config/MetricConfigSDOH'
+import {
+  PREVENTABLE_HOSP_METRICS,
+  UNINSURANCE_METRICS,
+} from '../data/config/MetricConfigSDOH'
 import { Fips } from '../data/utils/Fips'
 import { generateChartTitle, generateSubtitle } from './utils'
 import { describe, test, expect } from 'vitest'
@@ -20,30 +23,31 @@ describe('Tests generateChartTitle()', () => {
     const titleForUnknown = generateChartTitle(
       'Some title XYZ',
       new Fips('00'),
-      'sex'
+      'sex',
     )
     expect(titleForUnknown).toEqual(
-      'Some title XYZ with unknown sex in the United States'
+      'Some title XYZ with unknown sex in the United States',
     )
   })
 
   test('preventable hosp. subtitle', () => {
-
     const subTitle = generateSubtitle(
       'Male',
       'sex',
-      PREVENTABLE_HOSP_METRICS[0]
+      PREVENTABLE_HOSP_METRICS[0],
     )
-    expect(subTitle).toEqual('Medicare beneficiaries, Male')
+    expect(subTitle).toEqual('Medicare beneficiaries, Ages 18+, Male')
   })
 
   test('PHRMA subtitle', () => {
     const subTitle = generateSubtitle(
       'Male',
       'sex',
-      PHRMA_CARDIOVASCULAR_METRICS[0]
+      PHRMA_CARDIOVASCULAR_METRICS[0],
     )
-    expect(subTitle).toEqual('Medicare Beta-Blocker Beneficiaries, Male, Ages 18+')
+    expect(subTitle).toEqual(
+      'Medicare Beta-Blocker Beneficiaries, Male, Ages 18+',
+    )
   })
 
   test('Standard subtitle', () => {
@@ -58,4 +62,3 @@ describe('Tests generateSubtitle()', () => {
     expect(subTitle).toEqual('Male, Ages 13+')
   })
 })
-

--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -1,638 +1,638 @@
 import {
-	defaultHigherIsBetterMapConfig,
-	defaultHigherIsWorseMapConfig,
-	womenHigherIsWorseMapConfig,
-} from "../../charts/mapGlobals";
-import { type DataTypeConfig } from "./MetricConfig";
-import { populationPctShortLabel } from "./MetricConfigUtils";
+  defaultHigherIsBetterMapConfig,
+  defaultHigherIsWorseMapConfig,
+  womenHigherIsWorseMapConfig,
+} from '../../charts/mapGlobals'
+import type { DataTypeConfig } from './MetricConfig'
+import { populationPctShortLabel } from './MetricConfigUtils'
 
 export const HIV_CATEGORY_DROPDOWNIDS = [
-	"hiv",
-	"hiv_black_women",
-	"hiv_care",
-	"hiv_prep",
-	"hiv_stigma",
-] as const;
+  'hiv',
+  'hiv_black_women',
+  'hiv_care',
+  'hiv_prep',
+  'hiv_stigma',
+] as const
 
 export type HivCategoryDataTypeId =
-	| "hiv_deaths_black_women"
-	| "hiv_deaths"
-	| "hiv_diagnoses_black_women"
-	| "hiv_diagnoses"
-	| "hiv_prevalence_black_women"
-	| "hiv_prevalence";
+  | 'hiv_deaths_black_women'
+  | 'hiv_deaths'
+  | 'hiv_diagnoses_black_women'
+  | 'hiv_diagnoses'
+  | 'hiv_prevalence_black_women'
+  | 'hiv_prevalence'
 
 export type HivCategoryMetricId =
-	| "black_women_population_pct"
-	| "black_women_population_count"
-	| "hiv_care_linkage"
-	| "hiv_care_pct_relative_inequity"
-	| "hiv_care_pct_share"
-	| "hiv_care_population_pct"
-	| "hiv_care_population"
-	| "hiv_care"
-	| "hiv_deaths_black_women_pct_relative_inequity"
-	| "hiv_deaths_black_women_pct_share"
-	| "hiv_deaths_black_women_per_100k"
-	| "hiv_deaths_black_women"
-	| "hiv_deaths_pct_relative_inequity"
-	| "hiv_deaths_pct_share"
-	| "hiv_deaths_per_100k"
-	| "hiv_deaths_ratio_age_adjusted"
-	| "hiv_deaths"
-	| "hiv_diagnoses_black_women_pct_relative_inequity"
-	| "hiv_diagnoses_black_women_pct_share"
-	| "hiv_diagnoses_black_women_per_100k"
-	| "hiv_diagnoses_black_women"
-	| "hiv_diagnoses_pct_relative_inequity"
-	| "hiv_diagnoses_pct_share"
-	| "hiv_diagnoses_per_100k"
-	| "hiv_diagnoses"
-	| "hiv_population_pct"
-	| "hiv_population"
-	| "hiv_prep_coverage"
-	| "hiv_prep_pct_relative_inequity"
-	| "hiv_prep_pct_share"
-	| "hiv_prep_population_pct"
-	| "hiv_prep_population"
-	| "hiv_prep"
-	| "hiv_prevalence_black_women_pct_relative_inequity"
-	| "hiv_prevalence_black_women_pct_share"
-	| "hiv_prevalence_black_women_per_100k"
-	| "hiv_prevalence_black_women"
-	| "hiv_prevalence_pct_relative_inequity"
-	| "hiv_prevalence_pct_share"
-	| "hiv_prevalence_per_100k"
-	| "hiv_prevalence_ratio_age_adjusted"
-	| "hiv_prevalence"
-	| "hiv_stigma_index"
-	| "hiv_stigma_pct_share"
-	| "hiv_care_total_additional_gender"
-	| "hiv_care_total_trans_men"
-	| "hiv_care_total_trans_women"
-	| "hiv_deaths_total_additional_gender"
-	| "hiv_deaths_total_trans_men"
-	| "hiv_deaths_total_trans_women"
-	| "hiv_diagnoses_total_additional_gender"
-	| "hiv_diagnoses_total_trans_men"
-	| "hiv_diagnoses_total_trans_women"
-	| "hiv_prevalence_total_additional_gender"
-	| "hiv_prevalence_total_trans_men"
-	| "hiv_prevalence_total_trans_women";
+  | 'black_women_population_pct'
+  | 'black_women_population_count'
+  | 'hiv_care_linkage'
+  | 'hiv_care_pct_relative_inequity'
+  | 'hiv_care_pct_share'
+  | 'hiv_care_population_pct'
+  | 'hiv_care_population'
+  | 'hiv_care'
+  | 'hiv_deaths_black_women_pct_relative_inequity'
+  | 'hiv_deaths_black_women_pct_share'
+  | 'hiv_deaths_black_women_per_100k'
+  | 'hiv_deaths_black_women'
+  | 'hiv_deaths_pct_relative_inequity'
+  | 'hiv_deaths_pct_share'
+  | 'hiv_deaths_per_100k'
+  | 'hiv_deaths_ratio_age_adjusted'
+  | 'hiv_deaths'
+  | 'hiv_diagnoses_black_women_pct_relative_inequity'
+  | 'hiv_diagnoses_black_women_pct_share'
+  | 'hiv_diagnoses_black_women_per_100k'
+  | 'hiv_diagnoses_black_women'
+  | 'hiv_diagnoses_pct_relative_inequity'
+  | 'hiv_diagnoses_pct_share'
+  | 'hiv_diagnoses_per_100k'
+  | 'hiv_diagnoses'
+  | 'hiv_population_pct'
+  | 'hiv_population'
+  | 'hiv_prep_coverage'
+  | 'hiv_prep_pct_relative_inequity'
+  | 'hiv_prep_pct_share'
+  | 'hiv_prep_population_pct'
+  | 'hiv_prep_population'
+  | 'hiv_prep'
+  | 'hiv_prevalence_black_women_pct_relative_inequity'
+  | 'hiv_prevalence_black_women_pct_share'
+  | 'hiv_prevalence_black_women_per_100k'
+  | 'hiv_prevalence_black_women'
+  | 'hiv_prevalence_pct_relative_inequity'
+  | 'hiv_prevalence_pct_share'
+  | 'hiv_prevalence_per_100k'
+  | 'hiv_prevalence_ratio_age_adjusted'
+  | 'hiv_prevalence'
+  | 'hiv_stigma_index'
+  | 'hiv_stigma_pct_share'
+  | 'hiv_care_total_additional_gender'
+  | 'hiv_care_total_trans_men'
+  | 'hiv_care_total_trans_women'
+  | 'hiv_deaths_total_additional_gender'
+  | 'hiv_deaths_total_trans_men'
+  | 'hiv_deaths_total_trans_women'
+  | 'hiv_diagnoses_total_additional_gender'
+  | 'hiv_diagnoses_total_trans_men'
+  | 'hiv_diagnoses_total_trans_women'
+  | 'hiv_prevalence_total_additional_gender'
+  | 'hiv_prevalence_total_trans_men'
+  | 'hiv_prevalence_total_trans_women'
 
 export const HIV_CARE_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_care",
-		mapConfig: defaultHigherIsBetterMapConfig,
-		dataTypeShortLabel: "Linkage to HIV care",
-		fullDisplayName: "Linkage to HIV care",
-		fullDisplayNameInline: "linkage to HIV care",
-		definition: {
-			text: `Individuals ages 13+ with linkage to HIV care in a particular year. The per 100k rate is the number with linkage to HIV care per 100,000 HIV diagnoses in a particular year.`,
-		},
-		description: {
-			text: "Access to quality HIV care is essential for ensuring that people living with HIV can live long and healthy lives. However, not everyone with HIV has access to quality care. Studying HIV care in regard to health equity can help us to understand why these disparities exist and how to improve access to quality care for all people living with HIV.",
-		},
-		dataTableTitle: "Breakdown summary for linkage to HIV care",
-		ageSubPopulationLabel: "Ages 13+",
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_care',
+    mapConfig: defaultHigherIsBetterMapConfig,
+    dataTypeShortLabel: 'Linkage to HIV care',
+    fullDisplayName: 'Linkage to HIV care',
+    fullDisplayNameInline: 'linkage to HIV care',
+    definition: {
+      text: `Individuals ages 13+ with linkage to HIV care in a particular year. The per 100k rate is the number with linkage to HIV care per 100,000 HIV diagnoses in a particular year.`,
+    },
+    description: {
+      text: 'Access to quality HIV care is essential for ensuring that people living with HIV can live long and healthy lives. However, not everyone with HIV has access to quality care. Studying HIV care in regard to health equity can help us to understand why these disparities exist and how to improve access to quality care for all people living with HIV.',
+    },
+    dataTableTitle: 'Breakdown summary for linkage to HIV care',
+    ageSubPopulationLabel: 'People diagnosed with HIV, Ages 13+',
 
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total linkage to HIV care",
-				metricId: "hiv_care_pct_share",
-				columnTitleHeader: "Share of total linkage to HIV care",
-				trendsCardTitleName:
-					"Inequitable share of linkage to HIV care over time",
-				shortLabel: "% linkage",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Diagnosed population vs. distribution of linkage to HIV care",
-					metricId: "hiv_care_population_pct",
-					columnTitleHeader: "Diagnosed population share (ages 13+)", // populationPctTitle,
-					shortLabel: "% of diagnosed population",
-					type: "pct_share",
-				},
-			},
-			pct_rate: {
-				metricId: "hiv_care_linkage",
-				chartTitle: "Linkage to HIV care",
-				trendsCardTitleName: "Rates of linkage to HIV care over time",
-				columnTitleHeader: "Linkage to HIV care",
-				shortLabel: "% linkage",
-				type: "pct_rate",
-				rateNumeratorMetric: {
-					metricId: "hiv_care",
-					shortLabel: "Individuals with linkage to HIV care",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "hiv_care_population",
-					shortLabel: "Total HIV diagnoses",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Historical relative inequity in linkage to HIV care",
-				metricId: "hiv_care_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-];
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total linkage to HIV care',
+        metricId: 'hiv_care_pct_share',
+        columnTitleHeader: 'Share of total linkage to HIV care',
+        trendsCardTitleName:
+          'Inequitable share of linkage to HIV care over time',
+        shortLabel: '% linkage',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Diagnosed population vs. distribution of linkage to HIV care',
+          metricId: 'hiv_care_population_pct',
+          columnTitleHeader: 'Diagnosed population share (ages 13+)', // populationPctTitle,
+          shortLabel: '% of diagnosed population',
+          type: 'pct_share',
+        },
+      },
+      pct_rate: {
+        metricId: 'hiv_care_linkage',
+        chartTitle: 'Linkage to HIV care',
+        trendsCardTitleName: 'Rates of linkage to HIV care over time',
+        columnTitleHeader: 'Linkage to HIV care',
+        shortLabel: '% linkage',
+        type: 'pct_rate',
+        rateNumeratorMetric: {
+          metricId: 'hiv_care',
+          shortLabel: 'Individuals with linkage to HIV care',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'hiv_care_population',
+          shortLabel: 'Total HIV diagnoses',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Historical relative inequity in linkage to HIV care',
+        metricId: 'hiv_care_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+]
 
 export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_prevalence",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		dataTypeShortLabel: "Prevalence",
-		fullDisplayName: "HIV prevalence",
-		definition: {
-			text: `Individuals ages 13+ living with HIV (diagnosed & undiagnosed) in a particular year.`,
-		},
-		description: {
-			text: "HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.",
-		},
-		dataTableTitle: "Breakdown summary for HIV prevalence",
-		ageSubPopulationLabel: "Ages 13+",
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_prevalence',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'Prevalence',
+    fullDisplayName: 'HIV prevalence',
+    definition: {
+      text: `Individuals ages 13+ living with HIV (diagnosed & undiagnosed) in a particular year.`,
+    },
+    description: {
+      text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV prevalence',
+    ageSubPopulationLabel: 'Ages 13+',
 
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total HIV prevalence",
-				metricId: "hiv_prevalence_pct_share",
-				columnTitleHeader: "Share of total HIV prevalence",
-				trendsCardTitleName: "Inequitable share of HIV prevalence over time",
-				shortLabel: "% of HIV prevalence",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total HIV prevalence",
-					metricId: "hiv_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_prevalence_per_100k",
-				chartTitle: "HIV prevalence",
-				trendsCardTitleName: "HIV prevalence over time",
-				columnTitleHeader: "HIV prevalence per 100k people",
-				shortLabel: "HIV prevalence per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_prevalence",
-					shortLabel: "Individuals living with HIV",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "hiv_population",
-					shortLabel: "Total population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Historical relative inequity for HIV prevalence",
-				metricId: "hiv_prevalence_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_diagnoses",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		dataTypeShortLabel: "New diagnoses",
-		fullDisplayName: "New HIV diagnoses",
-		fullDisplayNameInline: "new HIV diagnoses",
-		definition: {
-			text: `Individuals ages 13+ diagnosed with HIV in a particular year.`,
-		},
-		description: {
-			text: "HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.",
-		},
-		dataTableTitle: "Breakdown summary for HIV diagnoses",
-		ageSubPopulationLabel: "Ages 13+",
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total HIV prevalence',
+        metricId: 'hiv_prevalence_pct_share',
+        columnTitleHeader: 'Share of total HIV prevalence',
+        trendsCardTitleName: 'Inequitable share of HIV prevalence over time',
+        shortLabel: '% of HIV prevalence',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total HIV prevalence',
+          metricId: 'hiv_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_prevalence_per_100k',
+        chartTitle: 'HIV prevalence',
+        trendsCardTitleName: 'HIV prevalence over time',
+        columnTitleHeader: 'HIV prevalence per 100k people',
+        shortLabel: 'HIV prevalence per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_prevalence',
+          shortLabel: 'Individuals living with HIV',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'hiv_population',
+          shortLabel: 'Total population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Historical relative inequity for HIV prevalence',
+        metricId: 'hiv_prevalence_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_diagnoses',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'New diagnoses',
+    fullDisplayName: 'New HIV diagnoses',
+    fullDisplayNameInline: 'new HIV diagnoses',
+    definition: {
+      text: `Individuals ages 13+ diagnosed with HIV in a particular year.`,
+    },
+    description: {
+      text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV diagnoses',
+    ageSubPopulationLabel: 'Ages 13+',
 
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total HIV diagnoses",
-				metricId: "hiv_diagnoses_pct_share",
-				columnTitleHeader: "Share of total HIV diagnoses",
-				trendsCardTitleName: "Inequitable share of HIV diagnoses over time",
-				shortLabel: "% of HIV diagnoses",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total HIV diagnoses",
-					metricId: "hiv_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_diagnoses_per_100k",
-				chartTitle: "HIV diagnoses",
-				trendsCardTitleName: "HIV diagnoses over time",
-				columnTitleHeader: "HIV diagnoses per 100k people",
-				shortLabel: "HIV diagnoses per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_diagnoses",
-					shortLabel: "HIV diagnoses",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "hiv_population",
-					shortLabel: "Total population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Historical relative inequity for new HIV diagnoses",
-				metricId: "hiv_diagnoses_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_deaths",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		dataTypeShortLabel: "Deaths",
-		fullDisplayName: "HIV deaths",
-		definition: {
-			text: `Individuals ages 13+ who died from HIV or AIDS in a particular year.`,
-		},
-		description: {
-			text: "HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.",
-		},
-		dataTableTitle: "Breakdown summary for HIV deaths",
-		ageSubPopulationLabel: "Ages 13+",
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total HIV diagnoses',
+        metricId: 'hiv_diagnoses_pct_share',
+        columnTitleHeader: 'Share of total HIV diagnoses',
+        trendsCardTitleName: 'Inequitable share of HIV diagnoses over time',
+        shortLabel: '% of HIV diagnoses',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total HIV diagnoses',
+          metricId: 'hiv_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_diagnoses_per_100k',
+        chartTitle: 'HIV diagnoses',
+        trendsCardTitleName: 'HIV diagnoses over time',
+        columnTitleHeader: 'HIV diagnoses per 100k people',
+        shortLabel: 'HIV diagnoses per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_diagnoses',
+          shortLabel: 'HIV diagnoses',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'hiv_population',
+          shortLabel: 'Total population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Historical relative inequity for new HIV diagnoses',
+        metricId: 'hiv_diagnoses_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_deaths',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'Deaths',
+    fullDisplayName: 'HIV deaths',
+    definition: {
+      text: `Individuals ages 13+ who died from HIV or AIDS in a particular year.`,
+    },
+    description: {
+      text: 'HIV is a serious and chronic disease that can be fatal if not treated. However, HIV is now a manageable condition thanks to effective antiretroviral therapy. Studying HIV in regard to health equity can help us to understand why certain populations are more likely to be diagnosed with HIV and why they are less likely to receive effective treatment.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV deaths',
+    ageSubPopulationLabel: 'Ages 13+',
 
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total HIV deaths",
-				metricId: "hiv_deaths_pct_share",
-				columnTitleHeader: "Share of total HIV deaths",
-				trendsCardTitleName: "Inequitable share of HIV deaths over time",
-				shortLabel: "% of HIV deaths",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total HIV deaths",
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total HIV deaths',
+        metricId: 'hiv_deaths_pct_share',
+        columnTitleHeader: 'Share of total HIV deaths',
+        trendsCardTitleName: 'Inequitable share of HIV deaths over time',
+        shortLabel: '% of HIV deaths',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total HIV deaths',
 
-					metricId: "hiv_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_deaths_per_100k",
-				chartTitle: "HIV deaths",
-				trendsCardTitleName: "Rates of HIV deaths over time",
-				columnTitleHeader: "HIV deaths per 100k people",
-				shortLabel: "deaths per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_deaths",
-					shortLabel: "HIV deaths",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "hiv_population",
-					shortLabel: "Total population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Historical relative inequity for HIV deaths",
-				metricId: "hiv_deaths_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-			age_adjusted_ratio: {
-				metricId: "hiv_deaths_ratio_age_adjusted",
-				chartTitle: "Age-adjusted HIV deaths compared to White (NH)",
-				shortLabel: "Ratio compared to White (NH)",
-				type: "age_adjusted_ratio",
-				ageAdjusted: true,
-			},
-		},
-	},
-];
+          metricId: 'hiv_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_deaths_per_100k',
+        chartTitle: 'HIV deaths',
+        trendsCardTitleName: 'Rates of HIV deaths over time',
+        columnTitleHeader: 'HIV deaths per 100k people',
+        shortLabel: 'deaths per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_deaths',
+          shortLabel: 'HIV deaths',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'hiv_population',
+          shortLabel: 'Total population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Historical relative inequity for HIV deaths',
+        metricId: 'hiv_deaths_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+      age_adjusted_ratio: {
+        metricId: 'hiv_deaths_ratio_age_adjusted',
+        chartTitle: 'Age-adjusted HIV deaths compared to White (NH)',
+        shortLabel: 'Ratio compared to White (NH)',
+        type: 'age_adjusted_ratio',
+        ageAdjusted: true,
+      },
+    },
+  },
+]
 
 export const HIV_STIGMA_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_stigma",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		dataTypeShortLabel: "Stigma",
-		fullDisplayName: "HIV stigma",
-		definition: {
-			text: `Self-reported stigma scores ranging from 0 (no stigma) to 100 (high stigma) for HIV-diagnosed individuals ages 18+ in a particular year.`,
-		},
-		description: {
-			text: "HIV stigma often intersects with other forms of stigma and discrimination, such as racism, homophobia, and sexism. Studying HIV stigma can shed light on broader issues of social injustice and inequality.",
-		},
-		dataTableTitle: "Breakdown summary for HIV stigma",
-		ageSubPopulationLabel: "Ages 18+",
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_stigma',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'Stigma',
+    fullDisplayName: 'HIV stigma',
+    definition: {
+      text: `Self-reported stigma scores ranging from 0 (no stigma) to 100 (high stigma) for HIV-diagnosed individuals ages 18+ in a particular year.`,
+    },
+    description: {
+      text: 'HIV stigma often intersects with other forms of stigma and discrimination, such as racism, homophobia, and sexism. Studying HIV stigma can shed light on broader issues of social injustice and inequality.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV stigma',
+    ageSubPopulationLabel: 'People living with HIV, Ages 18+',
 
-		metrics: {
-			index: {
-				metricId: "hiv_stigma_index",
-				chartTitle: "HIV stigma",
-				trendsCardTitleName: "Rates of HIV stigma over time",
-				columnTitleHeader: "HIV stigma",
-				shortLabel: " score out of 100",
-				type: "index",
-			},
-			pct_share: {
-				chartTitle: "Stigma scores", // needed for Unknowns Map Card Title
-				metricId: "hiv_stigma_pct_share",
-				shortLabel: "% of HIV stigma",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total HIV stigma",
-					metricId: "hiv_population_pct",
-					columnTitleHeader: "Population share (ages 18+)", // populationPctTitle,
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-			},
-		},
-	},
-];
+    metrics: {
+      index: {
+        metricId: 'hiv_stigma_index',
+        chartTitle: 'HIV stigma',
+        trendsCardTitleName: 'Rates of HIV stigma over time',
+        columnTitleHeader: 'HIV stigma',
+        shortLabel: ' score out of 100',
+        type: 'index',
+      },
+      pct_share: {
+        chartTitle: 'Stigma scores', // needed for Unknowns Map Card Title
+        metricId: 'hiv_stigma_pct_share',
+        shortLabel: '% of HIV stigma',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total HIV stigma',
+          metricId: 'hiv_population_pct',
+          columnTitleHeader: 'Population share (ages 18+)', // populationPctTitle,
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+      },
+    },
+  },
+]
 
 export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_prevalence_black_women",
-		mapConfig: womenHigherIsWorseMapConfig,
-		dataTypeShortLabel: "Prevalence for Black Women",
-		fullDisplayName: "HIV prevalence for Black women",
-		definition: {
-			text: `Black or African-American (NH) women ages 13+ living with HIV (diagnosed & undiagnosed) in a particular year.`,
-		},
-		description: {
-			text: "Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.",
-		},
-		dataTableTitle: "Breakdown summary for HIV prevalence for Black (NH) women",
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_prevalence_black_women',
+    mapConfig: womenHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'Prevalence for Black Women',
+    fullDisplayName: 'HIV prevalence for Black women',
+    definition: {
+      text: `Black or African-American (NH) women ages 13+ living with HIV (diagnosed & undiagnosed) in a particular year.`,
+    },
+    description: {
+      text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV prevalence for Black (NH) women',
 
-		ageSubPopulationLabel: "Ages 13+",
-		otherSubPopulationLabel: "Black Women",
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total HIV prevalence for Black (NH) women",
-				metricId: "hiv_prevalence_black_women_pct_share",
-				columnTitleHeader: "Share of total HIV prevalence for Black (NH) women",
-				trendsCardTitleName:
-					"Inequitable share of HIV prevalence for Black (NH) women over time",
-				shortLabel: "% of HIV prevalence (Black women)",
-				type: "pct_share",
+    ageSubPopulationLabel: 'Ages 13+',
+    otherSubPopulationLabel: 'Black Women',
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total HIV prevalence for Black (NH) women',
+        metricId: 'hiv_prevalence_black_women_pct_share',
+        columnTitleHeader: 'Share of total HIV prevalence for Black (NH) women',
+        trendsCardTitleName:
+          'Inequitable share of HIV prevalence for Black (NH) women over time',
+        shortLabel: '% of HIV prevalence (Black women)',
+        type: 'pct_share',
 
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total HIV prevalence for Black (NH) women",
-					metricId: "black_women_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: "% of population (Black women)",
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_prevalence_black_women_per_100k",
-				chartTitle: "HIV prevalence for Black (NH) women",
-				trendsCardTitleName: "HIV prevalence for Black (NH) women over time",
-				columnTitleHeader:
-					"HIV prevalence for Black (NH) women per 100k people",
-				shortLabel: "prevalence per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_prevalence_black_women",
-					shortLabel: "Black women living with HIV",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "black_women_population_count",
-					shortLabel: "Total Black women",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle:
-					"Historical relative inequity of HIV prevalence for Black (NH) women",
-				metricId: "hiv_prevalence_black_women_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_diagnoses_black_women",
-		mapConfig: womenHigherIsWorseMapConfig,
-		dataTypeShortLabel: "New Diagnoses for Black Women",
-		fullDisplayName: "New HIV diagnoses for Black women",
-		definition: {
-			text: `Black or African-American (NH) women ages 13+ diagnosed with HIV in a particular year.`,
-		},
-		description: {
-			text: "Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.",
-		},
-		dataTableTitle:
-			"Breakdown summary for new HIV diagnoses for Black (NH) women",
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total HIV prevalence for Black (NH) women',
+          metricId: 'black_women_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: '% of population (Black women)',
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_prevalence_black_women_per_100k',
+        chartTitle: 'HIV prevalence for Black (NH) women',
+        trendsCardTitleName: 'HIV prevalence for Black (NH) women over time',
+        columnTitleHeader:
+          'HIV prevalence for Black (NH) women per 100k people',
+        shortLabel: 'prevalence per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_prevalence_black_women',
+          shortLabel: 'Black women living with HIV',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'black_women_population_count',
+          shortLabel: 'Total Black women',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle:
+          'Historical relative inequity of HIV prevalence for Black (NH) women',
+        metricId: 'hiv_prevalence_black_women_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_diagnoses_black_women',
+    mapConfig: womenHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'New Diagnoses for Black Women',
+    fullDisplayName: 'New HIV diagnoses for Black women',
+    definition: {
+      text: `Black or African-American (NH) women ages 13+ diagnosed with HIV in a particular year.`,
+    },
+    description: {
+      text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
+    },
+    dataTableTitle:
+      'Breakdown summary for new HIV diagnoses for Black (NH) women',
 
-		ageSubPopulationLabel: "Ages 13+",
-		otherSubPopulationLabel: "Black Women",
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total new HIV diagnoses for Black (NH) women",
-				metricId: "hiv_diagnoses_black_women_pct_share",
-				columnTitleHeader:
-					"Share of total new HIV diagnoses for Black (NH) women",
-				trendsCardTitleName:
-					"Inequitable share of new HIV diagnoses for Black (NH) women over time",
-				shortLabel: "% of new HIV diagnoses (Black women)",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total new HIV diagnoses for Black (NH) women",
-					metricId: "black_women_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: "% of population (Black women)",
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_diagnoses_black_women_per_100k",
-				chartTitle: "New HIV diagnoses for Black (NH) women",
-				trendsCardTitleName:
-					"Rates of new HIV diagnoses for Black (NH) women over time",
-				columnTitleHeader: "New HIV diagnoses for Black (NH) women per 100k",
-				shortLabel: "diagnoses per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_diagnoses_black_women",
-					shortLabel: "HIV diagnoses for Black women",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "black_women_population_count",
-					shortLabel: "Total Black women",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle:
-					"Historical relative inequity of new HIV diagnoses for Black (NH) women",
-				metricId: "hiv_diagnoses_black_women_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_deaths_black_women",
-		mapConfig: womenHigherIsWorseMapConfig,
-		dataTypeShortLabel: "Deaths for Black women",
-		fullDisplayName: "HIV deaths for Black women",
-		definition: {
-			text: `Black or African-American (NH) women ages 13+ who died from HIV or AIDS in a particular year.`,
-		},
-		description: {
-			text: "Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.",
-		},
-		dataTableTitle: "Breakdown summary for HIV deaths for Black (NH) women",
+    ageSubPopulationLabel: 'Ages 13+',
+    otherSubPopulationLabel: 'Black Women',
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total new HIV diagnoses for Black (NH) women',
+        metricId: 'hiv_diagnoses_black_women_pct_share',
+        columnTitleHeader:
+          'Share of total new HIV diagnoses for Black (NH) women',
+        trendsCardTitleName:
+          'Inequitable share of new HIV diagnoses for Black (NH) women over time',
+        shortLabel: '% of new HIV diagnoses (Black women)',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total new HIV diagnoses for Black (NH) women',
+          metricId: 'black_women_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: '% of population (Black women)',
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_diagnoses_black_women_per_100k',
+        chartTitle: 'New HIV diagnoses for Black (NH) women',
+        trendsCardTitleName:
+          'Rates of new HIV diagnoses for Black (NH) women over time',
+        columnTitleHeader: 'New HIV diagnoses for Black (NH) women per 100k',
+        shortLabel: 'diagnoses per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_diagnoses_black_women',
+          shortLabel: 'HIV diagnoses for Black women',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'black_women_population_count',
+          shortLabel: 'Total Black women',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle:
+          'Historical relative inequity of new HIV diagnoses for Black (NH) women',
+        metricId: 'hiv_diagnoses_black_women_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_deaths_black_women',
+    mapConfig: womenHigherIsWorseMapConfig,
+    dataTypeShortLabel: 'Deaths for Black women',
+    fullDisplayName: 'HIV deaths for Black women',
+    definition: {
+      text: `Black or African-American (NH) women ages 13+ who died from HIV or AIDS in a particular year.`,
+    },
+    description: {
+      text: 'Black women are disproportionately affected by HIV. In fact, Black women are six times more likely to be diagnosed with HIV than white women. Studying HIV among Black women in regard to health equity can help us to understand why this disparity exists and how to address it.',
+    },
+    dataTableTitle: 'Breakdown summary for HIV deaths for Black (NH) women',
 
-		ageSubPopulationLabel: "Ages 13+",
-		otherSubPopulationLabel: "Black Women",
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total HIV deaths for Black (NH) Women",
-				metricId: "hiv_deaths_black_women_pct_share",
-				columnTitleHeader: "Share of total HIV deaths for Black women",
-				trendsCardTitleName:
-					"Inequitable share of HIV deaths for Black (NH) women over time",
-				shortLabel: "% of HIV deaths (Black women)",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total HIV deaths for Black (NH) women",
-					metricId: "black_women_population_pct",
-					columnTitleHeader: "Population share (ages 13+)", // populationPctTitle,
-					shortLabel: "% of population (Black women)",
-					type: "pct_share",
-				},
-			},
-			per100k: {
-				metricId: "hiv_deaths_black_women_per_100k",
-				chartTitle: "HIV deaths for Black (NH) women",
-				trendsCardTitleName:
-					"Rates of HIV deaths for Black (NH) women over time",
-				columnTitleHeader: "HIV deaths for Black (NH) women per 100k people",
-				shortLabel: "deaths per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "hiv_deaths_black_women",
-					shortLabel: "HIV deaths for Black women",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "black_women_population_count",
-					shortLabel: "Total Black women",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle:
-					"Historical relative inequity of HIV deaths for Black (NH) women",
-				metricId: "hiv_deaths_black_women_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-];
+    ageSubPopulationLabel: 'Ages 13+',
+    otherSubPopulationLabel: 'Black Women',
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total HIV deaths for Black (NH) Women',
+        metricId: 'hiv_deaths_black_women_pct_share',
+        columnTitleHeader: 'Share of total HIV deaths for Black women',
+        trendsCardTitleName:
+          'Inequitable share of HIV deaths for Black (NH) women over time',
+        shortLabel: '% of HIV deaths (Black women)',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total HIV deaths for Black (NH) women',
+          metricId: 'black_women_population_pct',
+          columnTitleHeader: 'Population share (ages 13+)', // populationPctTitle,
+          shortLabel: '% of population (Black women)',
+          type: 'pct_share',
+        },
+      },
+      per100k: {
+        metricId: 'hiv_deaths_black_women_per_100k',
+        chartTitle: 'HIV deaths for Black (NH) women',
+        trendsCardTitleName:
+          'Rates of HIV deaths for Black (NH) women over time',
+        columnTitleHeader: 'HIV deaths for Black (NH) women per 100k people',
+        shortLabel: 'deaths per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'hiv_deaths_black_women',
+          shortLabel: 'HIV deaths for Black women',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'black_women_population_count',
+          shortLabel: 'Total Black women',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle:
+          'Historical relative inequity of HIV deaths for Black (NH) women',
+        metricId: 'hiv_deaths_black_women_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+]
 
 export const HIV_PREP_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "hiv",
-		dataTypeId: "hiv_prep",
-		mapConfig: defaultHigherIsBetterMapConfig,
-		dataTypeShortLabel: "PrEP coverage",
-		fullDisplayName: "PrEP coverage",
-		definition: {
-			text: `Individuals ages 16+ prescribed PrEP medication in a particular year.`,
-		},
-		description: {
-			text: "HIV PrEP is a medication that can help to prevent HIV infection. PrEP is highly effective when taken as prescribed. Studying HIV PrEP in regard to health equity can help us to understand why certain populations are more likely to use PrEP and why others are less likely to use it.",
-		},
-		dataTableTitle: "Breakdown summary for PrEP coverage",
-		ageSubPopulationLabel: "Ages 16+",
-		metrics: {
-			pct_share: {
-				chartTitle: "Share of total PrEP prescriptions",
-				metricId: "hiv_prep_pct_share",
-				columnTitleHeader: "Share of total PrEP prescriptions",
-				trendsCardTitleName:
-					"Inequitable share of PrEP prescriptions over time",
-				shortLabel: "% of PrEP prescriptions",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"PrEP-eligible population vs. distribution of total PrEP prescriptions",
-					metricId: "hiv_prep_population_pct",
-					columnTitleHeader: "PrEP-eligible population share (ages 16+)", // populationPctTitle,
-					shortLabel: "% of PrEP-eligible population",
-					type: "pct_share",
-				},
-			},
-			pct_rate: {
-				metricId: "hiv_prep_coverage",
-				chartTitle: "PrEP coverage",
-				trendsCardTitleName: "Rates of PrEP coverage over time",
-				columnTitleHeader: "PrEP coverage",
-				shortLabel: "% PrEP coverage",
-				type: "pct_rate",
-				rateNumeratorMetric: {
-					metricId: "hiv_prep",
-					shortLabel: "PrEP prescriptions",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "hiv_prep_population",
-					shortLabel: "PrEP-eligible population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Historical relative inequity for PrEP coverage",
-				metricId: "hiv_prep_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-];
+  {
+    categoryId: 'hiv',
+    dataTypeId: 'hiv_prep',
+    mapConfig: defaultHigherIsBetterMapConfig,
+    dataTypeShortLabel: 'PrEP coverage',
+    fullDisplayName: 'PrEP coverage',
+    definition: {
+      text: `Individuals ages 16+ prescribed PrEP medication in a particular year. The rate percentage is calculated as the percentage of PrEP-eligible individuals who were prescribed PrEP.`,
+    },
+    description: {
+      text: 'HIV PrEP is a medication that can help to prevent HIV infection. PrEP is highly effective when taken as prescribed. Studying HIV PrEP in regard to health equity can help us to understand why certain populations are more likely to use PrEP and why others are less likely to use it.',
+    },
+    dataTableTitle: 'Breakdown summary for PrEP coverage',
+    ageSubPopulationLabel: 'PrEP-eligible population, Ages 16+',
+    metrics: {
+      pct_share: {
+        chartTitle: 'Share of total PrEP prescriptions',
+        metricId: 'hiv_prep_pct_share',
+        columnTitleHeader: 'Share of total PrEP prescriptions',
+        trendsCardTitleName:
+          'Inequitable share of PrEP prescriptions over time',
+        shortLabel: '% of PrEP prescriptions',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'PrEP-eligible population vs. distribution of total PrEP prescriptions',
+          metricId: 'hiv_prep_population_pct',
+          columnTitleHeader: 'PrEP-eligible population share (ages 16+)', // populationPctTitle,
+          shortLabel: '% of PrEP-eligible population',
+          type: 'pct_share',
+        },
+      },
+      pct_rate: {
+        metricId: 'hiv_prep_coverage',
+        chartTitle: 'PrEP coverage',
+        trendsCardTitleName: 'Rates of PrEP coverage over time',
+        columnTitleHeader: 'PrEP coverage',
+        shortLabel: '% PrEP coverage',
+        type: 'pct_rate',
+        rateNumeratorMetric: {
+          metricId: 'hiv_prep',
+          shortLabel: 'PrEP prescriptions',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'hiv_prep_population',
+          shortLabel: 'PrEP-eligible population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Historical relative inequity for PrEP coverage',
+        metricId: 'hiv_prep_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+]

--- a/frontend/src/data/config/MetricConfigPDOH.ts
+++ b/frontend/src/data/config/MetricConfigPDOH.ts
@@ -1,362 +1,362 @@
 // 123
 import {
-	defaultHigherIsBetterMapConfig,
-	defaultHigherIsWorseMapConfig,
-	womenHigherIsBetterMapConfig,
-} from "../../charts/mapGlobals";
-import { type DataTypeConfig } from "./MetricConfig";
+  defaultHigherIsBetterMapConfig,
+  defaultHigherIsWorseMapConfig,
+  womenHigherIsBetterMapConfig,
+} from '../../charts/mapGlobals'
+import type { DataTypeConfig } from './MetricConfig'
 import {
-	populationPctShortLabel,
-	populationPctTitle,
-} from "./MetricConfigUtils";
+  populationPctShortLabel,
+  populationPctTitle,
+} from './MetricConfigUtils'
 
 export const PDOH_CATEGORY_DROPDOWNIDS = [
-	"incarceration",
-	"voter_participation",
-	"women_in_gov",
-] as const;
+  'incarceration',
+  'voter_participation',
+  'women_in_gov',
+] as const
 
 export type PDOHDataTypeId =
-	| "jail"
-	| "prison"
-	| "women_in_state_legislature"
-	| "women_in_us_congress";
+  | 'jail'
+  | 'prison'
+  | 'women_in_state_legislature'
+  | 'women_in_us_congress'
 
 export type PDOHMetricId =
-	| "ahr_population_pct"
-	| "cawp_population_pct"
-	| "incarceration_population_pct"
-	| "incarceration_population_estimated_total"
-	| "jail_estimated_total"
-	| "jail_pct_relative_inequity"
-	| "jail_pct_share"
-	| "jail_per_100k"
-	| "pct_share_of_state_leg"
-	| "pct_share_of_us_congress"
-	| "pct_share_of_women_state_leg"
-	| "pct_share_of_women_us_congress"
-	| "prison_estimated_total"
-	| "prison_pct_relative_inequity"
-	| "prison_pct_share"
-	| "prison_per_100k"
-	| "total_confined_children"
-	| "total_state_leg_count"
-	| "total_us_congress_count"
-	| "total_us_congress_names"
-	| "voter_participation_pct_rate"
-	| "voter_participation_pct_share"
-	| "women_state_leg_pct_relative_inequity"
-	| "women_this_race_state_leg_count"
-	| "women_this_race_us_congress_count"
-	| "women_this_race_us_congress_names"
-	| "women_us_congress_pct_relative_inequity"
-	| "women_us_congress_ratio_age_adjusted";
+  | 'ahr_population_pct'
+  | 'cawp_population_pct'
+  | 'incarceration_population_pct'
+  | 'incarceration_population_estimated_total'
+  | 'jail_estimated_total'
+  | 'jail_pct_relative_inequity'
+  | 'jail_pct_share'
+  | 'jail_per_100k'
+  | 'pct_share_of_state_leg'
+  | 'pct_share_of_us_congress'
+  | 'pct_share_of_women_state_leg'
+  | 'pct_share_of_women_us_congress'
+  | 'prison_estimated_total'
+  | 'prison_pct_relative_inequity'
+  | 'prison_pct_share'
+  | 'prison_per_100k'
+  | 'total_confined_children'
+  | 'total_state_leg_count'
+  | 'total_us_congress_count'
+  | 'total_us_congress_names'
+  | 'voter_participation_pct_rate'
+  | 'voter_participation_pct_share'
+  | 'women_state_leg_pct_relative_inequity'
+  | 'women_this_race_state_leg_count'
+  | 'women_this_race_us_congress_count'
+  | 'women_this_race_us_congress_names'
+  | 'women_us_congress_pct_relative_inequity'
+  | 'women_us_congress_ratio_age_adjusted'
 
 export const VOTER_PARTICIPATION_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "pdoh",
-		dataTypeId: "voter_participation",
-		mapConfig: defaultHigherIsBetterMapConfig,
-		description: {
-			text: "Voter participation is important for ensuring that all voices are heard in the political process. People of color and people with low incomes are less likely to vote. Studying voter participation can help us understand why these disparities exist and how to address them.",
-		},
-		dataTypeShortLabel: "Voter participation",
-		fullDisplayName: "Voter participation",
-		fullDisplayNameInline: "voter participation",
-		surveyCollectedData: true,
-		dataTableTitle: "Breakdown summary for voter participation",
-		definition: {
-			text: `U.S. citizens ages 18 and older who voted in the last presidential election.`,
-		},
-		ageSubPopulationLabel: "Ages 18+",
-		metrics: {
-			pct_rate: {
-				metricId: "voter_participation_pct_rate",
-				columnTitleHeader: "Voter Participation",
-				chartTitle: "Voter participation",
-				shortLabel: "% voter participation",
-				type: "pct_rate",
-			},
-			pct_share: {
-				chartTitle: "Share of all voter participation",
-				metricId: "voter_participation_pct_share",
-				columnTitleHeader: "Share of all voter participation",
-				shortLabel: "% of voters",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total voter participation",
-					metricId: "ahr_population_pct",
-					columnTitleHeader: populationPctTitle,
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-			},
-		},
-	},
-];
+  {
+    categoryId: 'pdoh',
+    dataTypeId: 'voter_participation',
+    mapConfig: defaultHigherIsBetterMapConfig,
+    description: {
+      text: 'Voter participation is important for ensuring that all voices are heard in the political process. People of color and people with low incomes are less likely to vote. Studying voter participation can help us understand why these disparities exist and how to address them.',
+    },
+    dataTypeShortLabel: 'Voter participation',
+    fullDisplayName: 'Voter participation',
+    fullDisplayNameInline: 'voter participation',
+    surveyCollectedData: true,
+    dataTableTitle: 'Breakdown summary for voter participation',
+    definition: {
+      text: `U.S. citizens ages 18 and older who voted in the last presidential election.`,
+    },
+    ageSubPopulationLabel: 'U.S. citizens, Ages 18+',
+    metrics: {
+      pct_rate: {
+        metricId: 'voter_participation_pct_rate',
+        columnTitleHeader: 'Voter Participation',
+        chartTitle: 'Voter participation',
+        shortLabel: '% voter participation',
+        type: 'pct_rate',
+      },
+      pct_share: {
+        chartTitle: 'Share of all voter participation',
+        metricId: 'voter_participation_pct_share',
+        columnTitleHeader: 'Share of all voter participation',
+        shortLabel: '% of voters',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total voter participation',
+          metricId: 'ahr_population_pct',
+          columnTitleHeader: populationPctTitle,
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+      },
+    },
+  },
+]
 
 export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "pdoh",
-		dataTypeId: "women_in_us_congress",
-		mapConfig: womenHigherIsBetterMapConfig,
-		dataTypeShortLabel: "US Congress",
-		description: {
-			text: "The number of women in government has increased in recent years. However, women are still underrepresented in government, especially at the highest levels. Studying women in government in regard to health equity can help us to understand how to improve the health of women and to ensure that all voices are heard in the policymaking process.",
-		},
-		fullDisplayName: "Women in US Congress",
-		surveyCollectedData: true,
-		definition: {
-			text: `Individuals identifying as women who have served in the Congress of the United States, including members of the U.S. Senate and members, territorial delegates, and resident commissioners of the U.S. House of Representatives. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
-		},
-		dataTableTitle: "Breakdown summary for Women in US Congress",
-		otherSubPopulationLabel: "US Congress members incl. Territorial Delegates",
-		metrics: {
-			pct_rate: {
-				metricId: "pct_share_of_us_congress",
-				trendsCardTitleName:
-					"Yearly rates of US Congress members identifying as women",
-				columnTitleHeader: "Share of Congress for women of each race",
-				chartTitle: "Current rates of US Congress members identifying as women",
-				shortLabel: "% women in Congress",
-				type: "pct_rate",
-				rateNumeratorMetric: {
-					metricId: "women_this_race_us_congress_count",
-					shortLabel: "members",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "total_us_congress_count",
-					shortLabel: "Total members",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_share: {
-				chartTitle: "Percent share of women US Congress members",
-				metricId: "pct_share_of_women_us_congress",
-				trendsCardTitleName:
-					"Inequitable share of women in U.S. Congress over time",
-				columnTitleHeader: "Percent share of women US Congress members",
-				shortLabel: "% of women members",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total women in US congress",
-					metricId: "cawp_population_pct",
-					columnTitleHeader: "Total population share (all genders)",
-					shortLabel: `${populationPctShortLabel} (all genders)`,
-					type: "pct_share",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle:
-					"Relative racial inequity of women in US Congress over time",
-				metricId: "women_us_congress_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "pdoh",
-		dataTypeId: "women_in_state_legislature",
-		mapConfig: womenHigherIsBetterMapConfig,
-		dataTypeShortLabel: "State legislatures", // DATA TOGGLE
-		fullDisplayName: "Women in state legislatures", // TABLE TITLE,
-		surveyCollectedData: true,
-		definition: {
-			text: `Individuals identifying as women currently serving in their state or territory’s legislature. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
-		},
-		dataTableTitle: "Breakdown summary for Women in state legislatures",
-		otherSubPopulationLabel: "State and Territorial Legislators",
+  {
+    categoryId: 'pdoh',
+    dataTypeId: 'women_in_us_congress',
+    mapConfig: womenHigherIsBetterMapConfig,
+    dataTypeShortLabel: 'US Congress',
+    description: {
+      text: 'The number of women in government has increased in recent years. However, women are still underrepresented in government, especially at the highest levels. Studying women in government in regard to health equity can help us to understand how to improve the health of women and to ensure that all voices are heard in the policymaking process.',
+    },
+    fullDisplayName: 'Women in US Congress',
+    surveyCollectedData: true,
+    definition: {
+      text: `Individuals identifying as women who have served in the Congress of the United States, including members of the U.S. Senate and members, territorial delegates, and resident commissioners of the U.S. House of Representatives. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
+    },
+    dataTableTitle: 'Breakdown summary for Women in US Congress',
+    otherSubPopulationLabel: 'US Congress members incl. Territorial Delegates',
+    metrics: {
+      pct_rate: {
+        metricId: 'pct_share_of_us_congress',
+        trendsCardTitleName:
+          'Yearly rates of US Congress members identifying as women',
+        columnTitleHeader: 'Share of Congress for women of each race',
+        chartTitle: 'Current rates of US Congress members identifying as women',
+        shortLabel: '% women in Congress',
+        type: 'pct_rate',
+        rateNumeratorMetric: {
+          metricId: 'women_this_race_us_congress_count',
+          shortLabel: 'members',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'total_us_congress_count',
+          shortLabel: 'Total members',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_share: {
+        chartTitle: 'Percent share of women US Congress members',
+        metricId: 'pct_share_of_women_us_congress',
+        trendsCardTitleName:
+          'Inequitable share of women in U.S. Congress over time',
+        columnTitleHeader: 'Percent share of women US Congress members',
+        shortLabel: '% of women members',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total women in US congress',
+          metricId: 'cawp_population_pct',
+          columnTitleHeader: 'Total population share (all genders)',
+          shortLabel: `${populationPctShortLabel} (all genders)`,
+          type: 'pct_share',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle:
+          'Relative racial inequity of women in US Congress over time',
+        metricId: 'women_us_congress_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'pdoh',
+    dataTypeId: 'women_in_state_legislature',
+    mapConfig: womenHigherIsBetterMapConfig,
+    dataTypeShortLabel: 'State legislatures', // DATA TOGGLE
+    fullDisplayName: 'Women in state legislatures', // TABLE TITLE,
+    surveyCollectedData: true,
+    definition: {
+      text: `Individuals identifying as women currently serving in their state or territory’s legislature. Women who self-identify as more than one race/ethnicity are included in the rates for each group with which they identify.`,
+    },
+    dataTableTitle: 'Breakdown summary for Women in state legislatures',
+    otherSubPopulationLabel: 'State and Territorial Legislators',
 
-		metrics: {
-			pct_rate: {
-				metricId: "pct_share_of_state_leg",
-				chartTitle: "Percentage of state legislators identifying as women",
-				// MAP CARD HEADING, SIMPLE BAR TITLE, MAP INFO ALERT, TABLE COL HEADER, HI/LOW DROPDOWN FOOTNOTE
-				trendsCardTitleName: "Rates of women in state legislatures over time",
-				columnTitleHeader: "Percentage of women state legislators",
-				shortLabel: "% women in state legislature", // SIMPLE BAR LEGEND, MAP LEGEND, INFO BOX IN MAP CARD
-				type: "pct_rate",
-				rateNumeratorMetric: {
-					metricId: "women_this_race_state_leg_count",
-					shortLabel: "legislators",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "total_state_leg_count",
-					shortLabel: "Total legislators",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_share: {
-				chartTitle: "Percent share of women state legislators", // UNKNOWNS MAP TITLE, DISPARITY BAR TITLE
-				metricId: "pct_share_of_women_state_leg",
-				trendsCardTitleName:
-					"Inequitable share of women in state legislatures over time",
-				columnTitleHeader: "Percent share of women state legislators",
-				shortLabel: "% of women legislators", // DISPARITY BAR LEGEND
-				unknownsVegaLabel: "% unknown race",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle:
-						"Population vs. distribution of total women in state legislatures",
-					metricId: "cawp_population_pct",
-					columnTitleHeader: "Total population share (all genders)", // TABLE COLUMN HEADER
-					shortLabel: `${populationPctShortLabel} (all genders)`, // DISPARITY BAR LEGEND/AXIS
-					type: "pct_share",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle:
-					"Relative racial inequity of women state legislators over time",
-				metricId: "women_state_leg_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-];
+    metrics: {
+      pct_rate: {
+        metricId: 'pct_share_of_state_leg',
+        chartTitle: 'Percentage of state legislators identifying as women',
+        // MAP CARD HEADING, SIMPLE BAR TITLE, MAP INFO ALERT, TABLE COL HEADER, HI/LOW DROPDOWN FOOTNOTE
+        trendsCardTitleName: 'Rates of women in state legislatures over time',
+        columnTitleHeader: 'Percentage of women state legislators',
+        shortLabel: '% women in state legislature', // SIMPLE BAR LEGEND, MAP LEGEND, INFO BOX IN MAP CARD
+        type: 'pct_rate',
+        rateNumeratorMetric: {
+          metricId: 'women_this_race_state_leg_count',
+          shortLabel: 'legislators',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'total_state_leg_count',
+          shortLabel: 'Total legislators',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_share: {
+        chartTitle: 'Percent share of women state legislators', // UNKNOWNS MAP TITLE, DISPARITY BAR TITLE
+        metricId: 'pct_share_of_women_state_leg',
+        trendsCardTitleName:
+          'Inequitable share of women in state legislatures over time',
+        columnTitleHeader: 'Percent share of women state legislators',
+        shortLabel: '% of women legislators', // DISPARITY BAR LEGEND
+        unknownsVegaLabel: '% unknown race',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle:
+            'Population vs. distribution of total women in state legislatures',
+          metricId: 'cawp_population_pct',
+          columnTitleHeader: 'Total population share (all genders)', // TABLE COLUMN HEADER
+          shortLabel: `${populationPctShortLabel} (all genders)`, // DISPARITY BAR LEGEND/AXIS
+          type: 'pct_share',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle:
+          'Relative racial inequity of women state legislators over time',
+        metricId: 'women_state_leg_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+]
 
 export const INCARCERATION_METRICS: DataTypeConfig[] = [
-	{
-		categoryId: "pdoh",
-		dataTypeId: "prison",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		description: {
-			text: "Incarceration has a negative impact on health. People who are incarcerated are more likely to experience chronic diseases, mental illness, and substance use disorders. They are also less likely to have access to quality healthcare. Studying incarceration in regard to health equity can help us to understand how to improve the health of people who are incarcerated and to prevent people from being incarcerated in the first place.",
-		},
-		dataTypeShortLabel: "Prison",
-		fullDisplayName: "People in prison",
-		fullDisplayNameInline: "people in prison",
-		surveyCollectedData: true,
-		definition: {
-			text: `Individuals of any age, including children, under the jurisdiction of an adult prison facility. ‘Age’ reports at the national level include only the subset of this jurisdictional population who have been sentenced to one year or more, which accounted for 97% of the total U.S. prison population in 2020. For all national reports, this rate includes both state and federal prisons. For state number of people incarcerated under the jurisdiction of a state prison system on charges arising from a criminal case in that specific county, which are not available in every state. The county of court commitment is generally where a person was convicted; it is not necessarily the person’s county of residence, and may not even be the county where the crime was committed, but nevertheless is likely to be both.  AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Prisons are longer-term facilities run by the state or the federal government that typically hold felons and persons with sentences of more than one year. Definitions may vary by state.`,
-		},
-		dataTableTitle: "Breakdown summary for people in prison",
-		metrics: {
-			per100k: {
-				metricId: "prison_per_100k",
-				chartTitle: "Prison incarceration",
-				trendsCardTitleName: "Rates of prison incarceration over time",
-				columnTitleHeader: "People in prison per 100k",
-				shortLabel: "prison per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "prison_estimated_total",
-					shortLabel: "in prison",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "incarceration_population_estimated_total",
-					shortLabel: "Total population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_share: {
-				chartTitle: "Percent share of total prison population",
-				metricId: "prison_pct_share",
-				trendsCardTitleName:
-					"Inequitable share of prison incarceration over time",
-				columnTitleHeader: "Percent share of total prison population",
-				shortLabel: "% of prison pop.",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total people in prison",
-					metricId: "incarceration_population_pct",
-					columnTitleHeader: "Total population share",
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-				knownBreakdownComparisonMetric: {
-					chartTitle: "",
-					metricId: "prison_pct_share",
-					columnTitleHeader: "Percent share of total prison population",
-					shortLabel: "% of total prison population",
-					type: "pct_share",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Relative inequity of prison incarceration over time",
-				metricId: "prison_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-	{
-		categoryId: "pdoh",
-		dataTypeId: "jail",
-		mapConfig: defaultHigherIsWorseMapConfig,
-		description: {
-			text: "Incarceration has a negative impact on health. People who are incarcerated are more likely to experience chronic diseases, mental illness, and substance use disorders. They are also less likely to have access to quality healthcare. Studying incarceration in regard to health equity can help us to understand how to improve the health of people who are incarcerated and to prevent people from being incarcerated in the first place.",
-		},
-		dataTypeShortLabel: "Jail",
-		fullDisplayName: "People in jail",
-		fullDisplayNameInline: "people in jail",
-		surveyCollectedData: true,
-		definition: {
-			text: `Individuals of any age, including children, confined in a local, adult jail facility. AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Jails are locally operated short-term facilities that hold inmates awaiting trial or sentencing or both, and inmates sentenced to a term of less than one year, typically misdemeanants. Definitions may vary by state.`,
-		},
-		dataTableTitle: "Breakdown summary for people in jail",
-		metrics: {
-			per100k: {
-				metricId: "jail_per_100k",
-				chartTitle: "Jail incarceration",
-				trendsCardTitleName: "Rates of jail incarceration over time",
-				columnTitleHeader: "People in jail per 100k",
-				shortLabel: "jail per 100k",
-				type: "per100k",
-				rateNumeratorMetric: {
-					metricId: "jail_estimated_total",
-					shortLabel: "in jail",
-					chartTitle: "",
-					type: "count",
-				},
-				rateDenominatorMetric: {
-					metricId: "incarceration_population_estimated_total",
-					shortLabel: "Total population",
-					chartTitle: "",
-					type: "count",
-				},
-			},
-			pct_share: {
-				chartTitle: "Percent share of total jail population",
-				metricId: "jail_pct_share",
-				trendsCardTitleName:
-					"Inequitable share of jail incarceration over time",
-				columnTitleHeader: "Percent share of total jail population",
-				shortLabel: "% of total jail population",
-				type: "pct_share",
-				populationComparisonMetric: {
-					chartTitle: "Population vs. distribution of total people in jail",
-					metricId: "incarceration_population_pct",
-					columnTitleHeader: "Total population share",
-					shortLabel: populationPctShortLabel,
-					type: "pct_share",
-				},
-				knownBreakdownComparisonMetric: {
-					chartTitle: "",
-					metricId: "jail_pct_share",
-					columnTitleHeader: "Percent share of total jail population",
-					shortLabel: "% of total jail population",
-					type: "pct_share",
-				},
-			},
-			pct_relative_inequity: {
-				chartTitle: "Relative inequity of jail incarceration over time",
-				metricId: "jail_pct_relative_inequity",
-				shortLabel: "% relative inequity",
-				type: "pct_relative_inequity",
-			},
-		},
-	},
-];
+  {
+    categoryId: 'pdoh',
+    dataTypeId: 'prison',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    description: {
+      text: 'Incarceration has a negative impact on health. People who are incarcerated are more likely to experience chronic diseases, mental illness, and substance use disorders. They are also less likely to have access to quality healthcare. Studying incarceration in regard to health equity can help us to understand how to improve the health of people who are incarcerated and to prevent people from being incarcerated in the first place.',
+    },
+    dataTypeShortLabel: 'Prison',
+    fullDisplayName: 'People in prison',
+    fullDisplayNameInline: 'people in prison',
+    surveyCollectedData: true,
+    definition: {
+      text: `Individuals of any age, including children, under the jurisdiction of an adult prison facility. ‘Age’ reports at the national level include only the subset of this jurisdictional population who have been sentenced to one year or more, which accounted for 97% of the total U.S. prison population in 2020. For all national reports, this rate includes both state and federal prisons. For state number of people incarcerated under the jurisdiction of a state prison system on charges arising from a criminal case in that specific county, which are not available in every state. The county of court commitment is generally where a person was convicted; it is not necessarily the person’s county of residence, and may not even be the county where the crime was committed, but nevertheless is likely to be both.  AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Prisons are longer-term facilities run by the state or the federal government that typically hold felons and persons with sentences of more than one year. Definitions may vary by state.`,
+    },
+    dataTableTitle: 'Breakdown summary for people in prison',
+    metrics: {
+      per100k: {
+        metricId: 'prison_per_100k',
+        chartTitle: 'Prison incarceration',
+        trendsCardTitleName: 'Rates of prison incarceration over time',
+        columnTitleHeader: 'People in prison per 100k',
+        shortLabel: 'prison per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'prison_estimated_total',
+          shortLabel: 'in prison',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'incarceration_population_estimated_total',
+          shortLabel: 'Total population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_share: {
+        chartTitle: 'Percent share of total prison population',
+        metricId: 'prison_pct_share',
+        trendsCardTitleName:
+          'Inequitable share of prison incarceration over time',
+        columnTitleHeader: 'Percent share of total prison population',
+        shortLabel: '% of prison pop.',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total people in prison',
+          metricId: 'incarceration_population_pct',
+          columnTitleHeader: 'Total population share',
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+        knownBreakdownComparisonMetric: {
+          chartTitle: '',
+          metricId: 'prison_pct_share',
+          columnTitleHeader: 'Percent share of total prison population',
+          shortLabel: '% of total prison population',
+          type: 'pct_share',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Relative inequity of prison incarceration over time',
+        metricId: 'prison_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+  {
+    categoryId: 'pdoh',
+    dataTypeId: 'jail',
+    mapConfig: defaultHigherIsWorseMapConfig,
+    description: {
+      text: 'Incarceration has a negative impact on health. People who are incarcerated are more likely to experience chronic diseases, mental illness, and substance use disorders. They are also less likely to have access to quality healthcare. Studying incarceration in regard to health equity can help us to understand how to improve the health of people who are incarcerated and to prevent people from being incarcerated in the first place.',
+    },
+    dataTypeShortLabel: 'Jail',
+    fullDisplayName: 'People in jail',
+    fullDisplayNameInline: 'people in jail',
+    surveyCollectedData: true,
+    definition: {
+      text: `Individuals of any age, including children, confined in a local, adult jail facility. AK, CT, DE, HI, RI, and VT each operate an integrated system that combines prisons and jails; in accordance with the data sources we include those facilities as adult prisons but not as local jails. Jails are locally operated short-term facilities that hold inmates awaiting trial or sentencing or both, and inmates sentenced to a term of less than one year, typically misdemeanants. Definitions may vary by state.`,
+    },
+    dataTableTitle: 'Breakdown summary for people in jail',
+    metrics: {
+      per100k: {
+        metricId: 'jail_per_100k',
+        chartTitle: 'Jail incarceration',
+        trendsCardTitleName: 'Rates of jail incarceration over time',
+        columnTitleHeader: 'People in jail per 100k',
+        shortLabel: 'jail per 100k',
+        type: 'per100k',
+        rateNumeratorMetric: {
+          metricId: 'jail_estimated_total',
+          shortLabel: 'in jail',
+          chartTitle: '',
+          type: 'count',
+        },
+        rateDenominatorMetric: {
+          metricId: 'incarceration_population_estimated_total',
+          shortLabel: 'Total population',
+          chartTitle: '',
+          type: 'count',
+        },
+      },
+      pct_share: {
+        chartTitle: 'Percent share of total jail population',
+        metricId: 'jail_pct_share',
+        trendsCardTitleName:
+          'Inequitable share of jail incarceration over time',
+        columnTitleHeader: 'Percent share of total jail population',
+        shortLabel: '% of total jail population',
+        type: 'pct_share',
+        populationComparisonMetric: {
+          chartTitle: 'Population vs. distribution of total people in jail',
+          metricId: 'incarceration_population_pct',
+          columnTitleHeader: 'Total population share',
+          shortLabel: populationPctShortLabel,
+          type: 'pct_share',
+        },
+        knownBreakdownComparisonMetric: {
+          chartTitle: '',
+          metricId: 'jail_pct_share',
+          columnTitleHeader: 'Percent share of total jail population',
+          shortLabel: '% of total jail population',
+          type: 'pct_share',
+        },
+      },
+      pct_relative_inequity: {
+        chartTitle: 'Relative inequity of jail incarceration over time',
+        metricId: 'jail_pct_relative_inequity',
+        shortLabel: '% relative inequity',
+        type: 'pct_relative_inequity',
+      },
+    },
+  },
+]

--- a/frontend/src/data/config/MetricConfigSDOH.ts
+++ b/frontend/src/data/config/MetricConfigSDOH.ts
@@ -2,7 +2,7 @@ import {
   medicareHigherIsWorseMapConfig,
   defaultHigherIsWorseMapConfig,
 } from '../../charts/mapGlobals'
-import { type DataTypeConfig } from './MetricConfig'
+import type { DataTypeConfig } from './MetricConfig'
 import {
   populationPctShortLabel,
   populationPctTitle,
@@ -62,7 +62,6 @@ export const UNINSURANCE_METRICS: DataTypeConfig[] = [
     },
     dataTableTitle: 'Breakdown summary for uninsured people',
     metrics: {
-
       pct_rate: {
         metricId: 'uninsured_pct_rate',
         chartTitle: 'Uninsured people',
@@ -123,7 +122,6 @@ export const POVERTY_METRICS: DataTypeConfig[] = [
     },
     dataTableTitle: 'Breakdown summary for people below the poverty line',
     metrics: {
-
       pct_rate: {
         metricId: 'poverty_pct_rate',
         chartTitle: 'People below the poverty line',
@@ -228,7 +226,7 @@ export const PREVENTABLE_HOSP_METRICS: DataTypeConfig[] = [
       text: 'Studying preventable hospitalizations can help us understand why these disparities exist and how to address them.',
     },
     dataTableTitle: 'Breakdown summary for preventable hospitalizations',
-    otherSubPopulationLabel: 'Medicare beneficiaries',
+    otherSubPopulationLabel: 'Medicare beneficiaries, Ages 18+',
     metrics: {
       per100k: {
         metricId: 'preventable_hospitalizations_per_100k',
@@ -256,4 +254,3 @@ export const PREVENTABLE_HOSP_METRICS: DataTypeConfig[] = [
     },
   },
 ]
-


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

updates the sub-group population labels that appear on the cards

## Has this been tested? How?

tests passing

## Screenshots (if appropriate)
<img width="1165" alt="Screenshot 2024-07-30 at 9 17 15 AM" src="https://github.com/user-attachments/assets/4606d9d1-aa27-441c-93ef-5bc06ec880a9">

## Types of changes

(leave all that apply)


- New content or feature


## New frontend preview link is below in the Netlify comment 😎
