### PR TITLE
Rename state variable

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -119,7 +119,7 @@ function MapCardWithKey(props: MapCardProps) {
     ? EXTREMES_2_PARAM_KEY
     : EXTREMES_1_PARAM_KEY
 
-  const [extremesMode, setExtremesMode] = useParamState<boolean>(
+  const [isExtremesMode, setIsExtremesMode] = useParamState<boolean>(
     extremesParamsKey,
     false,
   )
@@ -267,7 +267,8 @@ function MapCardWithKey(props: MapCardProps) {
   )
   const pluralChildFips =
     props.fips.getPluralChildFipsTypeDisplayName() ?? 'places'
-  if (extremesMode) subtitle += ` (only ${pluralChildFips} with rate extremes)`
+  if (isExtremesMode)
+    subtitle += ` (only ${pluralChildFips} with rate extremes)`
   const filename = `${title} ${subtitle ? `for ${subtitle}` : ''}`
 
   return (
@@ -278,7 +279,7 @@ function MapCardWithKey(props: MapCardProps) {
       minHeight={preloadHeight}
       scrollToHash={HASH_ID}
       reportTitle={props.reportTitle}
-      expanded={extremesMode}
+      expanded={isExtremesMode}
       isCompareCard={props.isCompareCard}
       className={props.className}
     >
@@ -448,7 +449,7 @@ function MapCardWithKey(props: MapCardProps) {
           setParameter(MAP_GROUP_PARAM, groupCode)
         }
 
-        const displayData = extremesMode
+        const displayData = isExtremesMode
           ? highestValues.concat(lowestValues)
           : dataForActiveDemographicGroup
 
@@ -460,7 +461,7 @@ function MapCardWithKey(props: MapCardProps) {
 
         const mapConfig = props.dataTypeConfig.mapConfig
 
-        if (dataForActiveDemographicGroup?.length <= 1) setExtremesMode(false)
+        if (dataForActiveDemographicGroup?.length <= 1) setIsExtremesMode(false)
 
         if (!dataForActiveDemographicGroup?.length || !metricConfig)
           return (
@@ -570,17 +571,17 @@ function MapCardWithKey(props: MapCardProps) {
                     title={title}
                     subtitle={subtitle}
                     filterButton={
-                      extremesMode ? (
+                      isExtremesMode ? (
                         <HetLinkButton
                           buttonClassName='py-0 mx-0'
-                          onClick={() => setExtremesMode(false)}
+                          onClick={() => setIsExtremesMode(false)}
                         >
                           Reset to show all {pluralChildFips}
                         </HetLinkButton>
                       ) : null
                     }
                   />
-                  {isGeorgiaWithCountyData && !extremesMode && (
+                  {isGeorgiaWithCountyData && !isExtremesMode && (
                     <HetLinkButton
                       onClick={() => setIsAtlantaMode(!isAtlantaMode)}
                       className='flex items-center'
@@ -609,10 +610,10 @@ function MapCardWithKey(props: MapCardProps) {
                       fips={props.fips}
                       geoData={geoData}
                       hideLegend={true}
-                      hideMissingDataTooltip={extremesMode}
+                      hideMissingDataTooltip={isExtremesMode}
                       legendData={dataForActiveDemographicGroup}
                       legendTitle={metricConfig.shortLabel.toLowerCase()}
-                      extremesMode={extremesMode}
+                      isExtremesMode={isExtremesMode}
                       metricConfig={metricConfig}
                       showCounties={
                         !props.fips.isUsa() && !hasSelfButNotChildGeoData
@@ -666,8 +667,8 @@ function MapCardWithKey(props: MapCardProps) {
                       dataTypeConfig={props.dataTypeConfig}
                       selectedRaceSuffix={selectedRaceSuffix}
                       metricConfig={metricConfig}
-                      isOpen={extremesMode}
-                      setIsOpen={setExtremesMode}
+                      isOpen={isExtremesMode}
+                      setIsOpen={setIsExtremesMode}
                       highestValues={highestValues}
                       lowestValues={lowestValues}
                       parentGeoQueryResponse={parentGeoQueryResponse}

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -1,6 +1,5 @@
 import { useLocation } from 'react-router'
 import ChoroplethMap from '../charts/choroplethMap/index'
-import type { DataPoint } from '../charts/choroplethMap/types'
 import { MAP_SCHEMES } from '../charts/mapGlobals'
 import { generateChartTitle, generateSubtitle } from '../charts/utils'
 import type {
@@ -222,7 +221,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
                   countColsMap={{}}
                   data={unknowns}
                   demographicType={demographicType}
-                  extremesMode={false}
+                  isExtremesMode={false}
                   filename={chartTitle}
                   fips={props.fips}
                   geoData={geoData}

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -175,7 +175,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
                         signalListeners={multimapSignalListeners}
                         mapConfig={mapConfig}
                         isMulti={true}
-                        extremesMode={false}
+                        isExtremesMode={false}
                         isPhrmaAdherence={props.isPhrmaAdherence}
                         isAtlantaMode={props.isAtlantaMode}
                       />

--- a/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
+++ b/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
@@ -40,7 +40,7 @@ interface TerritoryCirclesProps {
   dataMap: Map<string, any>
   tooltipContainer: any
   geographyType: string
-  extremesMode: boolean
+  isExtremesMode: boolean
   mapConfig: MapConfig
   signalListeners: any
   isMobile: boolean
@@ -112,12 +112,12 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
           d: createTerritoryFeature(d.fips),
           dataMap: props.dataMap,
           colorScale: props.colorScale,
-          extremesMode: props.extremesMode,
+          isExtremesMode: props.isExtremesMode,
           mapConfig: props.mapConfig,
           isMultiMap: props.isMulti,
         }),
       )
-      .attr('stroke', props.extremesMode ? BORDER_GREY : WHITE)
+      .attr('stroke', props.isExtremesMode ? BORDER_GREY : WHITE)
       .attr('stroke-width', STROKE_WIDTH)
       .on(
         'mouseover',
@@ -161,7 +161,7 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
     props.dataWithHighestLowest,
     props.dataMap,
     props.colorScale,
-    props.extremesMode,
+    props.isExtremesMode,
     props.mapConfig,
     props.isPhrmaAdherence,
     props.signalListeners,

--- a/frontend/src/charts/choroplethMap/colorSchemes.ts
+++ b/frontend/src/charts/choroplethMap/colorSchemes.ts
@@ -145,7 +145,8 @@ export const createColorScale = (props: CreateColorScaleProps) => {
 }
 
 export const getFillColor = (props: GetFillColorProps): string => {
-  const { d, dataMap, mapConfig, extremesMode, colorScale, isMultiMap } = props
+  const { d, dataMap, mapConfig, isExtremesMode, colorScale, isMultiMap } =
+    props
 
   if (!isMultiMap && dataMap.size === 1) return mapConfig.mid
 
@@ -159,5 +160,5 @@ export const getFillColor = (props: GetFillColorProps): string => {
     return colorScale(value)
   }
 
-  return extremesMode ? WHITE : ALT_GREY
+  return isExtremesMode ? WHITE : ALT_GREY
 }

--- a/frontend/src/charts/choroplethMap/index.tsx
+++ b/frontend/src/charts/choroplethMap/index.tsx
@@ -30,7 +30,7 @@ const ChoroplethMap = ({
   countColsMap,
   isUnknownsMap = false,
   isMulti,
-  extremesMode,
+  isExtremesMode,
   mapConfig,
   signalListeners,
   filename,
@@ -144,7 +144,7 @@ const ChoroplethMap = ({
         isCawp,
         countColsMap,
         isUnknownsMap,
-        extremesMode,
+        isExtremesMode,
         mapConfig,
         signalListeners,
         isMulti,
@@ -177,7 +177,7 @@ const ChoroplethMap = ({
     countColsMap,
     isUnknownsMap,
     signalListeners,
-    extremesMode,
+    isExtremesMode,
   ])
 
   return (
@@ -212,7 +212,7 @@ const ChoroplethMap = ({
           dataMap={renderResult.dataMap}
           tooltipContainer={tooltipContainerRef.current}
           geographyType={getCountyAddOn(fips, showCounties)}
-          extremesMode={extremesMode}
+          isExtremesMode={isExtremesMode}
           mapConfig={mapConfig}
           signalListeners={signalListeners}
           isMobile={isMobile}

--- a/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
+++ b/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
@@ -21,7 +21,7 @@ interface MouseEventHandlerProps {
   dataMap: Map<string, any>
   tooltipContainer: any
   geographyType: string
-  extremesMode: boolean
+  isExtremesMode: boolean
   mapConfig: MapConfig
   isMultiMap: boolean
 }
@@ -41,7 +41,7 @@ export const createMouseEventProps = (
     dataMap: dataMap || props.dataMap,
     tooltipContainer: props.tooltipContainer,
     geographyType: geographyType || props.geographyType,
-    extremesMode: props.extremesMode,
+    isExtremesMode: props.isExtremesMode,
     mapConfig: props.mapConfig,
     isMultiMap: props.isMultiMap,
   }
@@ -117,7 +117,7 @@ const handleMouseEvent = (
           d,
           dataMap: props.dataMap,
           colorScale: props.colorScale,
-          extremesMode: props.extremesMode,
+          isExtremesMode: props.isExtremesMode,
           mapConfig: props.mapConfig,
           isMultiMap: props.isMultiMap,
         }),

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -92,12 +92,12 @@ export const renderMap = (props: RenderMapProps) => {
         d,
         dataMap,
         colorScale: props.colorScale,
-        extremesMode: props.extremesMode,
+        isExtremesMode: props.isExtremesMode,
         mapConfig: props.mapConfig,
         isMultiMap: props.isMulti,
       }),
     )
-    .attr('stroke', props.extremesMode ? BORDER_GREY : WHITE)
+    .attr('stroke', props.isExtremesMode ? BORDER_GREY : WHITE)
     .attr('stroke-width', STROKE_WIDTH)
     .on('mouseover', createEventHandler('mouseover', mouseEventProps))
     .on('mousemove', createEventHandler('mousemove', mouseEventProps))

--- a/frontend/src/charts/choroplethMap/types.ts
+++ b/frontend/src/charts/choroplethMap/types.ts
@@ -37,7 +37,7 @@ export interface ChoroplethMapProps {
   countColsMap: CountColsMap
   demographicType: DemographicType
   data: Array<Record<string, any>>
-  extremesMode: boolean
+  isExtremesMode: boolean
   fips: Fips
   fieldRange?: FieldRange
   filename?: string
@@ -91,7 +91,7 @@ export type GetFillColorProps = {
   dataMap: Map<string, MetricData>
   colorScale: ColorScale
   mapConfig: MapConfig
-  extremesMode?: boolean
+  isExtremesMode?: boolean
   isMultiMap?: boolean
 }
 
@@ -132,7 +132,7 @@ export type RenderMapProps = {
   fips: Fips
   isMobile: boolean
   isCawp: boolean
-  extremesMode: boolean
+  isExtremesMode: boolean
   mapConfig: MapConfig
   signalListeners: any
   isMulti?: boolean
@@ -153,7 +153,7 @@ interface MouseEventHandlerProps {
   dataMap: Map<string, MetricData>
   tooltipContainer: d3.Selection<HTMLDivElement, unknown, HTMLElement, any>
   geographyType?: string
-  extremesMode?: boolean
+  isExtremesMode?: boolean
   mapConfig: MapConfig
   fips?: Fips
   isPhrmaAdherence: boolean


### PR DESCRIPTION
should be consistent; easier to understand if boolean variables start with `is{Property}`