### PR TITLE
Frontend: Fixes hide nh, hides on unknowns card, fixes legend on unknown mobile

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -76,6 +76,7 @@ function CardWrapper(props: {
               <Sources
                 isCensusNotAcs={props.isCensusNotAcs}
                 metadata={metadata}
+                hideNH={props.hideNH}
                 queryResponses={queryResponses}
                 showDefinition={props.scrollToHash === 'rate-map'}
                 isCompareCard={props.isCompareCard}

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -131,6 +131,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
       minHeight={preloadHeight}
       scrollToHash={HASH_ID}
       reportTitle={props.reportTitle}
+      hideNH={true}
     >
       {([mapQueryResponse, alertQueryResponse], metadata, geoData) => {
         // MOST of the items rendered in the card refer to the unknowns at the CHILD geo level,

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -293,8 +293,7 @@ const initializeSvg = ({
   let { left, top } = MARGIN
   if (isUnknownsMap) {
     top = 20
-  }
-  if (isMobile) {
+  } else if (isMobile) {
     top = 0
   }
   const svg = d3

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -92,7 +92,6 @@ export const renderMap = ({
   const tooltipLabel = getTooltipLabel(
     isUnknownsMap,
     metric,
-    isCawp,
     activeDemographicGroup,
     demographicType,
   )

--- a/frontend/src/charts/choroplethMap/tooltipUtils.ts
+++ b/frontend/src/charts/choroplethMap/tooltipUtils.ts
@@ -52,7 +52,6 @@ const formatMetricValue = (
 export const getTooltipLabel = (
   isUnknownsMap: boolean | undefined,
   metric: MetricConfig,
-  isCawp: boolean,
   activeDemographicGroup: string,
   demographicType: DemographicType,
 ): string => {


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- some of #3927 
- `hideNH` wasn't being passed into the sources component for some reason; fixed
- hides NH footnote on unknowns map card since nothin in the card will have NH
- mobile unknowns maps still needed to be bumped down by 20; fixed `if` logic

## Has this been tested? How?

manually

## Types of changes

(leave all that apply)

- Bug fix


## New frontend preview link is below in the Netlify comment 😎
