### PR TITLE
Fix Docker build: run-tokens.ts not found during npm install

### DIFF
--- a/frontend_server/CLAUDE.md
+++ b/frontend_server/CLAUDE.md
@@ -17,4 +17,11 @@ npm test     # run utils tests
 
 ## Docker
 
-Built as a container, deployed to Cloud Run. See `Dockerfile`.
+Two-stage build defined in `Dockerfile`:
+
+1. **Stage 1 (`build_react`):** Builds the React frontend
+   - Installs frontend deps with `--ignore-scripts` (defers `postinstall` so `run-tokens.ts` isn't called before it's been copied into the image)
+   - Copies all frontend source, then runs `npm run build:$DEPLOY_CONTEXT` — the `prebuild` hook runs `npm run tokens` at the right time
+2. **Stage 2:** Copies the compiled `build/` output into the Node server image alongside the server code
+
+The `DEPLOY_CONTEXT` build arg selects which `.env` file the server loads at runtime (`dev`, `prod`, `deploy_preview`).

--- a/frontend_server/Dockerfile
+++ b/frontend_server/Dockerfile
@@ -7,7 +7,10 @@ WORKDIR /usr/src/build
 
 COPY ./frontend/package*.json ./
 
-RUN npm install
+# --ignore-scripts defers postinstall (npm run tokens) until after all files
+# are copied — run-tokens.ts doesn't exist yet at this point in the build.
+# The prebuild hook in npm run build:$DEPLOY_CONTEXT runs tokens instead.
+RUN npm install --ignore-scripts
 
 COPY ./frontend .
 

--- a/frontend_server/Dockerfile
+++ b/frontend_server/Dockerfile
@@ -10,7 +10,7 @@ COPY ./frontend/package*.json ./
 # --ignore-scripts defers postinstall (npm run tokens) until after all files
 # are copied — run-tokens.ts doesn't exist yet at this point in the build.
 # The prebuild hook in npm run build:$DEPLOY_CONTEXT runs tokens instead.
-RUN npm install --ignore-scripts
+RUN npm ci --ignore-scripts
 
 COPY ./frontend .
 


### PR DESCRIPTION
# Description and Motivation
The deploy-to-dev pipeline failed after the token pipeline PR merged.

**Root cause:** The Dockerfile installs packages *before* copying the frontend source:
```dockerfile
COPY ./frontend/package*.json ./
RUN npm install          ← postinstall fires here: tsx run-tokens.ts
COPY ./frontend .        ← run-tokens.ts arrives here (too late)
```

**Fix:** Add `--ignore-scripts` to the install step so `postinstall` doesn't fire before the files exist. The `prebuild` hook in `npm run build:$DEPLOY_CONTEXT` already runs `npm run tokens` — that's the right time since all source files are present by then.

## Has this been tested? How?
- One-line Dockerfile change; logic verified against the existing hook chain

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