### PR TITLE
Frontend: fixes invisible hover tooltip on trends charts

### DIFF
--- a/frontend/src/charts/trendsChart/TrendsTooltip.tsx
+++ b/frontend/src/charts/trendsChart/TrendsTooltip.tsx
@@ -84,7 +84,7 @@ export function TrendsTooltip({
     : F.dateFromString_YYYY(selectedDate ?? '')
 
   return (
-    <dialog className='h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
+    <aside className='z-top h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
       {/* Date title */}
       <div className='border-0 border-altGrey border-b border-solid pb-3 text-center'>
         <div>{displayDate}</div>
@@ -140,6 +140,6 @@ export function TrendsTooltip({
             },
           )}
       </div>
-    </dialog>
+    </aside>
   )
 }

--- a/frontend/src/charts/trendsChart/TrendsTooltip.tsx
+++ b/frontend/src/charts/trendsChart/TrendsTooltip.tsx
@@ -84,7 +84,7 @@ export function TrendsTooltip({
     : F.dateFromString_YYYY(selectedDate ?? '')
 
   return (
-    <aside className='z-top h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
+    <aside className='h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
       {/* Date title */}
       <div className='border-0 border-altGrey border-b border-solid pb-3 text-center'>
         <div>{displayDate}</div>

--- a/frontend/src/charts/trendsChart/TrendsTooltip.tsx
+++ b/frontend/src/charts/trendsChart/TrendsTooltip.tsx
@@ -84,9 +84,9 @@ export function TrendsTooltip({
     : F.dateFromString_YYYY(selectedDate ?? '')
 
   return (
-    <aside className='h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
+    <figure className='h-full w-min whitespace-nowrap rounded-sm border border-altGrey border-solid bg-white p-3 font-medium font-sansText text-small'>
       {/* Date title */}
-      <div className='border-0 border-altGrey border-b border-solid pb-3 text-center'>
+      <figcaption className='border-0 border-altGrey border-b border-solid pb-3 text-center'>
         <div>{displayDate}</div>
         {/* if per 100k chart and on mobile, add subtitle with units */}
         {isSkinny && type === TYPES.HUNDRED_K && (
@@ -94,7 +94,7 @@ export function TrendsTooltip({
             {F.capitalize(yAxisLabel)}
           </div>
         )}
-      </div>
+      </figcaption>
       <div
         className='grid items-center justify-items-start gap-x-2 gap-y-1 pt-3 text-smallest'
         style={{ gridTemplateColumns: '1fr 50px 1fr' }}
@@ -140,6 +140,6 @@ export function TrendsTooltip({
             },
           )}
       </div>
-    </aside>
+    </figure>
   )
 }


### PR DESCRIPTION
when switching to dialog from aside, the tooltip wasn't appearing anymore (probably a weird z index issue). this change uses `<figure>` and `<figcaption>` for the tooltip and title which is more semantically correct, and also solves the original issue of aside needing to be a top level landmark as flagged by biome a11y checker