### PR TITLE
Upgrades to React 19, with overrides

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,9 +28,9 @@
 				"jotai-location": "^0.5.5",
 				"just-debounce-it": "^3.2.0",
 				"lru-cache": "^11.1.0",
-				"react": "^18.3.1",
+				"react": "19.1.0",
 				"react-animate-height": "^3.2.3",
-				"react-dom": "^18.3.1",
+				"react-dom": "19.1.0",
 				"react-helmet-async": "^2.0.5",
 				"react-joyride": "^2.9.3",
 				"react-lazyload": "^3.2.1",
@@ -50,8 +50,8 @@
 				"@testing-library/react": "^16.3.0",
 				"@types/d3": "^7.4.3",
 				"@types/node": "^22.14.1",
-				"@types/react": "^18.3.20",
-				"@types/react-dom": "^18.3.6",
+				"@types/react": "19.1.2",
+				"@types/react-dom": "19.1.2",
 				"@types/react-lazyload": "^3.2.3",
 				"@types/react-router-hash-link": "^2.4.9",
 				"@types/react-scroll": "^1.8.10",
@@ -200,6 +200,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/babel"
 			}
+		},
+		"node_modules/@babel/core/node_modules/convert-source-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@babel/generator": {
 			"version": "7.27.0",
@@ -1331,21 +1338,6 @@
 				"find-root": "^1.1.0",
 				"source-map": "^0.5.7",
 				"stylis": "4.2.0"
-			}
-		},
-		"node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-			"version": "1.9.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
-			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
-			"license": "MIT"
-		},
-		"node_modules/@emotion/babel-plugin/node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@emotion/cache": {
@@ -2823,6 +2815,33 @@
 				"url": "https://github.com/sponsors/gregberge"
 			}
 		},
+		"node_modules/@svgr/core/node_modules/cosmiconfig": {
+			"version": "8.3.6",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
+			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0",
+				"path-type": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@svgr/hast-util-to-babel-ast": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-8.0.0.tgz",
@@ -2839,6 +2858,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/gregberge"
+			}
+		},
+		"node_modules/@svgr/hast-util-to-babel-ast/node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/@svgr/plugin-jsx": {
@@ -2875,9 +2907,9 @@
 			}
 		},
 		"node_modules/@tanstack/query-persist-client-core": {
-			"version": "5.74.4",
-			"resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.74.4.tgz",
-			"integrity": "sha512-jeFRIOfnoJUtivYv4KD0xFkQHtF4QpJl/hD3uvPSFH6qN51+cDUGRiEibLVjD8exkh48GTG8cmgk69ugMJ/S6Q==",
+			"version": "5.74.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.74.6.tgz",
+			"integrity": "sha512-9OJ4tz4evC53tS4NfxaohctFjE9/sqvK4U5HlUBsBcQRI/fn+75lIpD9RcLIbUPcx78hPC35NSUKD7OX6YNw4Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@tanstack/query-core": "5.74.4"
@@ -2888,13 +2920,13 @@
 			}
 		},
 		"node_modules/@tanstack/query-sync-storage-persister": {
-			"version": "5.74.4",
-			"resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-5.74.4.tgz",
-			"integrity": "sha512-hUg7RezHQTxschr2QGN3ELp69eindGe0z7ihDV7wyngXvQZdE0MATwql+efZp9fpATO5QzTm7sKQgwvGazZQcQ==",
+			"version": "5.74.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/query-sync-storage-persister/-/query-sync-storage-persister-5.74.6.tgz",
+			"integrity": "sha512-zMB14UUlEeACKu9GTSYLr2tgFIXZj+x0JbMlVHmmw8OnalrRTWc3TKSgHcPW3f6kPbilI0hU0fo8AnFdvAJUFw==",
 			"license": "MIT",
 			"dependencies": {
 				"@tanstack/query-core": "5.74.4",
-				"@tanstack/query-persist-client-core": "5.74.4"
+				"@tanstack/query-persist-client-core": "5.74.6"
 			},
 			"funding": {
 				"type": "github",
@@ -2918,12 +2950,12 @@
 			}
 		},
 		"node_modules/@tanstack/react-query-persist-client": {
-			"version": "5.74.4",
-			"resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.74.4.tgz",
-			"integrity": "sha512-JP1MyuzjVLpsJOCKPbiXki1nvYrBGFamnWV59kSS0R2zb3mxpDoNmrwBqUJOPFTLPUyMx1APqqF5FynX6ooeyA==",
+			"version": "5.74.6",
+			"resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.74.6.tgz",
+			"integrity": "sha512-gGJ+4IKIRWC9JeChBOvGgZj1lQcP3bAT8Kofv1Csx4CbqkyhbALlUkpiUXYyVpeS60acXS6NRAajlfzRtfsE+Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@tanstack/query-persist-client-core": "5.74.4"
+				"@tanstack/query-persist-client-core": "5.74.6"
 			},
 			"funding": {
 				"type": "github",
@@ -3406,23 +3438,22 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/react": {
-			"version": "18.3.20",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
-			"integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
+			"version": "19.1.2",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.2.tgz",
+			"integrity": "sha512-oxLPMytKchWGbnQM9O7D67uPa9paTNxO7jVoNMXgkkErULBPhPARCfkKL9ytcIJJRGjbsVwW4ugJzyFFvm/Tiw==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/prop-types": "*",
 				"csstype": "^3.0.2"
 			}
 		},
 		"node_modules/@types/react-dom": {
-			"version": "18.3.6",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
-			"integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
+			"version": "19.1.2",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.2.tgz",
+			"integrity": "sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
-				"@types/react": "^18.0.0"
+				"@types/react": "^19.0.0"
 			}
 		},
 		"node_modules/@types/react-lazyload": {
@@ -3887,31 +3918,6 @@
 				"npm": ">=6"
 			}
 		},
