### PR TITLE
Adds demographic breakdown component to behavioral health and medication utilization links in methodology

### DIFF
--- a/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
@@ -158,6 +158,7 @@ export const methodologyRouteConfigs: RouteConfig[] = [
         label: 'Behavioral and Mental Health Resources',
         path: 'behavioral-health-resources',
       },
+      { label: 'Demographics', path: 'demographic-stratification' },
     ],
     visible: true,
   },

--- a/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
@@ -147,6 +147,10 @@ export const methodologyRouteConfigs: RouteConfig[] = [
         path: 'behavioral-health-data-sourcing',
       },
       {
+        label: 'Demographics',
+        path: 'demographic-stratification',
+      },
+      {
         label: 'Data Sources',
         path: 'behavioral-health-data-sources',
       },
@@ -158,7 +162,6 @@ export const methodologyRouteConfigs: RouteConfig[] = [
         label: 'Behavioral and Mental Health Resources',
         path: 'behavioral-health-resources',
       },
-      { label: 'Demographics', path: 'demographic-stratification' },
     ],
     visible: true,
   },

--- a/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
@@ -357,6 +357,10 @@ export const methodologyRouteConfigs: RouteConfig[] = [
         path: 'medication-utilization-data-sourcing',
       },
       {
+        label: 'Demographics',
+        path: 'demographic-stratification',
+      },
+      {
         label: 'Data Sources',
         path: 'medication-utilization-data-sources',
       },

--- a/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/BehavioralHealthLink.tsx
@@ -2,6 +2,7 @@ import { dataSourceMetadataMap } from '../../../data/config/MetadataMap'
 import { METRIC_CONFIG } from '../../../data/config/MetricConfig'
 import { BEHAVIORAL_HEALTH_CATEGORY_DROPDOWNIDS } from '../../../data/config/MetricConfigBehavioralHealth'
 import LifelineAlert from '../../../reports/ui/LifelineAlert'
+import HetTopicDemographics from '../../../styles/HetComponents/HetTopicDemographics'
 import { urlMap } from '../../../utils/externalUrls'
 import { DATA_CATALOG_PAGE_LINK } from '../../../utils/internalRoutes'
 import { DATA_SOURCE_PRE_FILTERS } from '../../../utils/urlutils'
@@ -73,6 +74,16 @@ export default function BehavioralHealthLink() {
         <NoteBrfss />
 
         <AhrMetrics />
+        <h3
+          className='mt-12 font-medium text-title'
+          id='demographic-stratification'
+        >
+          Demographic Stratification
+        </h3>
+        <HetTopicDemographics
+          topicIds={[...BEHAVIORAL_HEALTH_CATEGORY_DROPDOWNIDS]}
+          datasourceMetadata={dataSourceMetadataMap.ahr}
+        />
 
         <h3
           className='mt-12 font-medium text-title'

--- a/frontend/src/pages/Methodology/methodologySections/MedicationUtilizationLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/MedicationUtilizationLink.tsx
@@ -3,6 +3,7 @@ import { dataSourceMetadataMap } from '../../../data/config/MetadataMap'
 import { METRIC_CONFIG } from '../../../data/config/MetricConfig'
 import { MEDICARE_CATEGORY_DROPDOWNIDS } from '../../../data/config/MetricConfigPhrma'
 import HetTerm from '../../../styles/HetComponents/HetTerm'
+import HetTopicDemographics from '../../../styles/HetComponents/HetTopicDemographics'
 import { DATA_CATALOG_PAGE_LINK } from '../../../utils/internalRoutes'
 import { DATA_SOURCE_PRE_FILTERS } from '../../../utils/urlutils'
 import KeyTermsTopicsAccordion from '../methodologyComponents/KeyTermsTopicsAccordion'
@@ -386,6 +387,16 @@ export default function MedicareMedicationLink() {
             </ul>
           </div>
         </section>
+        <h3
+          className='mt-12 font-medium text-title'
+          id='demographic-stratification'
+        >
+          Demographic Stratification
+        </h3>
+        <HetTopicDemographics
+          topicIds={[...MEDICARE_CATEGORY_DROPDOWNIDS]}
+          datasourceMetadata={dataSourceMetadataMap.phrma}
+        />
 
         <h3
           className='mt-12 font-medium text-title'


### PR DESCRIPTION
# Description and Motivation

- closes #4402
- closes #4408

## Has this been tested? How?

test passing, manually tested on this page clicking

## Screenshots (if appropriate)

<img width="484" alt="Screenshot 2025-05-15 at 4 22 50 PM" src="https://github.com/user-attachments/assets/c48ca913-0bf5-4386-8fcd-209274f38234" />

<img width="485" alt="Screenshot 2025-05-16 at 1 30 05 PM" src="https://github.com/user-attachments/assets/67c9cc28-1ae9-4770-accb-9c73f8b392b0" />

## Types of changes

(leave all that apply)

- New content or feature

## New frontend preview link is below in the Netlify comment 😎
