### PR TITLE
Update HIV Black Women tests for 65+ age category

### DIFF
--- a/frontend/playwright-tests/hiv_black_women.ci.spec.ts
+++ b/frontend/playwright-tests/hiv_black_women.ci.spec.ts
@@ -17,7 +17,7 @@ test('HIV Black Women: Prevalance Top Cards', async ({ page }) => {
       name: 'HIV prevalence for Black (NH) women over time in the United States',
     })
     .click()
-  await page.getByLabel('Include 55+').click()
+  await page.getByLabel('Include 65+').click()
   await page
     .locator('#rate-chart')
     .getByRole('heading', { name: 'HIV prevalence for Black (NH' })


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->
Updates Playwright tests to reflect the change in age category from "55+" to "65+" in the HIV Black Women data. This ensures tests accurately verify the new age grouping displayed in the UI.

## Has this been tested? How?
 Tests pass locally with updated age category
 Verified UI displays "Ages 65+" correctly

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎
