### PR TITLE
fix: E2E COVID tracker test

### DIFF
--- a/frontend/playwright-tests/covid_vaccinations.ci.spec.ts
+++ b/frontend/playwright-tests/covid_vaccinations.ci.spec.ts
@@ -1,36 +1,34 @@
-import { test, expect } from '@playwright/test';
-import AxeBuilder from '@axe-core/playwright';
+import AxeBuilder from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
 
-test.describe.configure({ mode: 'parallel' });
+test.describe.configure({ mode: 'parallel' })
 
 test.describe('Home to COVID Vax by Age', () => {
+  test('Tracker Default to Covid Vax', async ({ page }) => {
+    // Load Tracker Default helper view
+    await page.goto(`/exploredata`, { waitUntil: 'commit' })
 
+    // Stop the pulsing button so we can target it
+    await page.emulateMedia({ reducedMotion: 'reduce' })
 
-    test('Tracker Default to Covid Vax', async ({ page }) => {
+    // Choose VAXX from the no topic screen
+    const madLibTopic = await page.waitForSelector(
+      'button:visible:has-text("select a topic")',
+    )
+    await madLibTopic.click()
+    const covidVaxOption = await page.waitForSelector(
+      'span:has-text("COVID-19 Vaccinations")',
+    )
+    await covidVaxOption.click()
+    await expect(page).toHaveURL(/.*mls=1.covid_vaccinations-3.00/)
 
-        // Load Tracker Default helper view
-        await page.goto(`/exploredata`, { waitUntil: "commit" });
+    // Back button works properly for madlib condition changes
+    await page.goBack()
+    await expect(page).not.toHaveURL(/.*mls=1.covid_vaccinations-3.00/)
 
-        // stop the pulsing button so we can target it
-        await page.emulateMedia({ reducedMotion: "reduce" });
-
-        // choose VAXX from the no topic screen
-        const madLibTopic = page.locator('button:visible:has-text("select a topic")')
-        madLibTopic.click();
-        const covidVaxOption = page.locator('span:has-text("COVID-19 Vaccinations")')
-        covidVaxOption.click();
-        await expect(page).toHaveURL(/.*mls=1.covid_vaccinations-3.00/);
-
-        // back button works properly for madlib condition changes
-        await page.goBack()
-        await expect(page).not.toHaveURL(/.*mls=1.covid_vaccinations-3.00/);
-
-        const accessibilityScanResults = await new AxeBuilder({ page })
-            .exclude('iframe') // YouTube embed is not fully accessible
-            .analyze();
-        expect(accessibilityScanResults.violations).toEqual([]);
-
-    })
-
-
-});
+    const accessibilityScanResults = await new AxeBuilder({ page })
+      .exclude('iframe')
+      .analyze()
+    expect(accessibilityScanResults.violations).toEqual([])
+  })
+})


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
- Fixes E2E test failure in covid_vaccinations.ci.spec.ts
- Updates `page.locator()` to `page.waitForSelector()` for more reliable element selection
- Adds proper `async/await` handling for test actions

## Has this been tested? How?
Yes, this has been tested by:
- Running the specific E2E test locally
- Verifying that the test now passes consistently when selecting the COVID Vaccinations topic
- Confirming all other tests in the E2E suite continue to pass

## Screenshots (if appropriate)
- ![image](https://github.com/user-attachments/assets/dca04b84-b80e-4759-886b-bc677a490df4)
- ![Screenshot 2024-10-28 192627](https://github.com/user-attachments/assets/4984a4ea-169a-4c96-be67-e11cf4173ca1)


## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
