### PR TITLE
Joyride react 19

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -32,7 +32,7 @@
 				"react": "19.1.0",
 				"react-animate-height": "^3.2.3",
 				"react-dom": "19.1.0",
-				"react-joyride": "^2.9.3",
+				"react-joyride-react-19": "^2.9.2",
 				"react-lazyload": "^3.2.1",
 				"react-router": "^7.5.2",
 				"react-router-hash-link": "^2.4.3",
@@ -1467,9 +1467,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
-			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.3.tgz",
+			"integrity": "sha512-W8bFfPA8DowP8l//sxjJLSLkD8iEjMc7cBVyP+u4cEv9sM7mdUCkgsj+t0n/BWPFtv7WWCN5Yzj0N6FJNUUqBQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1484,9 +1484,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
-			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.3.tgz",
+			"integrity": "sha512-PuwVXbnP87Tcff5I9ngV0lmiSu40xw1At6i3GsU77U7cjDDB4s0X2cyFuBiDa1SBk9DnvWwnGvVaGBqoFWPb7A==",
 			"cpu": [
 				"arm"
 			],
@@ -1501,9 +1501,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
-			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.3.tgz",
+			"integrity": "sha512-XelR6MzjlZuBM4f5z2IQHK6LkK34Cvv6Rj2EntER3lwCBFdg6h2lKbtRjpTTsdEjD/WSe1q8UyPBXP1x3i/wYQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1518,9 +1518,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
-			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.3.tgz",
+			"integrity": "sha512-ogtTpYHT/g1GWS/zKM0cc/tIebFjm1F9Aw1boQ2Y0eUQ+J89d0jFY//s9ei9jVIlkYi8AfOjiixcLJSGNSOAdQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1535,9 +1535,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
-			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.3.tgz",
+			"integrity": "sha512-eESK5yfPNTqpAmDfFWNsOhmIOaQA59tAcF/EfYvo5/QWQCzXn5iUSOnqt3ra3UdzBv073ykTtmeLJZGt3HhA+w==",
 			"cpu": [
 				"arm64"
 			],
@@ -1552,9 +1552,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
-			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.3.tgz",
+			"integrity": "sha512-Kd8glo7sIZtwOLcPbW0yLpKmBNWMANZhrC1r6K++uDR2zyzb6AeOYtI6udbtabmQpFaxJ8uduXMAo1gs5ozz8A==",
 			"cpu": [
 				"x64"
 			],
@@ -1569,9 +1569,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.3.tgz",
+			"integrity": "sha512-EJiyS70BYybOBpJth3M0KLOus0n+RRMKTYzhYhFeMwp7e/RaajXvP+BWlmEXNk6uk+KAu46j/kaQzr6au+JcIw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1586,9 +1586,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
-			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.3.tgz",
+			"integrity": "sha512-Q+wSjaLpGxYf7zC0kL0nDlhsfuFkoN+EXrx2KSB33RhinWzejOd6AvgmP5JbkgXKmjhmpfgKZq24pneodYqE8Q==",
 			"cpu": [
 				"x64"
 			],
@@ -1603,9 +1603,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
-			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.3.tgz",
+			"integrity": "sha512-dUOVmAUzuHy2ZOKIHIKHCm58HKzFqd+puLaS424h6I85GlSDRZIA5ycBixb3mFgM0Jdh+ZOSB6KptX30DD8YOQ==",
 			"cpu": [
 				"arm"
 			],
@@ -1620,9 +1620,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
-			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.3.tgz",
+			"integrity": "sha512-xCUgnNYhRD5bb1C1nqrDV1PfkwgbswTTBRbAd8aH5PhYzikdf/ddtsYyMXFfGSsb/6t6QaPSzxtbfAZr9uox4A==",
 			"cpu": [
 				"arm64"
 			],
@@ -1637,9 +1637,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
-			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.3.tgz",
+			"integrity": "sha512-yplPOpczHOO4jTYKmuYuANI3WhvIPSVANGcNUeMlxH4twz/TeXuzEP41tGKNGWJjuMhotpGabeFYGAOU2ummBw==",
 			"cpu": [
 				"ia32"
 			],
@@ -1654,9 +1654,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
-			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.3.tgz",
+			"integrity": "sha512-P4BLP5/fjyihmXCELRGrLd793q/lBtKMQl8ARGpDxgzgIKJDRJ/u4r1A/HgpBpKpKZelGct2PGI4T+axcedf6g==",
 			"cpu": [
 				"loong64"
 			],
