### PR TITLE
adjusts spacing on demo, topic, and data type selectors

### DIFF
--- a/frontend/src/pages/ExploreData/DataTypeSelector.tsx
+++ b/frontend/src/pages/ExploreData/DataTypeSelector.tsx
@@ -33,8 +33,8 @@ export default function DataTypeSelector(props: DataTypeSelectorProps) {
         <HetPopover popover={popover}>
           {/* DataType SubTopic Dropdown */}
           <>
-            <div className='m-3 flex p-5'>
-              <menu className='m-0 pl-0'>
+          <div className='m-0 flex p-0'>
+          <menu className='m-0 px-0 py-2'>
                 {props.options.map((item: string[]) => {
                   const [optionId, optionDisplayName] = item
                   return (
@@ -45,6 +45,7 @@ export default function DataTypeSelector(props: DataTypeSelectorProps) {
                         popover.close()
                         props.onOptionUpdate(optionId)
                       }}
+                      className='mr-auto ml-6 p-6 text-left'
                     >
                       {optionDisplayName}
                     </HetListBoxOption>

--- a/frontend/src/pages/ExploreData/DataTypeSelector.tsx
+++ b/frontend/src/pages/ExploreData/DataTypeSelector.tsx
@@ -33,8 +33,8 @@ export default function DataTypeSelector(props: DataTypeSelectorProps) {
         <HetPopover popover={popover}>
           {/* DataType SubTopic Dropdown */}
           <>
-          <div className='m-0 flex p-0'>
-          <menu className='m-0 px-0 py-2'>
+            <div className='m-0 flex p-0'>
+              <menu className='m-0 px-0 py-2'>
                 {props.options.map((item: string[]) => {
                   const [optionId, optionDisplayName] = item
                   return (

--- a/frontend/src/pages/ExploreData/DemographicSelector.tsx
+++ b/frontend/src/pages/ExploreData/DemographicSelector.tsx
@@ -36,8 +36,8 @@ export default function DemographicSelector(props: DemographicSelectorProps) {
         <HetPopover popover={popover}>
           {/* Demographic Dropdown */}
           <>
-            <div className='m-3 flex p-5'>
-              <menu className='m-0 pl-0'>
+            <div className='m-0 flex p-0'>
+              <menu className='m-0 px-0 py-2'>
                 {props.options.map((item: string[]) => {
                   const [optionId, optionDisplayName] = item
 
@@ -49,6 +49,7 @@ export default function DemographicSelector(props: DemographicSelectorProps) {
                         popover.close()
                         setDemographicType(optionId as DemographicType)
                       }}
+                      className='mr-auto ml-6 p-6 text-left'
                     >
                       {optionDisplayName}
                     </HetListBoxOption>

--- a/frontend/src/pages/ExploreData/TopicSelector.tsx
+++ b/frontend/src/pages/ExploreData/TopicSelector.tsx
@@ -70,6 +70,7 @@ export default function TopicSelector(props: TopicSelectorProps) {
                             popover.close()
                             props.onOptionUpdate(optionId)
                           }}
+                          className='pl-2'
                         >
                           {DROPDOWN_TOPIC_MAP[optionId]}
                         </HetListBoxOption>


### PR DESCRIPTION
# Description and Motivation
piggybacks off of newly released #3870 with spacing adjustments on `HetListBoxOption` list items

## Has this been tested? How?
tests passing

## Screenshots (if appropriate)
![selectors](https://github.com/user-attachments/assets/e2a1f5cc-c397-4384-8da8-fd7673d2ca2f)

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
