### PR TITLE
Refactor Navigation Bar: Add Menu Folders for Improved Organization and Include CTA

### DIFF
--- a/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
+++ b/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
@@ -3,7 +3,7 @@ import {
   type DataSourceId,
   dataSourceMetadataMap,
 } from '../../data/config/MetadataMap'
-import { type DataSourceMetadata } from '../../data/utils/DatasetTypes'
+import type { DataSourceMetadata } from '../../data/utils/DatasetTypes'
 import {
   DATA_CATALOG_PAGE_LINK,
   EXPLORE_DATA_PAGE_LINK,
@@ -11,7 +11,7 @@ import {
 import { WithMetadata } from '../../data/react/WithLoadingOrErrorUI'
 import { Helmet, HelmetProvider } from 'react-helmet-async'
 import { DATA_SOURCE_PRE_FILTERS, useSearchParams } from '../../utils/urlutils'
-import HetBigCTA from '../../styles/HetComponents/HetBigCTA'
+import HetCTABig from '../../styles/HetComponents/HetCTABig'
 
 // Map of filter id to list of datasets selected by that filter, or empty list
 // for filters that don't have anything selected.
@@ -100,9 +100,9 @@ export default function DataCatalogPage() {
                     </li>
                   ))}
                   {viewingSubsetOfSources && (
-                    <HetBigCTA href={DATA_CATALOG_PAGE_LINK} className='mt-10'>
+                    <HetCTABig href={DATA_CATALOG_PAGE_LINK} className='mt-10'>
                       View All Datasets
-                    </HetBigCTA>
+                    </HetCTABig>
                   )}
                 </>
               )

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -15,7 +15,7 @@ import NewsPreviewCard from '../News/NewsPreviewCard'
 import { useQuery } from 'react-query'
 import type { Article } from '../News/NewsPage'
 import { usePrefersReducedMotion } from '../../utils/hooks/usePrefersReducedMotion'
-import HetBigCTA from '../../styles/HetComponents/HetBigCTA'
+import HetCTABig from '../../styles/HetComponents/HetCTABig'
 import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
 import HetPostsLoading from '../../styles/HetComponents/HetPostsLoading'
 import HetTextArrowLink from '../../styles/HetComponents/HetTextArrowLink'
