### PR TITLE
fix(ux): convert HetAppBar, SkipLink, and Banner to synchronous imports

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,9 @@ import {
 import { methodologyRouteConfigs } from './pages/Methodology/methodologyContent/methodologyRouteConfigs'
 import { policyRouteConfigs } from './pages/Policy/policyContent/policyRouteConfigs'
 import { wiheConfigs } from './pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu'
+import Banner from './reports/ui/Banner'
+import SkipLink from './SkipLink'
+import HetAppBar from './styles/HetComponents/HetAppBar'
 import muiTheme from './styles/theme/muiTheme'
 import { autoInitGlobals } from './utils/globals'
 import {
@@ -56,15 +59,10 @@ const ErrorBoundaryDropParams = React.lazy(
 const ExploreDataFallback = React.lazy(
   async () => await import('./pages/ExploreData/ExploreDataFallback'),
 )
-const SkipLink = React.lazy(async () => await import('./SkipLink'))
 const MethodologyPage = React.lazy(
   async () =>
     await import('./pages/Methodology/methodologyComponents/MethodologyPage'),
 )
-const HetAppBar = React.lazy(
-  async () => await import('./styles/HetComponents/HetAppBar'),
-)
-const Banner = React.lazy(async () => await import('./reports/ui/Banner'))
 const PolicyPage = React.lazy(
   async () => await import('./pages/Policy/policyComponents/PolicyPage'),
 )


### PR DESCRIPTION
## Problem

Three critical shell UI components were wrapped in `React.lazy()` but rendered **outside** the `<Suspense>` boundary in `App.tsx`:

- `HetAppBar` - global navigation bar
- `SkipLink` - accessible skip-to-main link
- `Banner` - informational banner

Because they were lazy but had no Suspense fallback wrapping them, React would either suspend the entire page or leave these slots empty until the async chunk resolved. In practice this caused:

- **Visible layout shift (CLS)** on initial load as the nav bar popped in after the page settled
- **Broken skip-link availability** for keyboard and screen-reader users - the `<a href="#main">` was not in the DOM on first paint, so focus management and AT navigation were broken
- **Inconsistent banner rendering** on `/exploredata`

Closes #4724, closes #4723

## Solution

Convert all three to synchronous imports. They are small, stateless (or near-stateless) components with no reason to be code-split:

- `SkipLink` - a single `<a>` element, ~10 lines
- `HetAppBar` - renders `HetMobileToolbar` / `HetDesktopToolbar` via CSS breakpoints; already has correct `aria-label` on nav landmarks
- `Banner` - defaults to hidden (`isVisible = false`), so it adds negligible weight even when not shown

All page-level routes and `Footer` remain lazy - those are the correct code-split boundaries.

## What was NOT changed

- Responsive layout: `HetAppBar` uses `md:hidden` / `hidden md:block` Tailwind classes
- A11y attributes: mobile toolbar has labeled expand/collapse buttons; desktop toolbar has `<nav aria-label='page navigation'>`
- All other lazy-loaded page routes - still lazy

## Test plan

- [x] Hard reload on landing page: nav bar visible immediately, no layout shift
- [x] Tab to first focusable element: "Skip to main content" link is reachable on first paint
- [x] Navigate to `/exploredata` with no query params: banner renders on first load
- [x] Mobile viewport: hamburger menu renders without flash
- [x] Screen reader: skip link announces and focuses `#main` correctly
- [x] `npx tsc --noEmit` passes
- [x] `npm run cleanup` passes

Generated with [Claude Code](https://claude.com/claude-code)
