### PR TITLE
fixes modal screenshot

### DIFF
--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -138,7 +138,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
     >
       <DialogContent
         dividers={true}
-        className='p-2 '
+        className='bg-white p-2'
         id={MULTIMAP_MODAL_CONTENT_ID}
       >
         {/* card options button */}
@@ -287,7 +287,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
       </DialogContent>
 
       {/* MODAL FOOTER */}
-      <section className='hide-on-screenshot'>
+      <footer className='' id='modal-footer'>
         <div className='flex items-center justify-between pl-2 text-left text-small'>
           {/* Desktop only Sources and Card Options */}
           <div className='hidden sm:block'>
@@ -308,7 +308,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
             </HetLinkButton>
           </div>
         </div>
-      </section>
+      </footer>
     </Dialog>
   )
 }


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

## Has this been tested? How?

This PR fixes issues with modal screenshot functionality by introducing modal-specific preparation and cleanup routines.

- fixes #4444 
- Adds new functions (prepareModalContentForCapture and cleanupModalContent) to handle modal-specific style adjustments for screenshots
- Adjusts image dimension calculations and target node selection for the multimap modal
- Updates modal markup in the MultiMapDialog component for clearer semantics and including real footer onto multimap screenshots

## Screenshots (if appropriate)

![good HET MULTIMAP-MODAL Investigate rates of HIV in United States  Jun 2025 (1)](https://github.com/user-attachments/assets/c6ca1cd9-21ea-47f1-b724-90264740e2af)


## Types of changes

(leave all that apply)

- Bug fix

## New frontend preview link is below in the Netlify comment 😎