@@ -1671,9 +1671,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
-			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.3.tgz",
+			"integrity": "sha512-eRAOV2ODpu6P5divMEMa26RRqb2yUoYsuQQOuFUexUoQndm4MdpXXDBbUoKIc0iPa4aCO7gIhtnYomkn2x+bag==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1688,9 +1688,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
-			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.3.tgz",
+			"integrity": "sha512-ZC4jV2p7VbzTlnl8nZKLcBkfzIf4Yad1SJM4ZMKYnJqZFD4rTI+pBG65u8ev4jk3/MPwY9DvGn50wi3uhdaghg==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1705,9 +1705,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
-			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.3.tgz",
+			"integrity": "sha512-LDDODcFzNtECTrUUbVCs6j9/bDVqy7DDRsuIXJg6so+mFksgwG7ZVnTruYi5V+z3eE5y+BJZw7VvUadkbfg7QA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1722,9 +1722,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
-			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.3.tgz",
+			"integrity": "sha512-s+w/NOY2k0yC2p9SLen+ymflgcpRkvwwa02fqmAwhBRI3SC12uiS10edHHXlVWwfAagYSY5UpmT/zISXPMW3tQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1739,9 +1739,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
-			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.3.tgz",
+			"integrity": "sha512-nQHDz4pXjSDC6UfOE1Fw9Q8d6GCAd9KdvMZpfVGWSJztYCarRgSDfOVBY5xwhQXseiyxapkiSJi/5/ja8mRFFA==",
 			"cpu": [
 				"x64"
 			],
@@ -1756,9 +1756,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.3.tgz",
+			"integrity": "sha512-1QaLtOWq0mzK6tzzp0jRN3eccmN3hezey7mhLnzC6oNlJoUJz4nym5ZD7mDnS/LZQgkrhEbEiTn515lPeLpgWA==",
 			"cpu": [
 				"arm64"
 			],
@@ -1773,9 +1773,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.3.tgz",
+			"integrity": "sha512-i5Hm68HXHdgv8wkrt+10Bc50zM0/eonPb/a/OFVfB6Qvpiirco5gBA5bz7S2SHuU+Y4LWn/zehzNX14Sp4r27g==",
 			"cpu": [
 				"x64"
 			],
@@ -1790,9 +1790,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.3.tgz",
+			"integrity": "sha512-zGAVApJEYTbOC6H/3QBr2mq3upG/LBEXr85/pTtKiv2IXcgKV0RT0QA/hSXZqSvLEpXeIxah7LczB4lkiYhTAQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1807,9 +1807,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.3.tgz",
+			"integrity": "sha512-fpqctI45NnCIDKBH5AXQBsD0NDPbEFczK98hk/aa6HJxbl+UtLkJV2+Bvy5hLSLk3LHmqt0NTkKNso1A9y1a4w==",
 			"cpu": [
 				"x64"
 			],
@@ -1824,9 +1824,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
-			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.3.tgz",
+			"integrity": "sha512-ROJhm7d8bk9dMCUZjkS8fgzsPAZEjtRJqCAmVgB0gMrvG7hfmPmz9k1rwO4jSiblFjYmNvbECL9uhaPzONMfgA==",
 			"cpu": [
 				"x64"
 			],
@@ -1841,9 +1841,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
-			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.3.tgz",
+			"integrity": "sha512-YWcow8peiHpNBiIXHwaswPnAXLsLVygFwCB3A7Bh5jRkIBFWHGmNQ48AlX4xDvQNoMZlPYzjVOQDYEzWCqufMQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1858,9 +1858,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
-			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.3.tgz",
+			"integrity": "sha512-qspTZOIGoXVS4DpNqUYUs9UxVb04khS1Degaw/MnfMe7goQ3lTfQ13Vw4qY/Nj0979BGvMRpAYbs/BAxEvU8ew==",
 			"cpu": [
 				"ia32"
 			],
@@ -1875,9 +1875,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
-			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.3.tgz",
+			"integrity": "sha512-ICgUR+kPimx0vvRzf+N/7L7tVSQeE3BYY+NhHRHXS1kBuPO7z2+7ea2HbhDyZdTephgvNvKrlDDKUexuCVBVvg==",
 			"cpu": [
 				"x64"
 			],
