### PR TITLE
Fix missing percent share and estimated total values in AHR age tables

### DIFF
--- a/python/tests/data/graphql_ahr/golden_data/behavioral_health_age_national_current.csv
+++ b/python/tests/data/graphql_ahr/golden_data/behavioral_health_age_national_current.csv
@@ -1,13 +1,13 @@
-age,state_fips,state_name,depression_per_100k,excessive_drinking_per_100k,frequent_mental_distress_per_100k,non_medical_drug_use_per_100k,suicide_per_100k,suicide_estimated_total,suicide_pct_share,ahr_population_estimated_total,ahr_population_pct
-15-24,00,United States,,,,,13.6,6058.0,12.4,44543621.0,13.3
-18-44,00,United States,23700.0,24400.0,20100.0,,,,,120601782.0,36.1
-25-34,00,United States,,,,,19.0,8704.0,17.8,45809071.0,13.7
-35-44,00,United States,,,,,18.7,8079.0,16.5,43204002.0,12.9
-45-54,00,United States,,,,,19.2,7970.0,16.3,41508942.0,12.4
-45-64,00,United States,20000.0,16500.0,14100.0,,,,,84527730.0,25.3
-55-64,00,United States,,,,,18.7,8045.0,16.5,43018788.0,12.9
-65+,00,United States,15500.0,7700.0,9400.0,,,,,55460582.0,16.6
-65-74,00,United States,,,,,16.0,5223.0,10.7,32641489.0,9.8
-75-84,00,United States,,,,,20.3,3292.0,6.7,16215371.0,4.8
-85+,00,United States,,,,,23.0,1519.0,3.1,6603722.0,2.0
-All,00,United States,21700.0,18400.0,15900.0,15.5,14.8,48890.0,100.0,334369975.0,100.0
+age,state_fips,state_name,depression_per_100k,depression_estimated_total,depression_pct_share,excessive_drinking_per_100k,excessive_drinking_estimated_total,excessive_drinking_pct_share,frequent_mental_distress_per_100k,frequent_mental_distress_estimated_total,frequent_mental_distress_pct_share,non_medical_drug_use_per_100k,non_medical_drug_use_estimated_total,non_medical_drug_use_pct_share,suicide_per_100k,suicide_estimated_total,suicide_pct_share,ahr_population_estimated_total,ahr_population_pct
+15-24,00,United States,,,,,,,,,,,,,13.6,6058.0,12.4,44543621.0,13.3
+18-44,00,United States,23700.0,28582622.0,52.8,24400.0,29426835.0,61.8,20100.0,24240958.0,58.6,,,,,,,120601782.0,36.1
+25-34,00,United States,,,,,,,,,,,,,19.0,8704.0,17.8,45809071.0,13.7
+35-44,00,United States,,,,,,,,,,,,,18.7,8079.0,16.5,43204002.0,12.9
+45-54,00,United States,,,,,,,,,,,,,19.2,7970.0,16.3,41508942.0,12.4
+45-64,00,United States,20000.0,16905546.0,31.3,16500.0,13947075.0,29.3,14100.0,11918410.0,28.8,,,,,,,84527730.0,25.3
+55-64,00,United States,,,,,,,,,,,,,18.7,8045.0,16.5,43018788.0,12.9
+65+,00,United States,15500.0,8596390.0,15.9,7700.0,4270465.0,9.0,9400.0,5213295.0,12.6,,,,,,,55460582.0,16.6
+65-74,00,United States,,,,,,,,,,,,,16.0,5223.0,10.7,32641489.0,9.8
+75-84,00,United States,,,,,,,,,,,,,20.3,3292.0,6.7,16215371.0,4.8
+85+,00,United States,,,,,,,,,,,,,23.0,1519.0,3.1,6603722.0,2.0
+All,00,United States,21700.0,54084558.0,100.0,18400.0,47644375.0,100.0,15900.0,41372663.0,100.0,15.5,0.0,,14.8,48890.0,100.0,334369975.0,100.0

