### PR TITLE
Typography cleanup

### DIFF
--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -136,12 +136,9 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
           {/* card heading row */}
           <div className='col-span-full flex w-full justify-between'>
             {/* Modal Title */}
-            <h2
-              className='m-2 w-full font-light text-small leading-lhNormal sm:text-text sm:leading-lhModalHeading md:m-2 md:text-exploreButton'
-              id='modalTitle'
-            >
+            <h3 className='m-2 w-full md:m-2' id='modalTitle'>
               {title}
-            </h2>
+            </h3>
           </div>
 
           <ul className='grid list-none grid-cols-2 justify-between gap-2 p-0 sm:grid-cols-3 md:grid-cols-4 md:gap-3 md:p-2 lg:grid-cols-5'>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -38,7 +38,7 @@
 		font-weight: 600;
 		color: theme('colors.altGreen');
 	}
-	h3, h4, h5, h6 {
+	h3, h4, h5 {
 		font-weight: 500;
 		color: theme('colors.altBlack');
 	}
@@ -76,14 +76,6 @@
 		letter-spacing: -0.0125rem;
 		@screen sm {
 			font-size: 1.1rem;
-		}
-	}
-	h6{
-		font-size: 1.125rem;
-		line-height: 1.111;
-		letter-spacing: -0.0125rem;
-		@screen sm {
-			font-size: 1rem;
 		}
 	}
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,11 +34,11 @@
 		letter-spacing: 0.0125rem;
 		text-decoration: none;
 	}
-	h1, h2, h3 {
+	h1, h2 {
 		font-weight: 600;
 		color: theme('colors.altGreen');
 	}
-	h4, h5, h6 {
+	h3, h4, h5, h6 {
 		font-weight: 500;
 		color: theme('colors.altBlack');
 	}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3,93 +3,91 @@
 @tailwind utilities;
 
 @layer base {
-  * {
-    box-sizing: border-box;
-    font-weight: 400;
-  }
-  #root {
-    height: 100%;
-  }
-  html {
-    scroll-behavior: smooth;
-    height: 100%;
-  }
-  body {
-    margin: 0;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    height: 100%;
-    background: theme('colors.white');
-    
-  }
-  ul {
-    margin: 0;
-  }
+	* {
+		box-sizing: border-box;
+		font-weight: 400;
+	}
+	#root {
+		height: 100%;
+	}
+	html {
+		scroll-behavior: smooth;
+		height: 100%;
+	}
+	body {
+		margin: 0;
+		-webkit-font-smoothing: antialiased;
+		-moz-osx-font-smoothing: grayscale;
+		height: 100%;
+		background: theme('colors.white');
+	}
+	ul {
+		margin: 0;
+	}
+	a, h2 > a{
+		font-weight:500;
+	}
+	a:hover{
+		text-decoration: underline;
+	}
+	a, li > button, button > span > span, a > span, button > span, div, div > p, li > span {
+		letter-spacing: 0.0125rem;
+		text-decoration: none;
+	}
+	h1, h2, h3 {
+		font-weight: 600;
+		color: theme('colors.altGreen');
+	}
+	h4, h5, h6 {
+		font-weight: 500;
+		color: theme('colors.altBlack');
+	}
+	h1{
+		font-size: 2.125rem;
+		line-height: 1;
+		letter-spacing: -0.0625rem;
+		@screen sm {
+			font-size: 2rem;
+		}
+	}
+	h2{
+		font-size: 1.875rem;
+		line-height: 1.067;
+		@screen sm {
+			font-size: 1.5rem;
+		}
+	}
+	h3{
+		font-size: 1.5rem;
+		line-height: 1.083;
+		letter-spacing: -0.0125rem;
+		@screen sm {
+			font-size: 1.125rem;
+		}
+	}
+	h4{
+		font-size: 1.125rem;
+		line-height: 1.1;
+		letter-spacing: -0.025rem;
+	}
+	h5{
+		font-size: 1.1rem;
+		line-height: 1.111;
+		letter-spacing: -0.0125rem;
+		@screen sm {
+			font-size: 1.1rem;
+		}
+	}
+	h6{
+		font-size: 1.125rem;
+		line-height: 1.111;
+		letter-spacing: -0.0125rem;
+		@screen sm {
+			font-size: 1rem;
+		}
+	}
+}
 
