### PR TITLE
Updates source DAG pipelines to use new deployer key

### DIFF
--- a/.github/workflows/dagAcsCondition.yml
+++ b/.github/workflows/dagAcsCondition.yml
@@ -29,7 +29,7 @@ jobs:
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           year: "2012"
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2013-2017 concurrently (APPEND operations)
   process-2013-2017:
@@ -49,7 +49,7 @@ jobs:
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           year: ${{ matrix.year }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2018-2021 concurrently (APPEND operations)
   process-2018-2021:
@@ -69,7 +69,7 @@ jobs:
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           year: ${{ matrix.year }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2022 separately (APPEND but also creates new tables)
   process-2022:
@@ -84,7 +84,7 @@ jobs:
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           year: "2022"
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Export demographic data - separate explicit jobs running in parallel
   export-race:
@@ -95,7 +95,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"
@@ -108,7 +108,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
           should_export_as_alls: "false"
@@ -121,7 +121,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "false"

--- a/.github/workflows/dagAcsConditionPreCache.yml
+++ b/.github/workflows/dagAcsConditionPreCache.yml
@@ -23,7 +23,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2012"
@@ -32,7 +32,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2013"
@@ -41,7 +41,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2014"
@@ -50,7 +50,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2015"
@@ -59,7 +59,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2016"
@@ -68,7 +68,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2017"
@@ -77,7 +77,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2018"
@@ -86,7 +86,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2019"
@@ -95,7 +95,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2020"
@@ -104,7 +104,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2021"
@@ -113,7 +113,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}
           year: "2022"

--- a/.github/workflows/dagAcsPopulation.yml
+++ b/.github/workflows/dagAcsPopulation.yml
@@ -29,7 +29,7 @@ jobs:
           year: "2009"
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2010-2016 concurrently (APPEND operations)
   process-2010-2016:
@@ -49,7 +49,7 @@ jobs:
           year: ${{ matrix.year }}
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2017-2021 concurrently (APPEND operations)
   process-2017-2021:
@@ -69,7 +69,7 @@ jobs:
           year: ${{ matrix.year }}
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Process 2022 separately (latest year)
   process-2022:
@@ -84,7 +84,7 @@ jobs:
           year: "2022"
           source_gcs_bucket: ${{ env.GCS_LANDING_BUCKET }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   # Export demographic data - separate explicit jobs running in parallel
   export-race:
@@ -95,7 +95,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE }}
           should_export_as_alls: "true"
@@ -108,7 +108,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
           should_export_as_alls: "false"
@@ -121,7 +121,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "false"

--- a/.github/workflows/dagAcsPopulationPreCache.yml
+++ b/.github/workflows/dagAcsPopulationPreCache.yml
@@ -24,6 +24,6 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           workflow_id: ${{ env.WORKFLOW_ID }}
           destination_gcs_bucket: ${{ env.GCS_LANDING_BUCKET}}

--- a/.github/workflows/dagAhr.yml
+++ b/.github/workflows/dagAhr.yml
@@ -30,7 +30,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE STATE
       - name: Process and write age state tables to BigQuery
@@ -42,14 +42,14 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT AGE
       - name: Export age NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.AGE }}
@@ -67,7 +67,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE STATE
       - name: Process and write race state tables to BigQuery
@@ -79,14 +79,14 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT RACE
       - name: Export race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
@@ -104,7 +104,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX STATE
       - name: Process and write sex state tables to BigQuery
@@ -116,14 +116,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT SEX
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.SEX }}

--- a/.github/workflows/dagAhrBehavioralHealth.yml
+++ b/.github/workflows/dagAhrBehavioralHealth.yml
@@ -30,7 +30,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE STATE
       - name: Process and write age state tables to BigQuery
@@ -42,14 +42,14 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT AGE
       - name: Export age NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.AGE }}
@@ -67,7 +67,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE STATE
       - name: Process and write race state tables to BigQuery
@@ -79,14 +79,14 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT RACE
       - name: Export race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
@@ -104,7 +104,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX STATE
       - name: Process and write sex state tables to BigQuery
@@ -116,14 +116,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORT SEX
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           category: ${{ env.CATEGORY }}
           demographic: ${{ env.SEX }}

