### PR TITLE
begins populating ATL gun violence policy content

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -160,10 +160,6 @@ export default function App() {
 											<Route path={POLICY_PAGE_LINK}>
 												<PolicyPage />
 											</Route>
-
-											<Route path={GUN_VIOLENCE_POLICY}>
-												<GunViolencePolicyHomeLink />
-											</Route>
 											
 											<Route path={TERMS_OF_USE_PAGE_LINK}>
 												<TermsOfUsePage />

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -1,7 +1,8 @@
 import { Helmet } from 'react-helmet-async'
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 import { routeConfigs } from '../policyContent/routeConfigs'
 import { GUN_VIOLENCE_POLICY } from '../../../utils/internalRoutes'
+import HetOnThisPageMenu from '../../../styles/HetComponents/HetOnThisPageMenu'
 
 export default function PolicyPage() {
   const location = useLocation()
@@ -23,6 +24,26 @@ export default function PolicyPage() {
 						Gun Violence Section
 					</a>
 
+					<div className='flex flex-wrap grow p-1'>
+						{/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}
+						<div className='px-12 md:hidden'>
+							{routeConfigs.map((routeConfig) => {
+								const match = useRouteMatch({
+									path: routeConfig.path,
+									exact: true,
+								});
+								const hasSublinks =
+									routeConfig.subLinks && routeConfig.subLinks.length > 0;
+								return match && hasSublinks ? (
+									<HetOnThisPageMenu
+										key={routeConfig.path}
+										links={routeConfig.subLinks}
+									/>
+								) : null;
+							})}
+						</div>
+						</div>
+					
 					<section className='m-[2%] max-w-lgXl flex flex-col grow smMd:flex-row smMd:gap-2 md:gap-12'>
 						<div className='flex flex-wrap grow p-1'>
 							<article className='flex w-full flex-col p-8 text-left md:p-0 '>
@@ -43,6 +64,24 @@ export default function PolicyPage() {
 							</article>
 						</div>
 					</section>
+					{/* ON THIS PAGE SUB-MENU - DESKTOP */}
+					<div className='hidden min-w-fit md:block'>
+						{routeConfigs.map((routeConfig) => {
+							const match = useRouteMatch({
+								path: routeConfig.path,
+								exact: true,
+							});
+							const hasSublinks =
+								routeConfig.subLinks && routeConfig.subLinks.length > 0;
+							return match && hasSublinks ? (
+								<HetOnThisPageMenu
+									key={routeConfig.path}
+									links={routeConfig.subLinks}
+									className='sticky right-0 top-4  z-top h-min'
+								/>
+							) : null;
+						})}
+					</div>
 				</div>
 			</>
 		)

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -1,91 +1,91 @@
 import { Helmet } from 'react-helmet-async'
 import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 import { routeConfigs } from '../policyContent/routeConfigs'
-import { GUN_VIOLENCE_POLICY } from '../../../utils/internalRoutes'
 import HetOnThisPageMenu from '../../../styles/HetComponents/HetOnThisPageMenu'
 import HetCardMenu from '../../../styles/HetComponents/HetCardMenu'
 import HetCardMenuMobile from '../../../styles/HetComponents/HetCardMenuMobile'
+import PolicyPagination from './PolicyPagination'
 
 export default function PolicyPage() {
-  const location = useLocation()
+	const location = useLocation()
 
-  const activeRoute = routeConfigs.find(
-    (route) => route.path === location.pathname,
-  )
+	const activeRoute = routeConfigs.find(
+		(route) => route.path === location.pathname,
+	)
 
-  return (
-			<>
-				<Helmet>
-					<title>Policy Context - Health Equity Tracker</title>
-				</Helmet>
+	return (
+		<>
+			<Helmet>
+				<title>Policy Context - Health Equity Tracker</title>
+			</Helmet>
+			<section className='flex w-full justify-center text-left' id='main'>
+				<div className='m-[2%] max-w-lgXl flex flex-col grow smMd:flex-row'>
+					<h2 className='sr-only'>Gun Violence Policy Context Page</h2>
 
-				<div className='flex w-full justify-center'>
-					<h2 className='sr-only'>Policy Context Page</h2>
-					{/* MAIN METHODOLOGY PAGES MENU */}
 					<div className='min-w-fit'>
 						<HetCardMenu className='sticky top-4 z-top hidden h-min max-w-menu smMd:block' />
 						<HetCardMenuMobile className='m-3 smMd:hidden' />
 					</div>
-
-					<div className='flex flex-wrap grow p-1'>
+					<div>
 						{/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}
 						<div className='px-12 md:hidden'>
 							{routeConfigs.map((routeConfig) => {
 								const match = useRouteMatch({
 									path: routeConfig.path,
 									exact: true,
-								});
+								})
 								const hasSublinks =
-									routeConfig.subLinks && routeConfig.subLinks.length > 0;
+									routeConfig.subLinks && routeConfig.subLinks.length > 0
 								return match && hasSublinks ? (
 									<HetOnThisPageMenu
 										key={routeConfig.path}
 										links={routeConfig.subLinks}
 									/>
-								) : null;
+								) : null
 							})}
 						</div>
-						</div>
-					
-					<section className='m-[2%] max-w-lgXl flex flex-col grow smMd:flex-row smMd:gap-2 md:gap-12' id='main'>
-						<div className='flex flex-wrap grow p-1'>
-							<article className='flex w-full flex-col p-8 text-left md:p-0 '>
-								<h2 className='font-serif text-header font-light' >
-									{activeRoute?.label}
-								</h2>
+					</div>
 
-								<Switch>
-									{routeConfigs.map((route) => (
-										<Route
-											key={route.path}
-											exact
-											path={route.path}
-											component={route.component}
-										/>
-									))}
-								</Switch>
-							</article>
-						</div>
+					<section className='flex flex-col justify-end grow mx-12'>
+						<h1 className='sr-only'>{activeRoute?.label}</h1>
+
+						<Switch>
+							<>
+								{/* TEXT */}
+								{routeConfigs.map((route) => (
+									<Route
+										key={route.path}
+										exact
+										path={route.path}
+										component={route.component}
+									/>
+								))}
+								{/* PREV / NEXT */}
+								<PolicyPagination />
+							</>
+						</Switch>
 					</section>
+
 					{/* ON THIS PAGE SUB-MENU - DESKTOP */}
 					<div className='hidden min-w-fit md:block'>
 						{routeConfigs.map((routeConfig) => {
 							const match = useRouteMatch({
 								path: routeConfig.path,
 								exact: true,
-							});
+							})
 							const hasSublinks =
-								routeConfig.subLinks && routeConfig.subLinks.length > 0;
+								routeConfig.subLinks && routeConfig.subLinks.length > 0
 							return match && hasSublinks ? (
 								<HetOnThisPageMenu
 									key={routeConfig.path}
 									links={routeConfig.subLinks}
 									className='sticky right-0 top-4  z-top h-min'
 								/>
-							) : null;
+							) : null
 						})}
 					</div>
 				</div>