-a, h2 > a{
-  font-weight:500;
-}
-  a:hover{
-    text-decoration: underline;
-  }
-  a, li > button, button > span > span, a > span, button > span, div, div > p, li > span {
-    letter-spacing: 0.0125rem;
-    text-decoration: none;
-  }
-  h1, h2, h3 {
-    font-weight: 600;
-    color: theme('colors.altGreen');
-  }
-  h4, h5, h6 {
-    font-weight: 500;
-    color: theme('colors.altBlack');
-  }
-  h1{
-    font-size: 2.125rem;
-  line-height: 1;
-  letter-spacing: -0.0625rem;
-    
-    @screen sm  {
-      font-size: 2rem;
-    }
-  }
-  h2{
-    font-size: 1.875rem;
-    line-height: 1.067;
-    
-      @screen sm  {
-        font-size: 1.5rem;
-      }
-  }
-  h3{    font-size: 1.5rem;
-    line-height: 1.083;
-    letter-spacing: -0.0125rem;
-      
-      @screen sm  {
-        font-size: 1.125rem;
-      }}
-  h4{    font-size: 1.125rem;
-    line-height: 1.1;
-    letter-spacing: -0.025rem;
-     
-}
-  h5{    font-size: 1.1rem;
-    line-height: 1.111;
-    letter-spacing: -0.0125rem;
-      
-      @screen sm  {
-        font-size: 1.1rem;
-      }
-  }
-  h6{    font-size: 1.125rem;
-    line-height: 1.111;
-    letter-spacing: -0.0125rem;
-      
-      @screen sm  {
-        font-size: 1rem;
-      }
-  }
-}
 
 /* DEFINE CSS VARIABLES / CUSTOM PROPERTIES */
 :root {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,6 +5,9 @@
 @layer base {
   * {
     box-sizing: border-box;
+    font-weight: 400;
+    font-size:1rem;
+    letter-spacing:-0.02rem;
   }
   #root {
     height: 100%;
@@ -22,6 +25,70 @@
   }
   ul {
     margin: 0;
+  }
+  span {
+    letter-spacing: -0.025rem;
+  }
+  a {
+    letter-spacing: -0.025rem;
+    text-decoration: none;
+  }
+  a:hover{
+    text-decoration: underline;
+  }
+  h1, h2, h3, h4, h5 {
+    font-weight: 700;
+  }
+  h1{
+    font-size: 2.125rem;
+  line-height: 1;
+  letter-spacing: -0.0625rem;
+    
+    @screen sm  {
+      font-size: 1.5rem;
+    }
+  }
+  h2{
+    font-size: 1.875rem;
+    line-height: 1.067;
+      @screen md  {
+        font-size: 1.5rem;
+        
+      }
+      @screen sm  {
+        font-size: 1.125rem;
+      }
+  }
+  h3{    font-size: 1.5rem;
+    line-height: 1.083;
+    letter-spacing: -0.03125rem;
+      
+      @screen sm  {
+        font-size: 1.125rem;
+      }}
+  h4{    font-size: 1.25rem;
+    line-height: 1.1;
+    letter-spacing: -0.025rem;
+      @screen md  {
+        font-size: 1.125rem;
+        
+      }
+}
+  h5{    font-size: 1.125rem;
+    line-height: 1.111;
+    letter-spacing: -0.0125rem;
+      
+      @screen sm  {
+        font-size: 1rem;
+      }
+  }
+  h6{    font-size: 1.125rem;
+    line-height: 1.111;
+    letter-spacing: -0.0125rem;
+      
+      @screen sm  {
+        font-size: 1rem;
+      }
   }
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -8,6 +8,7 @@
     font-weight: 400;
     font-size:1rem;
     letter-spacing:-0.02rem;
+    line-height: 1.5;
   }
   #root {
     height: 100%;
