### PR TITLE
fixes `View All Datasets` route

### DIFF
--- a/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
+++ b/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
@@ -7,7 +7,10 @@ import { WithMetadata } from '../../data/react/WithLoadingOrErrorUI'
 import type { DataSourceMetadata } from '../../data/utils/DatasetTypes'
 import HetCTASmall from '../../styles/HetComponents/HetCTASmall'
 import HetTextArrowLink from '../../styles/HetComponents/HetTextArrowLink'
-import { EXPLORE_DATA_PAGE_LINK } from '../../utils/internalRoutes'
+import {
+  DATA_CATALOG_PAGE_LINK,
+  EXPLORE_DATA_PAGE_LINK,
+} from '../../utils/internalRoutes'
 import { DATA_SOURCE_PRE_FILTERS, useSearchParams } from '../../utils/urlutils'
 import DataSourceListing from './DataSourceListing'
 
@@ -106,7 +109,7 @@ export default function DataCatalogPage() {
                   {viewingSubsetOfSources && (
                     <HetTextArrowLink
                       containerClassName='flex justify-center'
-                      link={`DATA_CATALOG_PAGE_LINK`}
+                      link={DATA_CATALOG_PAGE_LINK}
                       linkText={'View All Datasets'}
                     />
                   )}


### PR DESCRIPTION
# Description and Motivation
`DATA_CATALOG_PAGE_LINK` route was previously in string literals, pointing to a nonexistent route for the full Source Dataset Files. this PR fixes it to link correctly.

## Has this been tested? How?
manually; tests passing

## Screenshots (if appropriate)
![Screenshot 2025-04-15 at 3 10 43 PM](https://github.com/user-attachments/assets/bea8bf89-695c-49e3-93fc-f68b9f76ee6e)
<img width="630" alt="Screenshot 2025-04-15 at 3 09 45 PM" src="https://github.com/user-attachments/assets/b0d4bb3c-18dd-43bc-b1a1-0cb7e5902f3d" />
![Screenshot 2025-04-15 at 3 09 25 PM](https://github.com/user-attachments/assets/74298882-59ac-4bd1-b1dd-351833572d80)

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