-		"node_modules/babel-plugin-macros/node_modules/cosmiconfig": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-			"license": "MIT",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/babel-plugin-macros/node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4349,10 +4355,9 @@
 			}
 		},
 		"node_modules/convert-source-map": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
-			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"dev": true,
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+			"integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
 			"license": "MIT"
 		},
 		"node_modules/cookie": {
@@ -4372,30 +4377,28 @@
 			"license": "MIT"
 		},
 		"node_modules/cosmiconfig": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-			"dev": true,
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+			"integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
 			"license": "MIT",
 			"dependencies": {
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0",
-				"path-type": "^4.0.0"
+				"@types/parse-json": "^4.0.0",
+				"import-fresh": "^3.2.1",
+				"parse-json": "^5.0.0",
+				"path-type": "^4.0.0",
+				"yaml": "^1.10.0"
 			},
 			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
+				"node": ">=10"
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/yaml": {
+			"version": "1.10.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/cross-env": {
@@ -5174,6 +5177,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/deepmerge-ts": {
+			"version": "7.1.5",
+			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
+			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5319,9 +5331,9 @@
 			"license": "MIT"
 		},
 		"node_modules/entities": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+			"integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -6909,13 +6921,13 @@
 			}
 		},
 		"node_modules/parse5": {
-			"version": "7.2.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
-			"integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+			"version": "7.3.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"entities": "^4.5.0"
+				"entities": "^6.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
@@ -7056,17 +7068,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-			"license": "MIT",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
 			}
 		},
 		"node_modules/postcss": {
@@ -7312,13 +7313,10 @@
 			"license": "MIT"
 		},
 		"node_modules/react": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+			"integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
 			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7337,16 +7335,15 @@
 			}
 		},
 		"node_modules/react-dom": {
-			"version": "18.3.1",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-			"integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+			"version": "19.1.0",
+			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+			"integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
 			"license": "MIT",
 			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"scheduler": "^0.23.2"
+				"scheduler": "^0.26.0"
 			},
 			"peerDependencies": {
-				"react": "^18.3.1"
+				"react": "^19.1.0"
 			}
 		},
 		"node_modules/react-fast-compare": {
@@ -7356,42 +7353,19 @@
 			"license": "MIT"
 		},
 		"node_modules/react-floater": {
-			"version": "0.7.9",
-			"resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
-			"integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.9.4.tgz",
+			"integrity": "sha512-fVsomyiDzWEJHSdQ9/uLDZfe6VSoULfO/23BLXFAtmp83ObCC4SFwaDlDc2EZCyvqfOnyu6KaoQHoXolinourQ==",
 			"license": "MIT",
 			"dependencies": {
-				"deepmerge": "^4.3.1",
-				"is-lite": "^0.8.2",
-				"popper.js": "^1.16.0",
-				"prop-types": "^15.8.1",
-				"tree-changes": "^0.9.1"
+				"@popperjs/core": "^2.11.8",
+				"deepmerge-ts": "^7.1.0",
+				"is-lite": "^1.2.1",
+				"tree-changes-hook": "^0.11.2"
 			},
 			"peerDependencies": {
-				"react": "15 - 18",
-				"react-dom": "15 - 18"
-			}
-		},
-		"node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
-			"integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==",
-			"license": "MIT"
-		},
-		"node_modules/react-floater/node_modules/is-lite": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
-			"integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
-			"license": "MIT"
-		},
-		"node_modules/react-floater/node_modules/tree-changes": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
-			"integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@gilbarbara/deep-equal": "^0.1.1",
-				"is-lite": "^0.8.2"
+				"react": "16.8 - 19",
+				"react-dom": "16.8 - 19"
 			}
 		},
 		"node_modules/react-helmet-async": {
@@ -7776,6 +7750,16 @@
 				}
 			}
 		},