@@ -3447,9 +3447,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.14.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+			"version": "22.15.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.2.tgz",
+			"integrity": "sha512-uKXqKN9beGoMdBfcaTY1ecwz6ctxuJAcUlwE55938g0ZJ8lRxwAZqRz2AJ4pzpt5dHdTPMB863UZ0ESiFUcP7A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3914,9 +3914,9 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.8.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-			"integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+			"integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.15.6",
@@ -5198,15 +5198,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/deepmerge-ts": {
-			"version": "7.1.5",
-			"resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
-			"integrity": "sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=16.0.0"
-			}
-		},
 		"node_modules/defaults": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5338,9 +5329,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.140",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
-			"integrity": "sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q==",
+			"version": "1.5.142",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.142.tgz",
+			"integrity": "sha512-Ah2HgkTu/9RhTDNThBtzu2Wirdy4DC9b0sMT1pUhbkZQ5U/iwmE+PHZX1MpjD5IkJCc2wSghgGG/B04szAx07w==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5432,9 +5423,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5466,9 +5457,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
-			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+			"version": "0.25.3",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
+			"integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5479,31 +5470,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.2",
-				"@esbuild/android-arm": "0.25.2",
-				"@esbuild/android-arm64": "0.25.2",
-				"@esbuild/android-x64": "0.25.2",
-				"@esbuild/darwin-arm64": "0.25.2",
-				"@esbuild/darwin-x64": "0.25.2",
-				"@esbuild/freebsd-arm64": "0.25.2",
-				"@esbuild/freebsd-x64": "0.25.2",
-				"@esbuild/linux-arm": "0.25.2",
-				"@esbuild/linux-arm64": "0.25.2",
-				"@esbuild/linux-ia32": "0.25.2",
-				"@esbuild/linux-loong64": "0.25.2",
-				"@esbuild/linux-mips64el": "0.25.2",
-				"@esbuild/linux-ppc64": "0.25.2",
-				"@esbuild/linux-riscv64": "0.25.2",
-				"@esbuild/linux-s390x": "0.25.2",
-				"@esbuild/linux-x64": "0.25.2",
-				"@esbuild/netbsd-arm64": "0.25.2",
-				"@esbuild/netbsd-x64": "0.25.2",
-				"@esbuild/openbsd-arm64": "0.25.2",
-				"@esbuild/openbsd-x64": "0.25.2",
-				"@esbuild/sunos-x64": "0.25.2",
-				"@esbuild/win32-arm64": "0.25.2",
-				"@esbuild/win32-ia32": "0.25.2",
-				"@esbuild/win32-x64": "0.25.2"
+				"@esbuild/aix-ppc64": "0.25.3",
+				"@esbuild/android-arm": "0.25.3",
+				"@esbuild/android-arm64": "0.25.3",
+				"@esbuild/android-x64": "0.25.3",
+				"@esbuild/darwin-arm64": "0.25.3",
+				"@esbuild/darwin-x64": "0.25.3",
+				"@esbuild/freebsd-arm64": "0.25.3",
+				"@esbuild/freebsd-x64": "0.25.3",
+				"@esbuild/linux-arm": "0.25.3",
+				"@esbuild/linux-arm64": "0.25.3",
+				"@esbuild/linux-ia32": "0.25.3",
+				"@esbuild/linux-loong64": "0.25.3",
+				"@esbuild/linux-mips64el": "0.25.3",
+				"@esbuild/linux-ppc64": "0.25.3",
+				"@esbuild/linux-riscv64": "0.25.3",
+				"@esbuild/linux-s390x": "0.25.3",
+				"@esbuild/linux-x64": "0.25.3",
+				"@esbuild/netbsd-arm64": "0.25.3",
+				"@esbuild/netbsd-x64": "0.25.3",
+				"@esbuild/openbsd-arm64": "0.25.3",
+				"@esbuild/openbsd-x64": "0.25.3",
+				"@esbuild/sunos-x64": "0.25.3",
+				"@esbuild/win32-arm64": "0.25.3",
+				"@esbuild/win32-ia32": "0.25.3",
+				"@esbuild/win32-x64": "0.25.3"
 			}
 		},
 		"node_modules/escalade": {
@@ -7082,6 +7073,17 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/popper.js": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+			"deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/popperjs"
+			}
+		},
 		"node_modules/postcss": {
 			"version": "8.5.3",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
@@ -7358,22 +7360,6 @@
 				"react": "^19.1.0"
 			}
 		},
