### PR TITLE
Frontend: replace multimap with new D3 choropleth map

### DIFF
--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -1,8 +1,8 @@
 // TODO: eventually should make a HetDialog to handle modals
 import { Dialog, DialogContent } from '@mui/material'
 import { useState } from 'react'
-import ChoroplethMap from '../../charts/ChoroplethMap'
 import { Legend } from '../../charts/Legend'
+import ChoroplethMap from '../../charts/choroplethMap/index'
 import { type CountColsMap, RATE_MAP_SCALE } from '../../charts/mapGlobals'
 import type {
   DataTypeConfig,

--- a/frontend/src/charts/choroplethMap/colorSchemes.ts
+++ b/frontend/src/charts/choroplethMap/colorSchemes.ts
@@ -118,7 +118,7 @@ export const getFillColor = (props: GetFillColorProps): string => {
     return zeroColor
   }
 
-  if (value !== undefined) {
+  if (value != null) {
     return colorScale(value)
   }
 

--- a/frontend/src/charts/choroplethMap/index.tsx
+++ b/frontend/src/charts/choroplethMap/index.tsx
@@ -93,7 +93,7 @@ const ChoroplethMap = ({
         return
       }
 
-      tooltipContainerRef.current ??= createTooltipContainer()
+      tooltipContainerRef.current ??= createTooltipContainer(isMulti)
 
       const colorScale = createColorScale({
         dataWithHighestLowest,

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -5,21 +5,17 @@ import { GEOGRAPHIES_DATASET_ID } from '../../data/config/MetadataMap'
 import type { MetricConfig } from '../../data/config/MetricConfigTypes'
 import type { DemographicType } from '../../data/query/Breakdowns'
 import type { Fips } from '../../data/utils/Fips'
-import { het } from '../../styles/DesignTokens'
-import { type CountColsMap, DATA_SUPPRESSED } from '../mapGlobals'
+import {
+  type CountColsMap,
+  DATA_SUPPRESSED,
+  NO_DATA_MESSAGE,
+} from '../mapGlobals'
 import {
   getCawpMapGroupDenominatorLabel,
   getCawpMapGroupNumeratorLabel,
   getMapGroupLabel,
 } from '../mapHelperFunctions'
 import type { MetricData } from './types'
-
-const {
-  altGrey: ALT_GREY,
-  white: WHITE,
-  greyGridColorDarker: BORDER_GREY,
-  borderColor,
-} = het
 
 export const createFeatures = async (
   showCounties: boolean,
@@ -149,7 +145,8 @@ export const createDataMap = (
         [tooltipLabel]: d[metric.metricId],
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {
-          [`# ${numeratorPhrase}`]: d[countColsMap.numeratorConfig.metricId],
+          [`# ${numeratorPhrase}`]:
+            d?.[countColsMap.numeratorConfig.metricId] ?? NO_DATA_MESSAGE,
         }),
         ...(countColsMap?.denominatorConfig && {
           [`# ${denominatorPhrase}`]:

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -24,7 +24,7 @@ const {
 
 const STROKE_WIDTH = 0.5
 const TOOLTIP_OFFSET = { x: 10, y: 10 } as const
-const MARGIN = { top: 20, right: 20, bottom: 20, left: 20 } as const
+const MARGIN = { top: -40, right: 20, bottom: 20, left: 20 } as const
 
 export const renderMap = ({
   geoData,

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -24,7 +24,7 @@ const {
 
 const STROKE_WIDTH = 0.5
 const TOOLTIP_OFFSET = { x: 10, y: 10 } as const
-const MARGIN = { top: -40, right: 20, bottom: 20, left: 20 } as const
+const MARGIN = { top: -40, right: 20, bottom: 20, left: 20 }
 
 export const renderMap = ({
   geoData,
@@ -57,6 +57,7 @@ export const renderMap = ({
     width,
     height,
     isMobile,
+    isUnknownsMap,
   })
 
   projection.fitSize([width, height * 0.8], features)
@@ -163,7 +164,12 @@ const initializeSvg = ({
   width,
   height,
   isMobile,
+  isUnknownsMap,
 }: InitializeSvgProps) => {
+  let { left, top } = MARGIN
+  if (isUnknownsMap) {
+    top = 20
+  }
   const svg = d3
     .select(svgRef.current)
     .attr('width', width)
@@ -174,16 +180,13 @@ const initializeSvg = ({
     legendGroup: svg
       .append('g')
       .attr('class', 'legend-container')
-      .attr(
-        'transform',
-        `translate(${MARGIN.left}, ${isMobile ? 0 : MARGIN.top})`,
-      ),
+      .attr('transform', `translate(${left}, ${isMobile ? 0 : top})`),
     mapGroup: svg
       .append('g')
       .attr('class', 'map-container')
       .attr(
         'transform',
-        `translate(${MARGIN.left}, ${isMobile ? MARGIN.top + 10 : MARGIN.top + 50})`,
+        `translate(${left}, ${isMobile ? top + 10 : top + 50})`,
       ),
   }
 }

--- a/frontend/src/charts/choroplethMap/tooltipUtils.ts
+++ b/frontend/src/charts/choroplethMap/tooltipUtils.ts
@@ -7,13 +7,17 @@ import {
 } from '../../data/providers/CawpProvider'
 import type { DemographicType } from '../../data/query/Breakdowns'
 import { LESS_THAN_POINT_1 } from '../../data/utils/Constants'
-import { het } from '../../styles/DesignTokens'
+import { ThemeZIndexValues, het } from '../../styles/DesignTokens'
 import { getMapGroupLabel } from '../mapHelperFunctions'
 import type { MetricData } from './types'
 
 const { white: WHITE, greyGridColorDarker: BORDER_GREY, borderColor } = het
+const { multimapModalTooltip, mapTooltip } = ThemeZIndexValues
 
-export const createTooltipContainer = () => {
+export const createTooltipContainer = (isMultimap?: boolean) => {
+  const tooltipZnumber = isMultimap ? multimapModalTooltip : mapTooltip
+  const tooltipZIndex = tooltipZnumber.toString()
+
   return d3
     .select('body')
     .append('div')
@@ -24,7 +28,7 @@ export const createTooltipContainer = () => {
     .style('border-radius', '4px')
     .style('padding', '8px')
     .style('font-size', '12px')
-    .style('z-index', '1000')
+    .style('z-index', tooltipZIndex)
 }
 
 export const formatMetricValue = (

--- a/frontend/src/charts/choroplethMap/types.ts
+++ b/frontend/src/charts/choroplethMap/types.ts
@@ -116,6 +116,7 @@ export type InitializeSvgProps = {
   width: number
   height: number
   isMobile: boolean
+  isUnknownsMap?: boolean
 }
 
 export interface MetricData {

--- a/frontend/src/styles/DesignTokens.ts
+++ b/frontend/src/styles/DesignTokens.ts
@@ -21,10 +21,12 @@ const ThemeZIndexValues = {
   bottom: -999,
   middle: 0,
   almostTop: 3,
+  mapTooltip: 98,
   top: 99,
   stickyMadLib: 100,
   multimapModal: 101,
   skipLink: 102,
+  multimapModalTooltip: 1300,
 }
 
 const ThemeLineHeightValues = {
@@ -139,7 +141,7 @@ const het = {
 
 export {
   het,
-  ThemeZIndexValues,
   ThemeLineHeightValues,
   ThemeStandardScreenSizes,
+  ThemeZIndexValues,
 }


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- swap multimap to use new d3 map
- fix z index issues for tooltips
- fix missing data spaces rendering as black instead of grey (null vs undefined)
- fix top margin across maps (unknown needs to be lower to fit the gradient legend)

## Has this been tested? How?

passing, manually checked

## Types of changes

(leave all that apply)

- Bug fix
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
