### PR TITLE
Frontend: Stores recent locations in dropdown

### DIFF
--- a/frontend/playwright-tests/recent_locations.ci.spec.ts
+++ b/frontend/playwright-tests/recent_locations.ci.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from '@playwright/test'
+
+test('Recent Locations Feature', async ({ page }) => {
+  await page.goto('http://localhost:3000/exploredata?mls=1.hiv-3.23&group1=All')
+  await page
+    .locator('#madlib-box')
+    .getByRole('button', { name: 'Maine' })
+    .click()
+  await page.getByRole('combobox').click()
+  await page.getByRole('combobox').fill('florida')
+  await page.getByRole('combobox').press('Enter')
+  await page
+    .locator('#madlib-box')
+    .getByRole('button', { name: 'Florida' })
+    .click()
+  await page.getByRole('combobox').click()
+  await page.getByRole('combobox').fill('california')
+  await page.getByRole('combobox').press('Enter')
+  await page
+    .locator('#madlib-box')
+    .getByRole('button', { name: 'California' })
+    .click()
+  await page.getByRole('combobox').click()
+  await page.getByRole('option', { name: 'Florida', exact: true }).click()
+  await page
+    .locator('#madlib-box')
+    .getByRole('button', { name: 'Florida' })
+    .click()
+  await page.getByRole('combobox').click()
+  await page.getByRole('button', { name: 'Clear' }).click()
+  await page
+    .locator('#madlib-box')
+    .getByRole('button', { name: 'Florida' })
+    .click()
+  await page.getByRole('combobox').click()
+
+  await page.getByText('National').click()
+  await page.getByText('States', { exact: true }).click()
+  // assert that Recent Locations is NOT in the list
+  await expect(page.getByText('Recent Locations')).not.toBeVisible()
+})

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useRef } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
@@ -39,19 +39,11 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const options = [...recentLocations, ...filteredOptions]
 
   const handleOptionUpdate = (newValue: string) => {
-    const newFips = new Fips(newValue)
-    addRecentLocation(newFips)
+    if (newValue !== props.newValue) {
+      addRecentLocation(new Fips(props.newValue))
+    }
     props.onOptionUpdate(newValue)
   }
