### PR TITLE
Split CLAUDE.md into per-service files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,35 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 The [Health Equity Tracker](https://healthequitytracker.org/) aggregates demographic health data by race, ethnicity, sex, and socioeconomic status across the US. It consists of a React frontend, lightweight Node server, Python data server, and a GCP-hosted data pipeline.
 
-## Commands
-
-All frontend commands run from `frontend/`:
-
-```bash
-npm run localhost        # Start dev server at localhost:3000 (also starts tsc --watch)
-npm run test             # Run Vitest unit tests once
-npm run test:watch       # Run Vitest in watch mode
-npm run cleanup          # Lint + format with Biome (runs pre-commit)
-npx tsc --noEmit         # Type-check TypeScript
-
-# Run a single E2E test file (dev server must be running)
-npm run e2e statins.nightly.spec.ts
-npm run e2e hiv          # Matches any filename containing "hiv"
-```
-
-Python tests run from the repo root with the venv activated (`source .venv/bin/activate`):
-
-```bash
-pip install python/data_server/ python/datasources/ python/ingestion/ && pytest python/tests/
-pip install python/datasources/ && pytest python/tests/datasources/test_cdc_hiv.py -s
-```
+> **Service-specific guidance:** See each service's own `CLAUDE.md` for details.
+> `frontend/` · `frontend_server/` · `data_server/` · `exporter/` · `python/`
 
 ## Architecture
 
 ### Three-Tier Frontend
 
 ```
-frontend/         React app (TypeScript, Vite, MUI v7, Tailwind v4, D3, Jotai)
+frontend/         React app (TypeScript, Vite, MUI, Tailwind, D3, Jotai)
 frontend_server/  Lightweight Node server — serves React static files, proxies data requests
 data_server/      Python Flask server — responds with JSON files exported from BigQuery
 ```
@@ -55,69 +35,33 @@ git push origin HEAD:infra-test -f
 ```
 Then run the relevant DAG workflow from GitHub Actions against the test project.
 
-### Frontend Data Flow
+## Commands
 
-The URL encodes the entire report state via URL params. The "MadLib" pattern (`disparity` / `comparegeos` / `comparevars` modes) is the query-builder UI — users fill in topic, geography, and demographic group.
+Frontend commands run from `frontend/` — see `frontend/CLAUDE.md`.
 
-```
-URL params (mls, dt1, demo, etc.)
-  → MadLib selection state (src/utils/MadLibs.ts)
-    → MetricQuery (src/data/query/MetricQuery.ts)
-      → DataManager (src/data/loading/DataManager.ts) — LRU cache
-        → VariableProvider (per-topic, src/data/providers/)
-          → JSON fetch from data_server
-            → MetricQueryResponse → Cards render charts
+Python tests run from the repo root with the venv activated:
+
+```bash
+source .venv/bin/activate
+pip install python/data_server/ python/datasources/ python/ingestion/ && pytest python/tests/
+pip install python/datasources/ && pytest python/tests/datasources/test_cdc_hiv.py -s
 ```
 
-Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
-
-### Adding a New Health Topic
+## Adding a New Health Topic
 
 Both frontend and backend changes are required:
 
-**Frontend:**
-1. Create `src/data/config/MetricConfig<Topic>.ts` — define `MetricId`s, `DataTypeId`s, and chart configs
-2. Register the new `DropdownVarId` in `src/data/config/DropDownIds.ts`
-3. Create `src/data/config/DatasetMetadata<Topic>.ts` — list dataset IDs consumed
-4. Create `src/data/providers/<Topic>Provider.ts` — extends `VariableProvider`, maps metrics to dataset files
-5. Register provider in `src/data/loading/VariableProviderMap.ts`
+**Frontend** (see `frontend/CLAUDE.md` for file locations):
+1. Create `MetricConfig<Topic>.ts` — define `MetricId`s, `DataTypeId`s, and chart configs
+2. Register the new `DropdownVarId` in `DropDownIds.ts`
+3. Create `DatasetMetadata<Topic>.ts` — list dataset IDs consumed
+4. Create `<Topic>Provider.ts` — extends `VariableProvider`, maps metrics to dataset files
+5. Register provider in `VariableProviderMap.ts`
 
 **Backend:**
 1. Create `python/datasources/<source>.py` — extends `DataSource`, implements `write_to_bq()`
 2. Register in `python/datasources/data_sources.py`
 3. Add a DAG GitHub Actions workflow `.github/workflows/dag<Source>.yml`
-
-### Design System / Theme Architecture
-
-A single-source-of-truth "Pass-Through" system keeps Tailwind v4, MUI v7, and D3 in sync:
-
-```
-colorValues.ts  (raw hex constants)
-  → muiTheme.tsx  (MUI theme — hex required for MUI's color derivation)
-  → colorVars.css  (CSS custom properties, @theme block)
-      → colorVars.ts  (typed `het` aliases: e.g., `het.altGreen`)
-      → Tailwind utility classes
-```
-
-**Styling rules:**
-- Always prefer Tailwind utility classes as the primary method
-- Use `het.<token>` (e.g., `color: het.altGreen`) in TypeScript for CSS-variable-driven styles
-- Only modify MUI components via `styleOverrides` in `muiTheme.tsx` — avoid `sx` props and inline styles
-- D3/JS logic that requires a hex value imports directly from `colorValues.ts`
-- New tokens must be added across the full pipeline: `colorValues.ts` → `muiTheme.tsx` → `colorVars.css` → `colorVars.ts`
-
-### Environment Variables
-
-No secrets are stored in `.env` files — all are checked into git. Environments:
-
-| `.env` file | Frontend URL | GCP Project |
-|---|---|---|
-| `.env.localhost` | `localhost:3000` | `het-infra-test` |
-| `.env.deploy_preview` | Netlify PR preview | `het-infra-test` |
-| `.env.dev` | `dev.healthequitytracker.org` | `het-infra-test` |
-| `.env.prod` | `healthequitytracker.org` | `het-infra-prod` |
-
-To serve local data files instead of a real API during frontend development, set `VITE_BASE_API_URL` to empty and drop `.json` files into `frontend/public/tmp/`. Or use `VITE_FORCE_STATIC=file1.json,file2.json` to override specific files while keeping the rest live.
 
 ## Pre-Commit Hooks
 
@@ -133,16 +77,8 @@ All of the following run automatically on `git commit`:
 
 | Purpose | Path |
 |---|---|
-| Topic metric definitions | `frontend/src/data/config/MetricConfig*.ts` |
-| All topic dropdown IDs | `frontend/src/data/config/DropDownIds.ts` |
-| Data provider per topic | `frontend/src/data/providers/*Provider.ts` |
-| Provider registration | `frontend/src/data/loading/VariableProviderMap.ts` |
-| URL parameter constants | `frontend/src/utils/urlutils.tsx` |
-| Shared Jotai state | `frontend/src/utils/sharedSettingsState.ts` |
-| MUI theme | `frontend/src/styles/theme/muiTheme.tsx` |
-| Color tokens (hex) | `frontend/src/styles/theme/colorValues.ts` |
-| Color tokens (CSS vars / TS) | `frontend/src/styles/theme/colorVars.css`, `colorVars.ts` |
 | Python DataSource base class | `python/datasources/data_source.py` |
 | Python BQ/GCS utilities | `python/ingestion/gcs_to_bq_util.py` |
 | Python type definitions | `python/ingestion/het_types.py` |
 | GCP pipeline DAG workflows | `.github/workflows/dag*.yml` |
+| Frontend key files | See `frontend/CLAUDE.md` |

--- a/data_server/CLAUDE.md
+++ b/data_server/CLAUDE.md
@@ -1,0 +1,14 @@
+# Data Server
+
+Python Flask server that responds to data requests by serving pre-exported JSON files from GCS.
+
+## Commands
+
+```bash
+# Run locally (from repo root with venv active)
+pip install python/data_server/ && python data_server/main.py
+```
+
+## How it works
+
+Reads JSON files from a GCS bucket (or local `frontend/public/tmp/` during development). Each endpoint maps to a file exported by the `exporter/` service. The frontend sets `VITE_BASE_API_URL` to point at whichever data server environment to use.

--- a/exporter/CLAUDE.md
+++ b/exporter/CLAUDE.md
@@ -1,0 +1,14 @@
+# Exporter
+
+Splits BigQuery query results into per-state JSON files and uploads them to GCS for the data server to serve.
+
+## Commands
+
+```bash
+# Run locally (from repo root with venv active)
+pip install python/ingestion/ && python exporter/main.py
+```
+
+## How it works
+
+Triggered by Cloud Run after `run_gcs_to_bq/` completes. Reads from BigQuery, splits results by state/territory, and writes JSON files to the GCS bucket that `data_server/` reads from.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,111 @@
+# Frontend
+
+React app built with TypeScript, Vite, MUI, Tailwind, D3, and Jotai.
+All commands below run from `frontend/`.
+
+## Commands
+
+```bash
+npm run localhost        # Start dev server at localhost:3000 (also starts tsc --watch)
+npm run test             # Run Vitest unit tests once
+npm run test:watch       # Run Vitest in watch mode
+npm run cleanup          # Lint + format with Biome (runs pre-commit)
+npx tsc --noEmit         # Type-check TypeScript
+npm run tokens           # Regenerate design token files (auto-runs on install/dev/build)
+
+# Run a single E2E test file (dev server must be running)
+npm run e2e statins.nightly.spec.ts
+npm run e2e hiv          # Matches any filename containing "hiv"
+```
+
+## Frontend Data Flow
+
+The URL encodes the entire report state via URL params. The "MadLib" pattern (`disparity` / `comparegeos` / `comparevars` modes) is the query-builder UI — users fill in topic, geography, and demographic group.
+
+```
+URL params (mls, dt1, demo, etc.)
+  → MadLib selection state (src/utils/MadLibs.ts)
+    → MetricQuery (src/data/query/MetricQuery.ts)
+      → DataManager (src/data/loading/DataManager.ts) — LRU cache
+        → VariableProvider (per-topic, src/data/providers/)
+          → JSON fetch from data_server
+            → MetricQueryResponse → Cards render charts
+```
+
+Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
+
+## Adding a New Frontend Feature (health topic)
+
+1. Create `src/data/config/MetricConfig<Topic>.ts` — define `MetricId`s, `DataTypeId`s, and chart configs
+2. Register the new `DropdownVarId` in `src/data/config/DropDownIds.ts`
+3. Create `src/data/config/DatasetMetadata<Topic>.ts` — list dataset IDs consumed
+4. Create `src/data/providers/<Topic>Provider.ts` — extends `VariableProvider`, maps metrics to dataset files
+5. Register provider in `src/data/loading/VariableProviderMap.ts`
+
+## Design System / Token Pipeline
+
+Design tokens are defined once in W3C DTCG JSON and generated into typed TS + CSS files by [Terrazzo](https://terrazzo.app/) (`tsx run-tokens.ts`):
+
+```
+frontend/tokens/                   ← edit these
+  colors.tokens.json
+  typography.tokens.json
+  dimensions.tokens.json
+        ↓  npm run tokens  (auto-runs on install, predev, prebuild)
+src/styles/tokens/                 ← DO NOT EDIT (gitignored, generated)
+  colors.ts      — colors { altGreen: '#0b5240', … }
+  colors.css     — @theme block for Tailwind utility generation
+  typography.ts  — typography { fontSansText: "'Inter Variable'…", … }
+  typography.css
+  dimensions.ts  — dimensions { radiusSm: '4px', … } + breakpoints { sm: '600px', … }
+  dimensions.css
+```
+
+**Token API — always import raw values, use directly:**
+```ts
+import { colors }                             from '../../styles/tokens/colors'
+import { typography }                         from '../../styles/tokens/typography'
+import { dimensions, breakpoints }            from '../../styles/tokens/dimensions'
+import { type Breakpoint }                    from '../../styles/tokens/dimensions'
+
+colors.altGreen          // '#0b5240'
+typography.fontSansText  // "'Inter Variable', sans-serif"
+dimensions.radiusSm      // '4px'
+breakpoints.sm           // '600px'  ← short keys for useIsBreakpointAndUp
+```
+
+CSS vars are a Tailwind implementation detail — `@theme` registers tokens so utility classes like `bg-alt-green` work; app code never references `var(--color-*)` directly.
+
+**Styling rules:**
+- Always prefer Tailwind utility classes as the primary method
+- For inline/computed styles in TypeScript, import from `src/styles/tokens/` and use the raw value
+- Only modify MUI components via `styleOverrides` in `muiTheme.tsx` — avoid `sx` props and inline styles
+- **To add or change a token:** edit the relevant `tokens/*.tokens.json` file and run `npm run tokens`
+
+## Environment Variables
+
+No secrets are stored in `.env` files — all are checked into git. Environments:
+
+| `.env` file | Frontend URL | GCP Project |
+|---|---|---|
+| `.env.localhost` | `localhost:3000` | `het-infra-test` |
+| `.env.deploy_preview` | Netlify PR preview | `het-infra-test` |
+| `.env.dev` | `dev.healthequitytracker.org` | `het-infra-test` |
+| `.env.prod` | `healthequitytracker.org` | `het-infra-prod` |
+
+To serve local data files instead of a real API during frontend development, set `VITE_BASE_API_URL` to empty and drop `.json` files into `frontend/public/tmp/`. Or use `VITE_FORCE_STATIC=file1.json,file2.json` to override specific files while keeping the rest live.
+
+## Key File Locations
+
+| Purpose | Path |
+|---|---|
+| Topic metric definitions | `src/data/config/MetricConfig*.ts` |
+| All topic dropdown IDs | `src/data/config/DropDownIds.ts` |
+| Data provider per topic | `src/data/providers/*Provider.ts` |
+| Provider registration | `src/data/loading/VariableProviderMap.ts` |
+| URL parameter constants | `src/utils/urlutils.tsx` |
+| Shared Jotai state | `src/utils/sharedSettingsState.ts` |
+| MUI theme | `src/styles/theme/muiTheme.tsx` |
+| Design token sources | `tokens/*.tokens.json` |
+| Token build script | `run-tokens.ts`, `terrazzo.config.ts` |
+| Generated token files | `src/styles/tokens/` (gitignored) |

--- a/frontend_server/CLAUDE.md
+++ b/frontend_server/CLAUDE.md
@@ -1,0 +1,20 @@
+# Frontend Server
+
+Lightweight Node.js server that serves the React static build and proxies data requests to the Python data server.
+
+## Commands
+
+```bash
+npm start    # start server
+npm test     # run utils tests
+```
+
+## How it works
+
+- Serves static files from `../frontend/build/`
+- Proxies `/api/*` requests to `VITE_BASE_API_URL` (set per environment via `.env`)
+- Routes defined in `routes/`
+
+## Docker
+
+Built as a container, deployed to Cloud Run. See `Dockerfile`.

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -1,0 +1,36 @@
+# Python Data Pipeline
+
+Shared modules for data ingestion, transformation, and loading to BigQuery.
+
+## Commands
+
+```bash
+# From repo root with venv active
+source .venv/bin/activate
+pip install python/data_server/ python/datasources/ python/ingestion/ && pytest python/tests/
+
+# Single datasource test
+pip install python/datasources/ && pytest python/tests/datasources/test_cdc_hiv.py -s
+```
+
+## Structure
+
+```
+datasources/   DataSource subclasses — one per data source (e.g. CdcHiv, Phrma)
+ingestion/     Shared utilities: gcs_to_bq_util.py, het_types.py, BQ/GCS helpers
+tests/         Integration tests
+```
+
+## Adding a new data source
+
+1. Create `python/datasources/<source>.py` extending `DataSource`, implement `write_to_bq()`
+2. Register in `python/datasources/data_sources.py`
+3. Add DAG workflow `.github/workflows/dag<Source>.yml`
+
+## Key files
+
+| Purpose | Path |
+|---|---|
+| DataSource base class | `datasources/data_source.py` |
+| BigQuery/GCS utilities | `ingestion/gcs_to_bq_util.py` |
+| Shared type definitions | `ingestion/het_types.py` |


### PR DESCRIPTION
# Description and Motivation
- Root `CLAUDE.md` was frontend-heavy — when working in Python files, Claude was loading token pipeline details it didn't need
- Claude Code reads `CLAUDE.md` at every directory level, so per-service files give targeted context without bloating the root
- Root is now ~80 lines (was 171); frontend detail lives in `frontend/CLAUDE.md`

**New files:**
- `frontend/CLAUDE.md` — full frontend context (commands, data flow, token pipeline, env vars, key files)
- `frontend_server/CLAUDE.md` — stub to be fleshed out during future server work
- `data_server/CLAUDE.md` — stub
- `exporter/CLAUDE.md` — stub
- `python/CLAUDE.md` — stub with datasource pattern and test commands

## Types of changes
- Refactor / chore (docs only, no code changes)

## New frontend preview link is below in the Netlify comment 😎