### PR TITLE
chore: strip stale comments from playwright.config.ts

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,9 +1,6 @@
 /// <reference types="node" />
 import type { PlaywrightTestConfig } from '@playwright/test'
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 const config: PlaywrightTestConfig = {
   webServer: {
     command: 'npm run start:deploy_preview',
@@ -12,26 +9,20 @@ const config: PlaywrightTestConfig = {
     reuseExistingServer: true,
   },
   testDir: './playwright-tests',
-  /* Maximum time one test can run for, default was 30s. */
   timeout: process.env.CI ? 5 * 60 * 1000 : 60 * 1000,
-  /* Maximum time one "expect" can run for, default was 5 seconds and was too quick */
   expect: {
     timeout: process.env.CI ? 30 * 1000 : 10 * 1000,
   },
-  /* run all tests, even those within a shared file, in parallel  */
   fullyParallel: true,
   retries: process.env.CI ? 1 : 0,
   maxFailures: process.env.CI ? 2 : 0,
   reporter: [[process.env.CI ? 'github' : 'list'], ['html']],
 
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     browserName: 'chromium',
     headless: true,
-    /* 20s per action; prevents a stuck click/fill from consuming the full 5-min test timeout */
     actionTimeout: 20 * 1000,
     baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:3000',
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
@@ -40,15 +31,15 @@ const config: PlaywrightTestConfig = {
   projects: [
     {
       name: 'URL',
-      testMatch: /.*externalUrls.spec.ts/, // checks outgoing links
+      testMatch: /.*externalUrls.spec.ts/,
     },
     {
       name: 'E2E_NIGHTLY',
-      testIgnore: /.*externalUrls.spec.ts/, // both nightly + ci tests
+      testIgnore: /.*externalUrls.spec.ts/,
     },
     {
       name: 'E2E_CI',
-      testMatch: /.*ci.spec.ts/, // only most essential tests run on ci
+      testMatch: /.*ci.spec.ts/,
     },
   ],
 }


### PR DESCRIPTION
Removes inline commentary that explains default values and change rationale — that belongs in git history, not the file. Also serves as the measurement PR for the final e2e timing after #4741 + #4743 (single job + `trace:retain-on-failure`, no sharding).