-
-  // Store the current location in recent locations when component mounts or updates
-  // This ensures locations from map clicks, breadcrumbs, etc. are stored
-  useEffect(() => {
-    const currentFips = new Fips(props.newValue)
-    if (!recentLocations.some((recent) => recent.code === currentFips.code)) {
-      addRecentLocation(currentFips)
-    }
-  }, [props.newValue, recentLocations])
 
   return (
     <>

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -21,7 +21,9 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
 
-  const recentLocations = getRecentLocations()
+  const recentLocations = getRecentLocations().filter(
+    (location) => location.code !== props.newValue,
+  )
 
   const allOptions = Object.keys(props.phraseSegment)
     .sort((a: string, b: string) => {

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
@@ -39,9 +39,19 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const options = [...recentLocations, ...filteredOptions]
 
   const handleOptionUpdate = (newValue: string) => {
-    addRecentLocation(new Fips(newValue))
+    const newFips = new Fips(newValue)
+    addRecentLocation(newFips)
     props.onOptionUpdate(newValue)
   }
+
+  // Store the current location in recent locations when component mounts or updates
+  // This ensures locations from map clicks, breadcrumbs, etc. are stored
+  useEffect(() => {
+    const currentFips = new Fips(props.newValue)
+    if (!recentLocations.some((recent) => recent.code === currentFips.code)) {
+      addRecentLocation(currentFips)
+    }
+  }, [props.newValue, recentLocations])
 
   return (
     <>

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -21,10 +21,8 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
 
-  // Get recent locations
   const recentLocations = getRecentLocations()
 
-  // Get all available options
   const allOptions = Object.keys(props.phraseSegment)
     .sort((a: string, b: string) => {
       if (a.length === b.length) {
@@ -34,18 +32,14 @@ export default function LocationSelector(props: LocationSelectorProps) {
     })
     .map((fipsCode) => new Fips(fipsCode))
 
-  // Filter out recent locations from all options to avoid duplicates
   const filteredOptions = allOptions.filter(
     (option) => !recentLocations.some((recent) => recent.code === option.code),
   )
 
-  // Combine recent locations with filtered options
   const options = [...recentLocations, ...filteredOptions]
 
   const handleOptionUpdate = (newValue: string) => {
-    // Add the selected location to recent locations
     addRecentLocation(new Fips(newValue))
-    // Call the original onOptionUpdate
     props.onOptionUpdate(newValue)
   }
 

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
@@ -38,10 +38,14 @@ export default function LocationSelector(props: LocationSelectorProps) {
 
   const options = [...recentLocations, ...filteredOptions]
 
-  const handleOptionUpdate = (newValue: string) => {
-    if (newValue !== props.newValue) {
+  // Store the current location in recent locations when it changes
+  useEffect(() => {
+    if (props.newValue) {
       addRecentLocation(new Fips(props.newValue))
     }
+  }, [props.newValue])
+
+  const handleOptionUpdate = (newValue: string) => {
     props.onOptionUpdate(newValue)
   }
 

--- a/frontend/src/styles/HetComponents/HetClearButton.tsx
+++ b/frontend/src/styles/HetComponents/HetClearButton.tsx
@@ -1,0 +1,17 @@
+import type { MouseEvent } from 'react'
+
+interface HetClearButtonProps {
+  onClick: (event: MouseEvent<HTMLButtonElement>) => void
+}
+
+export default function HetClearButton(props: HetClearButtonProps) {
+  return (
+    <button
+      type='button'
+      onClick={props.onClick}
+      className='cursor-pointer border-0 bg-transparent text-altDark text-smallest hover:underline'
+    >
+      Clear
+    </button>
+  )
+}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -4,6 +4,7 @@ import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import type { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
 import { clearRecentLocations } from '../../utils/recentLocations'
+import HetClearButton from './HetClearButton'
 
 interface HetLocationSearchProps {
   options: Fips[]
@@ -135,13 +136,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
               </span>
               {params.group === 'recent_locations' &&
                 props.recentLocations.length > 0 && (
-                  <button
-                    type='button'
-                    onClick={handleClearRecent}
-                    className='cursor-pointer border-0 bg-transparent text-altDark text-smallest hover:underline'
-                  >
-                    Clear
-                  </button>
+                  <HetClearButton onClick={handleClearRecent} />
                 )}
             </ListSubheader>
             {params.children}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -14,7 +14,7 @@ interface HetLocationSearchProps {
   recentLocations: Fips[]
 }
 
-type GroupKey = 'recent_locations' | 'National' | 'States' | 'Territories'
+type GroupKey = 'Recent' | 'National' | 'States' | 'Territories'
 
 export default function HetLocationSearch(props: HetLocationSearchProps) {
   function handleUsaButton() {
@@ -42,14 +42,14 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
   const sortedOptions = useMemo(() => {
     const getGroup = (option: Fips): string => {
       if (props.recentLocations.some((recent) => recent.code === option.code)) {
-        return 'recent_locations'
+        return 'Recent'
       }
       return option.getFipsCategory()
     }
 
     // Define the order of groups
     const groupOrder: Record<GroupKey, number> = {
-      recent_locations: 0,
+      Recent: 0,
       National: 1,
       States: 2,
       Territories: 3,
@@ -93,7 +93,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           if (
             props.recentLocations.some((recent) => recent.code === option.code)
           ) {
-            return 'recent_locations' // Use a unique key for recent locations
+            return 'Recent' // Use a unique key for recent locations
           }
           return option.getFipsCategory()
         }}
@@ -130,11 +130,9 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           <div key={params.group}>
             <ListSubheader className='flex items-center justify-between'>
               <span>
-                {params.group === 'recent_locations'
-                  ? 'Recent Locations'
-                  : params.group}
+                {params.group === 'Recent' ? 'Recent Locations' : params.group}
               </span>
-              {params.group === 'recent_locations' &&
+              {params.group === 'Recent' &&
                 props.recentLocations.length > 0 && (
                   <HetClearButton onClick={handleClearRecent} />
                 )}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -91,11 +91,10 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         autoHighlight={true}
         options={sortedOptions}
         groupBy={(option) => {
-          // If it's a recent location, group it under "Recent Locations"
           if (
             props.recentLocations.some((recent) => recent.code === option.code)
           ) {
-            return RECENT_LOCATIONS_KEY // Use a unique key for recent locations
+            return RECENT_LOCATIONS_KEY
           }
           return option.getFipsCategory()
         }}
@@ -115,7 +114,6 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         renderInput={(params) => (
           <TextField
             placeholder=''
-            /* eslint-disable-next-line */
             autoFocus
             margin='dense'
             variant='outlined'

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -3,7 +3,11 @@ import { useMemo, useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import type { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
-import { clearRecentLocations } from '../../utils/recentLocations'
+import {
+  type GroupKey,
+  RECENT_LOCATIONS_KEY,
+  clearRecentLocations,
+} from '../../utils/recentLocations'
 import HetClearButton from './HetClearButton'
 
 interface HetLocationSearchProps {
@@ -13,8 +17,6 @@ interface HetLocationSearchProps {
   value: string
   recentLocations: Fips[]
 }
-
-type GroupKey = 'Recent' | 'National' | 'States' | 'Territories'
 
 export default function HetLocationSearch(props: HetLocationSearchProps) {
   function handleUsaButton() {
@@ -42,7 +44,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
   const sortedOptions = useMemo(() => {
     const getGroup = (option: Fips): string => {
       if (props.recentLocations.some((recent) => recent.code === option.code)) {
-        return 'Recent'
+        return RECENT_LOCATIONS_KEY
       }
       return option.getFipsCategory()
     }
@@ -93,7 +95,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           if (
             props.recentLocations.some((recent) => recent.code === option.code)
           ) {
-            return 'Recent' // Use a unique key for recent locations
+            return RECENT_LOCATIONS_KEY // Use a unique key for recent locations
           }
           return option.getFipsCategory()
         }}
@@ -130,9 +132,11 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           <div key={params.group}>
             <ListSubheader className='flex items-center justify-between'>
               <span>
-                {params.group === 'Recent' ? 'Recent Locations' : params.group}
+                {params.group === RECENT_LOCATIONS_KEY
+                  ? 'Recent Locations'
+                  : params.group}
               </span>
-              {params.group === 'Recent' &&
+              {params.group === RECENT_LOCATIONS_KEY &&
                 props.recentLocations.length > 0 && (
                   <HetClearButton onClick={handleClearRecent} />
                 )}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import type { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
+import { clearRecentLocations } from '../../utils/recentLocations'
 
 interface HetLocationSearchProps {
   options: Fips[]
@@ -71,6 +72,11 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
     })
   }, [props.options, props.recentLocations])
 
+  const handleClearRecent = () => {
+    clearRecentLocations()
+    props.popover.close()
+  }
+
   return (
     <div className='p-5'>
       <h3 className='my-1 font-semibold text-small md:text-title'>
@@ -121,10 +127,22 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         }}
         renderGroup={(params) => (
           <div key={params.group}>
-            <ListSubheader>
-              {params.group === 'recent_locations'
-                ? 'Recent Locations'
-                : params.group}
+            <ListSubheader className='flex items-center justify-between'>
+              <span>
+                {params.group === 'recent_locations'
+                  ? 'Recent Locations'
+                  : params.group}
+              </span>
+              {params.group === 'recent_locations' &&
+                props.recentLocations.length > 0 && (
+                  <button
+                    type='button'
+                    onClick={handleClearRecent}
+                    className='cursor-pointer border-0 bg-transparent text-altDark text-smallest hover:underline'
+                  >
+                    Clear
+                  </button>
+                )}
             </ListSubheader>
             {params.children}
           </div>

--- a/frontend/src/styles/HetComponents/HetNavButton.tsx
+++ b/frontend/src/styles/HetComponents/HetNavButton.tsx
@@ -19,7 +19,7 @@ const HetNavButton: React.FC<HetNavButtonProps> = ({
     <Button
       className={`mx-2 font-medium font-sansTitle text-navlinkColor text-small ${className}`}
       onClick={onClick}
-      endIcon={<ExpandMore />}
+      endIcon={<ExpandMore className='mt-1' />}
       aria-haspopup='true'
       aria-expanded={isExpanded}
     >

--- a/frontend/src/styles/MaterialTheme.tsx
+++ b/frontend/src/styles/MaterialTheme.tsx
@@ -56,7 +56,8 @@ const MaterialTheme = extendTheme({
     MuiAutocomplete: {
       styleOverrides: {
         endAdornment: {
-          top: 'inherit',
+          top: '50%',
+          transform: 'translateY(-55%)',
         },
       },
     },

--- a/frontend/src/utils/recentLocations.ts
+++ b/frontend/src/utils/recentLocations.ts
@@ -32,3 +32,11 @@ export function addRecentLocation(fips: Fips) {
     console.error('Error saving recent location:', e)
   }
 }
+
+export function clearRecentLocations() {
+  try {
+    localStorage.removeItem(RECENT_LOCATIONS_KEY)
+  } catch (e) {
+    console.error('Error clearing recent locations:', e)
+  }
+}

--- a/frontend/src/utils/recentLocations.ts
+++ b/frontend/src/utils/recentLocations.ts
@@ -1,6 +1,6 @@
 import { Fips } from '../data/utils/Fips'
 
-const RECENT_LOCATIONS_KEY = 'recent_locations'
+const RECENT_LOCATIONS_KEY = 'Recent'
 const MAX_RECENT_LOCATIONS = 5
 
 export function getRecentLocations(): Fips[] {

--- a/frontend/src/utils/recentLocations.ts
+++ b/frontend/src/utils/recentLocations.ts
@@ -1,0 +1,34 @@
+import { Fips } from '../data/utils/Fips'
+
+const RECENT_LOCATIONS_KEY = 'recent_locations'
+const MAX_RECENT_LOCATIONS = 5
+
+export function getRecentLocations(): Fips[] {
+  try {
+    const stored = localStorage.getItem(RECENT_LOCATIONS_KEY)
+    if (!stored) return []
+    const fipsCodes = JSON.parse(stored) as string[]
+    return fipsCodes.map((code) => new Fips(code))
+  } catch (e) {
+    console.error('Error reading recent locations:', e)
+    return []
+  }
+}
+
+export function addRecentLocation(fips: Fips) {
+  try {
+    const recent = getRecentLocations()
+    // Remove if already exists
+    const filtered = recent.filter((f) => f.code !== fips.code)
+    // Add to front
+    filtered.unshift(fips)
+    // Keep only most recent MAX_RECENT_LOCATIONS
+    const trimmed = filtered.slice(0, MAX_RECENT_LOCATIONS)
+    localStorage.setItem(
+      RECENT_LOCATIONS_KEY,
+      JSON.stringify(trimmed.map((f) => f.code)),
+    )
+  } catch (e) {
+    console.error('Error saving recent location:', e)
+  }
+}

--- a/frontend/src/utils/recentLocations.ts
+++ b/frontend/src/utils/recentLocations.ts
@@ -1,7 +1,10 @@
 import { Fips } from '../data/utils/Fips'
 
-const RECENT_LOCATIONS_KEY = 'Recent'
-const MAX_RECENT_LOCATIONS = 3
+export type GroupKey = 'Recent' | 'National' | 'States' | 'Territories'
+
+export const RECENT_LOCATIONS_KEY: GroupKey = 'Recent'
+
+const MAX_RECENT_LOCATIONS = 5
 
 export function getRecentLocations(): Fips[] {
   try {

--- a/frontend/src/utils/recentLocations.ts
+++ b/frontend/src/utils/recentLocations.ts
@@ -1,7 +1,7 @@
 import { Fips } from '../data/utils/Fips'
 
 const RECENT_LOCATIONS_KEY = 'Recent'
-const MAX_RECENT_LOCATIONS = 5
+const MAX_RECENT_LOCATIONS = 3
 
 export function getRecentLocations(): Fips[] {
   try {
@@ -18,11 +18,8 @@ export function getRecentLocations(): Fips[] {
 export function addRecentLocation(fips: Fips) {
   try {
     const recent = getRecentLocations()
-    // Remove if already exists
     const filtered = recent.filter((f) => f.code !== fips.code)
-    // Add to front
     filtered.unshift(fips)
-    // Keep only most recent MAX_RECENT_LOCATIONS
     const trimmed = filtered.slice(0, MAX_RECENT_LOCATIONS)
     localStorage.setItem(
       RECENT_LOCATIONS_KEY,


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

- closes #4428 
- adds Clear button allowing user to clear saved locations 
- significantly speeds up the location dropdown loading with debouncing
- better dropdown arrow vertical alignment

## Has this been tested? How?

e2e added for location stuff

## Screenshots (if appropriate)

![image](https://github.com/user-attachments/assets/0b5270c1-1853-4854-86cf-aaf613401c0b)

## Types of changes

(leave all that apply)

- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
