### PR TITLE
Removes duplicate `topic` property in methodology/policy content

### DIFF
--- a/frontend/src/pages/Methodology/methodologyComponents/GlossaryTerm.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/GlossaryTerm.tsx
@@ -4,15 +4,12 @@ interface GlossaryDefinition {
 }
 
 export interface GlossaryTermItem {
-  // TODO: GitHub #2916 refactor to remove 'topic' property; it's duplicate of the keys in the definitions Records<>
-  topic: string
   definitions: GlossaryDefinition[]
   path?: string
   id?: string
 }
 
 interface GlossaryTermProps {
-  topic: string
   definitionItems: Record<string, GlossaryTermItem>
   id?: string
 }

--- a/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
+++ b/frontend/src/pages/Methodology/methodologyComponents/KeyTermsAccordion.tsx
@@ -9,17 +9,10 @@ import type React from 'react'
 import { useState } from 'react'
 import HetTerm from '../../../styles/HetComponents/HetTerm'
 import { useIsBreakpointAndUp } from '../../../utils/hooks/useIsBreakpointAndUp'
+import type { GlossaryTermItem } from './GlossaryTerm'
 
 interface KeyTermsAccordionProps {
-  definitionsArray: Array<{
-    topic: string
-    definitions: Array<{
-      key: string
-      description: string
-    }>
-    path?: string
-    id?: string
-  }>
+  definitionsArray: Record<string, GlossaryTermItem>
   id?: string
 }
 
@@ -35,6 +28,10 @@ export default function KeyTermsAccordion(props: KeyTermsAccordionProps) {
     setExpanded(newExpanded)
   }
 
