### PR TITLE
Frontend: Restrict CAWP time charts to `twoYearly`

### DIFF
--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -197,8 +197,7 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
           demographicGroupsLabelled,
           props.demographicType,
           metricConfigRates.metricId,
-          /* keepOnlyElectionYears */ metricConfigRates.timeSeriesCadence ===
-            'fourYearly',
+          metricConfigRates.timeSeriesCadence
         )
 
         const nestedUnknownPctShareData = getNestedUnknowns(

--- a/frontend/src/data/config/MetricConfigPDOH.ts
+++ b/frontend/src/data/config/MetricConfigPDOH.ts
@@ -115,7 +115,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
     otherSubPopulationLabel: 'US Congress members incl. Territorial Delegates',
     metrics: {
       pct_rate: {
-        timeSeriesCadence: 'yearly',
+        timeSeriesCadence: 'twoYearly',
         metricId: 'pct_share_of_us_congress',
         trendsCardTitleName:
           'Yearly rates of US Congress members identifying as women',
@@ -154,7 +154,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
         },
       },
       pct_relative_inequity: {
-        timeSeriesCadence: 'yearly',
+        timeSeriesCadence: 'twoYearly',
         chartTitle:
           'Relative racial inequity of women in US Congress over time',
         metricId: 'women_us_congress_pct_relative_inequity',
@@ -178,7 +178,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
 
     metrics: {
       pct_rate: {
-        timeSeriesCadence: 'yearly',
+        timeSeriesCadence: 'twoYearly',
         metricId: 'pct_share_of_state_leg',
         chartTitle: 'Percentage of state legislators identifying as women',
         // MAP CARD HEADING, SIMPLE BAR TITLE, MAP INFO ALERT, TABLE COL HEADER, HI/LOW DROPDOWN FOOTNOTE
@@ -218,7 +218,7 @@ export const WOMEN_IN_GOV_METRICS: DataTypeConfig[] = [
         },
       },
       pct_relative_inequity: {
-        timeSeriesCadence: 'yearly',
+        timeSeriesCadence: 'twoYearly',
         chartTitle:
           'Relative racial inequity of women state legislators over time',
         metricId: 'women_state_leg_pct_relative_inequity',

--- a/frontend/src/data/config/MetricConfigTypes.ts
+++ b/frontend/src/data/config/MetricConfigTypes.ts
@@ -78,7 +78,11 @@ export type MetricType =
   | 'index'
   | 'age_adjusted_ratio'
 
-export type TimeSeriesCadenceType = 'monthly' | 'yearly' | 'fourYearly'
+export type TimeSeriesCadenceType =
+  | 'monthly'
+  | 'yearly'
+  | 'twoYearly'
+  | 'fourYearly'
 
 export interface MetricConfig {
   metricId: MetricId

--- a/frontend/src/data/utils/DatasetTimeUtils.test.ts
+++ b/frontend/src/data/utils/DatasetTimeUtils.test.ts
@@ -1,4 +1,3 @@
-import { DataFrame } from 'data-forge'
 import type { TrendsData } from '../../charts/trendsChart/types'
 import { METRIC_CONFIG } from '../config/MetricConfig'
 import {
@@ -217,25 +216,32 @@ describe('Tests getPrettyDate() function', () => {
 })
 
 describe('getElectionYearData', () => {
-  it('should return only election years (divisible by 4)', () => {
+  it('should return only election years (divisible by 4 or 2)', () => {
     const inputData: HetRow[] = [
       { time_period: '2008', voter_participation_pct_rate: 47.6 },
-      { time_period: '2009' },
+      { time_period: '2009', women_in_gov: 25.0 },
       { time_period: '2010' },
-      { time_period: '2011' },
+      { time_period: '2011', women_in_gov: 25.0 },
       { time_period: '2012', voter_participation_pct_rate: 47.3 },
-      { time_period: '2013' },
+      { time_period: '2013', women_in_gov: 25.0 },
       { time_period: '2014' },
-      { time_period: '2015' },
+      { time_period: '2015', women_in_gov: 25.0 },
       { time_period: '2016', voter_participation_pct_rate: 49 },
     ]
 
-    const result = getElectionYearData(inputData)
-
-    expect(result).toEqual([
+    const result4yearly = getElectionYearData(inputData, 'fourYearly')
+    expect(result4yearly).toEqual([
       { time_period: '2008', voter_participation_pct_rate: 47.6 },
       { time_period: '2012', voter_participation_pct_rate: 47.3 },
       { time_period: '2016', voter_participation_pct_rate: 49 },
+    ])
+
+    const result2yearly = getElectionYearData(inputData, 'twoYearly')
+    expect(result2yearly).toEqual([
+      { time_period: '2009', women_in_gov: 25.0 },
+      { time_period: '2011', women_in_gov: 25.0 },
+      { time_period: '2013', women_in_gov: 25.0 },
+      { time_period: '2015', women_in_gov: 25.0 },
     ])
   })
 })

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -656,7 +656,8 @@ def get_women_dfs():
     # keep only needed cols
     df = df[[ID, YEAR, STATE, FIRST_NAME, LAST_NAME, POSITION, RACE_ETH]]
 
-    df = df.dropna(subset=[STATE])
+    # keep only valid rows
+    df = df.dropna(subset=[STATE, RACE_ETH])
 
     # standardize postal codes (can't just swap codes because Michigan is also MI)
     df[STATE] = df[STATE].replace(

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -566,7 +566,8 @@ def get_us_congress_totals_df():
     for legislator in raw_legislators_json:
         # and each term they served
         for term in legislator[TERMS]:
-            term_years = list(range(int(term[START][:4]), int(term[END][:4]) + 1))
+
+            term_years = extract_term_years(term)
 
             # and each year of each term
             for year in term_years:
@@ -1061,3 +1062,22 @@ def handle_other_and_multi_races(df):
     df = df.explode(RACE_ETH)
 
     return df
+
+
+def extract_term_years(term):
+    """
+    Extract years from a term, with special handling for those finishing their term in the first weeks of January.
+
+    Args:
+        term (dict): Dictionary containing start and end date keys
+
+    Returns:
+        list: Years of the term
+    """
+    term_years = list(range(int(term[START][:4]), int(term[END][:4]) + 1))
+
+    # If the term ended the first week of January, don't count that year (to align with CAWP)
+    if term[END][5:7] == "01" and int(term[END][9:]) <= 7:
+        term_years = term_years[:-1]
+
+    return term_years

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -652,10 +652,9 @@ def get_women_dfs():
             columns "time_period" by year and "state_postal", "race_ethnicity"
             with specific CAWP race strings"""
 
-    df = gcs_to_bq_util.load_csv_as_df_from_data_dir("cawp", CAWP_LINE_ITEMS_FILE)
-
-    # keep only needed cols
-    df = df[[ID, YEAR, STATE, FIRST_NAME, LAST_NAME, POSITION, RACE_ETH]]
+    df = gcs_to_bq_util.load_csv_as_df_from_data_dir(
+        "cawp", CAWP_LINE_ITEMS_FILE, usecols=[ID, YEAR, STATE, FIRST_NAME, LAST_NAME, POSITION, RACE_ETH]
+    )
 
     # keep only valid rows
     df = df.dropna(subset=[STATE, RACE_ETH])

--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -216,7 +216,7 @@ class CAWPData(DataSource):
         raise NotImplementedError("upload_to_gcs should not be called for CAWPData")
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
-        base_df = self.generate_base_df()
+        base_df = self.generate_base_df()  #
         df_names = base_df.copy()
         df_names = self.generate_names_breakdown(df_names)
         column_types = gcs_to_bq_util.get_bq_column_types(df_names, [])

--- a/python/tests/data/cawp/mock_territory_leg_tables/cawp_state_leg_60.csv
+++ b/python/tests/data/cawp/mock_territory_leg_tables/cawp_state_leg_60.csv
@@ -57,3 +57,4 @@ time_period,state_fips,total_state_leg_count
 "2022","60",39
 "2023","60",39
 "2024","60",39
+"2025","60",39

--- a/python/tests/datasources/test_cawp.py
+++ b/python/tests/datasources/test_cawp.py
@@ -98,6 +98,8 @@ def _load_csv_as_df_from_data_dir(*args, **kwargs):
 
     print("MOCK READ FROM /data:", filename, kwargs)
 
+    usecols = kwargs.get("usecols", None)
+
     if filename == "cawp-by_race_and_ethnicity_time_series.csv":
         # READ IN CAWP DB (numerators)
         test_input_data_types = {
@@ -117,6 +119,7 @@ def _load_csv_as_df_from_data_dir(*args, **kwargs):
             os.path.join(TEST_DIR, f"test_input_{filename}"),
             dtype=test_input_data_types,
             index_col=False,
+            usecols=usecols,
         )
     else:
         # READ IN MANUAL TERRITORY STATELEG TOTAL TABLES

--- a/python/tests/datasources/test_cawp.py
+++ b/python/tests/datasources/test_cawp.py
@@ -9,12 +9,53 @@ from datasources.cawp import (
     US_CONGRESS_HISTORICAL_URL,
     US_CONGRESS_CURRENT_URL,
     get_consecutive_time_periods,
+    extract_term_years,
     FIPS_TO_STATE_TABLE_MAP,
 )
 
 FIPS_TO_TEST = ["02", "60"]
 
 # UNIT TESTS
+
+
+def test_extract_term_years():
+
+    entry_with_jan = {
+        "type": "rep",
+        "start": "2017-01-03",
+        "end": "2019-01-03",
+        "state": "MI",
+        "district": 5,
+        "party": "Democrat",
+        "phone": "202-225-3611",
+        "url": "https://dankildee.house.gov",
+        "rss_url": "http://dankildee.house.gov/rss.xml",
+        "address": "227 Cannon House Office Building; Washington DC 20515-2205",
+        "office": "227 Cannon House Office Building",
+        "fax": "202-225-6393",
+    }
+
+    term_years_excluding_jan = extract_term_years(entry_with_jan)
+    assert term_years_excluding_jan == [2017, 2018]
+
+    entry_special_election = {
+        "type": "sen",
+        "start": "2023-01-23",
+        "end": "2024-11-05",
+        "how": "appointment",
+        "end-type": "special-election",
+        "state": "NE",
+        "class": 2,
+        "state_rank": "junior",
+        "party": "Republican",
+        "url": "https://www.ricketts.senate.gov",
+        "address": "139 Russell Senate Office Building Washington DC 20510",
+        "office": "139 Russell Senate Office Building",
+        "phone": "202-224-4224",
+    }
+
+    term_years_special_election = extract_term_years(entry_special_election)
+    assert term_years_special_election == [2023, 2024]
 
 
 def test_get_consecutive_time_periods():


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- due to changeover, the counts become less accurate showing every single year, causing the line to pop up and down. by restricting to every two years, the line is more accurate 

## Has this been tested? How?

## Screenshots (if appropriate)

## Types of changes

(leave all that apply)

- Bug fix
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
