### PR TITLE
Fix vitest/globals TypeScript type error

### DIFF
--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-svgr/client" />
+/// <reference types="vitest/globals" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,14 +6,6 @@
       "dom.iterable",
       "es2024"
     ],
-    "types": [
-      "vite-plugin-svgr/client",
-      "vite/client",
-      "vitest/globals",
-    ],
-    "typeRoots": [
-      "./node_modules"
-    ],
     "noImplicitThis": false,
     "allowJs": true,
     "skipLibCheck": true,

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -6,6 +6,7 @@
       "dom.iterable",
       "es2024"
     ],
+    "types": [],
     "noImplicitThis": false,
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
# Description and Motivation
`Cannot find type definition file for 'vitest/globals'` was appearing in the IDE.

**Root cause:** `typeRoots: ["./node_modules"]` in tsconfig expects type entries to be directories (e.g. `vitest/globals/index.d.ts`), but vitest exports a flat file (`vitest/globals.d.ts`). TypeScript can't find it via this mechanism.

**Fix:** Move `vite-plugin-svgr/client` and `vitest/globals` into `src/vite-env.d.ts` as triple-slash references — the same pattern already used for `vite/client`. Remove the `types` array and `typeRoots` from tsconfig.json.

## Has this been tested? How?
- `tsc --noEmit` passes with zero errors

## Types of changes
- Bug fix

## New frontend preview link is below in the Netlify comment 😎