### PR TITLE
Revert "Bump gunicorn from 22.0.0 to 23.0.0 in /shared_requirements"

### DIFF
--- a/shared_requirements/requirements.txt
+++ b/shared_requirements/requirements.txt
@@ -25,7 +25,7 @@ googleapis-common-protos[grpc]==1.63.2
 grpc-google-iam-v1==0.13.1
 grpcio-status==1.65.4
 grpcio==1.65.4
-gunicorn==23.0.0
+gunicorn==22.0.0
 idna
 importlib-metadata==8.2.0
 iniconfig==2.0.0


### PR DESCRIPTION
Reverts SatcherInstitute/health-equity-tracker#3544