### PR TITLE
perf: run PR e2e against local vite build, shallow-clone all workflows

### DIFF
--- a/.github/workflows/e2eDev.yml
+++ b/.github/workflows/e2eDev.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: actions/setup-node@v6
         with:
           node-version-file: frontend/package.json

--- a/.github/workflows/e2eScheduled.yml
+++ b/.github/workflows/e2eScheduled.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -1,9 +1,5 @@
 name: RUN Frontend Tests
 
-env:
-  NETLIFY_SITE_NAME: 'health-equity-tracker'
-  GITHUB_PR_NUMBER: ${{github.event.pull_request.number}}
-
 on:
   push:
     branches: [main]
@@ -26,6 +22,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -55,24 +53,15 @@ jobs:
           VITE_NODE_OPTIONS: '--max_old_space_size=4096'
         run: npx tsc --noEmit && npm run build:deploy_preview
 
-      # --- E2E (PR only) ---
-
-      - name: Waiting for Netlify Preview
-        if: github.event_name == 'pull_request'
-        uses: Wandalen/wretry.action@master
-        with:
-          action: jakepartusch/wait-for-netlify-action@v1.4
-          attempt_limit: 3
-          attempt_delay: 10000
-          with: |
-            site_name: ${{env.NETLIFY_SITE_NAME}}
-            max_timeout: 180
+      # --- E2E (PR only, runs against the local vite preview of the built dist) ---
 
       - name: Get installed Playwright version
+        if: github.event_name == 'pull_request'
         id: playwright-version
         run: echo "version=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright binaries
+        if: github.event_name == 'pull_request'
         uses: actions/cache@v5
         id: playwright-cache
         with:
@@ -80,14 +69,12 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        if: github.event_name == 'pull_request' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E on deploy preview
+      - name: Run E2E against local build
         if: github.event_name == 'pull_request'
         run: npx playwright test --project=E2E_CI --workers 2
-        env:
-          E2E_BASE_URL: 'https://deploy-preview-${{env.GITHUB_PR_NUMBER}}--${{env.NETLIFY_SITE_NAME}}.netlify.app'
 
       - uses: actions/upload-artifact@v7
         if: ${{ failure() }}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -3,7 +3,11 @@ import type { PlaywrightTestConfig } from '@playwright/test'
 
 const config: PlaywrightTestConfig = {
   webServer: {
-    command: 'npm run start:deploy_preview',
+    // CI: serve the already-built dist (starts in ~2s, same bundle the build step just produced).
+    // Locally: use the dev server so developers don't need to build first.
+    command: process.env.CI
+      ? 'npx vite preview --port 3000'
+      : 'npm run start:deploy_preview',
     port: 3000,
     timeout: 60 * 1000,
     reuseExistingServer: true,


### PR DESCRIPTION
## What

Two changes to substantially speed up CI:

### 1. Run PR e2e tests against the local vite build (not Netlify)

The workflow already builds `dist/` via `npm run build:deploy_preview`. Previously that build was ignored for testing — playwright waited for Netlify then routed every `page.goto()` over the internet. Now:

- `playwright.config.ts` uses `npx vite preview --port 3000` in CI, serving the already-built `dist/` in ~2s as one shared instance for all workers
- The Netlify wait step and `E2E_BASE_URL` are removed entirely
- Locally, the dev server (`npm run start:deploy_preview`) is unchanged

Coverage is identical: same compiled bundle, same `VITE_BASE_API_URL=https://dev.healthequitytracker.org` for data fetching — data never went through Netlify anyway. What's eliminated is the per-navigation network round-trip to Netlify and the cold-start variability that caused e2e times to range from 99s to 411s across recent runs.

### 2. `fetch-depth: 1` on all three workflows

Checkout was taking 38–45s fetching full git history on every run. A shallow clone cuts this to ~5s.

Applied to `runFrontendTests.yml`, `e2eDev.yml`, and `e2eScheduled.yml`.

## Expected improvement

| | Before | After |
|---|---|---|
| Checkout | 38–45s | ~5s |
| Netlify wait | 2s | 0s (removed) |
| E2E step | 99–411s (network variability) | ~60–80s (local, consistent) |
| **Total PR run** | **208–450s** | **~130–145s** |

`e2eDev.yml` and `e2eScheduled.yml` gain the ~35s checkout saving; they continue to test against the live dev/prod sites as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
