### PR TITLE
Bump checkout action v4 -> v6

### DIFF
--- a/.github/workflows/cronUrlChecker.yml
+++ b/.github/workflows/cronUrlChecker.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: frontend/package.json

--- a/.github/workflows/deployInfraTest.yml
+++ b/.github/workflows/deployInfraTest.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/e2eDev.yml
+++ b/.github/workflows/e2eDev.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: frontend/package.json

--- a/.github/workflows/e2eScheduled.yml
+++ b/.github/workflows/e2eScheduled.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: frontend/package.json

--- a/.github/workflows/prepareReleaseBranch.yml
+++ b/.github/workflows/prepareReleaseBranch.yml
@@ -8,7 +8,7 @@ jobs:
   deploy_releases:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Needed to fetch all tags
           ref: release

--- a/.github/workflows/runDestroyInfraTest.yml
+++ b/.github/workflows/runDestroyInfraTest.yml
@@ -13,7 +13,7 @@ jobs:
       image-digest: ${{ steps.ingestion.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -36,7 +36,7 @@ jobs:
       image-digest: ${{ steps.gcstobq.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -60,7 +60,7 @@ jobs:
       image-digest: ${{ steps.exporter.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -83,7 +83,7 @@ jobs:
       image-digest: ${{ steps.serving.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -106,7 +106,7 @@ jobs:
       image-digest: ${{ steps.frontend.outputs.image-digest }}
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:
@@ -131,7 +131,7 @@ jobs:
 
     steps:
       - name: Check Out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - id: auth
         uses: google-github-actions/auth@v2
         with:

--- a/.github/workflows/runFrontendServerTests.yml
+++ b/.github/workflows/runFrontendServerTests.yml
@@ -23,7 +23,7 @@ jobs:
     name: Runs frontend server unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: frontend_server/package.json

--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -26,7 +26,7 @@ jobs:
 
       # 1. Fast Checkout
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # 2. Setup Node
       - name: Setup Node

--- a/.github/workflows/runPythonChecks.yml
+++ b/.github/workflows/runPythonChecks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/.github/workflows/runToolingSpellChecks.yml
+++ b/.github/workflows/runToolingSpellChecks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Run CSpell
         uses: streetsidesoftware/cspell-action@v8
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/testBackendChangesInfraTest.yml
+++ b/.github/workflows/testBackendChangesInfraTest.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deploy to Test Environment
         uses: ./.github/actions/buildAllAndDeploy


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

addresses a warning re: actions running on Node 20 which will be replaced by node 24 soon. this action was causing the warning. updates to the recent version 


## Has this been tested? How?

need to merge and ensure normal infra functionality

## Screenshots (if appropriate)

<img width="1344" height="179" alt="image" src="https://github.com/user-attachments/assets/7863146f-3bc1-45fb-a11a-68bbb9ed8e83" />


## Types of changes

(leave all that apply)

- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
