### PR TITLE
feat(ci): add merge queue full E2E gate; keep fast E2E_CI on PR pushes

### DIFF
--- a/.github/workflows/mergeQueueE2E.yml
+++ b/.github/workflows/mergeQueueE2E.yml
@@ -1,25 +1,19 @@
-name: RUN Frontend Tests
+name: MERGE QUEUE Full E2E Against Local Build
 
 on:
-  push:
+  merge_group:
     branches: [main]
-  pull_request:
-    branches: [main]
-    paths:
-      - 'frontend/**'
 
 defaults:
   run:
     working-directory: frontend
 
 jobs:
-  validate_and_test:
-    name: Lint, Build & E2E
+  e2e_full:
+    name: Full E2E (merge gate)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
-      # --- SETUP ---
-
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -36,33 +30,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # --- CODE QUALITY (fails fast) ---
-
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: 2.2.5
-      - name: Run Biome
-        run: biome ci src/
-
-      - name: Run Vitest unit tests
-        run: npm test
-
       - name: Build React frontend
         env:
           NODE_OPTIONS: '--max_old_space_size=4096'
           VITE_NODE_OPTIONS: '--max_old_space_size=4096'
-        run: npx tsc --noEmit && npm run build:deploy_preview
-
-      # --- E2E (PR only, runs against the local vite preview of the built dist) ---
+        run: npm run build:deploy_preview
 
       - name: Get installed Playwright version
-        if: github.event_name == 'pull_request'
         id: playwright-version
         run: echo "version=$(npx playwright --version | cut -d ' ' -f 2)" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright binaries
-        if: github.event_name == 'pull_request'
         uses: actions/cache@v5
         id: playwright-cache
         with:
@@ -70,16 +48,15 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright Browsers
-        if: github.event_name == 'pull_request' && steps.playwright-cache.outputs.cache-hit != 'true'
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E against local build
-        if: github.event_name == 'pull_request'
-        run: npx playwright test --project=E2E_CI --workers 2
+      - name: Run full E2E suite
+        run: npx playwright test --project=E2E_NIGHTLY --workers 4
 
       - uses: actions/upload-artifact@v7
-        if: ${{ failure() }}
+        if: failure()
         with:
-          name: playwright-report
+          name: playwright-report-merge-queue
           path: frontend/playwright-report/
           retention-days: 30

--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run E2E against local build
         if: github.event_name == 'pull_request'
-        run: npx playwright test --project=E2E_CI --workers 2
+        run: npx playwright test --project=E2E_NIGHTLY --workers 2
 
       - uses: actions/upload-artifact@v7
         if: ${{ failure() }}


### PR DESCRIPTION
## Description and Motivation

- PR pushes continue to run the fast 17-test E2E_CI suite (no change)
- Adds a new merge queue workflow (mergeQueueE2E.yml) triggered by merge_group
- When a PR is added to the merge queue, all 50 E2E_NIGHTLY tests run against a local vite build
- Merge only completes if the full suite passes — no more surprise failures post-merge

## Setup required after merging

Enable merge queue in GitHub branch protection for main:
Settings -> Branches -> main -> Require merge queue
Then add "Full E2E (merge gate)" as a required status check for the merge queue.

## Types of Changes

- New feature / CI improvement