### PR TITLE
perf: revert e2e sharding — single job is faster for current suite size

### DIFF
--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -17,18 +17,16 @@ defaults:
     working-directory: frontend
 
 jobs:
-  validate:
-    name: Lint, Unit Tests & Build
+  validate_and_test:
+    name: Lint, Build & E2E
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
-      # --- SETUP PHASE ---
+      # --- SETUP ---
 
-      # 1. Fast Checkout
       - name: Checkout
         uses: actions/checkout@v6
 
-      # 2. Setup Node
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -36,13 +34,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
 
-      # 3. Install Dependencies
       - name: Install dependencies
         run: npm ci
 
-      # --- CODE QUALITY PHASE (Fails Fast) ---
+      # --- CODE QUALITY (fails fast) ---
 
-      # 4. Lint
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
@@ -50,46 +46,19 @@ jobs:
       - name: Run Biome
         run: biome ci src/
 
-      # 5. Unit Tests
       - name: Run Vitest unit tests
         run: npm test
 
-      # 6. Build Check
       - name: Build React frontend
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           VITE_NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx tsc --noEmit && npm run build:deploy_preview
 
-  e2e:
-    name: E2E (shard ${{ matrix.shard }}/3)
-    needs: validate
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-    steps:
-      # --- SETUP PHASE ---
+      # --- E2E (PR only) ---
 
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: frontend/package.json
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
-      # --- WAIT FOR NETLIFY ---
-
-      - name: Waiting for "Success" from Netlify Preview
+      - name: Waiting for Netlify Preview
+        if: github.event_name == 'pull_request'
         uses: Wandalen/wretry.action@master
         with:
           action: jakepartusch/wait-for-netlify-action@v1.4
@@ -98,8 +67,6 @@ jobs:
           with: |
             site_name: ${{env.NETLIFY_SITE_NAME}}
             max_timeout: 180
-
-      # --- PLAYWRIGHT SETUP (Cached) ---
 
       - name: Get installed Playwright version
         id: playwright-version
@@ -116,16 +83,15 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      # --- E2E PHASE ---
-
-      - name: Run E2E shard ${{ matrix.shard }}/3
-        run: npx playwright test --project=E2E_CI --workers 2 --shard=${{ matrix.shard }}/3
+      - name: Run E2E on deploy preview
+        if: github.event_name == 'pull_request'
+        run: npx playwright test --project=E2E_CI --workers 2
         env:
           E2E_BASE_URL: 'https://deploy-preview-${{env.GITHUB_PR_NUMBER}}--${{env.NETLIFY_SITE_NAME}}.netlify.app'
 
       - uses: actions/upload-artifact@v7
         if: ${{ failure() }}
         with:
-          name: playwright-report-shard-${{ matrix.shard }}
+          name: playwright-report
           path: frontend/playwright-report/
           retention-days: 30


### PR DESCRIPTION
## What and why

Reverts the 3-shard matrix added in #4741 back to a single job.

**Measured result in CI (run 26252629357):**

| | Old single job | 3-shard matrix |
|---|---|---|
| E2E step / longest shard | 99s | 136s |
| Total wall-clock | 208s | 225s |

The sharding made it **17s slower**. Each of the 3 shard jobs carries ~75s of fixed setup overhead (checkout + npm ci + browser cache check) against only 29–43s of actual test execution per shard. Splitting into 3 triples the setup cost faster than it reduces the test time.

The single-job structure is the fastest configuration for this suite until test execution exceeds ~200s (3× the per-shard setup cost). The other improvements from #4741 — `trace: 'retain-on-failure'`, `actionTimeout: 20s`, and browser/npm caching in `e2eDev.yml` and `e2eScheduled.yml` — are all preserved.

Closes one item in #4742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