-			</>
-		)
+			</section>
+		</>
+	)
 }

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -44,10 +44,10 @@ export default function PolicyPage() {
 						</div>
 						</div>
 					
-					<section className='m-[2%] max-w-lgXl flex flex-col grow smMd:flex-row smMd:gap-2 md:gap-12'>
+					<section className='m-[2%] max-w-lgXl flex flex-col grow smMd:flex-row smMd:gap-2 md:gap-12' id='main'>
 						<div className='flex flex-wrap grow p-1'>
 							<article className='flex w-full flex-col p-8 text-left md:p-0 '>
-								<h2 className='font-serif text-header font-light' id='main'>
+								<h2 className='font-serif text-header font-light' >
 									{activeRoute?.label}
 								</h2>
 

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -3,6 +3,8 @@ import { Route, Switch, useLocation, useRouteMatch } from 'react-router-dom'
 import { routeConfigs } from '../policyContent/routeConfigs'
 import { GUN_VIOLENCE_POLICY } from '../../../utils/internalRoutes'
 import HetOnThisPageMenu from '../../../styles/HetComponents/HetOnThisPageMenu'
+import HetCardMenu from '../../../styles/HetComponents/HetCardMenu'
+import HetCardMenuMobile from '../../../styles/HetComponents/HetCardMenuMobile'
 
 export default function PolicyPage() {
   const location = useLocation()
@@ -19,10 +21,11 @@ export default function PolicyPage() {
 
 				<div className='flex w-full justify-center'>
 					<h2 className='sr-only'>Policy Context Page</h2>
-
-					<a href={GUN_VIOLENCE_POLICY}>
-						Gun Violence Section
-					</a>
+					{/* MAIN METHODOLOGY PAGES MENU */}
+					<div className='min-w-fit'>
+						<HetCardMenu className='sticky top-4 z-top hidden h-min max-w-menu smMd:block' />
+						<HetCardMenuMobile className='m-3 smMd:hidden' />
+					</div>
 
 					<div className='flex flex-wrap grow p-1'>
 						{/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}

--- a/frontend/src/pages/Policy/policyComponents/PolicyPagination.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPagination.tsx
@@ -1,8 +1,8 @@
 import { useHistory, useLocation } from 'react-router-dom'
-import { routeConfigs } from '../methodologyContent/routeConfigs'
+import { routeConfigs } from '../policyContent/routeConfigs'
 import HetPaginationButton from '../../../styles/HetComponents/HetPaginationButton'
 
-export default function MethodologyPagination() {
+export default function PolicyPagination() {
   const history = useHistory()
   const location = useLocation()
 
@@ -25,9 +25,8 @@ export default function MethodologyPagination() {
     }
   }
 
-  /* When a previous or next step isn't available, render empty div to keep flex alignment working */
   return (
-    <div className='mx-0 mb-0 mt-4 flex w-full flex-col justify-between md:mt-8 md:flex-row md:self-stretch max-h-32'>
+    <div className='mx-0 mb-0 mt-auto flex w-full flex-col justify-between md:mt-8 md:flex-row md:self-stretch '>
       {prevRoute ? (
         <HetPaginationButton direction='previous' onClick={goPrevious}>
           {prevRoute.label}

--- a/frontend/src/pages/Policy/policyContent/routeConfigs.tsx
+++ b/frontend/src/pages/Policy/policyContent/routeConfigs.tsx
@@ -23,7 +23,7 @@ export type RouteConfig = {
 export const routeConfigs: RouteConfig[] = [
 	{
 		isTopLevel: true,
-		label: `Georgia's Gun Violence Policy Context Overview`,
+		label: 'Policy Context Introduction',
 		path: GUN_VIOLENCE_POLICY,
 		component: GunViolencePolicyHomeLink,
 		subLinks: [],

--- a/frontend/src/pages/Policy/policySections/CrisisOverviewTab.tsx
+++ b/frontend/src/pages/Policy/policySections/CrisisOverviewTab.tsx
@@ -6,7 +6,75 @@ export default function CrisisOverviewTab() {
 			<Helmet>
 				<title>Crisis Overview - Health Equity Tracker</title>
 			</Helmet>
-			<h2 className='sr-only'>Crisis Overview</h2>
+			<h2 className='sr-only'>
+				Understanding the Crisis of Gun Violence in Atlanta
+			</h2>
+			<div className='flex flex-col gap-2'>			
+			<h2>
+				Understanding the Crisis of Gun Violence in Atlanta
+			</h2>
+				<section className='my-2' id='#introduction'>
+					<h3 className='text-title font-medium'>Introduction</h3>
+					<p>
+						The Health Equity Tracker (HET) in partnership with The Annie E. Casey
+						Foundation expanded its topics to track and integrate gun violence
+						data and community engagement in an initiative to promote community
+						safety and advance health equity within the Fulton and DeKalb counties
+						of Atlanta, Georgia. This research aims to highlight the experiences
+						of these young individuals by providing youth-focused reports to
+						contextualize the impact of the lived experiences and challenges the
+						affected youth have unfortunately faced in their adolescence.
+					</p>
+				</section>
+				<section className='my-2' id='#background'>
+					<div className='mb-2'>
+					<p className='my-0 text-left font-sansTitle text-smallest font-extrabold uppercase text-black tracking-widest'>
+						BY THE NUMBERS
+					</p>
+					<p className='my-0 text-left font-sansTitle text-smallest font-extrabold uppercase text-black tracking-widest'>
+						SOURCE: GUN VIOLENCE ARCHIVE
+					</p>
+					</div>
+					<h3 className='my-0 text-title font-medium text-altGreen'>Background</h3>
+					<p></p>
+					<ul className='list-disc pl-4'>
+						<li>
+							Only four months into 2024, Georgia has already witnessed a
+							staggering toll of over 92 lives lost to firearm-related incidents.
+						</li>
+						<li>
+							In 2023, Atlanta experienced no fewer than six mass shootings, with
+							each event tragically claiming six lives and injuring 22 others,
+							marking a series of deliberate, targeted attacks that shook the
+							community.
+						</li>
+						<li>
+							As of April 2024, firearms have injured four children in Atlanta,
+							raising the total to 53 children injured since 2021, underscoring an
+							urgent need for protective measures.
+						</li>
+						<li>
+							Since 2015, firearms have tragically claimed the lives of 22
+							children in Atlanta.
+						</li>
+					</ul>
+					<p>
+						By expanding the Health Equity Tracker to include gun violence data,
+						the project aims to offer informed insights and actionable
+						information, underpinned by the realities of the crisis in Atlanta.
+						The data aims to foster dialogue, ensuring that stakeholders and the
+						broader community are both informed and involved.
+						<br /><br />
+						We hope this report will equip fellow researchers, policymakers, and
+						other gun violence-prevention organizations with the data necessary to
+						advocate for policy reform that support the work to end the public
+						health crisis of youth-involved gun violence. This collaboration with
+						the Annie E. Casey Foundation not only broadens the scope of the HET
+						but also serves as a stepping-stone for capacity-building, promoting
+						lasting change, and community resilience.
+					</p>
+				</section>
+			</div>
 		</>
 	)
 }

--- a/frontend/src/pages/Policy/policySections/GunViolencePolicyHomeLink.tsx
+++ b/frontend/src/pages/Policy/policySections/GunViolencePolicyHomeLink.tsx
@@ -3,16 +3,6 @@ import { CRISIS_OVERVIEW_TAB, DATA_COLLECTION_TAB, ADDRESSING_INEQUITIES_TAB, CU
 export default function GunViolencePolicyHomeLink() {
 	return (
 		<>
-			<ul>
-				<li><a href={CRISIS_OVERVIEW_TAB}>CRISIS_OVERVIEW_TAB</a></li>
-				<li><a href={DATA_COLLECTION_TAB}>DATA_COLLECTION_TAB</a></li>
-				<li><a href={ADDRESSING_INEQUITIES_TAB}>ADDRESSING_INEQUITIES_TAB</a></li>
-				<li><a href={CURRENT_EFFORTS_TAB}>CURRENT_EFFORTS_TAB</a></li>
-				<li><a href={REFORM_OPPORTUNITIES_TAB}>REFORM_OPPORTUNITIES_TAB</a></li>
-				<li><a href={HOW_TO_USE_THE_DATA_TAB}>HOW_TO_USE_THE_DATA_TAB</a></li>
-				<li><a href={FAQS_TAB}>FAQS_TAB</a></li>
-				<li><a href={POLICY_PAGE_LINK}>POLICY_PAGE_LINK</a></li>
-			</ul>
 			<h1>Gun Violence Policy Context Overview</h1>
 			<section className='py-4 xs:px-8 md:px-24 lg:px-80 max-w-screen'>
 				<p className='my-3 text-center font-roboto text-smallest font-semibold uppercase text-black'>

--- a/frontend/src/pages/Policy/policySections/GunViolencePolicyHomeLink.tsx
+++ b/frontend/src/pages/Policy/policySections/GunViolencePolicyHomeLink.tsx
@@ -1,11 +1,8 @@
-import { CRISIS_OVERVIEW_TAB, DATA_COLLECTION_TAB, ADDRESSING_INEQUITIES_TAB, CURRENT_EFFORTS_TAB, REFORM_OPPORTUNITIES_TAB, HOW_TO_USE_THE_DATA_TAB, FAQS_TAB, POLICY_PAGE_LINK } from "../../../utils/internalRoutes";
-
 export default function GunViolencePolicyHomeLink() {
 	return (
 		<>
-			<h1>Gun Violence Policy Context Overview</h1>
-			<section className='py-4 xs:px-8 md:px-24 lg:px-80 max-w-screen'>
-				<p className='my-3 text-center font-roboto text-smallest font-semibold uppercase text-black'>
+			<section>
+				<p className='mb-3 mt-0 text-center font-roboto text-smallest font-semibold uppercase text-black'>
 					In Focus
 				</p>
 				<div className='flex w-full flex-col justify-center items-center'>

--- a/frontend/src/styles/HetComponents/HetCardMenu.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenu.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import HetListItemButton from './HetListItemButton';
+import HetDivider from './HetDivider';
+import { RouteConfig, routeConfigs } from '../../pages/Policy/policyContent/routeConfigs';
+
+interface HetCardMenuProps {
+	className?: string;
+}
+
+export default function HetCardMenu(props: HetCardMenuProps) {
+	return (
+		<nav
+			aria-label='policy context sections'
+			className={`flex flex-col rounded-sm py-0 tracking-normal shadow-raised-tighter ${props.className ?? ''
+				} `}
+		>
+			{routeConfigs.map((config) => (
+				<HetDesktopMenuItem key={config.path} routeConfig={config} />
+			))}
+		</nav>
+	);
+}
+
+interface HetDesktopMenuItemProps {
+	routeConfig: RouteConfig;
+}
+
+function HetDesktopMenuItem(props: HetDesktopMenuItemProps) {
+	return (
+		<>
+			{props.routeConfig.isTopLevel && <HetDivider />}
+			<Link className='no-underline' to={props.routeConfig.path}>
+				<HetListItemButton
+					className='mx-2 pl-2 font-roboto'
+					selected={window.location.pathname === props.routeConfig.path}
+					aria-label={props.routeConfig.label}
+					option={props.routeConfig.isTopLevel ? 'boldGreen' : 'normalBlack'}
+				>
+					{props.routeConfig.label}
+				</HetListItemButton>
+			</Link>
+		</>
+	);
+}

--- a/frontend/src/styles/HetComponents/HetCardMenuMobile.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenuMobile.tsx
@@ -1,0 +1,48 @@
+import Toolbar from '@mui/material/Toolbar';
+import { Select, FormControl, MenuItem, InputLabel } from '@mui/material';
+import { useHistory } from 'react-router-dom';
+import { routeConfigs } from '../../pages/Policy/policyContent/routeConfigs';
+
+interface HetCardMenuMobileProps {
+	className?: string;
+}
+
+export default function HetCardMenuMobile(
+	props: HetCardMenuMobileProps,
+) {
+	const history = useHistory();
+
+	const handleSelected = (event: any) => {
+		history.push(event.target.value);
+	};
+
+	return (
+		<>
+			<div
+				className={`top-0 z-almostTop flex items-center rounded-sm bg-white p-1 sm:items-start sm:justify-start md:justify-center ${
+					props.className ?? ''
+				}`}
+			>
+				<Toolbar className='w-full'>
+					<FormControl sx={{ minWidth: '90vw' }} size='medium'>
+						<InputLabel id='context-select-label'>
+							Policy Context Pages
+						</InputLabel>
+						<Select
+							labelId='context-select-label'
+							value={window.location.pathname}
+							onChange={handleSelected}
+							label='Policy Context Pages'
+						>
+							{routeConfigs.map((config) => (
+								<MenuItem key={config.path} value={config.path}>
+									{config.label}
+								</MenuItem>
+							))}
+						</Select>
+					</FormControl>
+				</Toolbar>
+			</div>
+		</>
+	);
+}

--- a/frontend/src/styles/HetComponents/HetOnThisPageMenu.tsx
+++ b/frontend/src/styles/HetComponents/HetOnThisPageMenu.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, type ReactNode } from 'react';
-import { Link as ScrollLink } from 'react-scroll';
+import { Link as ScrollLink, Events } from 'react-scroll';
 import { RouteConfig } from '../../pages/Methodology/methodologyContent/routeConfigs';
-
 
 interface HetOnThisPageMenuProps {
 	links?: RouteConfig[];
@@ -16,13 +15,24 @@ export default function HetOnThisPageMenu(props: HetOnThisPageMenuProps) {
 		if (storedActiveLink) {
 			setActiveLink(storedActiveLink);
 		}
-	}, []);
 
-	useEffect(() => {
-		if (activeLink) {
-			sessionStorage.setItem('activeLink', activeLink);
-		}
-	}, [activeLink]);
+		// Scroll event listener
+		Events.scrollEvent.register('end', () => {
+			const activeLinkElement = document.querySelector('.active');
+			if (activeLinkElement) {
+				const newActiveLink = activeLinkElement.getAttribute('to');
+				if (newActiveLink) {
+					setActiveLink(newActiveLink);
+					sessionStorage.setItem('activeLink', newActiveLink);
+				}
+			}
+		});
+
+		// Cleanup scroll event listener
+		return () => {
+			Events.scrollEvent.remove('end');
+		};
+	}, []);
 
 	const handleClick = (path: string) => {
 		setActiveLink(path);
@@ -37,10 +47,9 @@ export default function HetOnThisPageMenu(props: HetOnThisPageMenuProps) {
 				<h4 className='my-3 text-left font-roboto text-smallest font-semibold uppercase text-black'>
 					On this page
 				</h4>
-				<ul className='my-1 list-none space-y-1 pl-0 leading-lhTight lg:space-y-2'>
+				<ul className='my-1 list-none space-y-1 pl-0 leading-lhTight lg:space-y-2 font-roboto text-smallest '>
 					{props.links?.map((link) => (
 						<li key={link.path}>
-							{/* TODO: Keyboard navigation not working */}
 							<CombinedLink
 								to={link.path}
 								isScrollLink
@@ -48,17 +57,15 @@ export default function HetOnThisPageMenu(props: HetOnThisPageMenuProps) {
 								duration={200}
 								spy
 								hashSpy
-								onClick={() => {
-									handleClick(link.path);
-
-								}}
+								onClick={() => handleClick(link.path)}
+								tabIndex={0}
 								className={
-									activeLink === link.path ? 'font-semibold text-altGreen' : ''
+									activeLink === link.path
+										? 'font-semibold text-altGreen'
+										: 'hover:cursor-pointer text-altBlack'
 								}
 							>
-								<span className='font-roboto text-smallest text-altBlack hover:cursor-pointer'>
 									{link.label}
-								</span>
 							</CombinedLink>
 						</li>
 					))}
@@ -68,8 +75,6 @@ export default function HetOnThisPageMenu(props: HetOnThisPageMenuProps) {
 	);
 }
 
-
-
 interface CombinedLinkProps {
 	to: string;
 	isScrollLink: boolean;
@@ -78,13 +83,7 @@ interface CombinedLinkProps {
 }
 
 function CombinedLink(props: CombinedLinkProps) {
-
-	const {
-		to,
-		isScrollLink,
-		children,
-		...rest
-	} = props
+	const { to, isScrollLink, children, ...rest } = props;
 
 	if (isScrollLink) {
 		return (

--- a/frontend/src/styles/HetComponents/HetPaginationButton.tsx
+++ b/frontend/src/styles/HetComponents/HetPaginationButton.tsx
@@ -15,7 +15,7 @@ export default function HetPaginationButton(props: HetPaginationButtonsProps) {
   return (
     <Button
       onClick={props.onClick}
-      className='m-5 flex w-full flex-col justify-center rounded-3xl bg-methodologyGreen font-sansTitle  font-medium leading-lhSomeMoreSpace tracking-wide text-altBlack shadow-raised-tighter hover:shadow-raised lg:w-80 '
+      className='m-5 mt-auto flex md:w-full sm:w-auto flex-col justify-center rounded-3xl bg-methodologyGreen font-sansTitle  font-medium leading-lhSomeMoreSpace tracking-wide text-altBlack shadow-raised-tighter hover:shadow-raised lg:w-80 max-h-32 h-32'
     >
       {/* ARROW AND DIRECTION WORD */}
       <span
@@ -34,7 +34,7 @@ export default function HetPaginationButton(props: HetPaginationButtonsProps) {
         )}
       </span>
       {/* LABEL FOR LINKED PAGE */}
-      <span className='mb-5 flex shrink-0 flex-col justify-center gap-2 self-stretch p-2 text-exploreButton font-semibold'>
+      <span className='mb-5 flex shrink-0 flex-col justify-center gap-2 self-stretch p-2 md:text-exploreButton text-text font-semibold'>
         <span
           className={
             isPrevious


### PR DESCRIPTION
# Description and Motivation
This PR introduces essential context around gun violence in Atlanta and Georgia, enhancing the platform’s policy content. It incorporates card menus aligned with the new methodology redesign and adds pagination buttons for improved navigation across sections. Additionally, efforts were made to address the keyboard focusability issue with the existing ‘on this page’ sublink menu, ensuring it is now accessible and reusable for the policy context.

## Has this been tested? How?
tests passing

## Screenshots (if appropriate)

## Types of changes
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
ℹ️ add `/policy` at the end of preview link to view changes