### PR TITLE
Small refactor to InsightDisplay

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -7,6 +7,7 @@ import { WithMetadataAndMetrics } from '../data/react/WithLoadingOrErrorUI'
 import type { MapOfDatasetMetadata } from '../data/utils/DatasetTypes'
 import type { ScrollableHashId } from '../utils/hooks/useStepObserver'
 import CardOptionsMenu from './ui/CardOptionsMenu'
+import InsightDisplay, { SHOW_INSIGHT_GENERATION } from './ui/InsightDisplay'
 import { Sources } from './ui/Sources'
 
 function CardWrapper(props: {
@@ -22,6 +23,7 @@ function CardWrapper(props: {
     queryResponses: MetricQueryResponse[],
     metadata: MapOfDatasetMetadata,
     geoData?: Record<string, any>,
+    knownData?: Record<string, any>,
   ) => JSX.Element
   isCensusNotAcs?: boolean
   scrollToHash: ScrollableHashId
@@ -30,6 +32,9 @@ function CardWrapper(props: {
   isCompareCard?: boolean
   className?: string
   hasIntersectionalAllCompareBar?: boolean
+  shareConfig?: any
+  demographicType?: any
+  metricIds?: any
 }) {
   const loadingComponent = (
     <div
@@ -40,6 +45,8 @@ function CardWrapper(props: {
       <CircularProgress aria-label='loading' />
     </div>
   )
+
+  const shouldShowInsightDisplay = SHOW_INSIGHT_GENERATION && props.shareConfig
 
   return (
     <WithMetadataAndMetrics
@@ -53,6 +60,14 @@ function CardWrapper(props: {
             className={`rounded-sm relative m-2 p-3 shadow-raised bg-white ${props.className}`}
             tabIndex={-1}
           >
+            {shouldShowInsightDisplay && (
+              <InsightDisplay
+                demographicType={props.demographicType}
+                metricIds={props.metricIds}
+                queryResponses={queryResponses}
+                shareConfig={props.shareConfig}
+              />
+            )}
             <CardOptionsMenu
               reportTitle={props.reportTitle}
               scrollToHash={props.scrollToHash}

--- a/frontend/src/cards/DisparityBarChartCard.tsx
+++ b/frontend/src/cards/DisparityBarChartCard.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react'
 import { DisparityBarChart } from '../charts/disparityBarChart/Index'
 import { generateChartTitle, generateSubtitle } from '../charts/utils'
 import type { DataTypeConfig, MetricId } from '../data/config/MetricConfigTypes'
@@ -25,7 +24,6 @@ import {
   splitIntoKnownsAndUnknowns,
 } from '../data/utils/datasetutils'
 import type { Fips } from '../data/utils/Fips'
-import type { ChartData } from '../reports/Report'
 import HetNotice from '../styles/HetComponents/HetNotice'
 import { useGuessPreloadHeight } from '../utils/hooks/useGuessPreloadHeight'
 import type { ScrollableHashId } from '../utils/hooks/useStepObserver'
@@ -42,7 +40,6 @@ interface DisparityBarChartCardProps {
   fips: Fips
   reportTitle: string
   className?: string
-  onDataLoad?: (data: ChartData) => void
 }
 
 // This wrapper ensures the proper key is set to create a new instance when
@@ -106,6 +103,8 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
       minHeight={preloadHeight}
       reportTitle={props.reportTitle}
       className={props.className}
+      shareConfig={shareConfig}
+      metricIds={metricIds}
     >
       {([queryResponse]) => {
         const validData = queryResponse.getValidRowsForField(
@@ -116,14 +115,6 @@ function DisparityBarChartCardWithKey(props: DisparityBarChartCardProps) {
           validData,
           props.demographicType,
         )
-
-        useEffect(() => {
-          const loadData = async () => {
-            if (props.onDataLoad) props.onDataLoad({ knownData, metricIds })
-          }
-
-          loadData()
-        }, [props.onDataLoad])
 
         const isCawp = CAWP_METRICS.includes(shareConfig.metricId)
 

--- a/frontend/src/cards/generateInsights.tsx
+++ b/frontend/src/cards/generateInsights.tsx
@@ -5,6 +5,7 @@ import {
   extractRelevantData,
   getHighestDisparity,
 } from './generateInsightsUtils'
+import { SHOW_INSIGHT_GENERATION } from './ui/InsightDisplay'
 
 export type Dataset = Record<string, any>
 
@@ -77,6 +78,9 @@ export async function fetchAIInsight(prompt: string): Promise<string> {
 }
 
 function generateInsightPrompt(disparities: Disparity): string {
+  if (!SHOW_INSIGHT_GENERATION) {
+    return ''
+  }
   const { subgroup, location, measure, populationShare, outcomeShare, ratio } =
     disparities
 

--- a/frontend/src/cards/ui/InsightDisplay.tsx
+++ b/frontend/src/cards/ui/InsightDisplay.tsx
@@ -2,20 +2,58 @@ import { DeleteForever, TipsAndUpdatesOutlined } from '@mui/icons-material'
 import CircularProgress from '@mui/material/CircularProgress'
 import IconButton from '@mui/material/IconButton'
 import type React from 'react'
+import { useState } from 'react'
+import type {
+  MetricConfig,
+  MetricId,
+} from '../../data/config/MetricConfigTypes'
+import type { DemographicType } from '../../data/query/Breakdowns'
+import type { MetricQueryResponse } from '../../data/query/MetricQuery'
+import { splitIntoKnownsAndUnknowns } from '../../data/utils/datasetutils'
+import { generateInsight } from '../generateInsights'
+
+export const SHOW_INSIGHT_GENERATION = import.meta.env
+  .VITE_SHOW_INSIGHT_GENERATION
+
+export interface ChartData {
+  knownData: Readonly<Record<string, any>>[]
+  metricIds: MetricId[]
+}
 
 type InsightDisplayProps = {
-  insight: string
-  handleGenerateInsight: () => void
-  handleClearInsight: () => void
-  isGeneratingInsight: boolean
+  demographicType: DemographicType
+  metricIds: MetricId[]
+  queryResponses: MetricQueryResponse[]
+  shareConfig: MetricConfig
 }
 
 const InsightDisplay: React.FC<InsightDisplayProps> = ({
-  insight,
-  handleGenerateInsight,
-  handleClearInsight,
-  isGeneratingInsight,
+  queryResponses,
+  shareConfig,
+  demographicType,
+  metricIds,
 }) => {
+  const [insight, setInsight] = useState<string>('')
+  const [isGeneratingInsight, setIsGeneratingInsight] = useState<boolean>(false)
+
+  const queryResponse = queryResponses[0]
+  const validData = queryResponse.getValidRowsForField(shareConfig.metricId)
+  const [knownData] = splitIntoKnownsAndUnknowns(validData, demographicType)
+
+  const handleGenerateInsight = async () => {
+    if (!knownData.length || !metricIds.length) return
+
+    setIsGeneratingInsight(true)
+    try {
+      const newInsight = await generateInsight({ knownData, metricIds })
+      setInsight(newInsight)
+    } finally {
+      setIsGeneratingInsight(false)
+    }
+  }
+
+  const handleClearInsight = () => setInsight('')
+
   return (
     <>
       <IconButton

--- a/frontend/src/cards/ui/InsightDisplay.tsx
+++ b/frontend/src/cards/ui/InsightDisplay.tsx
@@ -33,9 +33,6 @@ const InsightDisplay: React.FC<InsightDisplayProps> = ({
   demographicType,
   metricIds,
 }) => {
-  if (!SHOW_INSIGHT_GENERATION) {
-    return
-  }
   const [insight, setInsight] = useState<string>('')
   const [isGeneratingInsight, setIsGeneratingInsight] = useState<boolean>(false)
 
@@ -44,7 +41,8 @@ const InsightDisplay: React.FC<InsightDisplayProps> = ({
   const [knownData] = splitIntoKnownsAndUnknowns(validData, demographicType)
 
   const handleGenerateInsight = async () => {
-    if (!knownData.length || !metricIds.length) return
+    if (!SHOW_INSIGHT_GENERATION || !knownData.length || !metricIds.length)
+      return
 
     setIsGeneratingInsight(true)
     try {

--- a/frontend/src/cards/ui/InsightDisplay.tsx
+++ b/frontend/src/cards/ui/InsightDisplay.tsx
@@ -33,6 +33,9 @@ const InsightDisplay: React.FC<InsightDisplayProps> = ({
   demographicType,
   metricIds,
 }) => {
+  if (!SHOW_INSIGHT_GENERATION) {
+    return
+  }
   const [insight, setInsight] = useState<string>('')
   const [isGeneratingInsight, setIsGeneratingInsight] = useState<boolean>(false)
 

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -1,16 +1,14 @@
 import { useAtom } from 'jotai'
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { Helmet } from 'react-helmet-async'
 import LazyLoad from 'react-lazyload'
 import AgeAdjustedTableCard from '../cards/AgeAdjustedTableCard'
 import DisparityBarChartCard from '../cards/DisparityBarChartCard'
-import { generateInsight } from '../cards/generateInsights'
 import MapCard from '../cards/MapCard'
 import RateBarChartCard from '../cards/RateBarChartCard'
 import RateTrendsChartCard from '../cards/RateTrendsChartCard'
 import ShareTrendsChartCard from '../cards/ShareTrendsChartCard'
 import TableCard from '../cards/TableCard'
-import InsightDisplay from '../cards/ui/InsightDisplay'
 import UnknownsMapCard from '../cards/UnknownsMapCard'
 import type { DropdownVarId } from '../data/config/DropDownIds'
 import { METRIC_CONFIG } from '../data/config/MetricConfig'
@@ -38,9 +36,6 @@ import { reportProviderSteps } from './ReportProviderSteps'
 import { getAllDemographicOptions } from './reportUtils'
 import ModeSelectorBoxMobile from './ui/ModeSelectorBoxMobile'
 import ShareButtons, { SHARE_LABEL } from './ui/ShareButtons'
-
-export const SHOW_INSIGHT_GENERATION = import.meta.env
-  .VITE_SHOW_INSIGHT_GENERATION
 
 interface ReportProps {
   key: string
@@ -75,30 +70,6 @@ export function Report(props: ReportProps) {
   const [dataTypeConfig, setDataTypeConfig] = useAtom(
     selectedDataTypeConfig1Atom,
   )
-
-  const [insight, setInsight] = useState<string>('')
-  const [isGeneratingInsight, setIsGeneratingInsight] = useState<boolean>(false)
-  const [chartData, setChartData] = useState<ChartData | null>(null)
-
-  const handleChartDataLoad = (data: ChartData) => {
-    setChartData(data)
-  }
-
-  const handleGenerateInsight = async () => {
-    if (!chartData) return
-
-    setIsGeneratingInsight(true)
-    try {
-      const newInsight = await generateInsight(chartData)
-      setInsight(newInsight)
-    } finally {
-      setIsGeneratingInsight(false)
-    }
-  }
-
-  const handleClearInsight = () => {
-    setInsight('')
-  }
 
   const { enabledDemographicOptionsMap, disabledDemographicOptions } =
     getAllDemographicOptions(dataTypeConfig, props.fips)
@@ -291,31 +262,14 @@ export function Report(props: ReportProps) {
                   }}
                 >
                   <LazyLoad offset={800} height={750} once>
-                    {shareMetricConfig &&
-                      (SHOW_INSIGHT_GENERATION ? (
-                        <div className='list-none rounded-md shadow-raised bg-white relative'>
-                          <InsightDisplay
-                            insight={insight}
-                            handleGenerateInsight={handleGenerateInsight}
-                            handleClearInsight={handleClearInsight}
-                            isGeneratingInsight={isGeneratingInsight}
-                          />
-                          <DisparityBarChartCard
-                            dataTypeConfig={dataTypeConfig}
-                            demographicType={demographicType}
-                            fips={props.fips}
-                            reportTitle={props.reportTitle}
-                            onDataLoad={handleChartDataLoad}
-                          />
-                        </div>
-                      ) : (
-                        <DisparityBarChartCard
-                          dataTypeConfig={dataTypeConfig}
-                          demographicType={demographicType}
-                          fips={props.fips}
-                          reportTitle={props.reportTitle}
-                        />
-                      ))}
+                    {shareMetricConfig && (
+                      <DisparityBarChartCard
+                        dataTypeConfig={dataTypeConfig}
+                        demographicType={demographicType}
+                        fips={props.fips}
+                        reportTitle={props.reportTitle}
+                      />
+                    )}
                   </LazyLoad>
                 </div>
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

-Fixes the missing static key word error. 
- Moves the InsightDisplay logic into CardWrapper and out of Report.
- Places insight-related state and handlers (insight, isGeneratingInsight) within the InsightDisplay component itself.
- Simplifies Report and other components by removing redundant logic and relying on centralized handling of insights.

## Screenshots (if appropriate)
![image](https://github.com/user-attachments/assets/e5d1bd63-39bf-4b08-8dc9-423c81375561)

## Types of changes

(leave all that apply)

- Bug fix
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