-		"node_modules/react-floater": {
-			"version": "0.9.4",
-			"resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.9.4.tgz",
-			"integrity": "sha512-fVsomyiDzWEJHSdQ9/uLDZfe6VSoULfO/23BLXFAtmp83ObCC4SFwaDlDc2EZCyvqfOnyu6KaoQHoXolinourQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@popperjs/core": "^2.11.8",
-				"deepmerge-ts": "^7.1.0",
-				"is-lite": "^1.2.1",
-				"tree-changes-hook": "^0.11.2"
-			},
-			"peerDependencies": {
-				"react": "16.8 - 19",
-				"react-dom": "16.8 - 19"
-			}
-		},
 		"node_modules/react-innertext": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/react-innertext/-/react-innertext-1.1.5.tgz",
@@ -7390,10 +7376,10 @@
 			"integrity": "sha512-Oe56aUPnkHyyDxxkvqtd7KkdQP5uIUfHxd5XTb3wE9d/kRnZLmKbDB0GWk919tdQ+mxxPtG6EAs6RMT6i1qtHg==",
 			"license": "MIT"
 		},
-		"node_modules/react-joyride": {
-			"version": "2.9.3",
-			"resolved": "https://registry.npmjs.org/react-joyride/-/react-joyride-2.9.3.tgz",
-			"integrity": "sha512-1+Mg34XK5zaqJ63eeBhqdbk7dlGCFp36FXwsEvgpjqrtyywX2C6h9vr3jgxP0bGHCw8Ilsp/nRDzNVq6HJ3rNw==",
+		"node_modules/react-joyride-react-19": {
+			"version": "2.9.2",
+			"resolved": "https://registry.npmjs.org/react-joyride-react-19/-/react-joyride-react-19-2.9.2.tgz",
+			"integrity": "sha512-/ruorGnSPr9UUHMbXg47W+N/1Tm7T/mkMlHZ/d9DFYeP86OFJURoHK0Ij2PdtlZL4y6xFV+3n6dm7D+cSzQijw==",
 			"license": "MIT",
 			"dependencies": {
 				"@gilbarbara/deep-equal": "^0.3.1",
@@ -7406,14 +7392,53 @@
 				"scroll": "^3.0.1",
 				"scrollparent": "^2.1.0",
 				"tree-changes": "^0.11.2",
-				"type-fest": "^4.27.0"
+				"type-fest": "^4.26.1"
+			},
+			"peerDependencies": {
+				"react": "16.3 - 19",
+				"react-dom": "16.3 - 19"
+			}
+		},
+		"node_modules/react-joyride-react-19/node_modules/react-floater": {
+			"version": "0.7.9",
+			"resolved": "https://registry.npmjs.org/react-floater/-/react-floater-0.7.9.tgz",
+			"integrity": "sha512-NXqyp9o8FAXOATOEo0ZpyaQ2KPb4cmPMXGWkx377QtJkIXHlHRAGer7ai0r0C1kG5gf+KJ6Gy+gdNIiosvSicg==",
+			"license": "MIT",
+			"dependencies": {
+				"deepmerge": "^4.3.1",
+				"is-lite": "^0.8.2",
+				"popper.js": "^1.16.0",
+				"prop-types": "^15.8.1",
+				"tree-changes": "^0.9.1"
 			},
 			"peerDependencies": {
 				"react": "15 - 18",
 				"react-dom": "15 - 18"
 			}
 		},
-		"node_modules/react-joyride/node_modules/react-is": {
+		"node_modules/react-joyride-react-19/node_modules/react-floater/node_modules/@gilbarbara/deep-equal": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/@gilbarbara/deep-equal/-/deep-equal-0.1.2.tgz",
+			"integrity": "sha512-jk+qzItoEb0D0xSSmrKDDzf9sheQj/BAPxlgNxgmOaA3mxpUa6ndJLYGZKsJnIVEQSD8zcTbyILz7I0HcnBCRA==",
+			"license": "MIT"
+		},
+		"node_modules/react-joyride-react-19/node_modules/react-floater/node_modules/is-lite": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/is-lite/-/is-lite-0.8.2.tgz",
+			"integrity": "sha512-JZfH47qTsslwaAsqbMI3Q6HNNjUuq6Cmzzww50TdP5Esb6e1y2sK2UAaZZuzfAzpoI2AkxoPQapZdlDuP6Vlsw==",
+			"license": "MIT"
+		},
+		"node_modules/react-joyride-react-19/node_modules/react-floater/node_modules/tree-changes": {
+			"version": "0.9.3",
+			"resolved": "https://registry.npmjs.org/tree-changes/-/tree-changes-0.9.3.tgz",
+			"integrity": "sha512-vvvS+O6kEeGRzMglTKbc19ltLWNtmNt1cpBoSYLj/iEcPVvpJasemKOlxBrmZaCtDJoF+4bwv3m01UKYi8mukQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@gilbarbara/deep-equal": "^0.1.1",
+				"is-lite": "^0.8.2"
+			}
+		},
+		"node_modules/react-joyride-react-19/node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
@@ -8336,19 +8361,6 @@
 				"is-lite": "^1.2.1"
 			}
 		},
