### PR TITLE
Bans unused vars in tsconfig and biome; cleans up lots of unused code

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -54,7 +54,9 @@
 				}
 			},
 			"correctness": {
-				"useExhaustiveDependencies": "off"
+				"useExhaustiveDependencies": "off",
+				"noUnusedVariables": "error",
+				"noUnusedImports": "error"
 			},
 			"style": {
 				"useTemplate": "off",

--- a/frontend/src/cards/UnknownsMapCard.tsx
+++ b/frontend/src/cards/UnknownsMapCard.tsx
@@ -126,7 +126,7 @@ function UnknownsMapCardWithKey(props: UnknownsMapCardProps) {
       reportTitle={props.reportTitle}
       hideNH={true}
     >
-      {([mapQueryResponse, alertQueryResponse], metadata, geoData) => {
+      {([mapQueryResponse, alertQueryResponse], _metadata, geoData) => {
         // MOST of the items rendered in the card refer to the unknowns at the CHILD geo level,
         //  e.g. if you look at the United States, we are dealing with the Unknown pct_share at the state level
         // the exception is the <UnknownsAlert /> which presents the amount of unknown demographic at the SELECTED level

--- a/frontend/src/cards/ui/AltTableView.tsx
+++ b/frontend/src/cards/ui/AltTableView.tsx
@@ -105,7 +105,7 @@ export default function AltTableView(props: AltTableViewProps) {
               <caption className='font-medium'>{props.tableCaption}</caption>
               <TableHead>
                 <TableRow>
-                  {Object.keys(accessibleData[0]).map((key, i) => {
+                  {Object.keys(accessibleData[0]).map((key) => {
                     const isTimeCol = key === TIME_PERIOD_LABEL
                     const isUnknownPctCol = key.includes('with unknown ')
 
@@ -137,14 +137,14 @@ export default function AltTableView(props: AltTableViewProps) {
               </TableHead>
 
               <TableBody>
-                {accessibleData.map((row, i) => {
+                {accessibleData.map((row) => {
                   const keys = Object.keys(row)
                   return (
                     <TableRow
                       key={row[TIME_PERIOD_LABEL]}
                       className='odd:bg-tableZebra even:bg-white'
                     >
-                      {keys.map((key, j) => {
+                      {keys.map((key) => {
                         const isTimePeriod = key === TIME_PERIOD_LABEL
 
                         const appendPct =

--- a/frontend/src/charts/AgeAdjustedTableChart.tsx
+++ b/frontend/src/charts/AgeAdjustedTableChart.tsx
@@ -128,7 +128,7 @@ export function AgeAdjustedTableChart(props: AgeAdjustedTableChartProps) {
               <TableBody>
                 {table.getRowModel().rows.map((row, rowIndex) => (
                   <TableRow key={row.id}>
-                    {row.getVisibleCells().map((cell, cellIndex) => {
+                    {row.getVisibleCells().map((cell) => {
                       const value = cell.getValue()
 
                       return value == null ? (

--- a/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
+++ b/frontend/src/charts/choroplethMap/TerritoryCircles.tsx
@@ -64,10 +64,7 @@ export default function TerritoryCircles(props: TerritoryCirclesProps) {
     const territorySpacing = territoryRadius * 2.5
 
     // Draw territory circles
-    const territoryData = extractTerritoryData(
-      props.fips.code,
-      props.dataWithHighestLowest,
-    )
+    const territoryData = extractTerritoryData(props.dataWithHighestLowest)
 
     const marginRightForTerrRow = props.isMulti
       ? 10

--- a/frontend/src/charts/choroplethMap/mapTerritoryHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapTerritoryHelpers.ts
@@ -26,7 +26,7 @@ export const createTerritoryFeature = (
   id: fipsCode,
 })
 
-export function extractTerritoryData(fipsCode: string, data: HetRow[]) {
+export function extractTerritoryData(data: HetRow[]) {
   return Object.entries(TERRITORY_CODES).map(([fips, fips_name]) => {
     const territoryRow: DataPoint | undefined = data.find(
       (d) => d.fips === fips,

--- a/frontend/src/charts/mapGlobals.ts
+++ b/frontend/src/charts/mapGlobals.ts
@@ -7,16 +7,6 @@ import { het } from '../styles/DesignTokens'
 import type { ColorScheme } from './choroplethMap/types'
 
 export const DATA_SUPPRESSED = 'Data suppressed'
-const COLOR_SCALE = 'COLOR_SCALE'
-const ZERO_SCALE = 'ZERO_SCALE'
-
-type ScaleType = 'quantile' | 'symlog'
-type StackingDirection = 'horizontal' | 'vertical'
-
-const RATE_MAP_SCALE: ScaleType = 'quantile'
-
-const ORDINAL = 'ordinal'
-
 export const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
 
 type PopulationSubset =
@@ -94,24 +84,8 @@ export const youthHigherIsWorseMapConfig: MapConfig = {
   higherIsBetter: false,
 }
 
-const DOT_SIZE_SCALE = 'dot_size_scale'
-const SUMMARY_SCALE = 'summary_scale'
-const GREY_DOT_SCALE = 'grey_dot_scale'
-const UNKNOWN_SCALE = 'unknown_scale'
-const ZERO_DOT_SCALE = 'zero_dot_scale'
-
-const RAW_VALUES = 'raw_values'
-const DATASET_VALUES = 'dataset_values'
-const NON_ZERO_DATASET_VALUES = 'non_zero_dataset_values'
-const SUMMARY_VALUE = 'summary_value'
-const ZERO_VALUES = 'zero_values'
-const MISSING_PLACEHOLDER_VALUES = 'missing_data'
-
-const LEGEND_SYMBOL_TYPE = 'square'
 export const NO_DATA_MESSAGE = 'no data'
 export const DEFAULT_LEGEND_COLOR_COUNT = 6
-
-const ZERO_BUCKET_LABEL = '0'
 
 export interface HighestLowest {
   highest?: DemographicGroup
@@ -119,21 +93,6 @@ export interface HighestLowest {
 }
 
 export const PHRMA_ADHERENCE_BREAKPOINTS = [60, 70, 75, 80, 85, 90]
-
-const PHRMA_COLOR_SCALE_SPEC = {
-  name: COLOR_SCALE,
-  type: 'threshold',
-  domain: PHRMA_ADHERENCE_BREAKPOINTS,
-  range: [
-    het.mapMedicareDarkest,
-    het.mapMedicareDark,
-    het.mapMedicareMid,
-    het.mapMedicareLight,
-    het.mapMedicareLighter,
-    het.mapMedicareEvenLighter,
-    het.mapMedicareLightest,
-  ],
-}
 
 export interface CountColsMap {
   numeratorConfig?: MetricConfig

--- a/frontend/src/charts/trendsChart/TrendsTooltip.tsx
+++ b/frontend/src/charts/trendsChart/TrendsTooltip.tsx
@@ -14,7 +14,7 @@ import { raceNameToCodeMap } from '../../data/utils/Constants'
 
 import { COLORS as C, FORMATTERS as F, TYPES } from './constants'
 /* Constants */
-import type { AxisConfig, GroupData, TimeSeries, TrendsData } from './types'
+import type { AxisConfig, GroupData, TrendsData } from './types'
 
 /* Helpers */
 import {
@@ -42,23 +42,25 @@ export function TrendsTooltip({
 }: TrendsTooltipProps) {
   const { type, yAxisLabel = '' } = axisConfig || {}
 
+  const zeroTranslate = () => 0
+
   const TYPE_CONFIG = {
     [TYPES.HUNDRED_K]: {
       UNIT: isSkinny ? '' : ' per 100k',
       width: getWidthHundredK,
-      translate_x: (d: TimeSeries) => 0,
+      translate_x: zeroTranslate,
       formatter: F.num100k,
     },
     [TYPES.PCT_RATE]: {
       UNIT: '',
       width: getWidthPctShare,
-      translate_x: (d: TimeSeries) => 0,
+      translate_x: zeroTranslate,
       formatter: F.pct,
     },
     [TYPES.PERCENT_SHARE]: {
       UNIT: '',
       width: getWidthPctShare,
-      translate_x: (d: TimeSeries) => 0,
+      translate_x: zeroTranslate,
       formatter: F.pct,
     },
     [TYPES.PERCENT_RELATIVE_INEQUITY]: {
@@ -70,7 +72,7 @@ export function TrendsTooltip({
     [TYPES.INDEX]: {
       UNIT: '',
       width: getWidthHundredK,
-      translate_x: (d: TimeSeries) => 0,
+      translate_x: zeroTranslate,
       formatter: F.num100k,
     },
   }

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -49,14 +49,6 @@ const {
   timeYellow,
   mapLight,
   mapLighter,
-  mapMedicareMid,
-  mapMedicareLight,
-  mapMedicareLighter,
-  mapMedicareLightest,
-  altGrey,
-  altOrange,
-  mapMedicareDarkest,
-  mapMedicareDark,
 } = het
 
 export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {

--- a/frontend/src/charts/trendsChart/helpers.ts
+++ b/frontend/src/charts/trendsChart/helpers.ts
@@ -34,7 +34,7 @@ function sortDataDescending(d: TrendsData, selectedDate: string) {
           getAmountsByDate(data, selectedDate) === 0,
       )
       // sort remaining data by number for this date, highest number first
-      .sort(([, aData]: GroupData, [group, bData]: GroupData) =>
+      .sort(([, aData]: GroupData, [_group, bData]: GroupData) =>
         descending(
           getAmountsByDate(aData, selectedDate),
           getAmountsByDate(bData, selectedDate),
@@ -45,7 +45,7 @@ function sortDataDescending(d: TrendsData, selectedDate: string) {
 
 /* Returns the highest absolute value amount (y value) at a given date (x value) */
 function getMaxNumberForDate(data: TrendsData, selectedDate: string | null) {
-  const numbers = data.flatMap(([group, d]) =>
+  const numbers = data.flatMap(([_group, d]) =>
     // filter out data points for selected date
     d
       .filter(([date]) => date === selectedDate)
@@ -142,16 +142,16 @@ function hasNonZeroUnknowns(data: TimeSeries | undefined) {
 }
 
 export {
-  hasNonZeroUnknowns,
   filterDataByGroup,
-  getAmountsByDate,
-  sortDataDescending,
-  getDates,
-  getAmounts,
-  getWidthPctShare,
-  getWidthHundredK,
-  translateXPctShare,
-  getMinNumber,
-  getMaxNumber,
   filterUnknownsByTimePeriod,
+  getAmounts,
+  getAmountsByDate,
+  getDates,
+  getMaxNumber,
+  getMinNumber,
+  getWidthHundredK,
+  getWidthPctShare,
+  hasNonZeroUnknowns,
+  sortDataDescending,
+  translateXPctShare,
 }

--- a/frontend/src/charts/trendsChart/types.ts
+++ b/frontend/src/charts/trendsChart/types.ts
@@ -1,4 +1,4 @@
-import type { ScaleLinear, ScaleOrdinal, ScaleTime } from 'd3'
+import type { ScaleLinear, ScaleTime } from 'd3'
 import type {
   MetricType,
   TimeSeriesCadenceType,
@@ -14,7 +14,6 @@ type Date = string
 
 type XScale = ScaleTime<number, number | undefined>
 type YScale = ScaleLinear<number, number | undefined>
-type ColorScale = ScaleOrdinal<string, string, never>
 
 interface AxisConfig {
   type: MetricType
@@ -25,11 +24,11 @@ interface AxisConfig {
 }
 
 export type {
-  TrendsData,
+  AxisConfig,
   GroupData,
   TimeSeries,
+  TrendsData,
   UnknownData,
   XScale,
   YScale,
-  AxisConfig,
 }

--- a/frontend/src/data/config/MetricConfigPhrma.ts
+++ b/frontend/src/data/config/MetricConfigPhrma.ts
@@ -4,11 +4,6 @@ import {
 } from '../../charts/mapGlobals'
 import type { DataTypeConfig } from './MetricConfigTypes'
 
-const MEDICARE_CATEGORY_HIV_AND_CVD_DROPDOWNIDS = [
-  'medicare_cardiovascular',
-  'medicare_hiv',
-] as const
-
 export const MEDICARE_CATEGORY_DROPDOWNIDS = [
   'medicare_cardiovascular',
   'medicare_hiv',

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -151,7 +151,7 @@ export class MetadataCache extends ResourceCache<string, MapOfDatasetMetadata> {
    * Since there's only one metadata entry this doesn't really matter - we just
    * use a constant factor per entry.
    */
-  getResourceSize(resource: MapOfDatasetMetadata, id: string): number {
+  getResourceSize(_resource: MapOfDatasetMetadata, _id: string): number {
     return 1
   }
 }
@@ -182,7 +182,7 @@ class DatasetCache extends ResourceCache<string, Dataset> {
    * across datasets and that key size plus metadata is roughly similar in size
    * to a small number of rows.
    */
-  getResourceSize(resource: Dataset, key: string): number {
+  getResourceSize(resource: Dataset): number {
     return resource.rows.length + 5
   }
 }
@@ -259,7 +259,7 @@ class MetricQueryCache extends ResourceCache<MetricQuery, MetricQueryResponse> {
    * across queries and that key size plus metadata is roughly similar in size
    * to a small number of rows.
    */
-  getResourceSize(resource: MetricQueryResponse, key: string): number {
+  getResourceSize(resource: MetricQueryResponse): number {
     return resource.data.length + 5
   }
 }

--- a/frontend/src/data/providers/CdcCancerProvider.ts
+++ b/frontend/src/data/providers/CdcCancerProvider.ts
@@ -1,5 +1,4 @@
 import { getDataManager } from '../../utils/globals'
-import type { DropdownVarId } from '../config/DropDownIds'
 import type { DataTypeId, MetricId } from '../config/MetricConfigTypes'
 import type { Breakdowns } from '../query/Breakdowns'
 import {
@@ -8,8 +7,6 @@ import {
   resolveDatasetId,
 } from '../query/MetricQuery'
 import VariableProvider from './VariableProvider'
-
-const CDC_CANCER_CONDITIONS: DropdownVarId[] = ['cancer_incidence']
 
 export const CDC_CANCER_SEX_SPECIFIC_DATATYPES: DataTypeId[] = [
   'breast_cancer_incidence',
@@ -20,11 +17,6 @@ export const CDC_CANCER_SEX_SPECIFIC_DATATYPES: DataTypeId[] = [
 export const CDC_CANCER_ALL_SEXES_DATATYPES: DataTypeId[] = [
   'colorectal_cancer_incidence',
   'lung_cancer_incidence',
-]
-
-const CDC_CANCER_DATATYPES: DataTypeId[] = [
-  ...CDC_CANCER_SEX_SPECIFIC_DATATYPES,
-  ...CDC_CANCER_ALL_SEXES_DATATYPES,
 ]
 
 const CDC_CANCER_METRICS: MetricId[] = [

--- a/frontend/src/data/providers/GeoContextProvider.ts
+++ b/frontend/src/data/providers/GeoContextProvider.ts
@@ -20,7 +20,7 @@ class GeoContextProvider extends VariableProvider {
   async getDataInternal(
     metricQuery: MetricQuery,
   ): Promise<MetricQueryResponse> {
-    const { datasetId, isFallbackId, breakdowns } = resolveDatasetId(
+    const { datasetId, breakdowns } = resolveDatasetId(
       'geo_context',
       '',
       metricQuery,

--- a/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
+++ b/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
@@ -1,5 +1,5 @@
 import { getDataManager } from '../../utils/globals'
-import type { DataTypeId, MetricId } from '../config/MetricConfigTypes'
+import type { MetricId } from '../config/MetricConfigTypes'
 import type { Breakdowns } from '../query/Breakdowns'
 import {
   type MetricQuery,
@@ -7,8 +7,6 @@ import {
   resolveDatasetId,
 } from '../query/MetricQuery'
 import VariableProvider from './VariableProvider'
-
-const GUN_DEATHS_BLACK_MEN_DATATYPES: DataTypeId[] = ['gun_deaths_black_men']
 
 const GUN_DEATHS_BLACK_MEN_METRIC_IDS: MetricId[] = [
   'gun_homicides_black_men_estimated_total',

--- a/frontend/src/data/providers/PhrmaBrfssProvider.ts
+++ b/frontend/src/data/providers/PhrmaBrfssProvider.ts
@@ -1,5 +1,4 @@
 import { getDataManager } from '../../utils/globals'
-import type { DropdownVarId } from '../config/DropDownIds'
 import type { DataTypeId, MetricId } from '../config/MetricConfigTypes'
 import type { Breakdowns } from '../query/Breakdowns'
 import {
@@ -10,8 +9,6 @@ import {
 import { appendFipsIfNeeded } from '../utils/datasetutils'
 import VariableProvider from './VariableProvider'
 
-const PHRMA_BRFSS_CONDITIONS: DropdownVarId[] = ['cancer_screening']
-
 export const PHRMA_BRFSS_SEX_SPECIFIC_DATATYPES: DataTypeId[] = [
   'breast_cancer_screening',
   'cervical_cancer_screening',
@@ -21,11 +18,6 @@ export const PHRMA_BRFSS_SEX_SPECIFIC_DATATYPES: DataTypeId[] = [
 export const PHRMA_BRFSS_ALL_SEXES_DATATYPES: DataTypeId[] = [
   'colorectal_cancer_screening',
   'lung_cancer_screening',
-]
-
-const PHRMA_BRFSS_DATATYPES: DataTypeId[] = [
-  ...PHRMA_BRFSS_SEX_SPECIFIC_DATATYPES,
-  ...PHRMA_BRFSS_ALL_SEXES_DATATYPES,
 ]
 
 const PHRMA_BRFSS_METRICS: MetricId[] = [

--- a/frontend/src/data/providers/TestUtils.ts
+++ b/frontend/src/data/providers/TestUtils.ts
@@ -1,14 +1,4 @@
-import type FakeDataFetcher from '../../testing/FakeDataFetcher'
-import type {
-  DatasetId,
-  DatasetIdWithStateFIPSCode,
-} from '../config/DatasetMetadata'
-import type { MetricId } from '../config/MetricConfigTypes'
-import { excludeAll } from '../query/BreakdownFilter'
-import type { Breakdowns, DemographicType } from '../query/Breakdowns'
-import { MetricQuery, MetricQueryResponse } from '../query/MetricQuery'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../utils/ConstantsGeography'
-import type VariableProvider from './VariableProvider'
 
 interface FipsSpec {
   code: string
@@ -18,30 +8,12 @@ export const CHATAM: FipsSpec = {
   code: '37037',
   name: 'Chatam County',
 }
-const DURHAM: FipsSpec = {
-  code: '37063',
-  name: 'Durham County',
-}
+
 export const NC: FipsSpec = {
   code: '37',
   name: 'North Carolina',
 }
-const AL: FipsSpec = {
-  code: '01',
-  name: 'Alabama',
-}
-const CA: FipsSpec = {
-  code: '06',
-  name: 'California',
-}
-const MARIN: FipsSpec = {
-  code: '06041',
-  name: 'Marin County',
-}
-const WA: FipsSpec = {
-  code: '53',
-  name: 'Washington',
-}
+
 export const VI: FipsSpec = {
   code: '78',
   name: 'U.S. Virgin Islands',
@@ -49,40 +21,4 @@ export const VI: FipsSpec = {
 export const USA: FipsSpec = {
   code: USA_FIPS,
   name: USA_DISPLAY_NAME,
-}
-
-function createWithAndWithoutAllEvaluator(
-  metricIds: MetricId | MetricId[],
-  dataFetcher: FakeDataFetcher,
-  variableProvider: VariableProvider,
-) {
-  return async (
-    datasetId: DatasetId | DatasetIdWithStateFIPSCode,
-    rawData: any[],
-    baseBreakdown: Breakdowns,
-    demographicType: DemographicType,
-    rowsExcludingAll: any[],
-    rowsIncludingAll: any[],
-  ) => {
-    dataFetcher.setFakeDatasetLoaded(datasetId, rawData)
-
-    // Evaluate the response with requesting "All" field
-    const responseWithAll = await variableProvider.getData(
-      new MetricQuery(metricIds, baseBreakdown.addBreakdown(demographicType)),
-    )
-    expect(responseWithAll).toEqual(
-      new MetricQueryResponse(rowsIncludingAll, [datasetId]),
-    )
-
-    // Evaluate the response without requesting "All" field
-    const responseWithoutAll = await variableProvider.getData(
-      new MetricQuery(
-        metricIds,
-        baseBreakdown.addBreakdown(demographicType, excludeAll()),
-      ),
-    )
-    expect(responseWithoutAll).toEqual(
-      new MetricQueryResponse(rowsExcludingAll, [datasetId]),
-    )
-  }
 }

--- a/frontend/src/data/query/BreakdownFilter.ts
+++ b/frontend/src/data/query/BreakdownFilter.ts
@@ -1,9 +1,4 @@
-import {
-  ALL,
-  type AgeBucket,
-  type DemographicGroup,
-  type RaceAndEthnicityGroup,
-} from '../utils/Constants'
+import { ALL, type DemographicGroup } from '../utils/Constants'
 
 /**
  * Specifies a set of filters to apply to a breakdown. When `include` is true,
@@ -15,46 +10,10 @@ export default interface BreakdownFilter {
   readonly include: boolean
 }
 
-const STANDARD_RACES: RaceAndEthnicityGroup[] = [
-  'Indigenous (NH)',
-  'Asian (NH)',
-  'Black or African American (NH)',
-  'Hispanic or Latino',
-  'Native Hawaiian and Pacific Islander (NH)',
-  'Unrepresented race (NH)',
-  'Two or more races (NH)',
-  'White (NH)',
-  ALL,
-]
-
-const DECADE_AGE_BRACKETS: AgeBucket[] = [
-  '0-9',
-  '10-19',
-  '20-29',
-  '30-39',
-  '40-49',
-  '50-59',
-  '60-69',
-  '70-79',
-  '80+',
-]
-
 export function exclude(
   ...valuesToExclude: DemographicGroup[]
 ): BreakdownFilter {
   return { include: false, values: [...valuesToExclude] }
-}
-
-function onlyInclude(...valuesToInclude: DemographicGroup[]): BreakdownFilter {
-  return { include: true, values: [...valuesToInclude] }
-}
-
-function onlyIncludeStandardRaces(): BreakdownFilter {
-  return onlyInclude(...STANDARD_RACES)
-}
-
-function onlyIncludeDecadeAgeBrackets(): BreakdownFilter {
-  return onlyInclude(...DECADE_AGE_BRACKETS)
 }
 
 export function excludeAll(): BreakdownFilter {

--- a/frontend/src/data/query/Breakdowns.ts
+++ b/frontend/src/data/query/Breakdowns.ts
@@ -253,7 +253,7 @@ export class Breakdowns {
   // Helper function returning how many demographic breakdowns are currently requested
   demographicBreakdownCount() {
     return Object.entries(this.demographicBreakdowns).filter(
-      ([k, v]) => v.enabled,
+      ([_k, v]) => v.enabled,
     ).length
   }
 
@@ -361,7 +361,7 @@ export class Breakdowns {
   getJoinColumns(): DemographicType[] {
     const joinCols: DemographicType[] = ['fips']
     Object.entries(this.demographicBreakdowns).forEach(
-      ([key, demographicBreakdown]) => {
+      ([_key, demographicBreakdown]) => {
         if (demographicBreakdown.enabled) {
           joinCols.push(demographicBreakdown.columnName)
         }

--- a/frontend/src/data/react/useResources.ts
+++ b/frontend/src/data/react/useResources.ts
@@ -27,7 +27,7 @@ export function useResources<K, R>(
       const promises = resources.map(async (resource) => await loadFn(resource))
       const results = await Promise.all(promises)
       setResourceState(results)
-    } catch (e) {
+    } catch (_e) {
       setResourceState('error')
     }
   }

--- a/frontend/src/data/sorting/AlphabeticalSorterStrategy.test.ts
+++ b/frontend/src/data/sorting/AlphabeticalSorterStrategy.test.ts
@@ -1,4 +1,3 @@
-import { Breakdowns } from '../query/Breakdowns'
 import { AlphabeticalSorterStrategy } from './AlphabeticalSorterStrategy'
 
 describe('dataset utils test', () => {
@@ -6,9 +5,6 @@ describe('dataset utils test', () => {
   const RACE_A = { race: 'a' }
   const RACE_B = { race: 'b' }
   const RACE_C = { race: 'c' }
-
-  const RACE_UNKNOWN = { race: 'unknown' }
-  const breakdown = Breakdowns.national()
 
   beforeEach(() => {})
 

--- a/frontend/src/data/sorting/sortingUtils.ts
+++ b/frontend/src/data/sorting/sortingUtils.ts
@@ -1,5 +1,4 @@
 import type { DemographicType } from '../query/Breakdowns'
-import type { HetRow } from '../utils/DatasetTypes'
 import { AgeSorterStrategy } from './AgeSorterStrategy'
 import { IncomeSorterStrategy } from './IncomeSorterStrategy'
 

--- a/frontend/src/data/utils/Constants.ts
+++ b/frontend/src/data/utils/Constants.ts
@@ -299,8 +299,6 @@ export const ACS_UNINSURANCE_CURRENT_AGE_BUCKETS = [
 // still need to be defined here to explicitly exclude from the TABLE
 const UNUSED_BUCKETS = ['15-17', '65-69', '70-74', '75-79', '80-84'] as const
 
-const UNDER_18_PRISON = `Children in Adult Prison`
-
 // COMBINE ALL AGE GROUP OPTIONS INTO A SINGLE ARRAY
 export const AGE_BUCKETS = [
   ALL,

--- a/frontend/src/data/utils/DatasetTypes.ts
+++ b/frontend/src/data/utils/DatasetTypes.ts
@@ -31,13 +31,6 @@ export interface DatasetMetadata {
   source_id: DataSourceId | 'error'
 }
 
-interface Field {
-  readonly data_type: string
-  readonly name: string
-  readonly description: string
-  readonly origin_dataset: string
-}
-
 export interface FieldRange {
   readonly min: number
   readonly max: number

--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -2,6 +2,5 @@ export const SHOW_INSIGHT_GENERATION = import.meta.env
   .VITE_SHOW_INSIGHT_GENERATION
 export const SHOW_CANCER_SCREENINGS = import.meta.env
   .VITE_SHOW_CANCER_SCREENINGS
-const SHOW_PHRMA_BRFSS = import.meta.env.VITE_SHOW_PHRMA_BRFSS
 export const SHOW_CORRELATION_CARD = import.meta.env.VITE_SHOW_CORRELATION_CARD
 export const SHOW_CHR_GUN_DEATHS = import.meta.env.VITE_SHOW_CHR_GUN_DEATHS

--- a/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
+++ b/frontend/src/pages/DataCatalog/DataCatalogPage.tsx
@@ -94,7 +94,7 @@ export default function DataCatalogPage() {
 
               return (
                 <>
-                  {filteredDatasets.map((sourceId, index) => (
+                  {filteredDatasets.map((sourceId) => (
                     <li key={sourceId}>
                       <DataSourceListing
                         key={dataSourceMetadataMap[sourceId].id}

--- a/frontend/src/pages/DataCatalog/downloadDataset.ts
+++ b/frontend/src/pages/DataCatalog/downloadDataset.ts
@@ -26,7 +26,7 @@ async function downloadDataset(
     const dataset = await getDataManager().loadDataset(datasetId)
     download('HET - ' + dataset.metadata.name + '.csv', dataset.toCsvString())
     return true
-  } catch (e) {
+  } catch (_e) {
     return false
   }
 }

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -103,13 +103,12 @@ export default function MadLibUI(props: MadLibUIProps) {
 
   const fipsList = getFipsListFromMadlib(props.madLib)
 
-  const { enabledDemographicOptionsMap, disabledDemographicOptions } =
-    getAllDemographicOptions(
-      selectedDataTypeConfig1,
-      fipsList[0],
-      selectedDataTypeConfig2,
-      fipsList?.[1],
-    )
+  const { enabledDemographicOptionsMap } = getAllDemographicOptions(
+    selectedDataTypeConfig1,
+    fipsList[0],
+    selectedDataTypeConfig2,
+    fipsList?.[1],
+  )
 
   const demographicOptions: Array<[DemographicType, string]> = Object.entries(
     enabledDemographicOptionsMap,

--- a/frontend/src/pages/FAQs/FaqsPageData.tsx
+++ b/frontend/src/pages/FAQs/FaqsPageData.tsx
@@ -482,8 +482,6 @@ const additionalFaqs: Faq[] = [
   },
 ]
 
-const consolidatedFaqs: Faq[] = [...faqMappings, ...additionalFaqs]
-
 export const dataFaqGroup: Faq[] = [
   faqMappings[2],
   faqMappings[3],

--- a/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
@@ -29,7 +29,7 @@ export default function KeyTermsAccordion(props: KeyTermsAccordionProps) {
   const [expanded, setExpanded] = useState(isMd)
 
   const handleAccordionToggle = (
-    event: React.SyntheticEvent,
+    _event: React.SyntheticEvent,
     newExpanded: boolean,
   ) => {
     setExpanded(newExpanded)

--- a/frontend/src/pages/Methodology/methodologyComponents/KeyTermsTopicsAccordion.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/KeyTermsTopicsAccordion.tsx
@@ -25,7 +25,7 @@ export default function KeyTermsTopicsAccordion(
   const [expanded, setExpanded] = useState(isMd)
 
   const handleAccordionToggle = (
-    event: React.SyntheticEvent,
+    _event: React.SyntheticEvent,
     newExpanded: boolean,
   ) => {
     setExpanded(newExpanded)

--- a/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/missingDataBlurbs.tsx
@@ -1,14 +1,5 @@
 import { urlMap } from '../../../utils/externalUrls'
 
-function MissingCdcAtlasData() {
-  return (
-    <>
-      <MissingHIVData />
-      <MissingPrepData />
-    </>
-  )
-}
-
 export function MissingIslandAreaPopulationData() {
   return (
     <>

--- a/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
@@ -86,7 +86,7 @@ export default function BehavioralHealthLink() {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={behavioralHealthDataSources.map((source, index) => ({
+          rows={behavioralHealthDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/ChronicDiseaseLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/ChronicDiseaseLink.tsx
@@ -81,7 +81,7 @@ const ChronicDiseaseLink = () => {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={chronicDiseaseDataSources.map((source, index) => ({
+          rows={chronicDiseaseDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/Covid19Link.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/Covid19Link.tsx
@@ -277,7 +277,7 @@ export default function Covid19Link() {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={covidDataSources.map((source, index) => ({
+          rows={covidDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/HivLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/HivLink.tsx
@@ -564,7 +564,7 @@ const HivLink = () => {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={hivDataSources.map((source, index) => ({
+          rows={hivDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/MaternalHealthLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/MaternalHealthLink.tsx
@@ -104,7 +104,7 @@ const MaternalHealthLink = () => {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={maternalHealthDataSources.map((source, index) => ({
+          rows={maternalHealthDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/MedicationUtilizationLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/MedicationUtilizationLink.tsx
@@ -399,7 +399,7 @@ export default function MedicareMedicationLink() {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={medicareMedicationDataSources.map((source, index) => ({
+          rows={medicareMedicationDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/PdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/PdohLink.tsx
@@ -358,7 +358,7 @@ const PdohLink = () => {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={pdohDataSources.map((source, index) => ({
+          rows={pdohDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Methodology/methodologySections/RacesEthnicitiesList.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/RacesEthnicitiesList.tsx
@@ -1,4 +1,3 @@
-import HetDivider from '../../../styles/HetComponents/HetDivider'
 import type { DataItem } from '../methodologyContent/RacesAndEthnicitiesDefinitions'
 
 interface RaceEthnicityListProps {

--- a/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
@@ -20,21 +20,6 @@ const sdohDataSources = [
   dataSourceMetadataMap.geo_context,
 ]
 
-// delete this, load from missingDataBlurbs instead
-const missingAhrDataArray = [
-  {
-    id: '',
-    topic: "Missing America's Health Rankings data",
-    definitions: [
-      {
-        key: 'Population data',
-        description:
-          'AHR does not have population data available for: preventable hospitalizations, voter participation, and non-medical drug use. We have chosen not to show any percent share metrics for the measures without population data because the source only provides the metrics as rates. Without population data, it is difficult to accurately calculate Percent share measures, which could potentially result in misleading data.',
-      },
-    ],
-  },
-]
-
 const datatypeConfigs = SDOH_CATEGORY_DROPDOWNIDS.flatMap((dropdownId) => {
   return METRIC_CONFIG[dropdownId]
 })
@@ -90,7 +75,7 @@ function SdohLink() {
             { header: 'Source', accessor: 'source' },
             { header: 'Update Frequency', accessor: 'updates' },
           ]}
-          rows={sdohDataSources.map((source, index) => ({
+          rows={sdohDataSources.map((source) => ({
             source: (
               <a
                 key={source.data_source_name}

--- a/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
+++ b/frontend/src/pages/Policy/policyComponents/PolicyPage.tsx
@@ -9,8 +9,7 @@ import PolicyPagination from './PolicyPagination'
 
 export default function PolicyPage() {
   const location = useLocation()
-  const [ref, width] = useResponsiveWidth()
-  const isMobileView = width < 960
+  const [ref] = useResponsiveWidth()
 
   const activeRoute = policyRouteConfigs.find(
     (route) => route.path === location.pathname,

--- a/frontend/src/pages/Policy/policyContent/CommunitySafetyFaqsContent.tsx
+++ b/frontend/src/pages/Policy/policyContent/CommunitySafetyFaqsContent.tsx
@@ -18,17 +18,6 @@ interface OptionGroupProps {
   children: React.ReactNode
 }
 
-interface DatasetItem {
-  label: string
-  included: boolean
-}
-
-interface Dataset {
-  datasetName: string
-  datasetNameDetails?: string
-  items: DatasetItem[]
-}
-
 interface Faq {
   question: string
   answer: React.ReactNode | string

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from 'react'
 import { useLocation } from 'react-router'
 import { HetOverline } from '../../styles/HetComponents/HetOverline'
 import { HetTermRaised } from '../../styles/HetComponents/HetTermRaised'
-import { useResponsiveWidth } from '../../utils/hooks/useResponsiveWidth'
 import { useScrollToAnchor } from '../../utils/hooks/useScrollToAnchor'
 import WIHECardMenu from './wiheComponents/WIHECardMenu'
 import ExternalResourcesTab from './wiheSections/ExternalResourcesTab'
@@ -11,7 +10,6 @@ import GuidesTab from './wiheSections/GuidesTab'
 
 export default function WhatIsHealthEquityPage() {
   const location = useLocation()
-  const [ref] = useResponsiveWidth()
   const scrollToAnchor = useScrollToAnchor()
   const [activeTab, setActiveTab] = useState<'guides' | 'resources'>('guides')
 

--- a/frontend/src/reports/CompareReport.tsx
+++ b/frontend/src/reports/CompareReport.tsx
@@ -260,8 +260,8 @@ export default function CompareReport(props: CompareReportProps) {
                 createCard={(
                   dataTypeConfig: DataTypeConfig,
                   fips: Fips,
-                  unusedUpdateFips: (fips: Fips) => void,
-                  unusedDropdown: any,
+                  _unusedUpdateFips: (fips: Fips) => void,
+                  _unusedDropdown: any,
                   isCompareCard: boolean | undefined,
                 ) => (
                   <RateTrendsChartCard
@@ -288,7 +288,7 @@ export default function CompareReport(props: CompareReportProps) {
               createCard={(
                 dataTypeConfig: DataTypeConfig,
                 fips: Fips,
-                unusedUpdateFips: (fips: Fips) => void,
+                _unusedUpdateFips: (fips: Fips) => void,
               ) => (
                 <RateBarChartCard
                   dataTypeConfig={dataTypeConfig}
@@ -342,8 +342,8 @@ export default function CompareReport(props: CompareReportProps) {
                 createCard={(
                   dataTypeConfig: DataTypeConfig,
                   fips: Fips,
-                  unusedUpdateFips: (fips: Fips) => void,
-                  unusedDropdown: any,
+                  _unusedUpdateFips: (fips: Fips) => void,
+                  _unusedDropdown: any,
                   isCompareCard: boolean | undefined,
                 ) => (
                   <ShareTrendsChartCard
@@ -369,7 +369,7 @@ export default function CompareReport(props: CompareReportProps) {
               createCard={(
                 dataTypeConfig: DataTypeConfig,
                 fips: Fips,
-                unusedUpdateFips: (fips: Fips) => void,
+                _unusedUpdateFips: (fips: Fips) => void,
               ) => (
                 <StackedSharesBarChartCard
                   dataTypeConfig={dataTypeConfig}
@@ -394,7 +394,7 @@ export default function CompareReport(props: CompareReportProps) {
               createCard={(
                 dataTypeConfig: DataTypeConfig,
                 fips: Fips,
-                updateFips: (fips: Fips) => void,
+                _unusedUpdateFips: (fips: Fips) => void,
               ) => (
                 <TableCard
                   fips={fips}
@@ -425,9 +425,8 @@ export default function CompareReport(props: CompareReportProps) {
                 createCard={(
                   dataTypeConfig: DataTypeConfig,
                   fips: Fips,
-                  updateFips: (fips: Fips) => void,
+                  _unusedUpdateFips: (fips: Fips) => void,
                   dropdownVarId?: DropdownVarId,
-                  isCompareCard?: boolean,
                 ) => (
                   <AgeAdjustedTableCard
                     fips={fips}

--- a/frontend/src/reports/CustomChoroplethMap.tsx
+++ b/frontend/src/reports/CustomChoroplethMap.tsx
@@ -1,6 +1,5 @@
 import type React from 'react'
 import MapCard from '../cards/MapCard'
-import { METRIC_CONFIG } from '../data/config/MetricConfig'
 import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
 import type { DemographicType } from '../data/query/Breakdowns'
 import { Fips } from '../data/utils/Fips'
@@ -27,7 +26,7 @@ const CustomChoroplethMap: React.FC<CustomChoroplethProps> = ({
       demographicType={demographicType}
       fips={fips}
       reportTitle={reportTitle}
-      updateFipsCallback={(fips: Fips) => {}}
+      updateFipsCallback={(_fips: Fips) => {}}
       trackerMode={'disparity'}
       className={className}
     />

--- a/frontend/src/reports/CustomUnknownMap.tsx
+++ b/frontend/src/reports/CustomUnknownMap.tsx
@@ -18,7 +18,7 @@ interface CustomUnknownMapProps {
 const CustomUnknownMap: React.FC<CustomUnknownMapProps> = ({
   headerScrollMargin = '50px',
   fips = new Fips('00'),
-  updateFipsCallback = (fips: Fips) => {},
+  updateFipsCallback = (_fips: Fips) => {},
   demographicType = UNKNOWN_RACE,
   shareMetricConfig = true,
   reportTitle = 'Custom Unknown Map Report',

--- a/frontend/src/reports/ReportProvider.tsx
+++ b/frontend/src/reports/ReportProvider.tsx
@@ -24,8 +24,6 @@ import LifelineAlert from './ui/LifelineAlert'
 import { RaceRelabelingsList } from './ui/RaceRelabelingsList'
 import VoteDotOrgBanner from './ui/VoteDotOrgBanner'
 
-const SINGLE_COLUMN_WIDTH = 12
-
 interface ReportProviderProps {
   isSingleColumn: boolean
   madLib: MadLib

--- a/frontend/src/reports/ui/ShareButtons.tsx
+++ b/frontend/src/reports/ui/ShareButtons.tsx
@@ -15,9 +15,6 @@ import { getHtml } from '../../utils/urlutils'
 
 export const SHARE_LABEL = 'Share this report:'
 
-const ARTICLE_DESCRIPTION =
-  'Article from the Health Equity Tracker: a free-to-use data and visualization platform that is enabling new insights into the impact of COVID-19 and other determinants of health on marginalized groups in the United States.'
-
 interface ShareButtonProps {
   isMobile: boolean
   reportTitle?: string

--- a/frontend/src/styles/HetComponents/HetAccordion.tsx
+++ b/frontend/src/styles/HetComponents/HetAccordion.tsx
@@ -30,7 +30,7 @@ const HetAccordion: React.FC<HetAccordionProps> = ({
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
 
   const handleChange =
-    (index: number) => (event: React.SyntheticEvent, isExpanded: boolean) => {
+    (index: number) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
       setExpandedIndex(isExpanded ? index : null)
     }
 

--- a/frontend/src/styles/HetComponents/HetLazyLoader.tsx
+++ b/frontend/src/styles/HetComponents/HetLazyLoader.tsx
@@ -19,7 +19,7 @@ export default function HetLazyLoader({
   className = '',
   placeholder = null,
 }: HetLazyLoaderProps) {
-  const { ref, inView, entry } = useInView({
+  const { ref, inView } = useInView({
     triggerOnce: once,
     rootMargin: `${offset}px ${offset}px ${offset}px ${offset}px`,
     threshold: 0,

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -68,7 +68,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
             {...params}
           />
         )}
-        onChange={(e, fips) => {
+        onChange={(_e, fips) => {
           props.onOptionUpdate(fips.code)
           setTextBoxValue('')
           props.popover.close()

--- a/frontend/src/styles/HetComponents/HetReturnToTop.tsx
+++ b/frontend/src/styles/HetComponents/HetReturnToTop.tsx
@@ -1,12 +1,7 @@
 import ArrowUpwardRoundedIcon from '@mui/icons-material/ArrowUpwardRounded'
 import { Button } from '@mui/material'
 
-interface HetReturnToTopProps {
-  id?: string
-  className?: string
-}
-
-export default function HetReturnToTop(props: HetReturnToTopProps) {
+export default function HetReturnToTop() {
   return (
     <Button
       aria-label='Scroll to Top'

--- a/frontend/src/utils/blogUtils.ts
+++ b/frontend/src/utils/blogUtils.ts
@@ -2,9 +2,6 @@
 const NEWS_URL = 'https://hetblog.dreamhosters.com/'
 const WP_API = 'wp-json/wp/v2/' // "?rest_route=/wp/v2/"
 const ALL_POSTS = 'posts'
-const ALL_MEDIA = 'media'
-const ALL_CATEGORIES = 'categories'
-const ALL_AUTHORS = 'authors'
 const WP_EMBED_PARAM = '_embed'
 const WP_PER_PAGE_PARAM = 'per_page='
 const MAX_FETCH = 100
@@ -12,7 +9,6 @@ const MAX_FETCH = 100
 // REACT QUERY
 export const ARTICLES_KEY = 'cached_wp_articles'
 export const ARTICLES_KEY_4 = 'cached_wp_articles_first_four'
-const ARTICLES_KEY_5 = 'cached_wp_articles_first_five'
 export const REACT_QUERY_OPTIONS = {
   cacheTime: 1000 * 60 * 5, // never garbage collect, always default to cache
   staleTime: 1000 * 30, // treat cache data as fresh and don't refetch

--- a/frontend/src/utils/globals.ts
+++ b/frontend/src/utils/globals.ts
@@ -74,12 +74,6 @@ export function autoInitGlobals() {
   initGlobals(environment, logger, dataFetcher, cache)
 }
 
-function getEnvironment(): Environment {
-  assertInitialized()
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  return globals.environment!
-}
-
 export function getLogger(): Logger {
   assertInitialized()
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/frontend/src/utils/hooks/useParamState.tsx
+++ b/frontend/src/utils/hooks/useParamState.tsx
@@ -1,4 +1,4 @@
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtom } from 'jotai'
 import { locationAtom } from '../sharedSettingsState'
 import {
   DATA_TYPE_1_PARAM,
@@ -55,14 +55,4 @@ export function useParamState<ParamStateType>(
   }
 
   return [paramState as ParamStateType, setParamState]
-}
-
-function useGetParamState<ParamStateType>(
-  paramKey: string,
-  paramDefaultValue?: ParamStateType,
-): ParamStateType {
-  const locationState = useAtomValue(locationAtom)
-  const paramState =
-    locationState.searchParams?.get(paramKey) ?? paramDefaultValue ?? ''
-  return paramState as ParamStateType
 }

--- a/frontend/src/utils/hooks/useStepObserver.ts
+++ b/frontend/src/utils/hooks/useStepObserver.ts
@@ -2,12 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 import { scrollIntoView } from 'seamless-scroll-polyfill'
 
-interface StepData {
-  label: string
-  hashId: ScrollableHashId
-  pluralOnCompare: boolean
-}
-
 export type ScrollableHashId =
   | 'rate-map'
   | 'rates-over-time'

--- a/frontend/src/utils/internalRoutes.ts
+++ b/frontend/src/utils/internalRoutes.ts
@@ -20,8 +20,6 @@ export const OLD_TERMS_OF_SERVICE_LINK = '/termsofservice'
 export const WHAT_IS_HEALTH_EQUITY_PAGE_LINK = '/whatishealthequity'
 export const HEALTH_EQUITY_GUIDES_TAB =
   WHAT_IS_HEALTH_EQUITY_PAGE_LINK + '/guides'
-const HEALTH_EQUITY_RESOURCES_TAB =
-  WHAT_IS_HEALTH_EQUITY_PAGE_LINK + '/external-resources'
 
 // CONTEXT TABS
 export const GUN_VIOLENCE_POLICY = POLICY_PAGE_LINK + '/gun-violence'
@@ -70,20 +68,11 @@ export const AGE_ADJUST_COVID_DEATHS_US_SETTING =
   '?mls=1.covid-3.00&group1=All&dt1=covid_deaths#age-adjusted-ratios'
 export const AGE_ADJUST_COVID_HOSP_US_SETTING =
   '?mls=1.covid-3.00&group1=All&dt1=covid_hospitalizations#age-adjusted-ratios'
-const COVID_HOSP_NY_COUNTY_SETTING = '?mls=1.covid_hospitalizations-3.36061'
-const COVID_VAX_US_SETTING = '?mls=1.covid_vaccinations-3.00'
-const COPD_US_SETTING = '?mls=1.copd-3.00'
-const DIABETES_US_SETTING = '?mls=1.diabetes-3.00'
-const UNINSURANCE_US_SETTING = '?mls=1.health_insurance-3.00'
-const POVERTY_US_SETTING = '?mls=1.poverty-3.00'
-const OPIOID_US_SETTING = '?dt1=non_medical_drug_use&mls=1.substance-3.00'
 
 export const GUN_DEATHS_YOUNG_ADULTS_USA_SETTING =
   '?mls=1.gun_violence_youth-3.00&group1=All&demo=race_and_ethnicity&dt1=gun_deaths_young_adults#rate-map'
 export const HIV_PREVALENCE_RACE_USA_SETTING =
   '?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence'
-const PHRMA_HIV_ELIGIBILITY_USA_MULTIMAP_SETTING =
-  '?mls=1.medicare_hiv-3.00&group1=All&demo=eligibility&dt1=medicare_hiv&multiple-maps=true'
 
 export const PRISON_VS_POVERTY_RACE_GA_SETTING =
   '?mls=1.incarceration-3.poverty-5.13&mlp=comparevars&dt1=prison'
@@ -96,5 +85,3 @@ export const WARM_WELCOME_DEMO_SETTING =
 
 // SECTION IDS
 export const WHAT_DATA_ARE_MISSING_ID = 'definitions-missing-data'
-const EXPLORE_DATA_PAGE_WHAT_DATA_ARE_MISSING_LINK =
-  EXPLORE_DATA_PAGE_LINK + '#' + WHAT_DATA_ARE_MISSING_ID

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -5,7 +5,7 @@ import {
   type DemographicGroup,
   raceNameToCodeMap,
 } from '../data/utils/Constants'
-import type { MadLibId, PhraseSelections } from './MadLibs'
+import type { PhraseSelections } from './MadLibs'
 import { urlMap } from './externalUrls'
 import { getLogger } from './globals'
 import {
@@ -62,10 +62,6 @@ export function swapOldDatatypeParams(oldParam: string) {
   return swaps[oldParam] || oldParam
 }
 
-function useUrlSearchParams() {
-  return new URLSearchParams(useLocation().search)
-}
-
 export function LinkWithStickyParams(props: {
   to: string
   target?: string
@@ -82,19 +78,6 @@ export function LinkWithStickyParams(props: {
   linkProps.to = newUrl
 
   return <Link {...linkProps}>{props.children}</Link>
-}
-
-const PAGE_URL_TO_NAMES: Record<string, string> = {
-  [WHAT_IS_HEALTH_EQUITY_PAGE_LINK]: 'What is Health Equity?',
-  [EXPLORE_DATA_PAGE_LINK]: 'Explore the Data',
-  [NEWS_PAGE_LINK]: 'News',
-  [DATA_CATALOG_PAGE_LINK]: 'Downloads',
-  [METHODOLOGY_PAGE_LINK]: 'Methodology',
-  [ABOUT_US_PAGE_LINK]: 'About Us',
-}
-
-const ADDED_MOBILE_PAGE_URL_TO_NAMES: Record<string, string> = {
-  '/': 'Home',
 }
 
 export const NAVIGATION_STRUCTURE = {
@@ -127,29 +110,6 @@ export const NAVIGATION_STRUCTURE = {
 export function useSearchParams() {
   const params = new URLSearchParams(useLocation().search)
   return Object.fromEntries(params.entries())
-}
-
-function linkToMadLib(
-  madLibId: MadLibId,
-  phraseSelections: PhraseSelections,
-  absolute = false,
-) {
-  const selectionOverrides = Object.keys(phraseSelections).map(
-    (key) => key + ':' + phraseSelections[Number(key)],
-  )
-
-  const url = [
-    EXPLORE_DATA_PAGE_LINK,
-    '?',
-    MADLIB_PHRASE_PARAM,
-    '=',
-    madLibId,
-    '&',
-    MADLIB_SELECTIONS_PARAM,
-    '=',
-    selectionOverrides.join(','),
-  ].join('')
-  return absolute ? window.location.host + url : url
 }
 
 export function setParameter(

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -26,7 +26,9 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [
     "src",


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- sets up tsconfig and biome to detect unused variables and parameters
- removes the ones that were exposed
- prepends unused positions parameters with underscore, like `_unusedVar1`

## Has this been tested? How?

tests passing

## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
