### PR TITLE
Pipeline: Fix CAWP error with terms ending in early January

### DIFF
--- a/python/datasources/cawp.py
+++ b/python/datasources/cawp.py
@@ -216,7 +216,7 @@ class CAWPData(DataSource):
         raise NotImplementedError("upload_to_gcs should not be called for CAWPData")
 
     def write_to_bq(self, dataset, gcs_bucket, **attrs):
-        base_df = self.generate_base_df()  #
+        base_df = self.generate_base_df()
         df_names = base_df.copy()
         df_names = self.generate_names_breakdown(df_names)
         column_types = gcs_to_bq_util.get_bq_column_types(df_names, [])

--- a/python/tests/data/cawp/mock_territory_leg_tables/cawp_state_leg_60.csv
+++ b/python/tests/data/cawp/mock_territory_leg_tables/cawp_state_leg_60.csv
@@ -57,3 +57,4 @@ time_period,state_fips,total_state_leg_count
 "2022","60",39
 "2023","60",39
 "2024","60",39
+"2025","60",39

--- a/python/tests/datasources/test_cawp.py
+++ b/python/tests/datasources/test_cawp.py
@@ -9,12 +9,53 @@ from datasources.cawp import (
     US_CONGRESS_HISTORICAL_URL,
     US_CONGRESS_CURRENT_URL,
     get_consecutive_time_periods,
+    extract_term_years,
     FIPS_TO_STATE_TABLE_MAP,
 )
 
 FIPS_TO_TEST = ["02", "60"]
 
 # UNIT TESTS
+
+
+def test_extract_term_years():
+
+    entry_with_jan = {
+        "type": "rep",
+        "start": "2017-01-03",
+        "end": "2019-01-03",
+        "state": "MI",
+        "district": 5,
+        "party": "Democrat",
+        "phone": "202-225-3611",
+        "url": "https://dankildee.house.gov",
+        "rss_url": "http://dankildee.house.gov/rss.xml",
+        "address": "227 Cannon House Office Building; Washington DC 20515-2205",
+        "office": "227 Cannon House Office Building",
+        "fax": "202-225-6393",
+    }
+
+    term_years_excluding_jan = extract_term_years(entry_with_jan)
+    assert term_years_excluding_jan == [2017, 2018]
+
+    entry_special_election = {
+        "type": "sen",
+        "start": "2023-01-23",
+        "end": "2024-11-05",
+        "how": "appointment",
+        "end-type": "special-election",
+        "state": "NE",
+        "class": 2,
+        "state_rank": "junior",
+        "party": "Republican",
+        "url": "https://www.ricketts.senate.gov",
+        "address": "139 Russell Senate Office Building Washington DC 20510",
+        "office": "139 Russell Senate Office Building",
+        "phone": "202-224-4224",
+    }
+
+    term_years_special_election = extract_term_years(entry_special_election)
+    assert term_years_special_election == [2023, 2024]
 
 
 def test_get_consecutive_time_periods():
@@ -57,6 +98,8 @@ def _load_csv_as_df_from_data_dir(*args, **kwargs):
 
     print("MOCK READ FROM /data:", filename, kwargs)
 
+    usecols = kwargs.get("usecols", None)
+
     if filename == "cawp-by_race_and_ethnicity_time_series.csv":
         # READ IN CAWP DB (numerators)
         test_input_data_types = {
@@ -76,6 +119,7 @@ def _load_csv_as_df_from_data_dir(*args, **kwargs):
             os.path.join(TEST_DIR, f"test_input_{filename}"),
             dtype=test_input_data_types,
             index_col=False,
+            usecols=usecols,
         )
     else:
         # READ IN MANUAL TERRITORY STATELEG TOTAL TABLES


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- fixes issue where CAWP was only listing women in the full year they served, but our code for extracting denominators for US Congress was counting the last few days of people's terms, (january 1-3) and including that year in the denominator calculations. this resulted in the weird "bumpiness" of the chart, which is now fixed
- adds `usecols` to speed up loading of giant csv file


## Has this been tested? How?

- tests passing

## Screenshots (if appropriate)

OLD DATA LEFT / NEW MORE ACCURATE DATA RIGHT

<img width="1425" alt="Screenshot 2025-01-23 at 2 10 33 PM" src="https://github.com/user-attachments/assets/2dc6d258-f6d2-4b5e-aae3-d428099cd8a4" />

## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