-		"node_modules/tree-changes-hook": {
-			"version": "0.11.3",
-			"resolved": "https://registry.npmjs.org/tree-changes-hook/-/tree-changes-hook-0.11.3.tgz",
-			"integrity": "sha512-cNHPuFc5Qbi2B74VqSqL/Ee/l4n0SFfzYKTnXYViJW1yCFZ0bl97QsgUIw9vdQtqpWDwo83mpNkGUvcjeQc0Xw==",
-			"license": "MIT",
-			"dependencies": {
-				"@gilbarbara/deep-equal": "^0.3.1",
-				"tree-changes": "0.11.3"
-			},
-			"peerDependencies": {
-				"react": "16.8 - 19"
-			}
-		},
 		"node_modules/ts-interface-checker": {
 			"version": "0.1.13",
 			"resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -8468,18 +8480,18 @@
 			"license": "MIT"
 		},
 		"node_modules/vite": {
-			"version": "6.3.2",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.2.tgz",
-			"integrity": "sha512-ZSvGOXKGceizRQIZSz7TGJ0pS3QLlVY/9hwxVh17W3re67je1RKYzFHivZ/t0tubU78Vkyb9WnHPENSBCzbckg==",
+			"version": "6.3.3",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.3.tgz",
+			"integrity": "sha512-5nXH+QsELbFKhsEfWLkHrvgRpTdGJzqOZ+utSdmPTvwHmvU6ITTm3xx+mRusihkcI8GeC7lCDyn3kDtiki9scw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"fdir": "^6.4.3",
+				"fdir": "^6.4.4",
 				"picomatch": "^4.0.2",
 				"postcss": "^8.5.3",
 				"rollup": "^4.34.9",
-				"tinyglobby": "^0.2.12"
+				"tinyglobby": "^0.2.13"
 			},
 			"bin": {
 				"vite": "bin/vite.js"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,11 +9,6 @@
 			"react": "^19.1.0",
 			"react-dom": "^19.1.0"
 		},
-		"react-joyride": {
-			"react": "^19.1.0",
-			"react-dom": "^19.1.0",
-			"react-floater": "^0.9.4"
-		},
 		"lodash": "^4.17.12",
 		"tough-cookie": ">=4.1.3"
 	},
@@ -42,7 +37,7 @@
 		"react": "19.1.0",
 		"react-animate-height": "^3.2.3",
 		"react-dom": "19.1.0",
-		"react-joyride": "^2.9.3",
+		"react-joyride-react-19": "^2.9.2",
 		"react-lazyload": "^3.2.1",
 		"react-router": "^7.5.2",
 		"react-router-hash-link": "^2.4.3",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,12 +94,7 @@
 button[data-action='back'] {
   color: theme('colors.white') !important;
 }
-
-/* all h4 that are any descendants of #react-floater-portal */
-
-
-
-#react-floater-portal h4 {
+.react-joyride__tooltip h4 {
   color: theme('colors.white') !important;
 
 }

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,6 +1,6 @@
 import { useAtomValue } from 'jotai'
 import { lazy, useCallback, useEffect, useState } from 'react'
-import { STATUS } from 'react-joyride'
+import { STATUS } from 'react-joyride-react-19' // TODO: ideally revert back to react-joyride and not this temporary fork
 import { useLocation } from 'react-router'
 import {
   type DropdownVarId,

--- a/frontend/src/pages/ExploreData/Onboarding.tsx
+++ b/frontend/src/pages/ExploreData/Onboarding.tsx
@@ -1,4 +1,4 @@
-import Joyride from 'react-joyride'
+import Joyride from 'react-joyride-react-19' // TODO: ideally revert back to react-joyride and not this temporary fork
 import { ThemeZIndexValues, het } from '../../styles/DesignTokens'
 import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
 import { getOnboardingSteps } from './OnboardingSteps'


### PR DESCRIPTION
temporarily uses fork of `react-joyride` to be compatible with React 19 (after #4298 the joyride was no longer visible)

we should revert back to using the main package if it is eventually updated and stays maintained. otherwise we might be better off replacing this temporary fork with another package entirely that's better maintained. following issue gilbarbara/react-joyride/issues/1151

also fixes a bug where the titles of the joyride steps where not rendering white and were basically unreadable