@@ -22,6 +23,7 @@
     -moz-osx-font-smoothing: grayscale;
     height: 100%;
     background: theme('colors.white');
+    
   }
   ul {
     margin: 0;
@@ -29,15 +31,20 @@
   span {
     letter-spacing: -0.025rem;
   }
-  a {
-    letter-spacing: -0.025rem;
+  a, li > button, button > span > span {
+    /* letter-spacing: -0.025rem; */
+    letter-spacing: 0.01rem;
     text-decoration: none;
   }
   a:hover{
     text-decoration: underline;
   }
+  a > span, button > span, div, div > p {
+    letter-spacing: 0.0125rem;
+  }
   h1, h2, h3, h4, h5 {
-    font-weight: 700;
+    font-weight: 600;
+    color: rgb(11 82 64 / var(--tw-text-opacity, 1));
   }
   h1{
     font-size: 2.125rem;
@@ -51,12 +58,9 @@
   h2{
     font-size: 1.875rem;
     line-height: 1.067;
-      @screen md  {
-        font-size: 1.5rem;
-        
-      }
+    
       @screen sm  {
-        font-size: 1.125rem;
+        font-size: 1.5rem;
       }
   }
   h3{    font-size: 1.5rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -7,7 +7,7 @@
     box-sizing: border-box;
     font-weight: 400;
     font-size:1rem;
-    letter-spacing:-0.02rem;
+    letter-spacing:0.01rem;
     line-height: 1.5;
   }
   #root {
@@ -31,20 +31,23 @@
   span {
     letter-spacing: -0.025rem;
   }
-  a, li > button, button > span > span {
-    /* letter-spacing: -0.025rem; */
-    letter-spacing: 0.01rem;
-    text-decoration: none;
-  }
+a, h2 > a{
+  font-weight:500;
+}
   a:hover{
     text-decoration: underline;
   }
-  a > span, button > span, div, div > p {
+  a, li > button, button > span > span, a > span, button > span, div, div > p {
     letter-spacing: 0.0125rem;
+    text-decoration: none;
   }
-  h1, h2, h3, h4, h5 {
+  h1, h2, h3 {
     font-weight: 600;
-    color: rgb(11 82 64 / var(--tw-text-opacity, 1));
+    color: theme('colors.altGreen');
+  }
+  h4, h5, h6 {
+    font-weight: 500;
+    color: theme('colors.altBlack');
   }
   h1{
     font-size: 2.125rem;
@@ -52,7 +55,7 @@
   letter-spacing: -0.0625rem;
     
     @screen sm  {
-      font-size: 1.5rem;
+      font-size: 2rem;
     }
   }
   h2{
@@ -70,20 +73,17 @@
       @screen sm  {
         font-size: 1.125rem;
       }}
-  h4{    font-size: 1.25rem;
+  h4{    font-size: 1.125rem;
     line-height: 1.1;
     letter-spacing: -0.025rem;
-      @screen md  {
-        font-size: 1.125rem;
-        
-      }
+     
 }
-  h5{    font-size: 1.125rem;
+  h5{    font-size: 1.1rem;
     line-height: 1.111;
     letter-spacing: -0.0125rem;
       
       @screen sm  {
-        font-size: 1rem;
+        font-size: 1.1rem;
       }
   }
   h6{    font-size: 1.125rem;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -6,9 +6,6 @@
   * {
     box-sizing: border-box;
     font-weight: 400;
-    font-size:1rem;
-    letter-spacing:0.01rem;
-    line-height: 1.5;
   }
   #root {
     height: 100%;
@@ -28,16 +25,14 @@
   ul {
     margin: 0;
   }
-  span {
-    letter-spacing: -0.025rem;
-  }
+
 a, h2 > a{
   font-weight:500;
 }
   a:hover{
     text-decoration: underline;
   }
-  a, li > button, button > span > span, a > span, button > span, div, div > p {
+  a, li > button, button > span > span, a > span, button > span, div, div > p, li > span {
     letter-spacing: 0.0125rem;
     text-decoration: none;
   }
@@ -68,7 +63,7 @@ a, h2 > a{
   }
   h3{    font-size: 1.5rem;
     line-height: 1.083;
-    letter-spacing: -0.03125rem;
+    letter-spacing: -0.0125rem;
       
       @screen sm  {
         font-size: 1.125rem;

--- a/frontend/src/pages/AboutUs/GoalListItem.tsx
+++ b/frontend/src/pages/AboutUs/GoalListItem.tsx
@@ -19,7 +19,7 @@ export default function GoalListItem(props: GoalListItemProps) {
           />
         </LazyLoad>
       )}
-      <h3 className='p-0 text-left font-light font-sansTitle text-smallestHeader'>
+      <h3 className='p-0 text-left font-sansTitle text-smallestHeader'>
         {props.title}
       </h3>
       <p className='my-0 text-left font-sansText '>{props.text}</p>

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -117,7 +117,7 @@ function LandingPage() {
         <div className='relative m-0 p-0 text-left sm:w-full md:w-full lg:w-3/4'>
           <h1 className='mt-4 mb-0 text-left font-medium font-serif text-black xs:text-header leading-lhSomeSpace sm:text-bigHeader lg:text-heroHeader'>
             Where will the <br aria-hidden />
-            <span className='text-altGreen'>Health Equity Tracker</span>
+            <span className='font-medium font-serif text-altGreen xs:text-header leading-lhSomeSpace sm:text-bigHeader lg:text-heroHeader'>Health Equity Tracker</span>
             <br aria-hidden /> take you?
           </h1>
           <HetCTABig id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>

--- a/frontend/src/pages/Landing/LandingPage.tsx
+++ b/frontend/src/pages/Landing/LandingPage.tsx
@@ -117,7 +117,9 @@ function LandingPage() {
         <div className='relative m-0 p-0 text-left sm:w-full md:w-full lg:w-3/4'>
           <h1 className='mt-4 mb-0 text-left font-medium font-serif text-black xs:text-header leading-lhSomeSpace sm:text-bigHeader lg:text-heroHeader'>
             Where will the <br aria-hidden />
-            <span className='font-medium font-serif text-altGreen xs:text-header leading-lhSomeSpace sm:text-bigHeader lg:text-heroHeader'>Health Equity Tracker</span>
+            <span className='font-medium font-serif text-altGreen xs:text-header leading-lhSomeSpace sm:text-bigHeader lg:text-heroHeader'>
+              Health Equity Tracker
+            </span>
             <br aria-hidden /> take you?
           </h1>
           <HetCTABig id='landingPageCTA' href={EXPLORE_DATA_PAGE_LINK}>

--- a/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
@@ -12,7 +12,7 @@ export function MissingCdcAtlasData() {
 export function MissingIslandAreaPopulationData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing population data for Census Island Areas
       </h4>
 
@@ -41,7 +41,7 @@ export function MissingIslandAreaPopulationData() {
 export function MissingCovidData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing and suppressed COVID data
       </h4>
       <p className='m-0 ml-1 self-start text-altBlack text-small'>
@@ -62,7 +62,7 @@ export function MissingCovidData() {
 export function MissingCovidVaccinationData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing COVID-19 vaccination data
       </h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
@@ -92,7 +92,7 @@ export function MissingCovidVaccinationData() {
 export function MissingCAWPData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing data for women in legislative office
       </h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
@@ -118,7 +118,7 @@ export function MissingCAWPData() {
 export function MissingHIVData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing data for HIV deaths, diagnoses, and prevalence
       </h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
@@ -154,7 +154,7 @@ export function MissingHIVData() {
 export function MissingPrepData() {
   return (
     <>
-      <h4 className='font-light text-text'>PrEP Coverage and Prescriptions</h4>
+      <h4>PrEP Coverage and Prescriptions</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           The race and ethnicity of individuals prescribed PrEP are only
@@ -179,7 +179,7 @@ export function MissingPrepData() {
 export function MissingPhrmaData() {
   return (
     <>
-      <h4 className='font-light text-text'>Medicare Administration Data</h4>
+      <h4>Medicare Administration Data</h4>
 
       <p className='m-0 ml-1 self-start text-altBlack text-small'>
         What demographic data are missing?
@@ -227,7 +227,7 @@ export function MissingPhrmaData() {
 export function MissingAHRData() {
   return (
     <>
-      <h4 className='font-light text-text'>
+      <h4>
         Missing America's Health Rankings data
       </h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
@@ -248,7 +248,7 @@ export function MissingAHRData() {
 export function MissingWisqarsData() {
   return (
     <>
-      <h4 className='font-light text-text'>Missing WISQARS Data</h4>
+      <h4>Missing WISQARS Data</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           <b>Legal intervention data:</b> Data on deaths caused by legal

--- a/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
@@ -12,9 +12,7 @@ export function MissingCdcAtlasData() {
 export function MissingIslandAreaPopulationData() {
   return (
     <>
-      <h4>
-        Missing population data for Census Island Areas
-      </h4>
+      <h4>Missing population data for Census Island Areas</h4>
 
       <p className='m-0 ml-1 self-start text-altBlack text-small'>
         Population data for <b>Northern Mariana Islands</b>, <b>Guam</b>,{' '}
@@ -41,9 +39,7 @@ export function MissingIslandAreaPopulationData() {
 export function MissingCovidData() {
   return (
     <>
-      <h4>
-        Missing and suppressed COVID data
-      </h4>
+      <h4>Missing and suppressed COVID data</h4>
       <p className='m-0 ml-1 self-start text-altBlack text-small'>
         For COVID-19 related reports, this tracker uses disaggregated,
         individual{' '}
@@ -62,9 +58,7 @@ export function MissingCovidData() {
 export function MissingCovidVaccinationData() {
   return (
     <>
-      <h4>
-        Missing COVID-19 vaccination data
-      </h4>
+      <h4>Missing COVID-19 vaccination data</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           <b>Population data:</b> Because state-reported population categories
@@ -92,9 +86,7 @@ export function MissingCovidVaccinationData() {
 export function MissingCAWPData() {
   return (
     <>
-      <h4>
-        Missing data for women in legislative office
-      </h4>
+      <h4>Missing data for women in legislative office</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           The Center for American Women in Politics (CAWP) dataset uses unique
@@ -118,9 +110,7 @@ export function MissingCAWPData() {
 export function MissingHIVData() {
   return (
     <>
-      <h4>
-        Missing data for HIV deaths, diagnoses, and prevalence
-      </h4>
+      <h4>Missing data for HIV deaths, diagnoses, and prevalence</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           County-level data is suppressed when the population denominator is
@@ -227,9 +217,7 @@ export function MissingPhrmaData() {
 export function MissingAHRData() {
   return (
     <>
-      <h4>
-        Missing America's Health Rankings data
-      </h4>
+      <h4>Missing America's Health Rankings data</h4>
       <ul className='m-0 ml-1 self-start text-altBlack text-small'>
         <li>
           <b>Population data:</b> AHR does not have population data available

--- a/frontend/src/pages/Methodology/methodologySections/Covid19Link.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/Covid19Link.tsx
@@ -55,7 +55,7 @@ export default function Covid19Link() {
           ]}
         />
 
-        <h2 className='mt-12 font-medium text-title' id='covid-data-sourcing'>
+        <h2 className='mt-12' id='covid-data-sourcing'>
           Data Sourcing
         </h2>
         <p>
@@ -67,10 +67,7 @@ export default function Covid19Link() {
           Times itself now relies on the CDC dataset making comparisons less
           useful.
         </p>
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-age-and-demographic-data-analysis'
-        >
+        <h3 className='mt-12' id='covid-age-and-demographic-data-analysis'>
           Age and Demographic Data Analysis
         </h3>
         <p>
@@ -79,14 +76,11 @@ export default function Covid19Link() {
           breakdown by both race and age.
         </p>
 
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-geographical-reporting'
-        >
+        <h3 className='mt-12' id='covid-geographical-reporting'>
           Geographical Distribution and Reporting
         </h3>
 
-        <h4 className='font-light text-text'>National Data</h4>
+        <h4>National Data</h4>
         <p>
           National statistics are based on summations of all state level cases.
         </p>
@@ -95,7 +89,7 @@ export default function Covid19Link() {
           aggregations may be incomplete and potentially skewed.
         </blockquote>
 
-        <h4 className='font-light text-text'>County Data</h4>
+        <h4>County Data</h4>
         <p>
           Specific figures might be concealed in counties with low case counts
           to protect the privacy of affected individuals. The foundational data
@@ -105,7 +99,7 @@ export default function Covid19Link() {
           lapse in accurate demographic reporting.
         </p>
 
-        <h3 className='mt-12 font-medium text-title' id='covid-time-series'>
+        <h3 className='mt-12' id='covid-time-series'>
           Time-Series and Temporal Analysis
         </h3>
         <p>
@@ -146,10 +140,7 @@ export default function Covid19Link() {
           group might be lacking.
         </p>
 
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-missing-and-suppressed-data'
-        >
+        <h3 className='mt-12' id='covid-missing-and-suppressed-data'>
           Addressing Missing and Suppressed Data
         </h3>
 
@@ -160,10 +151,7 @@ export default function Covid19Link() {
           COVID-19's overall impact.
         </blockquote>
 
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-vaccination-data-analysis'
-        >
+        <h3 className='mt-12' id='covid-vaccination-data-analysis'>
           Vaccination Data Compilation and Analysis
         </h3>
         <p>
@@ -176,16 +164,16 @@ export default function Covid19Link() {
           dataset, multiple sources are use across different geographic levels:
         </p>
 
-        <h4 className='font-light text-text'>National Data</h4>
+        <h4>National Data</h4>
         <p>Derived from the CDC vaccine demographic dataset.</p>
 
-        <h4 className='font-light text-text'>State Data</h4>
+        <h4>State Data</h4>
         <p>
           Extracted from the Kaiser Family Foundation's COVID-19 Indicators
           dataset.
         </p>
 
-        <h4 className='font-light text-text'>County Data</h4>
+        <h4>County Data</h4>
         <p>
           At the county level, we utilize the{' '}
           <HetTerm>COVID-19 Vaccinations in the United States, County</HetTerm>{' '}
@@ -196,10 +184,7 @@ export default function Covid19Link() {
           near future.
         </p>
 
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-vaccination-demographic-estimates'
-        >
+        <h3 className='mt-12' id='covid-vaccination-demographic-estimates'>
           Demographic Population Estimates for Vaccination Data
         </h3>
 
@@ -214,7 +199,7 @@ export default function Covid19Link() {
             estimates that the CDC offers.
           </p>
         </HetNotice>
-        <h4 className='font-light text-text'>National Estimates</h4>
+        <h4>National Estimates</h4>
         <p>
           We use the CDC's population numbers for our national figures,
           especially when considering regions like Palau, Micronesia, and the
@@ -222,7 +207,7 @@ export default function Covid19Link() {
           challenging.
         </p>
 
-        <h4 className='font-light text-text'>State and County Estimates</h4>
+        <h4>State and County Estimates</h4>
         <p>
           Accurate population estimates are essential for understanding the
           distribution of vaccinations and pinpointing disparities, especially
@@ -256,10 +241,7 @@ export default function Covid19Link() {
           without any demographic breakdown.
         </p>
 
-        <h3
-          className='mt-12 font-medium text-title'
-          id='covid-data-limitations'
-        >
+        <h3 className='mt-12' id='covid-data-limitations'>
           Data Limitations and Specific Considerations
         </h3>
         <p>
@@ -289,7 +271,7 @@ export default function Covid19Link() {
           administered, adding another layer to our comprehensive analysis.
         </p>
 
-        <h3 className='mt-12 font-medium text-title' id='covid-data-sources'>
+        <h3 className='mt-12' id='covid-data-sources'>
           COVID-19 Data Sources
         </h3>
         <StripedTable

--- a/frontend/src/pages/Methodology/methodologySections/LimitationsLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/LimitationsLink.tsx
@@ -16,10 +16,10 @@ export default function LimitationsLink() {
           <title>Limitations and Missing Data - Health Equity Tracker</title>
         </Helmet>
 
-        <h2 className='mt-12 font-medium text-title'>Limitations</h2>
+        <h2 className='mt-12'>Limitations</h2>
         <p>While we strive for accuracy, some of the limitations include:</p>
 
-        <h3 className='font-light text-text'>Data Accuracy and Completeness</h3>
+        <h3>Data Accuracy and Completeness</h3>
         <p>
           Data collected from sources like the CDC may have inaccuracies or
           incompleteness due to errors in reporting, variations in data
@@ -27,14 +27,14 @@ export default function LimitationsLink() {
           populations. This can lead to biases or distortions in the
           representation of disease prevalence.
         </p>
-        <h3 className='font-light text-text'>Temporal Lag</h3>
+        <h3>Temporal Lag</h3>
         <p>
           There might be a lag between the occurrence of a disease and its
           reporting. This delay can affect the timeliness of the data presented
           on the health equity tracker, potentially hindering real-time
           decision-making.
         </p>
-        <h3 className='font-light text-text'>Geographical Resolution</h3>
+        <h3>Geographical Resolution</h3>
 
         <p>
           While choropleth maps provide a visual representation of data at the
@@ -42,7 +42,7 @@ export default function LimitationsLink() {
           may not be sufficient for detecting localized outbreaks or disparities
           within smaller geographic areas.
         </p>
-        <h3 className='font-light text-text'>Population Heterogeneity</h3>
+        <h3>Population Heterogeneity</h3>
 
         <p>
           Population characteristics can vary significantly across different
@@ -51,7 +51,7 @@ export default function LimitationsLink() {
           as differences in socioeconomic status, access to healthcare, or
           cultural factors that influence health outcomes.
         </p>
-        <h3 className='font-light text-text'>Ecological Fallacy</h3>
+        <h3>Ecological Fallacy</h3>
 
         <p>
           This occurs when inferences about individuals are drawn from
@@ -60,7 +60,7 @@ export default function LimitationsLink() {
           affected similarly. Drawing conclusions about individuals based solely
           on aggregated data can lead to erroneous assumptions.
         </p>
-        <h3 className='font-light text-text'>Data Interpretation</h3>
+        <h3>Data Interpretation</h3>
 
         <p>
           Visualizations like choropleth maps can simplify complex data, but
@@ -68,7 +68,7 @@ export default function LimitationsLink() {
           to ensure that interpretations of the maps consider the context,
           potential confounding variables, and limitations of the data source.
         </p>
-        <h3 className='font-light text-text'>External Factors</h3>
+        <h3>External Factors</h3>
 
         <p>
           Other external factors, such as changes in healthcare policies,
@@ -77,7 +77,7 @@ export default function LimitationsLink() {
           adequately captured in the data or accounted for in the analysis.
         </p>
         <div id='missing-data'>
-          <h2 className='mt-12 font-medium text-title' id='limitations'>
+          <h2 className='mt-12' id='limitations'>
             What Data Are Missing
           </h2>
           <WhatDataAreMissing

--- a/frontend/src/pages/Methodology/methodologySections/PdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/PdohLink.tsx
@@ -69,7 +69,7 @@ const PdohLink = () => {
           Offers detailed research on incarceration trends at the county level.
         </p>
         <h3>Breakdown of Our Reports</h3>
-        <h4 className='font-light text-text'>By Age</h4>
+        <h4>By Age</h4>
         <ul className='list-disc pl-4'>
           <li className='font-medium'>
             Nationwide data: From BJS's "Prisoners Table 10"
@@ -78,20 +78,20 @@ const PdohLink = () => {
             State-specific data: From BJS's "Prisoners Table 2".
           </li>
         </ul>
-        <h4 className='font-light text-text'>By Race</h4>
+        <h4>By Race</h4>
         <ul className='list-disc pl-4'>
           <li className='font-medium'>
             Nationwide & State-specific data: From BJS's "Prisoners Appendix
             Table 2".
           </li>
         </ul>
-        <h4 className='font-light text-text'>By Sex</h4>
+        <h4>By Sex</h4>
         <ul className='list-disc pl-4'>
           <li className='font-medium'>
             Nationwide & State-specific data: From BJS's "Prisoners Table 2".
           </li>
         </ul>
-        <h4 className='font-light text-text'>Special Reports</h4>
+        <h4>Special Reports</h4>
         <ul className='list-disc pl-4'>
           <li className='font-medium'>
             Information on children in prison: From BJS's "Prisoners Table 13".
@@ -123,22 +123,22 @@ const PdohLink = () => {
           person, not necessarily where they're held.
         </p>
         <p>Our data varies slightly based on the location and type:</p>
-        <h4 className='font-light text-text'>National report</h4>
+        <h4>National report</h4>
         <p>
           Includes all under the jurisdiction of a state or federal adult
           prison. Excludes territorial, military, or Indian Country facilities.
         </p>
-        <h4 className='font-light text-text'>State reports</h4>
+        <h4>State reports</h4>
         <p>
           Focuses on individuals within a state's prison system. Age-specific
           data is not available.
         </p>
-        <h4 className='font-light text-text'>Territory reports</h4>
+        <h4>Territory reports</h4>
         <p>
           Covers individuals in a territory's adult prison facilities. No
           specific demographic breakdown.
         </p>
-        <h4 className='font-light text-text'>County reports</h4>
+        <h4>County reports</h4>
         <p>
           Considers those under state prison systems but charged in a specific
           county.

--- a/frontend/src/reports/WhatDataAreMissing.tsx
+++ b/frontend/src/reports/WhatDataAreMissing.tsx
@@ -49,7 +49,7 @@ export default function WhatDataAreMissing(props: WhatDataAreMissingProps) {
 
   return (
     <>
-      <h3 className='font-light text-text'>Missing and misidentified people</h3>
+      <h3>Missing and misidentified people</h3>
       <p>
         Currently, there are no required or standardized race and ethnicity
         categories for data collection across state and local jurisdictions. The

--- a/frontend/src/styles/HetComponents/HetPaginationButton.tsx
+++ b/frontend/src/styles/HetComponents/HetPaginationButton.tsx
@@ -43,7 +43,7 @@ export default function HetPaginationButton({
         )}
       </span>
       {/* LABEL FOR LINKED PAGE */}
-      <span className='mb-5 flex shrink-0 flex-col justify-center gap-2 self-stretch p-2 font-semibold text-text leading-lhNormal md:text-exploreButton'>
+      <span className='mb-5 flex shrink-0 flex-col justify-center gap-2 self-stretch p-2 font-semibold text-text leading-lhNormal'>
         <span
           className={
             isPrevious


### PR DESCRIPTION
# Description and Motivation
This PR defines our global typography sizing, letter spacing, line-heights, mostly for the headings used across the app. Tailwind defined typography classes will be reserved for special use cases

## Has this been tested? How?
manually

## Screenshots (if appropriate)
<img width="1512" alt="Screenshot 2025-01-22 at 1 00 17 PM" src="https://github.com/user-attachments/assets/c6e8fdd4-ef97-4957-ad72-d56aedbc4cf6" />
<img width="1512" alt="Screenshot 2025-01-22 at 12 59 49 PM" src="https://github.com/user-attachments/assets/25702553-08e0-447a-bc7a-d7626b6c91df" />

## Types of changes
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
