### PR TITLE
Updated content for cancer and cancer screening topics

### DIFF
--- a/frontend/src/data/config/MetricConfigPhrmaBrfss.ts
+++ b/frontend/src/data/config/MetricConfigPhrmaBrfss.ts
@@ -55,7 +55,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
     fullDisplayName: 'Breast cancer screening',
     surveyCollectedData: true,
     definition: {
-      text: ``,
+      text: `The percentage of women ages 50-74 who report having received a mammogram within the recommended timeframe, based on survey responses.`,
       citations: [
         {
           shortLabel: '',
@@ -65,7 +65,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
       ],
     },
     description: {
-      text: ``,
+      text: `Regular breast cancer screening through mammography can detect cancer early when it is most treatable. Monitoring screening rates helps identify populations that may face barriers to preventive care and enables targeted interventions to improve early detection and reduce breast cancer mortality.`,
       citations: [
         {
           shortLabel: '',
@@ -131,10 +131,10 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Summary for prostate cancer screening',
     mapConfig: medicareAdherenceHigherIsBetterMapConfig,
     dataTypeShortLabel: 'Prostate cancer',
-    fullDisplayName: 'prostate cancer screening',
+    fullDisplayName: 'Prostate cancer screening',
     surveyCollectedData: true,
     definition: {
-      text: ``,
+      text: `The percentage of men ages 55-69 who report having received prostate cancer screening (such as PSA testing or digital rectal exam) within the recommended timeframe, based on survey responses.`,
       citations: [
         {
           shortLabel: '',
@@ -144,7 +144,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
       ],
     },
     description: {
-      text: ``,
+      text: `Prostate cancer screening can help detect cancer early in high-risk populations. Understanding screening patterns across different communities helps identify disparities in access to preventive services and supports efforts to ensure informed decision-making about prostate cancer screening.`,
       citations: [
         {
           shortLabel: '',
@@ -210,10 +210,10 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Summary for colorectal cancer screening',
     mapConfig: medicareAdherenceHigherIsBetterMapConfig,
     dataTypeShortLabel: 'Colorectal cancer',
-    fullDisplayName: 'colorectal cancer screening',
+    fullDisplayName: 'Colorectal cancer screening',
     surveyCollectedData: true,
     definition: {
-      text: ``,
+      text: `The percentage of people ages 45-74 who report having received colorectal cancer screening (such as colonoscopy, sigmoidoscopy, or stool-based tests) within the recommended timeframe, based on survey responses.`,
       citations: [
         {
           shortLabel: '',
@@ -223,7 +223,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
       ],
     },
     description: {
-      text: ``,
+      text: `Colorectal cancer screening is highly effective at detecting cancer early and identifying precancerous polyps that can be removed before they become cancerous. Tracking screening rates helps identify gaps in preventive care and supports initiatives to increase screening adherence and reduce colorectal cancer mortality.`,
       citations: [
         {
           shortLabel: '',
@@ -289,10 +289,10 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Summary for cervical cancer screening',
     mapConfig: medicareAdherenceHigherIsBetterMapConfig,
     dataTypeShortLabel: 'Cervical cancer',
-    fullDisplayName: 'cervical cancer screening',
+    fullDisplayName: 'Cervical cancer screening',
     surveyCollectedData: true,
     definition: {
-      text: ``,
+      text: `The percentage of women ages 21-65 who report having received cervical cancer screening (such as Pap test or HPV test) within the recommended timeframe, based on survey responses.`,
       citations: [
         {
           shortLabel: '',
@@ -302,7 +302,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
       ],
     },
     description: {
-      text: ``,
+      text: `Cervical cancer screening is one of the most effective cancer prevention tools, capable of detecting precancerous changes before they develop into cancer. Monitoring screening rates helps identify populations that may lack access to preventive care and informs strategies to reduce cervical cancer incidence and mortality.`,
       citations: [
         {
           shortLabel: '',
@@ -367,10 +367,10 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
     dataTableTitle: 'Summary for lung cancer screening',
     mapConfig: medicareAdherenceHigherIsBetterMapConfig,
     dataTypeShortLabel: 'Lung cancer',
-    fullDisplayName: 'lung cancer screening',
+    fullDisplayName: 'Lung cancer screening',
     surveyCollectedData: true,
     definition: {
-      text: ``,
+      text: `The percentage of people ages 50-79 with a significant smoking history who report having received low-dose CT screening for lung cancer within the recommended timeframe, based on survey responses.`,
       citations: [
         {
           shortLabel: '',
@@ -380,7 +380,7 @@ export const PHRMA_BRFSS_CANCER_SCREENING_METRICS: DataTypeConfig[] = [
       ],
     },
     description: {
-      text: ``,
+      text: `Lung cancer screening with low-dose CT scans can detect lung cancer at earlier, more treatable stages among high-risk individuals with smoking history. Tracking screening rates in eligible populations helps identify gaps in preventive care delivery and supports efforts to reduce lung cancer mortality through early detection.`,
       citations: [
         {
           shortLabel: '',

--- a/frontend/src/pages/Methodology/methodologySections/CancerLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/CancerLink.tsx
@@ -2,6 +2,8 @@ import { datasourceMetadataCdcWonder } from '../../../data/config/DatasetMetadat
 import { dataSourceMetadataMap } from '../../../data/config/MetadataMap'
 import { METRIC_CONFIG } from '../../../data/config/MetricConfig'
 import { CDC_CANCER_CATEGORY_DROPDOWNIDS } from '../../../data/config/MetricConfigCancer'
+import { CANCER_SCREENING_CATEGORY_DROPDOWNIDS } from '../../../data/config/MetricConfigPhrmaBrfss'
+import HetNotice from '../../../styles/HetComponents/HetNotice'
 import HetTopicDemographics from '../../../styles/HetComponents/HetTopicDemographics'
 import { DATA_CATALOG_PAGE_LINK } from '../../../utils/internalRoutes'
 import { DATA_SOURCE_PRE_FILTERS } from '../../../utils/urlutils'
@@ -11,17 +13,22 @@ import StripedTable from '../methodologyComponents/StripedTable'
 import { CANCER_RESOURCES } from '../methodologyContent/ResourcesData'
 import { buildTopicsString } from './linkUtils'
 
-const cancerDataSources = [dataSourceMetadataMap.cdc_wonder]
+const cancerDataSources = [
+  dataSourceMetadataMap.cdc_wonder,
+  dataSourceMetadataMap.phrma_brfss,
+]
 
-const datatypeConfigs = CDC_CANCER_CATEGORY_DROPDOWNIDS.flatMap(
-  (dropdownId) => {
-    return METRIC_CONFIG[dropdownId]
-  },
-)
+const datatypeConfigs = [
+  ...CDC_CANCER_CATEGORY_DROPDOWNIDS,
+  ...CANCER_SCREENING_CATEGORY_DROPDOWNIDS,
+].flatMap((dropdownId) => {
+  return METRIC_CONFIG[dropdownId]
+})
 
-export const cancerTopicsString = buildTopicsString(
-  CDC_CANCER_CATEGORY_DROPDOWNIDS,
-)
+export const cancerTopicsString = buildTopicsString([
+  ...CDC_CANCER_CATEGORY_DROPDOWNIDS,
+  ...CANCER_SCREENING_CATEGORY_DROPDOWNIDS,
+])
 
 function CancerLink() {
   return (
@@ -46,8 +53,37 @@ function CancerLink() {
         <h2 className='mt-12 font-medium text-title' id='cancer-data-sourcing'>
           Data Sourcing
         </h2>
-        {/* TODO: NEED CANCER WRITEUP, INCLUDING CDC WONDER FOR DISEASE RATES AND BRFSS/PHRMA FOR SCREENING ADHERENCE */}
         <p>CDC Wonder</p>
+        <p>
+          The CDC's Wide-ranging Online Data for Epidemiologic Research (WONDER)
+          provides access to the United States Cancer Statistics (USCS), the
+          official federal statistics on cancer incidence compiled from
+          high-quality registries through the CDC's National Program of Cancer
+          Registries (NPCR) and the National Cancer Institute's Surveillance,
+          Epidemiology and End Results (SEER) program. The dataset covers
+          1999-2022 and allows users to explore data by location, demographics,
+          and cancer type, providing incidence counts, crude rates, and
+          age-adjusted rates to support public health surveillance and policy
+          decisions.
+        </p>
+        <p>CDC BRFSS</p>
+        <p>
+          For cancer screening adherence data, we use the Behavioral Risk Factor
+          Surveillance System (BRFSS), the nation's largest continuously
+          conducted health survey. BRFSS collects state-level data on preventive
+          health services, including cancer screenings, through telephone
+          surveys of U.S. residents across all 50 states, the District of
+          Columbia, and three U.S. territories.
+        </p>
+        <HetNotice className='my-12'>
+          Cancer incidence data coverage varies by state and year. While most
+          recent data covers 100% of the U.S. population, earlier years exclude
+          certain states (Mississippi 1999-2002, South Dakota 1999-2000), and
+          Puerto Rico data is only available from 2005 onward. It's important to
+          note that because BRFSS is survey-based, it sometimes lacks sufficient
+          data for smaller or marginalized racial groups, making some estimates
+          less statistically robust.
+        </HetNotice>
         {/* KEEP THIS BRFSS NOTICE? DOES IT APPLY TO THE SCREENING DATA? */}
         {/* <NoteBrfss /> */}
 


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
Added cancer incidence and cancer screening data to the methodology page. Cancer incidence data is sourced from CDC WONDER (USCS dataset, 1999-2022) and cancer screening adherence data is sourced from BRFSS. This includes:

- 5 cancer types (breast, cervical, colorectal, lung, prostate) with incidence metrics
- 5 corresponding cancer screening metrics
- Data source descriptions and definitions for all metrics

## Has this been tested? How?
Confirmed all metric definitions and clinical importance sections display properly

## Types of changes
- New content or feature

## New frontend preview link is below in the Netlify comment 😎
