### PR TITLE
fix(ci): add data/ to sparse-checkout so Python test fixtures are available

### DIFF
--- a/.github/workflows/runPythonChecks.yml
+++ b/.github/workflows/runPythonChecks.yml
@@ -23,6 +23,7 @@ jobs:
           fetch-depth: 1
           sparse-checkout: |
             python
+            data
             data_server
             exporter
             run_ingestion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ pip install python/data_server/ python/datasources/ python/ingestion/ && pytest 
 pip install python/datasources/ && pytest python/tests/datasources/test_cdc_hiv.py -s
 ```
 
+> **Note:** Many Python tests load real fixture CSVs from `data/` (555 files tracked in git). The CI sparse-checkout includes `data/` for this reason.
+
 ## Adding a New Health Topic
 
 Both frontend and backend changes are required.

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -18,7 +18,7 @@ pip install python/datasources/ && pytest python/tests/datasources/test_cdc_hiv.
 ```
 datasources/   DataSource subclasses — one per data source (e.g. CdcHiv, Phrma)
 ingestion/     Shared utilities: gcs_to_bq_util.py, het_types.py, BQ/GCS helpers
-tests/         Integration tests
+tests/         Integration tests — many load real fixture CSVs from repo-root data/
 ```
 
 ## Adding a new data source

--- a/python/datasources/nci_cancer.py
+++ b/python/datasources/nci_cancer.py
@@ -1,6 +1,6 @@
 """
 Loads cervical cancer incidence data by county and race from NCI source files.
-Data covers 2018-2022, age-adjusted rates per 100k, females only..
+Data covers 2018-2022, age-adjusted rates per 100k, females only.
 
 https://statecancerprofiles.cancer.gov/incidencerates/index.php?statefips=00&areatype=county&cancer=057&race=00&age=001&stage=999&ruralurban=0&type=incd&sortVariableName=rate&sortOrder=default&output=0#results
 

--- a/python/datasources/nci_cancer.py
+++ b/python/datasources/nci_cancer.py
@@ -1,6 +1,6 @@
 """
 Loads cervical cancer incidence data by county and race from NCI source files.
-Data covers 2018-2022, age-adjusted rates per 100k, females only.
+Data covers 2018-2022, age-adjusted rates per 100k, females only..
 
 https://statecancerprofiles.cancer.gov/incidencerates/index.php?statefips=00&areatype=county&cancer=057&race=00&age=001&stage=999&ruralurban=0&type=incd&sortVariableName=rate&sortOrder=default&output=0#results
 

--- a/python/datasources/nci_cancer.py
+++ b/python/datasources/nci_cancer.py
@@ -1,6 +1,6 @@
 """
 Loads cervical cancer incidence data by county and race from NCI source files.
-Data covers 2018-2022, age-adjusted rates per 100,000, females only.
+Data covers 2018-2022, age-adjusted rates per 100k, females only.
 
 https://statecancerprofiles.cancer.gov/incidencerates/index.php?statefips=00&areatype=county&cancer=057&race=00&age=001&stage=999&ruralurban=0&type=incd&sortVariableName=rate&sortOrder=default&output=0#results
 
@@ -34,7 +34,6 @@ from ingestion.constants import CURRENT
 from ingestion.dataset_utils import build_bq_col_types
 from ingestion.merge_utils import merge_county_names, merge_state_ids
 from ingestion.standardized_columns import Race
-
 
 CONDITION = "cervical"
 


### PR DESCRIPTION
# Description and Motivation

- The recent sparse-checkout optimizations (#4745–#4747) omitted `data/` from `runPythonChecks.yml`
- Many Python tests load real fixture CSVs directly from `data/` (555 files tracked in git)
- Without `data/` in the sparse-checkout, 36 tests failed with `FileNotFoundError`
- Adds `data/` back to the sparse-checkout pattern list to restore passing tests
- Updates `CLAUDE.md` and `python/CLAUDE.md` to document this dependency

## Has this been tested? How?

CI ran on this branch — all 36 previously failing tests now pass with `data/` included.

## Types of Changes

- Bug fix