+		"node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
 		"node_modules/rrweb-cssom": {
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -7833,13 +7817,10 @@
 			}
 		},
 		"node_modules/scheduler": {
-			"version": "0.23.2",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-			"integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.1.0"
-			}
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+			"integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+			"license": "MIT"
 		},
 		"node_modules/scroll": {
 			"version": "3.0.1",
@@ -7936,13 +7917,12 @@
 			}
 		},
 		"node_modules/source-map": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-			"integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-			"dev": true,
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
 			"license": "BSD-3-Clause",
 			"engines": {
-				"node": ">= 8"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/source-map-js": {
@@ -8381,6 +8361,19 @@
 			"dependencies": {
 				"@gilbarbara/deep-equal": "^0.3.1",
 				"is-lite": "^1.2.1"
+			}
+		},
+		"node_modules/tree-changes-hook": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/tree-changes-hook/-/tree-changes-hook-0.11.3.tgz",
+			"integrity": "sha512-cNHPuFc5Qbi2B74VqSqL/Ee/l4n0SFfzYKTnXYViJW1yCFZ0bl97QsgUIw9vdQtqpWDwo83mpNkGUvcjeQc0Xw==",
+			"license": "MIT",
+			"dependencies": {
+				"@gilbarbara/deep-equal": "^0.3.1",
+				"tree-changes": "0.11.3"
+			},
+			"peerDependencies": {
+				"react": "16.8 - 19"
 			}
 		},
 		"node_modules/ts-interface-checker": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,12 +6,21 @@
 	"overrides": {
 		"chokidar": "3.5.3",
 		"react-lazyload": {
-			"react": "^19.0.0",
-			"react-dom": "^19.0.0"
+			"react": "^19.1.0",
+			"react-dom": "^19.1.0"
 		},
 		"react-table": {
-			"react": "^19.0.0",
-			"react-dom": "^19.0.0"
+			"react": "^19.1.0",
+			"react-dom": "^19.1.0"
+		},
+		"react-joyride": {
+			"react": "^19.1.0",
+			"react-dom": "^19.1.0",
+			"react-floater": "^0.9.4"
+		},
+		"react-helmet-async": {
+			"react": "^19.1.0",
+			"react-dom": "^19.1.0"
 		},
 		"lodash": "^4.17.12",
 		"tough-cookie": ">=4.1.3"
@@ -37,9 +46,9 @@
 		"jotai-location": "^0.5.5",
 		"just-debounce-it": "^3.2.0",
 		"lru-cache": "^11.1.0",
-		"react": "^18.3.1",
+		"react": "19.1.0",
 		"react-animate-height": "^3.2.3",
-		"react-dom": "^18.3.1",
+		"react-dom": "19.1.0",
 		"react-helmet-async": "^2.0.5",
 		"react-joyride": "^2.9.3",
 		"react-lazyload": "^3.2.1",
@@ -59,8 +68,8 @@
 		"@testing-library/react": "^16.3.0",
 		"@types/d3": "^7.4.3",
 		"@types/node": "^22.14.1",
-		"@types/react": "^18.3.20",
-		"@types/react-dom": "^18.3.6",
+		"@types/react": "19.1.2",
+		"@types/react-dom": "19.1.2",
 		"@types/react-lazyload": "^3.2.3",
 		"@types/react-router-hash-link": "^2.4.9",
 		"@types/react-scroll": "^1.8.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,8 +6,12 @@
 	"overrides": {
 		"chokidar": "3.5.3",
 		"react-lazyload": {
-			"react": "^18.2.0",
-			"react-dom": "^18.2.0"
+			"react": "^19.0.0",
+			"react-dom": "^19.0.0"
+		},
+		"react-table": {
+			"react": "^19.0.0",
+			"react-dom": "^19.0.0"
 		},
 		"lodash": "^4.17.12",
 		"tough-cookie": ">=4.1.3"

--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -15,7 +15,7 @@ function CardWrapper(props: {
   // prevent layout shift as component loads
   minHeight?: number
   downloadTitle: string
-  infoPopover?: JSX.Element
+  infoPopover?: React.ReactNode
   hideFooter?: boolean
   hideNH?: boolean
   queries: MetricQuery[]
@@ -25,7 +25,7 @@ function CardWrapper(props: {
     metadata: MapOfDatasetMetadata,
     geoData?: Record<string, any>,
     knownData?: Record<string, any>,
-  ) => JSX.Element
+  ) => React.ReactNode
   isCensusNotAcs?: boolean
   scrollToHash: ScrollableHashId
   reportTitle: string

--- a/frontend/src/cards/ui/DemographicGroupMenu.tsx
+++ b/frontend/src/cards/ui/DemographicGroupMenu.tsx
@@ -33,7 +33,7 @@ interface MenuPopoverProps {
   onClose?: () => void
 }
 
-function MenuPopover(props: MenuPopoverProps): JSX.Element {
+function MenuPopover(props: MenuPopoverProps): React.ReactElement {
   // calculate page size for responsive layout
   const isSm = useIsBreakpointAndUp('sm')
   const anchorOrigin: PopoverOrigin = {

--- a/frontend/src/cards/ui/DemographicGroupMenu.tsx
+++ b/frontend/src/cards/ui/DemographicGroupMenu.tsx
@@ -33,7 +33,7 @@ interface MenuPopoverProps {
   onClose?: () => void
 }
 
-function MenuPopover(props: MenuPopoverProps): React.ReactElement {
+function MenuPopover(props: MenuPopoverProps): React.ReactElement<any> {
   // calculate page size for responsive layout
   const isSm = useIsBreakpointAndUp('sm')
   const anchorOrigin: PopoverOrigin = {

--- a/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
+++ b/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
@@ -30,7 +30,7 @@ const TERRITORIES_CONFIG = {
 }
 
 interface TerritoryCirclesProps {
-  svgRef: React.RefObject<SVGSVGElement>
+  svgRef: React.RefObject<SVGSVGElement | null>
   width: number
   mapHeight: number
   fips: Fips

--- a/frontend/src/charts/choroplethMap/types.ts
+++ b/frontend/src/charts/choroplethMap/types.ts
@@ -100,7 +100,7 @@ export type HetRow = DataPoint & {
 }
 
 export type InitializeSvgProps = {
-  svgRef: React.RefObject<SVGSVGElement>
+  svgRef: React.RefObject<SVGSVGElement | null>
   width: number
   height: number
   isMobile: boolean
@@ -126,7 +126,7 @@ export type RenderMapProps = {
   isUnknownsMap?: boolean
   metricConfig: MetricConfig
   showCounties: boolean
-  svgRef: RefObject<SVGSVGElement>
+  svgRef: RefObject<SVGSVGElement | null>
   tooltipContainer: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>
   width: number
   fips: Fips

--- a/frontend/src/charts/rateBarChart/useRateChartTooltip.tsx
+++ b/frontend/src/charts/rateBarChart/useRateChartTooltip.tsx
@@ -5,7 +5,7 @@ import { formatValue } from '../sharedBarChartPieces/helpers'
 import type { BarChartTooltipData } from './BarChartTooltip'
 
 export function useRateChartTooltip(
-  containerRef: RefObject<HTMLDivElement>,
+  containerRef: RefObject<HTMLDivElement | null>,
   metricConfig: MetricConfig,
   demographicType: string,
   isTinyAndUp: boolean,

--- a/frontend/src/custom.d.ts
+++ b/frontend/src/custom.d.ts
@@ -1,1 +1,2 @@
 declare module 'dom-to-image-more'
+declare module 'react-lazyload'

--- a/frontend/src/data/react/WithLoadingOrErrorUI.tsx
+++ b/frontend/src/data/react/WithLoadingOrErrorUI.tsx
@@ -20,8 +20,8 @@ import {
  */
 function WithLoadingOrErrorUI<R>(props: {
   resources: R[] | IncompleteLoadStatus
-  children: (resources: R[]) => JSX.Element
-  loadingComponent?: JSX.Element
+  children: (resources: R[]) => React.ReactNode
+  loadingComponent?: React.ReactNode
 }) {
   if (props.resources === 'loading') {
     return props.loadingComponent ? (
@@ -52,8 +52,8 @@ function WithLoadingOrErrorUI<R>(props: {
 }
 
 export function WithMetadata(props: {
-  children: (metadata: MapOfDatasetMetadata) => JSX.Element
-  loadingComponent?: JSX.Element
+  children: (metadata: MapOfDatasetMetadata) => React.ReactNode
+  loadingComponent?: React.ReactNode
 }) {
   const metadatas = useResources<string, MapOfDatasetMetadata>(
     [MetadataCache.METADATA_KEY],
@@ -79,8 +79,8 @@ export function WithMetadata(props: {
  */
 export function WithMetrics(props: {
   queries: MetricQuery[]
-  children: (responses: MetricQueryResponse[]) => JSX.Element
-  loadingComponent?: JSX.Element
+  children: (responses: MetricQueryResponse[]) => React.ReactNode
+  loadingComponent?: React.ReactNode
 }) {
   const queryResponses = useMetrics(props.queries)
   return (
@@ -95,8 +95,8 @@ export function WithMetrics(props: {
 
 function WithDatasets(props: {
   datasetIds: Array<DatasetId | DatasetIdWithStateFIPSCode>
-  children: (datasets: Dataset[]) => JSX.Element
-  loadingComponent?: JSX.Element
+  children: (datasets: Dataset[]) => React.ReactNode
+  loadingComponent?: React.ReactNode
 }) {
   const datasets = useResources<
     DatasetId | DatasetIdWithStateFIPSCode,
@@ -127,8 +127,8 @@ interface WithMetadataAndMetricsProps {
     metadata: MapOfDatasetMetadata,
     queryResponses: MetricQueryResponse[],
     geoData?: Record<string, any>,
-  ) => JSX.Element
-  loadingComponent?: JSX.Element
+  ) => React.ReactNode
+  loadingComponent?: React.ReactNode
   loadGeographies?: boolean
 }
 

--- a/frontend/src/pages/ExploreData/DefaultHelperBoxData.tsx
+++ b/frontend/src/pages/ExploreData/DefaultHelperBoxData.tsx
@@ -1,4 +1,5 @@
 import FiberNewIcon from '@mui/icons-material/FiberNew'
+import type React from 'react'
 import { lazy } from 'react'
 import {
   GUN_DEATHS_YOUNG_ADULTS_USA_SETTING,
@@ -26,9 +27,9 @@ type ReportMapping = {
   preview: string
   description: string
   categories: string[]
-  icon?: JSX.Element
+  icon?: React.ReactNode
   previewImg: string
-  customCard: JSX.Element | null
+  customCard: React.ReactNode | null
 }
 
 export const reportMappings: ReportMapping[] = [

--- a/frontend/src/pages/ExploreData/OnboardingSteps.tsx
+++ b/frontend/src/pages/ExploreData/OnboardingSteps.tsx
@@ -101,7 +101,7 @@ export function getOnboardingSteps(pageIsWide: boolean) {
 function onboardingStep(
   targetId: string,
   title: string,
-  content: JSX.Element,
+  content: React.ReactNode,
   hideCloseButton: boolean,
   placement:
     | 'auto'

--- a/frontend/src/pages/News/NewsAndStoriesPreviewCardOutlined.tsx
+++ b/frontend/src/pages/News/NewsAndStoriesPreviewCardOutlined.tsx
@@ -17,7 +17,7 @@ export default function NewsAndStoriesPreviewCardOutlined({
   article,
   bgHeight = '10rem',
   linkClassName = '',
-}: NewsAndStoriesPreviewCardOutlinedProps): React.ReactElement {
+}: NewsAndStoriesPreviewCardOutlinedProps): React.ReactElement<any> {
   const navigate = useNavigate()
   const getImageSource = (): string => {
     const imageSource =

--- a/frontend/src/pages/News/NewsAndStoriesPreviewCardOutlined.tsx
+++ b/frontend/src/pages/News/NewsAndStoriesPreviewCardOutlined.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import LazyLoad from 'react-lazyload'
 import { Link, useNavigate } from 'react-router'
 import AppbarLogo from '../../assets/AppbarLogo.png'
@@ -16,7 +17,7 @@ export default function NewsAndStoriesPreviewCardOutlined({
   article,
   bgHeight = '10rem',
   linkClassName = '',
-}: NewsAndStoriesPreviewCardOutlinedProps): JSX.Element {
+}: NewsAndStoriesPreviewCardOutlinedProps): React.ReactElement {
   const navigate = useNavigate()
   const getImageSource = (): string => {
     const imageSource =

--- a/frontend/src/pages/Policy/policyComponents/ResourceSection.tsx
+++ b/frontend/src/pages/Policy/policyComponents/ResourceSection.tsx
@@ -5,10 +5,10 @@ interface ResourceSectionProps {
   id: string
   icon: React.ReactNode
   title: string
-  description: string | JSX.Element
+  description: React.ReactNode
   resources: {
     title: string
-    description: string | JSX.Element
+    description: React.ReactNode
     link?: string
   }[]
 }

--- a/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
+++ b/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
@@ -20,7 +20,7 @@ interface RowOfTwoOptionalMetricsProps {
     updateFips: (fips: Fips) => void,
     dropdownVarId?: DropdownVarId,
     isCompareCard?: boolean,
-  ) => React.ReactElement
+  ) => React.ReactElement<any>
   dropdownVarId1?: DropdownVarId
   dropdownVarId2?: DropdownVarId
   headerScrollMargin: number

--- a/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
+++ b/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
@@ -20,7 +20,7 @@ interface RowOfTwoOptionalMetricsProps {
     updateFips: (fips: Fips) => void,
     dropdownVarId?: DropdownVarId,
     isCompareCard?: boolean,
-  ) => JSX.Element
+  ) => React.ReactElement
   dropdownVarId1?: DropdownVarId
   dropdownVarId2?: DropdownVarId
   headerScrollMargin: number

--- a/frontend/src/reports/ui/DefinitionsList.tsx
+++ b/frontend/src/reports/ui/DefinitionsList.tsx
@@ -13,9 +13,7 @@ interface DefinitionsListProps {
   dataTypesToDefine: Array<[string, DataTypeConfig[]]>
 }
 
-export default function DefinitionsList(
-  props: DefinitionsListProps,
-): JSX.Element {
+export default function DefinitionsList(props: DefinitionsListProps) {
   // collect relevant categories
   const relevantCategoriesSet = new Set<Category>()
   props.dataTypesToDefine.forEach((dataType) => {

--- a/frontend/src/styles/HetComponents/HetTerm.tsx
+++ b/frontend/src/styles/HetComponents/HetTerm.tsx
@@ -1,5 +1,5 @@
 interface HetTermProps {
-  children?: JSX.Element | string | string[]
+  children?: React.ReactNode
 }
 export default function HetTerm(props: HetTermProps) {
   return (

--- a/frontend/src/utils/hooks/useResponsiveWidth.tsx
+++ b/frontend/src/utils/hooks/useResponsiveWidth.tsx
@@ -8,7 +8,10 @@ import {
 /*
 Allow visualizations to calculate their updated width when the window is resized / re-zoomed. This function is debounced to restrict how often the calculation is done. Also prevents them from rendering before the width has been established based on the ref
 */
-export function useResponsiveWidth(): [RefObject<HTMLDivElement>, number] {
+export function useResponsiveWidth(): [
+  RefObject<HTMLDivElement | null>,
+  number,
+] {
   const [width, setWidth] = useState<number>(INVISIBLE_PRELOAD_WIDTH)
   const ref = useRef<HTMLDivElement>(document.createElement('div'))
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

keepin up with the new JS toys. React 19 should allow us to use the react compiler which could have significant performance benefits by auto-memoizing our complex data components. we can also remove `react-helmet-async` now as React19 can set page-level titles and meta data on its own; see #4326 

- closes #4299 
- follows process at https://react.dev/blog/2024/04/25/react-19-upgrade-guide#typescript-changes
- update types of JSX.Element to React.ReactNode or React.ReactElement instead
- codemod added lots of optional null to refs
- typescript updates
- force override of react sub-dependencies to use 19

## Has this been tested? How?

test passing, site renders as expected

## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