--- a/.github/workflows/dagBjsIncarceration.yml
+++ b/.github/workflows/dagBjsIncarceration.yml
@@ -24,12 +24,12 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export race_and_ethnicity NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"
@@ -37,13 +37,13 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}

--- a/.github/workflows/dagCawp.yml
+++ b/.github/workflows/dagCawp.yml
@@ -18,12 +18,12 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagCdcHiv.yml
+++ b/.github/workflows/dagCdcHiv.yml
@@ -27,7 +27,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE STATE
       - name: Process and write race state tables to BigQuery
@@ -38,7 +38,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE COUNTY
       - name: Process and write race county tables to BigQuery
@@ -49,7 +49,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Age adjustment for race data
       - name: Process age adjustment for HIV data
@@ -58,14 +58,14 @@ jobs:
           workflow_id: ${{ env.AGE_ADJUST_WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export race data
       - name: Export age-adjusted race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
 
@@ -81,7 +81,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX STATE
       - name: Process and write sex state tables to BigQuery
@@ -92,7 +92,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX COUNTY
       - name: Process and write sex county tables to BigQuery
@@ -103,14 +103,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export sex data
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"
@@ -127,7 +127,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE STATE
       - name: Process and write age state tables to BigQuery
@@ -138,7 +138,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE COUNTY
       - name: Process and write age county tables to BigQuery
@@ -149,13 +149,13 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export age data
       - name: Export age NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}

--- a/.github/workflows/dagCdcHivBlackWomen.yml
+++ b/.github/workflows/dagCdcHivBlackWomen.yml
@@ -25,7 +25,7 @@ jobs:
           demographic: ${{ env.BLACK_WOMEN }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # BLACK WOMEN STATE
       - name: Process and write black women state to BigQuery
@@ -36,13 +36,13 @@ jobs:
           demographic: ${{ env.BLACK_WOMEN }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export black women data
       - name: Export black women NDJSON files from BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.BLACK_WOMEN }}

--- a/.github/workflows/dagCdcMiovd.yml
+++ b/.github/workflows/dagCdcMiovd.yml
@@ -19,12 +19,12 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           demographic: ${{ env.ALLS }}
           geographic: ${{ env.COUNTY }}
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}

