### PR TITLE
Frontend: Fix demo labels

### DIFF
--- a/frontend/src/data/providers/PhrmaBrfssProvider.ts
+++ b/frontend/src/data/providers/PhrmaBrfssProvider.ts
@@ -65,17 +65,15 @@ const phrmaBrfssReason =
   'only available when comparing two cancer screening topics'
 
 export const PHRMA_BRFSS_RESTRICTED_DEMOGRAPHIC_DETAILS = [
-  ['income', phrmaBrfssReason],
-  ['insurance_status', phrmaBrfssReason],
-  ['education', phrmaBrfssReason],
+  ['Income', phrmaBrfssReason],
+  ['Insurance Status', phrmaBrfssReason],
+  ['Education', phrmaBrfssReason],
 ]
 
 export const PHRMA_BRFSS_RESTRICTED_DEMOGRAPHIC_WITH_SEX_DETAILS = [
-  ['income', phrmaBrfssReason],
-  ['insurance_status', phrmaBrfssReason],
-  ['education', phrmaBrfssReason],
+  ...PHRMA_BRFSS_RESTRICTED_DEMOGRAPHIC_DETAILS,
   [
-    'sex',
+    'Sex',
     "only available when comparing cancer screening topics that aren't sex-specific",
   ],
 ]

--- a/frontend/src/data/providers/PhrmaProvider.ts
+++ b/frontend/src/data/providers/PhrmaProvider.ts
@@ -92,7 +92,7 @@ export const PHRMA_METRICS: MetricId[] = [
 const phrmaReason = 'only available when comparing two Medicare topics'
 
 export const PHRMA_RESTRICTED_DEMOGRAPHIC_DETAILS = [
-  ['lis', phrmaReason],
+  ['Low Income Subsidy', phrmaReason],
   ['Eligibility', phrmaReason],
 ]
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- fixes #3820
- we should improve this by keeping a unified record of demo type ids and their respective human-readable, title-cased labels. Then each provider can create its own subset of that mapping

## Has this been tested? How?

manually

## Screenshots (if appropriate)

<img width="336" alt="Screenshot 2024-12-05 at 8 16 33 AM" src="https://github.com/user-attachments/assets/fb0ee700-5c02-43ed-a608-17849997b556">


## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