@@ -125,9 +125,9 @@ function LandingPage() {
             <span className='text-altGreen'>Health Equity Tracker</span>
             <br /> take you?
           </h1>
-          <HetBigCTA id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>
+          <HetCTABig id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>
             Explore the data
-          </HetBigCTA>
+          </HetCTABig>
           <div className='border-solid border-timberwolf border-l-2 border-0 py-0 pl-2 z-1'>
             <p className='py-0 my-0 z-1'>
               Data sourced from major public health agencies
@@ -274,7 +274,7 @@ function LandingPage() {
           </div>
         </div>
         <div className='my-0 py-0 xs:py-0'>
-          <HetBigCTA href={EXPLORE_DATA_PAGE_LINK}>Explore the data</HetBigCTA>
+          <HetCTABig href={EXPLORE_DATA_PAGE_LINK}>Explore the data</HetCTABig>
         </div>
       </section>
 

--- a/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/MethodologyPage.tsx
@@ -65,7 +65,7 @@ export default function MethodologyPage() {
 
               <section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
               {activeRoute?.visible && (
-								<h1 className='font-sansTitle text-bigHeader font-bold my-0 leading-tight'>
+								<h1 className='font-sansTitle text-bigHeader font-bold my-0 leading-lhNormal mb-8'>
 									{activeRoute?.label}
 								</h1>
 							)}

--- a/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom'
 import KeyTermsAccordion from '../methodologyComponents/KeyTermsAccordion'
 import Resources from '../methodologyComponents/Resources'
 import HetNotice from '../../../styles/HetComponents/HetNotice'
-import HetBigCTA from '../../../styles/HetComponents/HetBigCTA'
+import HetCTABig from '../../../styles/HetComponents/HetCTABig'
 import HetTerm from '../../../styles/HetComponents/HetTerm'
 import FormulaFormat from '../methodologyComponents/FormulaFormat'
 import { metricDefinitions } from '../methodologyContent/MetricsDefinitions'
@@ -884,12 +884,12 @@ const AgeAdjustmentLink = () => {
             </table>
 
             <div className='mb-12 mt-24 flex w-full justify-center'>
-              <HetBigCTA
+              <HetCTABig
                 href={EXPLORE_DATA_PAGE_LINK + AGE_ADJUST_HIV_DEATHS_US_SETTING}
                 id='#age-adjustment-explore'
               >
                 <span>Explore age-adjusted ratios →</span>
-              </HetBigCTA>
+              </HetCTABig>
             </div>
           </div>
         </article>

--- a/frontend/src/pages/News/ShareYourStory.tsx
+++ b/frontend/src/pages/News/ShareYourStory.tsx
@@ -1,4 +1,4 @@
-import HetBigCTA from '../../styles/HetComponents/HetBigCTA'
+import HetCTABig from '../../styles/HetComponents/HetCTABig'
 
 export default function ShareYourStory() {
   return (
@@ -128,9 +128,9 @@ export default function ShareYourStory() {
           more inclusive and informed community.
         </p>
         <div className='mt-20 flex justify-center'>
-          <HetBigCTA href='mailto:info@healthequitytracker.org'>
+          <HetCTABig href='mailto:info@healthequitytracker.org'>
             Share your story
-          </HetBigCTA>
+          </HetCTABig>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/News/SinglePost.tsx
+++ b/frontend/src/pages/News/SinglePost.tsx
@@ -11,7 +11,7 @@ import { NEWS_PAGE_LINK } from '../../utils/internalRoutes'
 import { Helmet } from 'react-helmet-async'
 import { useQuery } from 'react-query'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
-import { type Article } from './NewsPage'
+import type { Article } from './NewsPage'
 import hetLogo from '../../assets/AppbarLogo.png'
 import SignupSection from '../ui/SignupSection'
 import ShareButtons, {
@@ -19,7 +19,7 @@ import ShareButtons, {
 } from '../../reports/ui/ShareButtons'
 import HetLinkButton from '../../styles/HetComponents/HetLinkButton'
 import HetPaginationButton from '../../styles/HetComponents/HetPaginationButton'
-import HetBigCTA from '../../styles/HetComponents/HetBigCTA'
+import HetCTABig from '../../styles/HetComponents/HetCTABig'
 
 function prettyDate(dateString: string) {
   const options = { year: 'numeric', month: 'long', day: 'numeric' }
@@ -290,7 +290,7 @@ export default function SinglePost(props: SinglePostProps) {
           {/* OPTIONALLY RENDER CONTINUE READING BUTTON */}
           {fullArticle?.acf?.full_article_url && (
             <div>
-              <HetBigCTA
+              <HetCTABig
                 href={fullArticle.acf.full_article_url}
                 className='mt-10'
               >
@@ -299,7 +299,7 @@ export default function SinglePost(props: SinglePostProps) {
                   ? ` on ${fullArticle.acf.friendly_site_name}`
                   : ''}{' '}
                 <OpenInNewIcon />
-              </HetBigCTA>
+              </HetCTABig>
             </div>
           )}
 

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -60,7 +60,7 @@ export default function PolicyPage() {
 
           <section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
           {activeRoute?.visible && (
-								<h1 className='font-sansTitle text-bigHeader font-bold my-0 leading-tight'>
+								<h1 className='font-sansTitle text-bigHeader font-bold my-0 leading-lhNormal'>
 									{activeRoute?.label}
 								</h1>
 							)}

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -30,6 +30,7 @@ export default function PolicyPage() {
       <div className='smMd:m-5 max-w-lgXl flex flex-col grow smMd:flex-row'>
         <h2 className='sr-only'>Gun Violence Policy Context Page</h2>
 
+<<<<<<< HEAD
         <div className='min-w-fit w-fit max-w-screen'>
           <PolicyCardMenu />
           <PolicyCardMenuMobile />
@@ -105,6 +106,90 @@ export default function PolicyPage() {
                 >
                   {routeConfig.label}
                 </h4>
+=======
+					<div className='min-w-fit w-fit max-w-screen'>
+						<HetCardMenu className='sticky top-24 z-top hidden h-min max-w-menu smMd:block' />
+						<HetCardMenuMobile className='p-3 smMd:hidden max-w-screen min-w-full w-screen mx-auto my-0 px-4 flex justify-center' />
+					</div>
+					<div className='flex grow smMd:flex-col xs:block'>
+						{/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}
+						<div className='md:hidden px-8'>
+							{routeConfigs.map((routeConfig) => {
+								const match = useRouteMatch({
+									path: routeConfig.path,
+									exact: true,
+								})
+								const hasSublinks =
+									routeConfig.subLinks && routeConfig.subLinks.length > 0
+								return match && hasSublinks ? (
+									<div className='mt-2 mb-12' key={routeConfig.path}>
+										<p className='my-0 text-left font-roboto text-smallest font-semibold uppercase text-black'>
+											On this page
+										</p>
+										<HetOnThisPageMenu
+											links={routeConfig.subLinks}
+<<<<<<< HEAD
+											className='w-full'
+=======
+											className=''
+>>>>>>> a3558109 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
+										/>
+									</div>
+								) : null
+							})}
+						</div>
+
+<<<<<<< HEAD
+							<h1 className='sr-only'>{activeRoute?.label}</h1>
+							<h1 className='md:hidden font-sansTitle text-bigHeader font-bold mt-0 mb-2 px-4 leading-[1]'>
+								{activeRoute?.label}
+							</h1>
+						<section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
+=======
+						<section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
+							<h1 className='sr-only'>{activeRoute?.label}</h1>
+							<h1 className='md:hidden font-sansTitle text-bigHeader font-bold mt-0 leading-tight'>
+								{activeRoute?.label}
+							</h1>
+>>>>>>> a3558109 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
+							<Switch>
+								<>
+									{/* TEXT */}
+									{routeConfigs.map((route) => (
+										<Route
+											key={route.path}
+											exact
+											path={route.path}
+											component={route.component}
+										/>
+									))}
+									{/* PREV / NEXT */}
+									<PolicyPagination />
+								</>
+							</Switch>
+						</section>
+					</div>
+					{/* ON THIS PAGE SUB-MENU - DESKTOP */}
+					<div className='hidden min-w-fit md:block'>
+						{routeConfigs.map((routeConfig) => {
+							const match = useRouteMatch({
+								path: routeConfig.path,
+								exact: true,
+							})
+							const hasSublinks =
+								routeConfig.subLinks && routeConfig.subLinks.length > 0
+							return match && hasSublinks ? (
+								<div
+									className='min-w-40 w-48 max-w-40 sticky top-24 z-top hidden h-min max-w-menu smMd:block flex flex-col'
+									key={routeConfig.path}
+								>
+									<p className='my-0 text-left font-roboto text-smallest font-semibold uppercase text-black'>
+										On this page
+									</p>
+									<h4 className='mt-2 mb-4 font-sansTitle text-smallestHeader leading-lhNormal'>
+										{routeConfig.label}
+									</h4>
+>>>>>>> 0b3ae534 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
 
                 <HetOnThisPageMenu
                   links={routeConfig.subLinks}

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -30,7 +30,6 @@ export default function PolicyPage() {
       <div className='smMd:m-5 max-w-lgXl flex flex-col grow smMd:flex-row'>
         <h2 className='sr-only'>Gun Violence Policy Context Page</h2>
 
-<<<<<<< HEAD
         <div className='min-w-fit w-fit max-w-screen'>
           <PolicyCardMenu />
           <PolicyCardMenuMobile />
@@ -106,90 +105,6 @@ export default function PolicyPage() {
                 >
                   {routeConfig.label}
                 </h4>
-=======
-					<div className='min-w-fit w-fit max-w-screen'>
-						<HetCardMenu className='sticky top-24 z-top hidden h-min max-w-menu smMd:block' />
-						<HetCardMenuMobile className='p-3 smMd:hidden max-w-screen min-w-full w-screen mx-auto my-0 px-4 flex justify-center' />
-					</div>
-					<div className='flex grow smMd:flex-col xs:block'>
-						{/* ON THIS PAGE SUB-MENU - MOBILE/TABLET */}
-						<div className='md:hidden px-8'>
-							{routeConfigs.map((routeConfig) => {
-								const match = useRouteMatch({
-									path: routeConfig.path,
-									exact: true,
-								})
-								const hasSublinks =
-									routeConfig.subLinks && routeConfig.subLinks.length > 0
-								return match && hasSublinks ? (
-									<div className='mt-2 mb-12' key={routeConfig.path}>
-										<p className='my-0 text-left font-roboto text-smallest font-semibold uppercase text-black'>
-											On this page
-										</p>
-										<HetOnThisPageMenu
-											links={routeConfig.subLinks}
-<<<<<<< HEAD
-											className='w-full'
-=======
-											className=''
->>>>>>> a3558109 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
-										/>
-									</div>
-								) : null
-							})}
-						</div>
-
-<<<<<<< HEAD
-							<h1 className='sr-only'>{activeRoute?.label}</h1>
-							<h1 className='md:hidden font-sansTitle text-bigHeader font-bold mt-0 mb-2 px-4 leading-[1]'>
-								{activeRoute?.label}
-							</h1>
-						<section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
-=======
-						<section className='flex flex-col justify-end grow mx-8 lg:mx-12 my-0'>
-							<h1 className='sr-only'>{activeRoute?.label}</h1>
-							<h1 className='md:hidden font-sansTitle text-bigHeader font-bold mt-0 leading-tight'>
-								{activeRoute?.label}
-							</h1>
->>>>>>> a3558109 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
-							<Switch>
-								<>
-									{/* TEXT */}
-									{routeConfigs.map((route) => (
-										<Route
-											key={route.path}
-											exact
-											path={route.path}
-											component={route.component}
-										/>
-									))}
-									{/* PREV / NEXT */}
-									<PolicyPagination />
-								</>
-							</Switch>
-						</section>
-					</div>
-					{/* ON THIS PAGE SUB-MENU - DESKTOP */}
-					<div className='hidden min-w-fit md:block'>
-						{routeConfigs.map((routeConfig) => {
-							const match = useRouteMatch({
-								path: routeConfig.path,
-								exact: true,
-							})
-							const hasSublinks =
-								routeConfig.subLinks && routeConfig.subLinks.length > 0
-							return match && hasSublinks ? (
-								<div
-									className='min-w-40 w-48 max-w-40 sticky top-24 z-top hidden h-min max-w-menu smMd:block flex flex-col'
-									key={routeConfig.path}
-								>
-									<p className='my-0 text-left font-roboto text-smallest font-semibold uppercase text-black'>
-										On this page
-									</p>
-									<h4 className='mt-2 mb-4 font-sansTitle text-smallestHeader leading-lhNormal'>
-										{routeConfig.label}
-									</h4>
->>>>>>> 0b3ae534 (replace taviraj h1 with dm sans, shows submenu on all breakpoints)
 
                 <HetOnThisPageMenu
                   links={routeConfig.subLinks}

--- a/frontend/src/reports/ui/Banner.tsx
+++ b/frontend/src/reports/ui/Banner.tsx
@@ -1,78 +1,67 @@
-import React, { useState, useEffect } from 'react';
-import FlagIcon from '@mui/icons-material/Flag';
-import { METHODOLOGY_PAGE_LINK } from '../../utils/internalRoutes';
-import { IconButton } from '@mui/material';
-import HetTextArrowLink from '../../styles/HetComponents/HetTextArrowLink';
+import type React from 'react'
+import { useState, useEffect } from 'react'
+import FlagIcon from '@mui/icons-material/Flag'
+import { METHODOLOGY_PAGE_LINK } from '../../utils/internalRoutes'
+import { IconButton } from '@mui/material'
+import HetTextArrowLink from '../../styles/HetComponents/HetTextArrowLink'
+import { Close } from '@mui/icons-material'
 
 const Banner: React.FC = () => {
-  const [isVisible, setIsVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
-    const currentPath = window.location.pathname;
-    const currentSearch = window.location.search;
-    const bannerClosed = sessionStorage.getItem('bannerClosed');
+    const currentPath = window.location.pathname
+    const currentSearch = window.location.search
+    const bannerClosed = sessionStorage.getItem('bannerClosed')
 
     if (currentPath === '/exploredata' && currentSearch === '' && !bannerClosed) {
-      setIsVisible(true);
+      setIsVisible(true)
     } else {
-      setIsVisible(false);
+      setIsVisible(false)
     }
-  }, [window.location.pathname, window.location.search]);
+  }, [window.location.pathname, window.location.search])
 
   const handleClose = () => {
-    setIsVisible(false);
-    sessionStorage.setItem('bannerClosed', 'true');
-  };
+    setIsVisible(false)
+    sessionStorage.setItem('bannerClosed', 'true')
+  }
 
   if (!isVisible) {
-    return null;
+    return null
   }
 
   return (
-    <section className="bg-infobarColor text-center p-4" aria-labelledby="banner-heading">
-      <div className="flex justify-between">
-        <div className="flex lg:flex-row flex-wrap items-center justify-start md:items-center lg:justify-start m-0 px-2">
+    <section className='bg-infobarColor text-center p-4' aria-labelledby='banner-heading'>
+      <div className='flex justify-between'>
+        <div className='flex lg:flex-row flex-wrap items-center justify-start md:items-center lg:justify-start m-0 px-2'>
           <FlagIcon
-            className="lg:visible hidden mr-2 text-alertColor"
-            aria-hidden="true"
+            className='lg:visible hidden mr-2 text-alertColor'
+            aria-hidden='true'
           />
-          <p className="text-small p-0 my-0 text-left lg:mr-8" id="banner-heading">
-            <span className="font-sansTitle text-small lg:text-text font-bold m-0 p-0">
+          <p className='text-small p-0 my-0 text-left lg:mr-8' id='banner-heading'>
+            <span className='font-sansTitle text-small lg:text-text font-bold m-0 p-0'>
               Major gaps in the data:
             </span>{' '}
             Structural racism causes health inequities. We’re closing these gaps to improve U.S. health policies.
           </p>
           <HetTextArrowLink
             link={`${METHODOLOGY_PAGE_LINK}/limitations#missing-data`}
-            linkText="Learn more"
-            containerClassName="block md:mx-2 md:my-0 mx-0 my-4"
-            linkClassName="text-black"
+            linkText='Learn more'
+            containerClassName='block md:mx-2 md:my-0 mx-0 my-4'
+            linkClassName='text-black'
           />
         </div>
         <IconButton
           onClick={handleClose}
-          className="banner-close-button p-2.5 md:my-auto mb-auto xs:mt-[2px]"
-          aria-label="Close banner"
+          className='banner-close-button p-2.5 md:my-auto mb-auto'
+          aria-label='Close banner'
+          sx={{ borderRadius: 1 }}
         >
-          <div className="icon-small w-embed">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="24"
-              height="24"
-              viewBox="0 0 16 16"
-              fill="none"
-              aria-hidden="true"
-            >
-              <path
-                d="M12.2 3.80667C11.94 3.54667 11.52 3.54667 11.26 3.80667L7.99998 7.06L4.73998 3.8C4.47998 3.54 4.05998 3.54 3.79998 3.8C3.53998 4.06 3.53998 4.48 3.79998 4.74L7.05998 8L3.79998 11.26C3.53998 11.52 3.53998 11.94 3.79998 12.2C4.05998 12.46 4.47998 12.46 4.73998 12.2L7.99998 8.94L11.26 12.2C11.52 12.46 11.94 12.46 12.2 12.2C12.46 11.94 12.46 11.52 12.2 11.26L8.93998 8L12.2 4.74C12.4533 4.48667 12.4533 4.06 12.2 3.80667Z"
-                fill="currentColor"
-              ></path>
-            </svg>
-          </div>
+          <Close/>
         </IconButton>
       </div>
     </section>
-  );
-};
+  )
+}
 
-export default Banner;
+export default Banner

--- a/frontend/src/styles/HetComponents/HetAppBar.tsx
+++ b/frontend/src/styles/HetComponents/HetAppBar.tsx
@@ -5,10 +5,10 @@ import HetMobileToolbar from './HetMobileToolbar'
 export default function HetAppBar() {
   return (
     <AppBar position='static' elevation={0} className='sticky top-0 z-top'>
-      <div className='smMd:hidden'>
+      <div className='md:hidden'>
         <HetMobileToolbar />
       </div>
-      <div className='hidden smMd:block'>
+      <div className='hidden md:block'>
         <HetDesktopToolbar />
       </div>
     </AppBar>

--- a/frontend/src/styles/HetComponents/HetCTABig.tsx
+++ b/frontend/src/styles/HetComponents/HetCTABig.tsx
@@ -1,15 +1,15 @@
 import { Button } from '@mui/material'
-import { type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { useHistory } from 'react-router-dom'
 
-interface HetBigCTAProps {
+interface HetCTABigProps {
 	children: ReactNode
 	href: string
 	id?: string
 	className?: string
 }
 
-export default function HetBigCTA(props: HetBigCTAProps) {
+export default function HetCTABig(props: HetCTABigProps) {
 	const history = useHistory()
 
 	let handleClick = () => {

--- a/frontend/src/styles/HetComponents/HetCTASmall.tsx
+++ b/frontend/src/styles/HetComponents/HetCTASmall.tsx
@@ -3,37 +3,35 @@ import type { ReactNode } from 'react'
 import { useHistory } from 'react-router-dom'
 
 interface HetCTASmallProps {
-	children: ReactNode
-	href: string
-	id?: string
-	className?: string
+  children: ReactNode
+  href: string
+  id?: string
+  className?: string
 }
 
-export default function HetCTASmall(props: HetCTASmallProps) {
-	const history = useHistory()
+export default function HetCTASmall({ children, href, id, className }: HetCTASmallProps) {
+  const history = useHistory()
 
-	let handleClick = () => {
-		history.push(props.href)
-	}
-	let optionalMailTo = undefined
-	if (props.href.startsWith('mailto:')) {
-		handleClick = () => null
-		optionalMailTo = props.href
-	}
+  const handleClick = () => {
+    if (!href.startsWith('mailto:')) {
+      history.push(href)
+    }
+  }
 
-	return (
-		<Button
-			id={props.id}
-			variant='outlined'
-			className={`rounded-2xl my-2 px-8 py-2 w-auto bg-altGreen ${
-				props.className ?? ''
-			}`}
-			href={optionalMailTo}
-			onClick={handleClick}
-		>
-			<span className='text-small text-white font-bold'>
-				{props.children}
-			</span>
-		</Button>
-	)
+  const isMailTo = href.startsWith('mailto:')
+  const optionalMailTo = isMailTo ? href : undefined
+
+  return (
+    <Button
+      id={id}
+      variant='outlined'
+      className={`rounded-2xl my-2 px-8 py-2 w-auto bg-altGreen ${className ?? ''}`}
+      href={optionalMailTo}
+      onClick={isMailTo ? undefined : handleClick}
+    >
+      <span className='text-small text-white font-bold'>
+        {children}
+      </span>
+    </Button>
+  )
 }

--- a/frontend/src/styles/HetComponents/HetCTASmall.tsx
+++ b/frontend/src/styles/HetComponents/HetCTASmall.tsx
@@ -24,8 +24,8 @@ export default function HetCTASmall(props: HetCTASmallProps) {
 	return (
 		<Button
 			id={props.id}
-			variant='contained'
-			className={`rounded-2xl my-2 px-8 py-2 w-auto ${
+			variant='outlined'
+			className={`rounded-2xl my-2 px-8 py-2 w-auto bg-altGreen ${
 				props.className ?? ''
 			}`}
 			href={optionalMailTo}

--- a/frontend/src/styles/HetComponents/HetCTASmall.tsx
+++ b/frontend/src/styles/HetComponents/HetCTASmall.tsx
@@ -1,0 +1,39 @@
+import { Button } from '@mui/material'
+import type { ReactNode } from 'react'
+import { useHistory } from 'react-router-dom'
+
+interface HetCTASmallProps {
+	children: ReactNode
+	href: string
+	id?: string
+	className?: string
+}
+
+export default function HetCTASmall(props: HetCTASmallProps) {
+	const history = useHistory()
+
+	let handleClick = () => {
+		history.push(props.href)
+	}
+	let optionalMailTo = undefined
+	if (props.href.startsWith('mailto:')) {
+		handleClick = () => null
+		optionalMailTo = props.href
+	}
+
+	return (
+		<Button
+			id={props.id}
+			variant='contained'
+			className={`rounded-2xl my-2 px-8 py-2 w-auto ${
+				props.className ?? ''
+			}`}
+			href={optionalMailTo}
+			onClick={handleClick}
+		>
+			<span className='text-small text-white font-bold'>
+				{props.children}
+			</span>
+		</Button>
+	)
+}

--- a/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
@@ -4,7 +4,7 @@ import AppBarLogo from '../../assets/AppbarLogo.png'
 import { NAVIGATION_STRUCTURE } from '../../utils/urlutils'
 import HetNavLink from './HetNavLink'
 import HetNavButton from './HetNavButton'
-import HetCTABig from './HetCTABig'
+import HetCTASmall from './HetCTASmall'
 import { EXPLORE_DATA_PAGE_LINK } from '../../utils/internalRoutes'
 
 export default function HetAppToolbar() {
@@ -25,7 +25,7 @@ export default function HetAppToolbar() {
     return Object.entries(structure).map(([key, value]) => {
       if ('pages' in value) {
         return (
-          <div className='relative' key={key}>
+          <div className='relative flex items-center' key={key}>
             <HetNavButton
               label={value.label}
               onClick={(e) => handleClick(e, key)}
@@ -69,17 +69,17 @@ export default function HetAppToolbar() {
             className='h-littleHetLogo w-littleHetLogo'
             alt='Health Equity Tracker logo'
           />
-          <span className='grow pl-5 text-left font-sansTitle text-navBarHeader font-medium leading-lhSomeSpace text-altGreen no-underline'>
+          <span className='grow pl-5 text-left font-sansTitle text-navBarHeader font-medium leading-lhSomeSpace text-altGreen no-underline lg:flex xs:hidden'>
             Health Equity Tracker
           </span>
         </HetNavLink>
       </h1>
 
-      <nav className='flex max-w-sm flex-wrap justify-evenly lg:max-w-lg'>
+      <nav className='flex flex-wrap justify-evenly'>
         {renderNavItems(NAVIGATION_STRUCTURE)}
-        <HetCTABig id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>
+        <HetCTASmall id='navigationCTA' href={EXPLORE_DATA_PAGE_LINK}>
             Explore the data
-          </HetCTABig>
+          </HetCTASmall>
       </nav>
     </Toolbar>
   )

--- a/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
@@ -11,7 +11,10 @@ export default function HetAppToolbar() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const [activeMenu, setActiveMenu] = useState<string | null>(null)
 
-  const handleClick = (event: React.MouseEvent<HTMLButtonElement>, menuName: string) => {
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    menuName: string,
+  ) => {
     setAnchorEl(event.currentTarget)
     setActiveMenu(menuName)
   }
@@ -45,7 +48,9 @@ export default function HetAppToolbar() {
             </Menu>
           </div>
         )
-      } else if ('link' in value) {
+      }
+
+      if ('link' in value) {
         return (
           <HetNavLink
             key={key}
@@ -56,6 +61,7 @@ export default function HetAppToolbar() {
           </HetNavLink>
         )
       }
+
       return null
     })
   }
@@ -78,8 +84,8 @@ export default function HetAppToolbar() {
       <nav className='flex flex-wrap justify-evenly'>
         {renderNavItems(NAVIGATION_STRUCTURE)}
         <HetCTASmall id='navigationCTA' href={EXPLORE_DATA_PAGE_LINK}>
-            Explore the data
-          </HetCTASmall>
+          Explore the data
+        </HetCTASmall>
       </nav>
     </Toolbar>
   )

--- a/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
@@ -1,9 +1,11 @@
-import { Toolbar, Menu, MenuItem } from '@mui/material'
 import { useState } from 'react'
+import { Toolbar, Menu, MenuItem } from '@mui/material'
 import AppBarLogo from '../../assets/AppbarLogo.png'
-import { PAGE_URL_TO_NAMES } from '../../utils/urlutils'
+import { NAVIGATION_STRUCTURE } from '../../utils/urlutils'
 import HetNavLink from './HetNavLink'
 import HetNavButton from './HetNavButton'
+import HetCTABig from './HetCTABig'
+import { EXPLORE_DATA_PAGE_LINK } from '../../utils/internalRoutes'
 
 export default function HetAppToolbar() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
@@ -17,6 +19,45 @@ export default function HetAppToolbar() {
   const handleClose = () => {
     setAnchorEl(null)
     setActiveMenu(null)
+  }
+
+  const renderNavItems = (structure: typeof NAVIGATION_STRUCTURE) => {
+    return Object.entries(structure).map(([key, value]) => {
+      if ('pages' in value) {
+        return (
+          <div className='relative' key={key}>
+            <HetNavButton
+              label={value.label}
+              onClick={(e) => handleClick(e, key)}
+              isExpanded={activeMenu === key}
+            />
+            <Menu
+              anchorEl={anchorEl}
+              open={activeMenu === key}
+              onClose={handleClose}
+              classes={{ paper: 'bg-white' }}
+            >
+              {Object.entries(value.pages).map(([subKey, subValue]) => (
+                <MenuItem key={subKey} onClick={handleClose}>
+                  <HetNavLink href={subKey}>{subValue}</HetNavLink>
+                </MenuItem>
+              ))}
+            </Menu>
+          </div>
+        )
+      } else if ('link' in value) {
+        return (
+          <HetNavLink
+            key={key}
+            href={value.link}
+            className='my-0 w-auto p-0 font-sansTitle text-small font-medium text-navlinkColor'
+          >
+            {value.label}
+          </HetNavLink>
+        )
+      }
+      return null
+    })
   }
 
   return (
@@ -35,55 +76,10 @@ export default function HetAppToolbar() {
       </h1>
 
       <nav className='flex max-w-sm flex-wrap justify-evenly lg:max-w-lg'>
-        {Object.entries(PAGE_URL_TO_NAMES).map(([pageUrl, pageName]) => (
-          <HetNavLink
-            key={pageUrl}
-            href={pageUrl}
-          
-          >
-            {pageName}
-          </HetNavLink>
-        ))}
-        <div className='relative'>
-        <HetNavButton
-            label='Data'
-            onClick={(e) => handleClick(e, 'Data')}
-            isExpanded={activeMenu === 'Data'}
-          />
-          <Menu
-            anchorEl={anchorEl}
-            open={activeMenu === 'Data'}
-            onClose={handleClose}
-            classes={{ paper: 'bg-white' }}
-          >
-            <MenuItem onClick={handleClose}>
-              <HetNavLink href='/data/explore'>Explore Data</HetNavLink>
-            </MenuItem>
-            <MenuItem onClick={handleClose}>
-              <HetNavLink href='/data/catalog'>Data Catalog</HetNavLink>
-            </MenuItem>
-          </Menu>
-        </div>
-        <div className='relative'>
-        <HetNavButton
-            label='Data'
-            onClick={(e) => handleClick(e, 'Data')}
-            isExpanded={activeMenu === 'Data'}
-          />
-          <Menu
-            anchorEl={anchorEl}
-            open={activeMenu === 'About'}
-            onClose={handleClose}
-            classes={{ paper: 'bg-white' }}
-          >
-            <MenuItem onClick={handleClose}>
-              <HetNavLink href='/about/mission'>Our Mission</HetNavLink>
-            </MenuItem>
-            <MenuItem onClick={handleClose}>
-              <HetNavLink href='/about/team'>Our Team</HetNavLink>
-            </MenuItem>
-          </Menu>
-        </div>
+        {renderNavItems(NAVIGATION_STRUCTURE)}
+        <HetCTABig id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>
+            Explore the data
+          </HetCTABig>
       </nav>
     </Toolbar>
   )

--- a/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetDesktopToolbar.tsx
@@ -1,8 +1,9 @@
-import { Toolbar, Menu, MenuItem, Button, IconButton } from '@mui/material'
+import { Toolbar, Menu, MenuItem } from '@mui/material'
 import { useState } from 'react'
 import AppBarLogo from '../../assets/AppbarLogo.png'
 import { PAGE_URL_TO_NAMES } from '../../utils/urlutils'
 import HetNavLink from './HetNavLink'
+import HetNavButton from './HetNavButton'
 
 export default function HetAppToolbar() {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
@@ -27,22 +28,62 @@ export default function HetAppToolbar() {
             className='h-littleHetLogo w-littleHetLogo'
             alt='Health Equity Tracker logo'
           />
-          <span className='grow pl-5 text-left font-sansTitle text-navBarHeader font-medium leading-lhSomeSpace text-altGreen no-underline lg:inline xs:hidden'>
+          <span className='grow pl-5 text-left font-sansTitle text-navBarHeader font-medium leading-lhSomeSpace text-altGreen no-underline'>
             Health Equity Tracker
           </span>
         </HetNavLink>
       </h1>
 
-      <nav className='flex max-w-md justify-evenly lg:max-w-lg items-center'>
+      <nav className='flex max-w-sm flex-wrap justify-evenly lg:max-w-lg'>
         {Object.entries(PAGE_URL_TO_NAMES).map(([pageUrl, pageName]) => (
           <HetNavLink
             key={pageUrl}
             href={pageUrl}
-            className='my-0 w-fit p-0 font-sansTitle md:text-small sm:text-smallest font-medium text-navlinkColor'
+          
           >
             {pageName}
           </HetNavLink>
         ))}
+        <div className='relative'>
+        <HetNavButton
+            label='Data'
+            onClick={(e) => handleClick(e, 'Data')}
+            isExpanded={activeMenu === 'Data'}
+          />
+          <Menu
+            anchorEl={anchorEl}
+            open={activeMenu === 'Data'}
+            onClose={handleClose}
+            classes={{ paper: 'bg-white' }}
+          >
+            <MenuItem onClick={handleClose}>
+              <HetNavLink href='/data/explore'>Explore Data</HetNavLink>
+            </MenuItem>
+            <MenuItem onClick={handleClose}>
+              <HetNavLink href='/data/catalog'>Data Catalog</HetNavLink>
+            </MenuItem>
+          </Menu>
+        </div>
+        <div className='relative'>
+        <HetNavButton
+            label='Data'
+            onClick={(e) => handleClick(e, 'Data')}
+            isExpanded={activeMenu === 'Data'}
+          />
+          <Menu
+            anchorEl={anchorEl}
+            open={activeMenu === 'About'}
+            onClose={handleClose}
+            classes={{ paper: 'bg-white' }}
+          >
+            <MenuItem onClick={handleClose}>
+              <HetNavLink href='/about/mission'>Our Mission</HetNavLink>
+            </MenuItem>
+            <MenuItem onClick={handleClose}>
+              <HetNavLink href='/about/team'>Our Team</HetNavLink>
+            </MenuItem>
+          </Menu>
+        </div>
       </nav>
     </Toolbar>
   )

--- a/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
@@ -31,10 +31,7 @@ export default function HetMobileAppToolbar() {
       if ('pages' in value) {
         return (
           <div key={key}>
-            <ListItemButton
-              onClick={() => handleToggle(key)}
-              className='w-full'
-            >
+            <ListItemButton onClick={() => handleToggle(key)} className='w-full'>
               <ListItemText primary={value.label} />
               {expandedMenu === key ? <ExpandLess /> : <ExpandMore />}
             </ListItemButton>
@@ -42,23 +39,23 @@ export default function HetMobileAppToolbar() {
               <List component='div' disablePadding>
                 {Object.entries(value.pages).map(([subKey, subValue]) => (
                   <ListItemLink href={subKey} key={subKey} sx={{ pl: 4 }}>
-                    <ListItemText
-                      className='text-altBlack'
-                      primary={subValue}
-                    />
+                    <ListItemText className='text-altBlack' primary={subValue} />
                   </ListItemLink>
                 ))}
               </List>
             </Collapse>
           </div>
         )
-      } else if ('link' in value) {
+      }
+      
+      if ('link' in value) {
         return (
           <ListItemLink href={value.link} key={key}>
             <ListItemText className='text-altBlack' primary={value.label} />
           </ListItemLink>
         )
       }
+
       return null
     })
   }

--- a/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
@@ -1,17 +1,18 @@
 import {
-  Button,
   Drawer,
   IconButton,
   List,
-  ListItem,
   ListItemText,
   Collapse,
   Toolbar,
+  ListItemButton,
 } from '@mui/material'
-import MenuIcon from '@mui/icons-material/Menu'
-import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
-import ExpandLess from '@mui/icons-material/ExpandLess'
-import ExpandMore from '@mui/icons-material/ExpandMore'
+import {
+  Close,
+  ExpandLess,
+  ExpandMore,
+  Menu as MenuIcon,
+} from '@mui/icons-material'
 import { useState } from 'react'
 import { NAVIGATION_STRUCTURE } from '../../utils/urlutils'
 import HetCTASmall from './HetCTASmall'
@@ -30,15 +31,21 @@ export default function HetMobileAppToolbar() {
       if ('pages' in value) {
         return (
           <div key={key}>
-            <ListItem button onClick={() => handleToggle(key)}>
+            <ListItemButton
+              onClick={() => handleToggle(key)}
+              className='w-full'
+            >
               <ListItemText primary={value.label} />
               {expandedMenu === key ? <ExpandLess /> : <ExpandMore />}
-            </ListItem>
-            <Collapse in={expandedMenu === key} timeout="auto" unmountOnExit>
-              <List component="div" disablePadding>
+            </ListItemButton>
+            <Collapse in={expandedMenu === key} timeout='auto' unmountOnExit>
+              <List component='div' disablePadding>
                 {Object.entries(value.pages).map(([subKey, subValue]) => (
                   <ListItemLink href={subKey} key={subKey} sx={{ pl: 4 }}>
-                    <ListItemText primary={subValue} />
+                    <ListItemText
+                      className='text-altBlack'
+                      primary={subValue}
+                    />
                   </ListItemLink>
                 ))}
               </List>
@@ -48,7 +55,7 @@ export default function HetMobileAppToolbar() {
       } else if ('link' in value) {
         return (
           <ListItemLink href={value.link} key={key}>
-            <ListItemText primary={value.label} />
+            <ListItemText className='text-altBlack' primary={value.label} />
           </ListItemLink>
         )
       }
@@ -62,24 +69,43 @@ export default function HetMobileAppToolbar() {
         onClick={() => setOpen(true)}
         aria-label='Expand site navigation'
         size='large'
+        sx={{ borderRadius: 1 }}
       >
         <MenuIcon className='text-white' />
       </IconButton>
-      <Drawer variant='temporary' anchor='left' open={open} onClose={() => setOpen(false)}>
-        <Button
+      <Drawer
+        variant='temporary'
+        anchor='left'
+        open={open}
+        onClose={() => setOpen(false)}
+        sx={{
+          '& .MuiDrawer-paper': {
+            width: '16rem',
+            maxWidth: '100%',
+            padding: '0 16px',
+          },
+        }}
+      >
+        <IconButton
           aria-label='Collapse site navigation'
           onClick={() => setOpen(false)}
+          className='p-2.5 ml-auto mx-2 my-4 text-altBlack'
+          sx={{ borderRadius: 1 }}
         >
-          <ChevronLeftIcon />
-        </Button>
+          <Close />
+        </IconButton>
+
         <nav>
-          <List>
+          <List className='flex flex-col justify-center pt-0'>
             {renderNavItems(NAVIGATION_STRUCTURE)}
-            <HetCTASmall id='navigationCTA' href={EXPLORE_DATA_PAGE_LINK}>
-            Explore the data
-          </HetCTASmall>
+            <HetCTASmall
+              className='my-4'
+              id='navigationCTA'
+              href={EXPLORE_DATA_PAGE_LINK}
+            >
+              Explore the data
+            </HetCTASmall>
           </List>
-          
         </nav>
       </Drawer>
     </Toolbar>
@@ -87,5 +113,5 @@ export default function HetMobileAppToolbar() {
 }
 
 function ListItemLink(props: any) {
-  return <ListItem button component='a' {...props} />
+  return <ListItemButton component='a' {...props} />
 }

--- a/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
+++ b/frontend/src/styles/HetComponents/HetMobileToolbar.tsx
@@ -5,60 +5,81 @@ import {
   List,
   ListItem,
   ListItemText,
+  Collapse,
   Toolbar,
 } from '@mui/material'
 import MenuIcon from '@mui/icons-material/Menu'
 import ChevronLeftIcon from '@mui/icons-material/ChevronLeft'
+import ExpandLess from '@mui/icons-material/ExpandLess'
+import ExpandMore from '@mui/icons-material/ExpandMore'
 import { useState } from 'react'
-import {
-  ADDED_MOBILE_PAGE_URL_TO_NAMES,
-  PAGE_URL_TO_NAMES,
-} from '../../utils/urlutils'
+import { NAVIGATION_STRUCTURE } from '../../utils/urlutils'
+import HetCTASmall from './HetCTASmall'
+import { EXPLORE_DATA_PAGE_LINK } from '../../utils/internalRoutes'
 
 export default function HetMobileAppToolbar() {
   const [open, setOpen] = useState(false)
+  const [expandedMenu, setExpandedMenu] = useState<string | null>(null)
+
+  const handleToggle = (menuName: string) => {
+    setExpandedMenu(expandedMenu === menuName ? null : menuName)
+  }
+
+  const renderNavItems = (structure: typeof NAVIGATION_STRUCTURE) => {
+    return Object.entries(structure).map(([key, value]) => {
+      if ('pages' in value) {
+        return (
+          <div key={key}>
+            <ListItem button onClick={() => handleToggle(key)}>
+              <ListItemText primary={value.label} />
+              {expandedMenu === key ? <ExpandLess /> : <ExpandMore />}
+            </ListItem>
+            <Collapse in={expandedMenu === key} timeout="auto" unmountOnExit>
+              <List component="div" disablePadding>
+                {Object.entries(value.pages).map(([subKey, subValue]) => (
+                  <ListItemLink href={subKey} key={subKey} sx={{ pl: 4 }}>
+                    <ListItemText primary={subValue} />
+                  </ListItemLink>
+                ))}
+              </List>
+            </Collapse>
+          </div>
+        )
+      } else if ('link' in value) {
+        return (
+          <ListItemLink href={value.link} key={key}>
+            <ListItemText primary={value.label} />
+          </ListItemLink>
+        )
+      }
+      return null
+    })
+  }
 
   return (
-    <Toolbar
-      onBlur={() => {
-        setOpen(false)
-      }}
-    >
+    <Toolbar>
       <IconButton
-        onClick={() => {
-          setOpen(true)
-        }}
+        onClick={() => setOpen(true)}
         aria-label='Expand site navigation'
         size='large'
       >
         <MenuIcon className='text-white' />
       </IconButton>
-      <Drawer variant='persistent' anchor='left' open={open}>
+      <Drawer variant='temporary' anchor='left' open={open} onClose={() => setOpen(false)}>
         <Button
           aria-label='Collapse site navigation'
-          onClick={() => {
-            setOpen(false)
-          }}
+          onClick={() => setOpen(false)}
         >
           <ChevronLeftIcon />
         </Button>
         <nav>
           <List>
-            {Object.keys(ADDED_MOBILE_PAGE_URL_TO_NAMES).map(
-              (pageUrl, index) => (
-                <ListItemLink href={pageUrl} key={index}>
-                  <ListItemText
-                    primary={ADDED_MOBILE_PAGE_URL_TO_NAMES[pageUrl]}
-                  />
-                </ListItemLink>
-              )
-            )}
-            {Object.keys(PAGE_URL_TO_NAMES).map((pageUrl, index) => (
-              <ListItemLink href={pageUrl} key={index}>
-                <ListItemText primary={PAGE_URL_TO_NAMES[pageUrl]} />
-              </ListItemLink>
-            ))}
+            {renderNavItems(NAVIGATION_STRUCTURE)}
+            <HetCTASmall id='navigationCTA' href={EXPLORE_DATA_PAGE_LINK}>
+            Explore the data
+          </HetCTASmall>
           </List>
+          
         </nav>
       </Drawer>
     </Toolbar>
@@ -66,5 +87,5 @@ export default function HetMobileAppToolbar() {
 }
 
 function ListItemLink(props: any) {
-  return <ListItem component='a' {...props} />
+  return <ListItem button component='a' {...props} />
 }

--- a/frontend/src/styles/HetComponents/HetNavButton.tsx
+++ b/frontend/src/styles/HetComponents/HetNavButton.tsx
@@ -17,7 +17,7 @@ const HetNavButton: React.FC<HetNavButtonProps> = ({
 }) => {
   return (
     <Button
-      className={`font-sansTitle text-small font-medium text-navlinkColor ${className}`}
+      className={`font-sansTitle text-small font-medium text-navlinkColor mx-2 ${className}`}
       onClick={onClick}
       endIcon={<ExpandMore />}
       aria-haspopup='true'

--- a/frontend/src/styles/HetComponents/HetNavButton.tsx
+++ b/frontend/src/styles/HetComponents/HetNavButton.tsx
@@ -1,0 +1,31 @@
+import type React from 'react'
+import { Button } from '@mui/material'
+import {ExpandMore} from '@mui/icons-material'
+
+interface HetNavButtonProps {
+  label: string
+  onClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+  className?: string
+  isExpanded?: boolean
+}
+
+const HetNavButton: React.FC<HetNavButtonProps> = ({
+  label,
+  onClick,
+  className = '',
+  isExpanded = false,
+}) => {
+  return (
+    <Button
+      className={`font-sansTitle text-small font-medium text-navlinkColor ${className}`}
+      onClick={onClick}
+      endIcon={<ExpandMore />}
+      aria-haspopup='true'
+      aria-expanded={isExpanded}
+    >
+      {label}
+    </Button>
+  )
+}
+
+export default HetNavButton

--- a/frontend/src/styles/HetComponents/HetNavLink.tsx
+++ b/frontend/src/styles/HetComponents/HetNavLink.tsx
@@ -20,7 +20,7 @@ export default function HetNavLink(props: HetNavLinkProps) {
       onClick={props.onClick}
       aria-label={props.ariaLabel}
       className={`no-underline ${props.linkClassName ?? ''}`}>
-      <span className={`px-6 flex items-center justify-center text-altBlack hover:text-altGreen ${props.className ?? ''}`}>
+      <span className={`py-2 px-6 flex items-center justify-center text-altBlack hover:text-altGreen my-0 w-auto font-sansTitle text-small font-medium text-navlinkColor ${props.className ?? ''}`}>
         {props.children}
       </span>
     </Link>

--- a/frontend/src/styles/HetComponents/HetNavLink.tsx
+++ b/frontend/src/styles/HetComponents/HetNavLink.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 interface HetNavLinkProps {
   children: ReactNode
   href?: string
-  onClick?: () => void
+  onClick?: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
   id?: string
   className?: string
   linkClassName?: string
@@ -12,16 +12,30 @@ interface HetNavLinkProps {
   underline?: boolean
 }
 
-export default function HetNavLink(props: HetNavLinkProps) {
+export default function HetNavLink({
+  children,
+  href,
+  onClick,
+  id,
+  className,
+  linkClassName,
+  ariaLabel,
+  underline = false,
+}: HetNavLinkProps) {
   return (
     <Link
       color='primary'
-      href={props.href}
-      onClick={props.onClick}
-      aria-label={props.ariaLabel}
-      className={`no-underline ${props.linkClassName ?? ''}`}>
-      <span className={`py-2 px-6 flex items-center justify-center text-altBlack hover:text-altGreen my-0 w-auto font-sansTitle text-small font-medium text-navlinkColor ${props.className ?? ''}`}>
-        {props.children}
+      href={href || '#'}
+      onClick={onClick}
+      aria-label={ariaLabel}
+      id={id}
+      underline={underline ? 'always' : 'none'}
+      className={`no-underline cursor-pointer flex items-center ${linkClassName ?? ''}`}
+    >
+      <span
+        className={`mx-6 text-altBlack hover:text-altGreen w-auto font-sansTitle text-small font-medium text-navlinkColor ${className ?? ''}`}
+      >
+        {children}
       </span>
     </Link>
   )

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from 'react-router-dom'
-import { type DataTypeId } from '../data/config/MetricConfig'
+import type { DataTypeId } from '../data/config/MetricConfig'
 import { getLogger } from './globals'
 import {
   ABOUT_US_PAGE_LINK,
@@ -11,12 +11,12 @@ import {
   FAQ_TAB_LINK,
   GUN_VIOLENCE_POLICY,
 } from './internalRoutes'
-import { type MadLibId, type PhraseSelections } from './MadLibs'
+import type { MadLibId, PhraseSelections } from './MadLibs'
 import {
   raceNameToCodeMap,
   type DemographicGroup,
 } from '../data/utils/Constants'
-import { type ReactNode } from 'react'
+import type { ReactNode } from 'react'
 import { urlMap } from './externalUrls'
 
 // OLDER HANDLING PARAMS
@@ -101,7 +101,7 @@ export const NAVIGATION_STRUCTURE = {
     label: 'About',
     pages: {
       [WHAT_IS_HEALTH_EQUITY_PAGE_LINK]: 'What is Health Equity?',
-      [GUN_VIOLENCE_POLICY]: 'Policy Context',
+      // [GUN_VIOLENCE_POLICY]: 'Policy Context',
       [ABOUT_US_PAGE_LINK]: 'About Us',
     },
   },

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -8,6 +8,8 @@ import {
   NEWS_PAGE_LINK,
   METHODOLOGY_PAGE_LINK,
   WHAT_IS_HEALTH_EQUITY_PAGE_LINK,
+  FAQ_TAB_LINK,
+  GUN_VIOLENCE_POLICY,
 } from './internalRoutes'
 import { type MadLibId, type PhraseSelections } from './MadLibs'
 import {
@@ -15,6 +17,7 @@ import {
   type DemographicGroup,
 } from '../data/utils/Constants'
 import { type ReactNode } from 'react'
+import { urlMap } from './externalUrls'
 
 // OLDER HANDLING PARAMS
 
@@ -91,6 +94,35 @@ export const PAGE_URL_TO_NAMES: Record<string, string> = {
 
 export const ADDED_MOBILE_PAGE_URL_TO_NAMES: Record<string, string> = {
   '/': 'Home',
+}
+
+export const NAVIGATION_STRUCTURE = {
+  home: { label: 'Home', link: '/' },
+  about: {
+    label: 'About',
+    pages: {
+      [WHAT_IS_HEALTH_EQUITY_PAGE_LINK]: 'What is Health Equity?',
+      [GUN_VIOLENCE_POLICY]: 'Policy Context',
+      [ABOUT_US_PAGE_LINK]: 'About Us',
+    },
+  },
+  exploreTheData: {
+    label: 'Explore the Data',
+    pages: {
+      [EXPLORE_DATA_PAGE_LINK]: 'Explore the Data',
+      [DATA_CATALOG_PAGE_LINK]: 'Data Downloads',
+      [METHODOLOGY_PAGE_LINK]: 'Methodology'
+    },
+  },
+  mediaAndUpdates: {
+    label: 'Media & Updates',
+    pages: {
+      [NEWS_PAGE_LINK]: 'News',
+      [urlMap.hetYouTubeShorts]: 'Videos',
+    },
+  },
+  faqs: { label: 'FAQs', link: FAQ_TAB_LINK },
+  
 }
 
 export function useSearchParams() {

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -97,7 +97,6 @@ export const ADDED_MOBILE_PAGE_URL_TO_NAMES: Record<string, string> = {
 }
 
 export const NAVIGATION_STRUCTURE = {
-  home: { label: 'Home', link: '/' },
   about: {
     label: 'About',
     pages: {


### PR DESCRIPTION
# Description and Motivation
This pull request refactors the existing navigation bar by introducing menu folders (dropdowns) to better organize the menu options and enhance user navigation. The restructured menu allows for grouping related links under expandable sections, improving the overall user experience by reducing visual clutter and providing a more intuitive navigation structure. Additionally, addresses issue #1127 

In addition to the menu folders, a Call to Action (CTA) has been added to the navigation bar, providing users with quick access to our data landing page. This enhancement aims to increase user engagement by making key actions more prominent and accessible.

## Has this been tested? How?
Tests passing

## Screenshots (if appropriate)

> ### Previous version at 1279px
> <img width="1312" alt="Screenshot 2024-08-26 at 9 43 27 PM" src="https://github.com/user-attachments/assets/16250c80-f780-4a43-8d04-17a05c17cdf4">

> ### New version at 1279px
> <img width="1490" alt="Screenshot 2024-08-26 at 9 41 42 PM" src="https://github.com/user-attachments/assets/eabc03aa-9801-4c0e-a33e-884b20ca3dfa">
> 

> ### Previous version at 969px to 768px
> <img width="1312" alt="Screenshot 2024-08-26 at 9 43 45 PM" src="https://github.com/user-attachments/assets/c21a5dfe-e66b-4f18-b61b-f3441a536d3c">
> <img width="1312" alt="Screenshot 2024-08-26 at 9 44 19 PM" src="https://github.com/user-attachments/assets/cc8463ea-158c-412e-8572-0c2dfb39fdd2">

> ### New version at 969px
> <img width="1490" alt="Screenshot 2024-08-26 at 9 42 00 PM" src="https://github.com/user-attachments/assets/7dc2f5b7-0542-493d-9ad9-7ab83152f3f5">

> ### Previous version - mobile
> <img width="210" alt="Screenshot 2024-08-26 at 9 44 37 PM" src="https://github.com/user-attachments/assets/b58c73e9-f3d9-4d35-9578-6d8e8adf440d">

> ### New version - mobile
> <img width="260" alt="Screenshot 2024-08-26 at 9 42 26 PM" src="https://github.com/user-attachments/assets/83519fef-e642-4d34-afcc-7b7771127c17">

> ### New version - desktop folders

> <img width="1490" alt="Screenshot 2024-08-26 at 9 40 50 PM" src="https://github.com/user-attachments/assets/14e40c18-63d9-452a-8e44-49c8a79c98f4">
> <img width="1490" alt="Screenshot 2024-08-26 at 9 40 56 PM" src="https://github.com/user-attachments/assets/72222117-80fe-4997-b6c0-0aadfe0741a2">
> <img width="1490" alt="Screenshot 2024-08-26 at 9 41 01 PM" src="https://github.com/user-attachments/assets/87b73729-167f-40a3-9361-b8fa92d172d1">


## Types of changes
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