+  const sortedDefinitions = Object.entries(props.definitionsArray).sort(
+    ([keyA], [keyB]) => keyA.localeCompare(keyB),
+  )
+
   return (
     <div id={props.id} className='mt-8 w-full'>
       <Paper>
@@ -44,10 +41,10 @@ export default function KeyTermsAccordion(props: KeyTermsAccordionProps) {
           </AccordionSummary>
 
           <AccordionDetails>
-            {props.definitionsArray.map((item) => {
+            {sortedDefinitions.map(([topic, item]) => {
               return (
-                <div className='mb-8' id={item.id} key={item.topic}>
-                  <HetTerm>{item.topic}</HetTerm>
+                <div className='mb-8' id={item.id} key={topic}>
+                  <HetTerm>{topic}</HetTerm>
                   {item.definitions.map((def) => {
                     return (
                       <figure

--- a/frontend/src/pages/Methodology/methodologyContent/MetricsDefinitions.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/MetricsDefinitions.tsx
@@ -2,7 +2,6 @@ import type { GlossaryTermItem } from '../methodologyComponents/GlossaryTerm'
 
 export const metricDefinitions: Record<string, GlossaryTermItem> = {
   'Age-adjusted ratios': {
-    topic: 'Age-adjusted ratios',
     path: '',
     id: '#age-adjusted-ratios-metrics',
     definitions: [
@@ -19,7 +18,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Total cases per 100k people': {
-    topic: 'Total cases per 100k people',
     path: '',
     id: '#per-100k-metrics',
     definitions: [
@@ -36,7 +34,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Share of total cases with unknown race and ethnicity': {
-    topic: 'Share of total cases with unknown race and ethnicity',
     path: '',
     id: '#unknown-cases-metrics',
     definitions: [
@@ -58,7 +55,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Index score': {
-    topic: 'Index score',
     path: '',
     definitions: [
       {
@@ -69,7 +65,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Percent share': {
-    topic: 'Percent share',
     path: '',
     definitions: [
       {
@@ -80,7 +75,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Share of total cases': {
-    topic: 'Share of total cases',
     path: '',
     id: '#total-share-metrics',
     definitions: [
@@ -97,7 +91,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Population share': {
-    topic: 'Population share',
     path: '',
     id: '#population-share-metrics',
     definitions: [
@@ -114,7 +107,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Percent rate': {
-    topic: 'Percent rate',
     path: '',
     definitions: [
       {
@@ -125,7 +117,6 @@ export const metricDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Relative inequity': {
-    topic: 'Relative inequity',
     path: '',
     id: '#relative-inequity-metrics',
     definitions: [

--- a/frontend/src/pages/Methodology/methodologyContent/TermDefinitions.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/TermDefinitions.tsx
@@ -2,7 +2,6 @@ import type { GlossaryTermItem } from '../methodologyComponents/GlossaryTerm'
 
 export const termDefinitions: Record<string, GlossaryTermItem> = {
   'Direct standardization method': {
-    topic: 'Direct standardization method',
     path: '',
     definitions: [
       {
@@ -18,7 +17,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Internal standard population': {
-    topic: 'Internal standard population',
     path: '',
     definitions: [
       {
@@ -34,7 +32,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Condition counts broken down by both age and race': {
-    topic: 'Condition counts broken down by both age and race',
     path: '',
     definitions: [
       {
@@ -50,7 +47,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Population counts broken down by both age and race': {
-    topic: 'Population counts broken down by both age and race',
     path: '',
     definitions: [
       {
@@ -66,7 +62,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Age-specific rate': {
-    topic: 'Age-specific rate',
     path: '',
     definitions: [
       {
@@ -82,7 +77,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Standard population': {
-    topic: 'Standard population',
     path: '',
     definitions: [
       {
@@ -98,7 +92,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Expected condition counts': {
-    topic: 'Expected condition counts',
     path: '',
     definitions: [
       {
@@ -114,7 +107,6 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
     ],
   },
   'Edge cases': {
-    topic: 'Edge cases',
     path: '',
     definitions: [
       {
@@ -129,9 +121,7 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
       },
     ],
   },
-
   'Time-series': {
-    topic: 'Time-series',
     path: '',
     definitions: [
       {
@@ -146,9 +136,7 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
       },
     ],
   },
-
   'Crude rates': {
-    topic: 'Crude rates',
     path: '',
     definitions: [
       {
@@ -158,9 +146,7 @@ export const termDefinitions: Record<string, GlossaryTermItem> = {
       },
     ],
   },
-
   'Inequitable Burden': {
-    topic: 'Inequitable burden',
     path: '',
     definitions: [
       {

--- a/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/AgeAdjustmentLink.tsx
@@ -14,17 +14,21 @@ import Resources from '../methodologyComponents/Resources'
 import { metricDefinitions } from '../methodologyContent/MetricsDefinitions'
 import { termDefinitions } from '../methodologyContent/TermDefinitions'
 
-const ageAdjustTerms = [
-  metricDefinitions['Age-adjusted ratios'],
-  termDefinitions['Direct standardization method'],
-  termDefinitions['Internal standard population'],
-  termDefinitions['Condition counts broken down by both age and race'],
-  termDefinitions['Population counts broken down by both age and race'],
-  termDefinitions['Age-specific rate'],
-  termDefinitions['Standard population'],
-  termDefinitions['Expected condition counts'],
-  termDefinitions['Edge cases'],
-]
+const ageAdjustTerms = {
+  'Age-adjusted ratios': metricDefinitions['Age-adjusted ratios'],
+  'Direct standardization method':
+    termDefinitions['Direct standardization method'],
+  'Internal standard population':
+    termDefinitions['Internal standard population'],
+  'Condition counts broken down by both age and race':
+    termDefinitions['Condition counts broken down by both age and race'],
+  'Population counts broken down by both age and race':
+    termDefinitions['Population counts broken down by both age and race'],
+  'Age-specific rate': termDefinitions['Age-specific rate'],
+  'Standard population': termDefinitions['Standard population'],
+  'Expected condition counts': termDefinitions['Expected condition counts'],
+  'Edge cases': termDefinitions['Edge cases'],
+}
 
 const AGE_ADJUSTED_RESOURCES = [
   {
@@ -94,8 +98,8 @@ const AgeAdjustmentLink = () => {
               </Link>
               , and we present the findings in a distinct, age-adjusted table.
               All of the other data shown on the tracker, including
-              visualizations across all topics, are not age-adjusted, or ‘crude
-              rates’. Showing non-adjusted data can mask disparities, and we are
+              visualizations across all topics, are not age-adjusted, or 'crude
+              rates'. Showing non-adjusted data can mask disparities, and we are
               working to expand our analysis to provide a more equitable view of
               the impact to racial and ethnic minorities.
             </p>

--- a/frontend/src/pages/Methodology/methodologySections/GlossaryLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/GlossaryLink.tsx
@@ -21,7 +21,7 @@ function GlossaryLink() {
       <article>
         <title>Glossary - Health Equity Tracker</title>
 
-        <GlossaryTerm topic={''} definitionItems={termDefinitions} />
+        <GlossaryTerm definitionItems={termDefinitions} />
 
         <Resources resourceGroups={[RESOURCES]} id='health-equity-resources' />
         <Resources


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

closes #2916 
Note: did this entirely with agent mode in cursor 🤯 under 10 minutes

## Has this been tested? How?

passing


## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
