### PR TITLE
fix(ux): eliminate double history pushes causing stuck back-button navigation

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -41,10 +41,17 @@ Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`s
 
 | Tier | Params | Written via | Read via |
 |---|---|---|---|
-| MadLib | `mls`, `dt1`, `dt2`, `group1`, `group2`, `mlp`, `extremes` | `history.replaceState` (bypasses Jotai) | `window.location.search` |
+| MadLib | `mls`, `dt1`, `dt2`, `group1`, `group2`, `mlp`, `extremes` | `setParameters` → `history.pushState` (bypasses Jotai) | `window.location.search` |
 | UI / modal | `demo`, `topic-info`, `multiple-maps`, `chlp-maps`, `vote-dot-org`, `report-insight`, `atl` | `useParamState` → `locationAtom` | `urlParamAtom(key)` — fine-grained, only re-renders on that param's change |
 
 `useParamState` (`src/utils/hooks/useParamState.tsx`) is the hook for Tier 2 params. Its setter reads from `window.location.search` (not Jotai state) so that MadLib params written outside Jotai are preserved in the URL.
+
+**MadLib navigation invariants** — critical rules for the `ExploreDataPage` / `MadLibUI` navigation machinery. Violating these causes duplicate history entries or blank DataTypeSelector buttons.
+
+- `setMadLibWithParam` is the single point of truth for all MadLib URL writes. It calls `history.replaceState` (cleanup only — deletes `dt2` when not in comparevars mode) and then `setParameters` → `history.pushState`. Never call `setParameters` or `history.pushState` separately before or after `setMadLibWithParam` for the same user action — that creates duplicate history entries.
+- Pass `dtOverrides: { dt1: newId }` (or `dt2`) when changing data sub-types so the new value reaches `setParameters` in one shot. Do not write the dt param to the URL via a separate call first.
+- On topic changes (`handleOptionUpdate` with a non-Fips value), pass `dtOverrides: { dt1: '' }` to delete the stale dt from the pushed URL and reset the corresponding `selectedDataTypeConfig` atom. The old data type ID does not apply to the new topic, so carrying it forward causes the DataTypeSelector to render an empty button.
+- `readParams` (the `psSubscribe` popstate handler in `ExploreDataPage`) is responsible for restoring full UI state on browser back/forward. It must sync the `selectedDataTypeConfig1`/`2` jotai atoms from `dt1`/`dt2` in the URL, in addition to calling `setMadLib`. If you add a new atom that should survive back-navigation, restore it in `readParams`.
 
 ## Adding a New Frontend Feature (health topic)
 

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -85,12 +85,16 @@ test('Clear selections button from Compare Topics mode returns tracker to defaul
 test('Including the Extremes Mode Param in URL should load report with Extremes Mode Enabled', async ({
   page,
 }) => {
+  // Previously used mls=1.incarceration with dt1=hiv_prevalence — mismatched
+  // topic/data-type so no data loaded and extremes UI never rendered. Fixed to
+  // use a consistent HIV topic + HIV data type at national level.
   await page.goto(
-    '/exploredata?mls=1.incarceration-3.00&mlp=disparity&dt1=hiv_prevalence&extremes=true',
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence&extremes=true',
     { waitUntil: 'domcontentloaded' },
   )
 
   const rateMap = page.locator('#rate-map')
+  await expect(rateMap).toBeVisible()
 
   // Verify Extremes Mode UI elements are present using Parallel Soft Assertions
   await Promise.all([
@@ -118,13 +122,17 @@ test('Including the Extremes Mode Param in URL should load report with Extremes 
 test('Extremes Mode Param in URL should work for both sides of Compare mode report', async ({
   page,
 }) => {
+  // Previously missing the leading "/" so Playwright resolved the URL
+  // relative to the current path instead of the base URL root.
   await page.goto(
-    'exploredata?mls=1.hiv-3.00-5.13&mlp=comparegeos&dt1=hiv_prevalence&extremes2=true',
+    '/exploredata?mls=1.hiv-3.00-5.13&mlp=comparegeos&dt1=hiv_prevalence&extremes2=true',
     { waitUntil: 'domcontentloaded' },
   )
 
   const rateMap1 = page.locator('#rate-map')
   const rateMap2 = page.locator('#rate-map2')
+  await expect(rateMap1).toBeVisible()
+  await expect(rateMap2).toBeVisible()
 
   await test.step('Verify Compare Mode Extremes', async () => {
     await Promise.all([

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -181,3 +181,75 @@ test('Selecting a demographic writes the demo param to the URL', async ({
   await expect(page).toHaveURL(/demo=age/)
 })
 
+test('Data sub-type change produces one history entry; back returns to previous sub-type', async ({
+  page,
+}) => {
+  // Start with HIV Prevalence
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+
+  // Switch to New diagnoses via the DataTypeSelector popover
+  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  // One back-press must return to hiv_prevalence — not stay on hiv_diagnoses.
+  // A double-pushState bug would leave the back button stuck on the same state.
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+  await expect(page).not.toHaveURL(/dt1=hiv_diagnoses/)
+})
+
+test('Sequential topic and geo changes each produce one history entry', async ({
+  page,
+}) => {
+  // State 1: HIV national
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence',
+    { waitUntil: 'domcontentloaded' },
+  )
+
+  // State 2: switch sub-type to Deaths
+  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('menuitem', { name: 'Deaths' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+
+  // State 3: switch sub-type to New diagnoses (exact: true avoids matching
+  // the "Click for more info on HIV deaths" info button also on the page)
+  await page.getByRole('button', { name: 'Deaths', exact: true }).click()
+  await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  // Back from state 3 → state 2 (hiv_deaths)
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+
+  // Back from state 2 → state 1 (hiv_prevalence)
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+})
+
+test('Default reset from Compare Topics mode creates one history entry; back returns to compare state', async ({
+  page,
+}) => {
+  // Start in Compare Topics mode
+  await page.goto(
+    '/exploredata?mls=1.incarceration-3.poverty-5.13&mlp=comparevars&dt1=prison',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/mlp=comparevars/)
+
+  // Trigger the DEFAULT reset via "Clear selections"
+  await page.getByRole('button', { name: 'Poverty', exact: true }).click()
+  await page.getByRole('link', { name: 'Clear selections' }).click()
+  await expect(page).toHaveURL('/exploredata')
+
+  // One back-press should return to the comparevars report, not stay on /exploredata.
+  // A double-pushState bug would leave the previous comparevars state unreachable.
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/mlp=comparevars/)
+})
+

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -240,6 +240,68 @@ test('Sequential topic and geo changes each produce one history entry', async ({
   await expect(page).toHaveURL(/dt1=hiv_prevalence/)
 })
 
+test('Cross-topic navigation: back button traverses all steps including topic switch', async ({
+  page,
+}) => {
+  // State 1: HIV national, Prevalence
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+
+  // State 2: HIV New diagnoses
+  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  // State 3: HIV Deaths (exact: true avoids "info on HIV deaths" button)
+  await page.getByRole('button', { name: 'New diagnoses', exact: true }).click()
+  await page.getByRole('menuitem', { name: 'Deaths' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+
+  // State 4: Switch parent topic to HIV (Black Women).
+  // After the topic switch the stale hiv_deaths dt is cleared from the URL
+  // (Fix A) and the DataTypeSelector resets to the first BW option so the
+  // button is no longer empty.
+  await page.getByRole('button', { name: 'HIV', exact: true }).click()
+  await page.getByRole('menuitem', { name: 'HIV (Black Women)' }).click()
+  await expect(page).toHaveURL(/mls=1.hiv_black_women/)
+  await expect(page).not.toHaveURL(/dt1=hiv_deaths/)
+
+  // State 5: BW New Diagnoses — button now shows first BW option label
+  await page
+    .getByRole('button', { name: 'Prevalence for Black Women', exact: true })
+    .click()
+  await page.getByRole('menuitem', { name: 'New Diagnoses for Black Women' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses_black_women/)
+
+  // State 6: BW Deaths
+  await page
+    .getByRole('button', { name: 'New Diagnoses for Black Women', exact: true })
+    .click()
+  await page.getByRole('menuitem', { name: 'Deaths for Black women' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_deaths_black_women/)
+
+  // Walk all 5 back steps — each must reach a distinct meaningful state.
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses_black_women/)
+
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/mls=1.hiv_black_women/)
+  await expect(page).not.toHaveURL(/dt1=/)
+
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+  await expect(page).toHaveURL(/mls=1.hiv-/)
+
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  await page.goBack({ waitUntil: 'commit' })
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+})
+
 test('Default reset from Compare Topics mode creates one history entry; back returns to compare state', async ({
   page,
 }) => {

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -123,10 +123,10 @@ function ExploreDataPage() {
       const dt1Param = getParameter(DATA_TYPE_1_PARAM, '')
       const dt2Param = getParameter(DATA_TYPE_2_PARAM, '')
       setSelectedDataTypeConfig1(
-        dt1Param ? getConfigFromDataTypeId(dt1Param) : null,
+        dt1Param ? (getConfigFromDataTypeId(dt1Param) ?? null) : null,
       )
       setSelectedDataTypeConfig2(
-        dt2Param ? getConfigFromDataTypeId(dt2Param) : null,
+        dt2Param ? (getConfigFromDataTypeId(dt2Param) ?? null) : null,
       )
 
       setMadLib({

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,4 +1,4 @@
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { lazy, useCallback, useEffect, useState } from 'react'
 import { STATUS } from 'react-joyride-react-19' // TODO: ideally revert back to react-joyride and not this temporary fork
 import { useLocation } from 'react-router'
@@ -20,6 +20,7 @@ import { urlMap } from '../../utils/externalUrls'
 import useDeprecatedParamRedirects from '../../utils/hooks/useDeprecatedParamRedirects'
 import { useHeaderScrollMargin } from '../../utils/hooks/useHeaderScrollMargin'
 import {
+  getConfigFromDataTypeId,
   getMadLibPhraseText,
   getSelectedConditions,
   MADLIB_LIST,
@@ -70,6 +71,8 @@ function ExploreDataPage() {
   const dtId2: DataTypeId | undefined = useAtomValue(
     selectedDataTypeConfig2Atom,
   )?.dataTypeId
+  const setSelectedDataTypeConfig1 = useSetAtom(selectedDataTypeConfig1Atom)
+  const setSelectedDataTypeConfig2 = useSetAtom(selectedDataTypeConfig2Atom)
   const showStickyLifeline = LIFELINE_IDS.some(
     (id) => id === dtId1 || id === dtId2,
   )
@@ -112,6 +115,18 @@ function ExploreDataPage() {
         MADLIB_SELECTIONS_PARAM,
         MADLIB_LIST[index].defaultSelections,
         parseMls,
+      )
+
+      // Restore the DataTypeSelector atom state from the URL so that back/forward
+      // navigation shows the correct data type button label instead of a stale
+      // or empty value from the previous forward-navigation state.
+      const dt1Param = getParameter(DATA_TYPE_1_PARAM, '')
+      const dt2Param = getParameter(DATA_TYPE_2_PARAM, '')
+      setSelectedDataTypeConfig1(
+        dt1Param ? getConfigFromDataTypeId(dt1Param) : null,
+      )
+      setSelectedDataTypeConfig2(
+        dt2Param ? getConfigFromDataTypeId(dt2Param) : null,
       )
 
       setMadLib({

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -130,7 +130,10 @@ function ExploreDataPage() {
     }
   }, [])
 
-  const setMadLibWithParam = (ml: MadLib) => {
+  const setMadLibWithParam = (
+    ml: MadLib,
+    dtOverrides?: { dt1?: string; dt2?: string },
+  ) => {
     // ONLY SOME TOPICS HAVE SUB DATA TYPES
     const var1HasDataTypes =
       isDropdownVarId(ml.activeSelections[1]) &&
@@ -148,17 +151,22 @@ function ExploreDataPage() {
       history.replaceState(null, '', '?' + params + window.location.hash)
     }
 
-    //  GET REMAINING PARAMS FROM URL
+    //  GET REMAINING PARAMS FROM URL (caller may override dt values to avoid
+    //  a separate replaceState that would corrupt the back-button history)
     const groupParam1 = getParameter(MAP1_GROUP_PARAM, ALL)
     const groupParam2 = getParameter(MAP2_GROUP_PARAM, ALL)
-    const dtParam1 = getParameter(DATA_TYPE_1_PARAM, '')
-    const dtParam2 = getParameter(DATA_TYPE_2_PARAM, '')
+    const dtParam1 = dtOverrides?.dt1 ?? getParameter(DATA_TYPE_1_PARAM, '')
+    const dtParam2 = dtOverrides?.dt2 ?? getParameter(DATA_TYPE_2_PARAM, '')
 
     // BUILD REPLACEMENT PARAMS
     const newParams = [
       {
         name: MADLIB_SELECTIONS_PARAM,
         value: stringifyMls(ml.activeSelections),
+      },
+      {
+        name: MADLIB_PHRASE_PARAM,
+        value: ml.id,
       },
       {
         name: MAP1_GROUP_PARAM,

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -45,8 +45,24 @@ export default function MadLibUI(props: MadLibUIProps) {
     if (newValue === DEFAULT) {
       props.setMadLibWithParam(MADLIB_LIST[0])
     } else {
+      // Topic changes (non-Fips values) carry a stale dt param into the new
+      // URL because the old dt doesn't apply to the new topic. Clear it so
+      // the new topic starts at its default data type instead of showing an
+      // empty DataTypeSelector button.
+      const isTopicChange = !isFipsString(newValue)
+      if (isTopicChange) {
+        index === 1
+          ? setSelectedDataTypeConfig1(null)
+          : setSelectedDataTypeConfig2(null)
+      }
+      const dtOverrides = isTopicChange
+        ? index === 1
+          ? { dt1: '' }
+          : { dt2: '' }
+        : undefined
       props.setMadLibWithParam(
         getMadLibWithUpdatedValue(props.madLib, index, newValue),
+        dtOverrides,
       )
     }
     // drop card hash from url and scroll to top

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -27,14 +27,6 @@ import {
   selectedDataTypeConfig1Atom,
   selectedDataTypeConfig2Atom,
 } from '../../utils/sharedSettingsState'
-import {
-  DATA_TYPE_1_PARAM,
-  DATA_TYPE_2_PARAM,
-  MADLIB_PHRASE_PARAM,
-  MADLIB_SELECTIONS_PARAM,
-  setParameters,
-  stringifyMls,
-} from '../../utils/urlutils'
 import DataTypeSelector from './DataTypeSelector'
 import DemographicSelector from './DemographicSelector'
 import LocationSelector from './LocationSelector'
@@ -42,23 +34,16 @@ import TopicSelector from './TopicSelector'
 
 interface MadLibUIProps {
   madLib: MadLib
-  setMadLibWithParam: (updatedMadLib: MadLib) => void
+  setMadLibWithParam: (
+    updatedMadLib: MadLib,
+    dtOverrides?: { dt1?: string; dt2?: string },
+  ) => void
 }
 
 export default function MadLibUI(props: MadLibUIProps) {
   function handleOptionUpdate(newValue: string, index: number) {
     if (newValue === DEFAULT) {
       props.setMadLibWithParam(MADLIB_LIST[0])
-      setParameters([
-        {
-          name: MADLIB_SELECTIONS_PARAM,
-          value: stringifyMls(MADLIB_LIST[0].defaultSelections),
-        },
-        {
-          name: MADLIB_PHRASE_PARAM,
-          value: MADLIB_LIST[0].id,
-        },
-      ])
     } else {
       props.setMadLibWithParam(
         getMadLibWithUpdatedValue(props.madLib, index, newValue),
@@ -77,20 +62,15 @@ export default function MadLibUI(props: MadLibUIProps) {
     index: number,
     setConfig: any,
   ) {
-    const dtPosition = index === 1 ? DATA_TYPE_1_PARAM : DATA_TYPE_2_PARAM
     const newConfig = getConfigFromDataTypeId(newDataType)
     newConfig && setConfig(newConfig)
-    setParameters([
-      {
-        name: dtPosition,
-        value: newDataType,
-      },
-    ])
     const dropdownId: DropdownVarId =
       getParentDropdownFromDataTypeId(newDataType)
-    // madlib with updated topic
+    const dtOverrides =
+      index === 1 ? { dt1: newDataType } : { dt2: newDataType }
     props.setMadLibWithParam(
       getMadLibWithUpdatedValue(props.madLib, index, dropdownId),
+      dtOverrides,
     )
   }
 

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -126,7 +126,9 @@ export function Report(props: ReportProps) {
         )
       },
     )
-    setDataTypeConfig(dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId]?.[0])
+    setDataTypeConfig(
+      dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId]?.[0] ?? null,
+    )
     setSelectedFips(props.fips)
     setSelectedDemographicType(demographicType)
   }, [props.dropdownVarId, demographicType, props.fips])

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -39,7 +39,6 @@ import {
   DATA_TYPE_1_PARAM,
   DEMOGRAPHIC_PARAM,
   getParameter,
-  psSubscribe,
   REPORT_INSIGHT_PARAM_KEY,
   swapOldDatatypeParams,
 } from '../utils/urlutils'
@@ -114,29 +113,22 @@ export function Report(props: ReportProps) {
   }, [resolvedConfig, demographicType, enabledDemographicOptionsMap])
 
   useEffect(() => {
-    const readParams = () => {
-      const dtParam1 = getParameter(
-        DATA_TYPE_1_PARAM,
-        undefined,
-        (val: string) => {
-          val = swapOldDatatypeParams(val)
-          return METRIC_CONFIG[props.dropdownVarId]?.find(
-            (cfg) => cfg.dataTypeId === val,
-          )
-        },
-      )
-      setDataTypeConfig(dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId]?.[0])
-    }
-    const psHandler = psSubscribe(readParams, 'vardisp')
-    readParams()
+    // No psSubscribe here: ExploreDataPage.readParams owns selectedDataTypeConfig1Atom
+    // on popstate. A stale closure over props.dropdownVarId would corrupt the atom,
+    // triggering a spurious demographic-reset pushState that breaks back navigation.
+    const dtParam1 = getParameter(
+      DATA_TYPE_1_PARAM,
+      undefined,
+      (val: string) => {
+        val = swapOldDatatypeParams(val)
+        return METRIC_CONFIG[props.dropdownVarId]?.find(
+          (cfg) => cfg.dataTypeId === val,
+        )
+      },
+    )
+    setDataTypeConfig(dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId]?.[0])
     setSelectedFips(props.fips)
     setSelectedDemographicType(demographicType)
-
-    return () => {
-      if (psHandler) {
-        psHandler.unsubscribe()
-      }
-    }
   }, [props.dropdownVarId, demographicType, props.fips])
 
   // when variable config changes (new data type), re-calc available card steps TableOfContents


### PR DESCRIPTION
## Root cause

The MadLib URL system uses \`history.pushState\` to create back-navigable history entries when the user changes topic, geography, or mode. Three related bugs existed; all are now fixed in this PR.

---

## Bug 1 - Double pushState in \`handleOptionUpdate\` DEFAULT branch

When the user selected the default/reset option, the code called \`setMadLibWithParam\` (one push) and then \`setParameters\` again (second push). Fixed by removing the redundant call. \`setMadLibWithParam\` also now includes \`MADLIB_PHRASE_PARAM\` in its push so the mode is correctly restored on popstate.

## Bug 2 - Double pushState in \`handleDataTypeUpdate\`

The original fix used \`history.replaceState\` to pre-seed the dt param before \`setMadLibWithParam\`, but \`replaceState\` overwrites the current history entry before the push, so back-navigation landed on the same state twice. Fixed by adding a \`dtOverrides\` parameter to \`setMadLibWithParam\` so the new dt value is included in a single \`pushState\` with no intermediate history manipulation.

## Bug 3 - Stale dt and blank DataTypeSelector after topic switches

**Root cause (MadLibUI.tsx \`handleOptionUpdate\`):** when switching parent topics (HIV to HIV Black Women), the old \`dt1=hiv_deaths\` was carried into the new URL unchanged. \`hiv_deaths\` is not a valid Black Women data type, so the DataTypeSelector received an unknown ID and rendered an empty button. After 4-5 navigations this appeared to users as the back button "not working" because the UI showed blank/stale data type buttons at each back step.

**Root cause (ExploreDataPage.tsx \`readParams\`):** the \`selectedDataTypeConfig\` atoms were only ever written by \`handleDataTypeUpdate\` (user clicks), never by \`readParams\` (the popstate handler). On back navigation the atoms retained the last forward value, so the DataTypeSelector showed a type from a later state instead of what was actually in the URL.

**Fixes:**
- \`handleOptionUpdate\`: detect topic changes (non-Fips \`newValue\`) and pass \`dtOverrides = { dt1: '' }\` (or dt2) to clear the stale dt from the URL. Also reset the atom to null so the selector defaults to the first available type for the new topic.
- \`readParams\`: read \`DATA_TYPE_1_PARAM\` / \`DATA_TYPE_2_PARAM\` from the URL and write the matching \`DataTypeConfig\` (or null) to the atoms. This also improves initial page load from a shared URL - the DataTypeSelector now correctly shows the URL data type immediately on mount.

## Bug 4 - Spurious pushState from stale Report popstate handler (CI regression)

This bug only surfaced in CI after the fixes above because the cross-topic back-navigation test exposed it for the first time.

**Root cause:** \`Report.tsx\` had its own \`psSubscribe('vardisp', ...)\` handler to sync \`selectedDataTypeConfig1Atom\` from the URL on \`popstate\`. The handler's \`readParams\` closure captured \`props.dropdownVarId\` at registration time. When navigating back across a topic boundary (e.g., HIV Black Women → HIV), the handler was still closed over the OLD \`dropdownVarId = 'hiv_black_women'\`. It searched \`METRIC_CONFIG['hiv_black_women']\` for the new URL's \`dt1=hiv_deaths\`, found nothing, and fell back to writing \`hiv_prevalence_black_women_config\` to the shared atom - overwriting what \`ExploreDataPage.readParams\` had just correctly set.

The new 'hiv' Report then rendered with this wrong Black Women config. \`getAllDemographicOptions\` returned \`ONLY_AGE_TYPE_MAP\` (Black Women data is age-only), while the 'hiv' Report's default demographic is \`RACE\`. The mismatch triggered the demographic-reset \`useEffect\`, which called \`setDemographicType\` → \`useParamState\` setter → \`history.pushState(\`&demo=age\`)\`. This inserted a spurious history entry between \`hiv_deaths\` and \`hiv_diagnoses\`, so back press 4 landed on the spurious entry instead of advancing to \`hiv_diagnoses\`.

**Fix:** since \`ExploreDataPage.readParams\` now correctly sets \`selectedDataTypeConfig1Atom\` on every \`popstate\` (added as part of Bug 3), the Report's competing \`psSubscribe\` handler was both redundant and harmful. Removing it leaves the atom update exclusively in \`ExploreDataPage\`, eliminating the stale-closure corruption.

**Underlying structural cause:** the two-tier URL system (MadLib params written via direct \`history.pushState\`, bypassing Jotai) forces atom state and URL state to be synced manually via multiple competing \`psSubscribe\` handlers. Stale closures in those handlers are an inherent risk of this pattern. See the linked issue for a plan to migrate to full Jotai URL management, which would eliminate this class of bug entirely.

---

## Files changed

| File | Change |
|---|---|
| \`ExploreDataPage.tsx\` | Add \`MADLIB_PHRASE_PARAM\` to \`setMadLibWithParam\` push; add \`useSetAtom\` for both config atoms; seed atoms from URL in \`readParams\`; \`?? null\` guards on \`getConfigFromDataTypeId\` |
| \`MadLibUI.tsx\` | Remove redundant \`setParameters\` from DEFAULT branch; \`dtOverrides\` pattern for \`handleDataTypeUpdate\`; clear stale dt and reset atom on topic changes in \`handleOptionUpdate\` |
| \`Report.tsx\` | Remove \`psSubscribe\` handler; \`?? null\` guard on \`setDataTypeConfig\` fallback |
| \`navigation.ci.spec.ts\` | Fix two broken extremes tests; add 4 back-button regression tests including the full 6-state cross-topic flow |

## Test plan

- [x] Change data sub-type (e.g., from "HIV diagnoses" to "HIV deaths") - one back-press returns to the previous sub-type
- [x] Multi-step navigation: 5+ distinct states, verify back steps through each one in order
- [x] Cross-topic back navigation: HIV prevalence, diagnoses, deaths, topic switch to HIV Black Women, BW diagnoses, BW deaths - all 5 back presses each land on the correct distinct URL
- [x] Select the default/reset option from the topic dropdown - back button returns to the previous topic correctly
- [x] Switch between Compare Rates / Explore Relationships / Investigate Rates tabs - back navigates each mode change individually
- [x] \`npx tsc --noEmit\` passes

Closes #2712

Generated with [Claude Code](https://claude.com/claude-code)