--- a/.github/workflows/dagCdcRestrictedCovid.yml
+++ b/.github/workflows/dagCdcRestrictedCovid.yml
@@ -29,7 +29,7 @@ jobs:
           geographic: ${{ env.NATIONAL }}
           demographic: ${{ env.SEX }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write sex state tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -40,7 +40,7 @@ jobs:
           geographic: ${{ env.STATE }}
           demographic: ${{ env.SEX }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write sex county tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -51,13 +51,13 @@ jobs:
           geographic: ${{ env.COUNTY }}
           demographic: ${{ env.SEX }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export sex data NDJSON files to GCS buckets
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"
@@ -75,7 +75,7 @@ jobs:
           geographic: ${{ env.NATIONAL }}
           demographic: ${{ env.AGE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write age state tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -86,7 +86,7 @@ jobs:
           geographic: ${{ env.STATE }}
           demographic: ${{ env.AGE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write age county tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -97,13 +97,13 @@ jobs:
           geographic: ${{ env.COUNTY }}
           demographic: ${{ env.AGE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export age data NDJSON files to GCS buckets
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -120,7 +120,7 @@ jobs:
           geographic: ${{ env.NATIONAL }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write race state tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -131,7 +131,7 @@ jobs:
           geographic: ${{ env.STATE }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write race county tables to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -142,7 +142,7 @@ jobs:
           geographic: ${{ env.COUNTY }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Race-specific age adjustment step right before export
       - name: Run age adjustment for race data
@@ -151,13 +151,13 @@ jobs:
           workflow_id: ${{ env.AGE_ADJUST_WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
 
       - name: Export race data NDJSON files to GCS buckets
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}

--- a/.github/workflows/dagCdcVaccinationCounty.yml
+++ b/.github/workflows/dagCdcVaccinationCounty.yml
@@ -21,11 +21,11 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.ALLS }}

--- a/.github/workflows/dagCdcVaccinationNational.yml
+++ b/.github/workflows/dagCdcVaccinationNational.yml
@@ -23,26 +23,26 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
       - name: Export age NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagCdcWisqarsBlackMenGunDeaths.yml
+++ b/.github/workflows/dagCdcWisqarsBlackMenGunDeaths.yml
@@ -24,7 +24,7 @@ jobs:
           demographic: ${{ env.URBANICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # URBANICITY STATE
       - name: Process and write urbanicity state tables to BigQuery
@@ -35,7 +35,7 @@ jobs:
           demographic: ${{ env.URBANICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE NATIONAL
       - name: Process and write age national tables to BigQuery
@@ -46,7 +46,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE STATE
       - name: Process and write age state tables to BigQuery
@@ -57,14 +57,14 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORTERS
       - name: Export NDJSON files for urbanicity to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.URBANICITY }}
           should_export_as_alls: "true"
@@ -73,6 +73,6 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}

--- a/.github/workflows/dagCdcWisqarsGunDeaths.yml
+++ b/.github/workflows/dagCdcWisqarsGunDeaths.yml
@@ -25,7 +25,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # AGE STATE
       - name: Process and write age state tables to BigQuery
@@ -36,7 +36,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE NATIONAL
       - name: Process and write race and ethnicity national tables to BigQuery
@@ -47,7 +47,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE STATE
       - name: Process and write race and ethnicity state tables to BigQuery
@@ -58,7 +58,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX NATIONAL
       - name: Process and write sex national tables to BigQuery
@@ -69,7 +69,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # SEX STATE
       - name: Process and write sex state tables to BigQuery
@@ -80,14 +80,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORTERS
       - name: Export NDJSON files for age to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -95,7 +95,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
 
@@ -103,7 +103,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagCdcWisqarsYouthGunDeaths.yml
+++ b/.github/workflows/dagCdcWisqarsYouthGunDeaths.yml
@@ -23,7 +23,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # RACE STATE
       - name: Process and write race and ethnicity state tables to BigQuery
@@ -34,14 +34,14 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # EXPORTER
       - name: Export NDJSON files for race and ethnicity to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagCdcWonderCancer.yml
+++ b/.github/workflows/dagCdcWonderCancer.yml
@@ -24,7 +24,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   age-national-bq:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   sex-national-bq:
     runs-on: ubuntu-latest
@@ -50,7 +50,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   race-state-bq:
     runs-on: ubuntu-latest
@@ -63,7 +63,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   age-state-bq:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   sex-state-bq:
     runs-on: ubuntu-latest
@@ -89,7 +89,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
   race-exporter:
     needs: [race-national-bq, race-state-bq]
@@ -99,7 +99,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
 
@@ -111,7 +111,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -123,7 +123,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagCensusPopRaceSexAge.yml
+++ b/.github/workflows/dagCensusPopRaceSexAge.yml
@@ -20,11 +20,11 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           source_gcs_bucket: ${{ env.GCS_MANUAL_UPLOADS_BUCKET }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}

--- a/.github/workflows/dagChr.yml
+++ b/.github/workflows/dagChr.yml
@@ -19,12 +19,12 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagDecia2010TerritoryPop.yml
+++ b/.github/workflows/dagDecia2010TerritoryPop.yml
@@ -20,25 +20,25 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export race NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
       - name: Export age NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
       - name: Export sex NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}

--- a/.github/workflows/dagDecia2020TerritoryPop.yml
+++ b/.github/workflows/dagDecia2020TerritoryPop.yml
@@ -25,7 +25,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write age state data to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -35,7 +35,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write sex state data to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -45,7 +45,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level ingest steps
       - name: Process and write race_and_ethnicity county data to BigQuery
@@ -56,7 +56,7 @@ jobs:
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write age county data to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -66,7 +66,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Process and write sex county data to BigQuery
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runSourceToBqPipeline@main
@@ -76,14 +76,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export steps
       - name: Export race_and_ethnicity NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
 
@@ -91,7 +91,7 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -99,6 +99,6 @@ jobs:
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}

--- a/.github/workflows/dagGeoContext.yml
+++ b/.github/workflows/dagGeoContext.yml
@@ -17,10 +17,10 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}

--- a/.github/workflows/dagKffVaccinationState.yml
+++ b/.github/workflows/dagKffVaccinationState.yml
@@ -21,13 +21,13 @@ jobs:
           workflow_id: ${{ env.WORKFLOW_ID }}
           dataset_name: ${{ env.DATASET_NAME }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagMaternalMortality.yml
+++ b/.github/workflows/dagMaternalMortality.yml
@@ -22,13 +22,13 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export NDJSON files to GCS buckets from BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/.github/workflows/dagPhrma.yml
+++ b/.github/workflows/dagPhrma.yml
@@ -32,7 +32,7 @@ jobs:
           demographic: ${{ env.RACE_ETH }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write race tables to BigQuery (state)
@@ -43,7 +43,7 @@ jobs:
           demographic: ${{ env.RACE_ETH }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level
       - name: Process and write race tables to BigQuery (county)
@@ -54,14 +54,14 @@ jobs:
           demographic: ${{ env.RACE_ETH }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from race tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_ETH }}
 
@@ -78,7 +78,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write age tables to BigQuery (state)
@@ -89,7 +89,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level
       - name: Process and write age tables to BigQuery (county)
@@ -100,14 +100,14 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from age tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -124,7 +124,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write sex tables to BigQuery (state)
@@ -135,7 +135,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level
       - name: Process and write sex tables to BigQuery (county)
@@ -146,14 +146,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from sex tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"
@@ -171,7 +171,7 @@ jobs:
           demographic: ${{ env.LIS }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write lis tables to BigQuery (state)
@@ -182,7 +182,7 @@ jobs:
           demographic: ${{ env.LIS }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level
       - name: Process and write lis tables to BigQuery (county)
@@ -193,14 +193,14 @@ jobs:
           demographic: ${{ env.LIS }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from lis tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.LIS }}
 
@@ -217,7 +217,7 @@ jobs:
           demographic: ${{ env.ELIGIBILITY }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write eligibility tables to BigQuery (state)
@@ -228,7 +228,7 @@ jobs:
           demographic: ${{ env.ELIGIBILITY }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # County level
       - name: Process and write eligibility tables to BigQuery (county)
@@ -239,13 +239,13 @@ jobs:
           demographic: ${{ env.ELIGIBILITY }}
           geographic: ${{ env.COUNTY }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from eligibility tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.ELIGIBILITY }}

--- a/.github/workflows/dagPhrmaBrfss.yml
+++ b/.github/workflows/dagPhrmaBrfss.yml
@@ -32,7 +32,7 @@ jobs:
           demographic: ${{ env.RACE_ETH }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write race tables to BigQuery (state)
@@ -43,14 +43,14 @@ jobs:
           demographic: ${{ env.RACE_ETH }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from race tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_ETH }}
 
@@ -67,7 +67,7 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write age tables to BigQuery (state)
@@ -78,14 +78,14 @@ jobs:
           demographic: ${{ env.AGE }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from age tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -102,7 +102,7 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write sex tables to BigQuery (state)
@@ -113,14 +113,14 @@ jobs:
           demographic: ${{ env.SEX }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from sex tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"
@@ -138,7 +138,7 @@ jobs:
           demographic: ${{ env.EDUCATION }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write education tables to BigQuery (state)
@@ -149,14 +149,14 @@ jobs:
           demographic: ${{ env.EDUCATION }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from education tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.EDUCATION }}
 
@@ -173,7 +173,7 @@ jobs:
           demographic: ${{ env.INCOME }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write income tables to BigQuery (state)
@@ -184,14 +184,14 @@ jobs:
           demographic: ${{ env.INCOME }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from income tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.INCOME }}
 
@@ -208,7 +208,7 @@ jobs:
           demographic: ${{ env.INSURANCE_STATUS }}
           geographic: ${{ env.NATIONAL }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # State level
       - name: Process and write insurance_status tables to BigQuery (state)
@@ -219,13 +219,13 @@ jobs:
           demographic: ${{ env.INSURANCE_STATUS }}
           geographic: ${{ env.STATE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       # Export to GCS
       - name: Export NDJSON files to GCS buckets from insurance_status tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.INSURANCE_STATUS }}

--- a/.github/workflows/dagVeraIncarcerationCounty.yml
+++ b/.github/workflows/dagVeraIncarcerationCounty.yml
@@ -24,13 +24,13 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_ETH }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export NDJSON files to GCS buckets from by race BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.RACE_ETH }}
 
@@ -44,13 +44,13 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export NDJSON files to GCS buckets from by age BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.AGE }}
 
@@ -64,13 +64,13 @@ jobs:
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           service_url: ${{ env.GCS_TO_BQ_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
 
       - name: Export NDJSON files to GCS buckets from by sex BigQuery tables
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runExportBqToGcsJsonPipeline@main
         with:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
-          gcp_sa_key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
           demographic: ${{ env.SEX }}
           should_export_as_alls: "true"

--- a/.github/workflows/deployInfraTest.yml
+++ b/.github/workflows/deployInfraTest.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           ref: main
           environment: dev
-          deployer-sa-key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          deployer-sa-key: ${{ secrets.DEPLOYER_SA_KEY }}
           project-id: ${{ secrets.TEST_PROJECT_ID }}
           tf-state-bucket: ${{ secrets.TEST_TF_STATE_BUCKET }}
           ahr-api-key: ${{ secrets.AHR_API_KEY }}

--- a/.github/workflows/runDestroyInfraTest.yml
+++ b/.github/workflows/runDestroyInfraTest.yml
@@ -17,7 +17,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -40,7 +40,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -64,7 +64,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -87,7 +87,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -110,7 +110,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -135,7 +135,7 @@ jobs:
       - id: auth
         uses: google-github-actions/auth@v3
         with:
-          credentials_json: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          credentials_json: ${{ secrets.DEPLOYER_SA_KEY }}
       - name: Set Up gcloud
         uses: google-github-actions/setup-gcloud@v3
         with:
@@ -149,7 +149,7 @@ jobs:
         working-directory: ./config
         run: |
           cat > creds.json << EOF
-          ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          ${{ secrets.DEPLOYER_SA_KEY }}
           EOF
       - name: Terraform Init
         working-directory: ./config
@@ -162,7 +162,7 @@ jobs:
         run: |
           terraform destroy -auto-approve -var-file=gcp.tfvars \
           -var-file=common.tfvars \
-          -var 'gcp_credentials=${{ secrets.TEST_DEPLOYER_SA_KEY }}' \
+          -var 'gcp_credentials=${{ secrets.DEPLOYER_SA_KEY }}' \
           -var 'project_id=${{ secrets.TEST_PROJECT_ID }}' \
           -var 'ingestion_image_digest=${{ needs.build-ingestion.outputs.image-digest }}' \
           -var 'gcs_to_bq_image_digest=${{ needs.build-gcs-to-bq.outputs.image-digest }}' \

--- a/.github/workflows/testBackendChangesInfraTest.yml
+++ b/.github/workflows/testBackendChangesInfraTest.yml
@@ -22,7 +22,7 @@ jobs:
           ref: infra-test
           environment: dev
           terraform-var-file: gcp.tfvars
-          deployer-sa-key: ${{ secrets.TEST_DEPLOYER_SA_KEY }}
+          deployer-sa-key: ${{ secrets.DEPLOYER_SA_KEY }}
           project-id: ${{ secrets.TEST_PROJECT_ID }}
           tf-state-bucket: ${{ secrets.TEST_TF_STATE_BUCKET }}
           ahr-api-key: ${{ secrets.AHR_API_KEY }}


### PR DESCRIPTION
# Description and Motivation
<!--- bulleted, high level items. use keywords (eg "closes #144" or "fixes #4323") -->

since the PROD DAGs reuse these, it's easiest to create a new naming scheme for the deployer key that gets properly overwritten by inherited prod secrets

## Has this been tested? How?

## Screenshots (if appropriate)

## Types of changes

(leave all that apply)

- Bug fix
- New content or feature
- Refactor / chore

## New frontend preview link is below in the Netlify comment 😎