--- a/python/tests/data/graphql_ahr/golden_data/non-behavioral_health_age_national_current.csv
+++ b/python/tests/data/graphql_ahr/golden_data/non-behavioral_health_age_national_current.csv
@@ -1,6 +1,6 @@
-age,state_fips,state_name,asthma_per_100k,avoided_care_pct_rate,cardiovascular_diseases_per_100k,chronic_kidney_disease_per_100k,copd_per_100k,diabetes_per_100k,preventable_hospitalizations_per_100k,ahr_population_estimated_total,ahr_population_pct,voter_participation_pct_rate
-18-44,00,United States,9800.0,15.2,2300.0,1300.0,2800.0,3600.0,,120601782.0,36.1,
-45-64,00,United States,10600.0,10.6,9900.0,3800.0,7900.0,15700.0,,84527730.0,25.3,
-65+,00,United States,9200.0,3.7,22400.0,8300.0,13100.0,23900.0,,55460582.0,16.6,74.5
-65-74,00,United States,,,,,,,1452.0,32641489.0,9.8,
-All,00,United States,10400.0,10.1,9100.0,3500.0,6800.0,11500.0,2665.0,334369975.0,100.0,66.8
+age,state_fips,state_name,asthma_per_100k,asthma_estimated_total,asthma_pct_share,avoided_care_pct_rate,avoided_care_estimated_total,avoided_care_pct_share,cardiovascular_diseases_per_100k,cardiovascular_diseases_estimated_total,cardiovascular_diseases_pct_share,chronic_kidney_disease_per_100k,chronic_kidney_disease_estimated_total,chronic_kidney_disease_pct_share,copd_per_100k,copd_estimated_total,copd_pct_share,diabetes_per_100k,diabetes_estimated_total,diabetes_pct_share,preventable_hospitalizations_per_100k,ahr_population_estimated_total,ahr_population_pct,voter_participation_pct_rate
+18-44,00,United States,9800.0,11818975.0,45.7,15.2,18331471.0,62.5,2300.0,2773841.0,11.8,1300.0,1567823.0,16.7,2800.0,3376850.0,19.5,3600.0,4341664.0,14.1,,120601782.0,36.1,
+45-64,00,United States,10600.0,8959939.0,34.6,10.6,8959939.0,30.5,9900.0,8368245.0,35.5,3800.0,3212054.0,34.2,7900.0,6677691.0,38.6,15700.0,13270854.0,43.0,,84527730.0,25.3,
+65+,00,United States,9200.0,5102374.0,19.7,3.7,2052042.0,7.0,22400.0,12423170.0,52.7,8300.0,4603228.0,49.1,13100.0,7265336.0,41.9,23900.0,13255079.0,42.9,,55460582.0,16.6,74.5
+65-74,00,United States,,,,,,,,,,,,,,,,,,,1452.0,32641489.0,9.8,
+All,00,United States,10400.0,25881288.0,100.0,10.1,29343452.0,100.0,9100.0,23565256.0,100.0,3500.0,9383105.0,100.0,6800.0,17319877.0,100.0,11500.0,30867597.0,100.0,2665.0,334369975.0,100.0,66.8


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
This PR adds missing percent share and estimated total calculations to the AHR age tables. This fixes the issue where "Share of all adult asthma cases" and similar metrics were missing on PROD.

- Fixed the post-processing method to properly calculate and include estimated total values for all metrics
- Added percent share calculations for both all-ages metrics (like suicide) and 18+ metrics (like asthma, depression, etc.)

## Testing
- Verified that the share percentages for each age group sum to 100% for each metric
- Confirmed that all age breakdowns now display proper percentage values instead of alert icons

## Has this been tested? How?

## Screenshots (if appropriate)
PROD:
![image](https://github.com/user-attachments/assets/71a01f83-d399-4c83-9b38-8204f0b0bbb6)

FIX:
![image](https://github.com/user-attachments/assets/036d5eac-5569-4e06-b0a5-fc054caf67cf)

## Types of changes
- Bug fix
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
