### PR TITLE
docs/ci: document fork PR workflow; fix E2E_DEV race with deploy

### DIFF
--- a/.github/workflows/e2eDev.yml
+++ b/.github/workflows/e2eDev.yml
@@ -1,9 +1,10 @@
 name: RUN Frontend E2Es Against Dev Site
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: ["DEPLOY MAIN CODE TO INFRA-TEST GCP (DEV SITE)"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
 
 defaults:
@@ -14,6 +15,7 @@ jobs:
   e2e_dev:
     name: Runs frontend E2E_DEV on main whenever code is pushed (or merged)
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,8 @@ from there against `origin/main`.
 # Check your remotes — your fork should be listed alongside origin
 git remote -v
 
-# Push a feature branch to your own fork remote (not origin)
-git push <your-fork-remote> <branch-name>
+# Push a feature branch to your fork (sets upstream for subsequent git push/pull)
+git push -u <your-remote-name> <branch-name>
 
 # Open a PR from the GitHub URL printed in the push output, or via gh:
 gh pr create --base main --head <your-github-username>:<branch-name>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,19 +40,20 @@ Then run the relevant DAG workflow from GitHub Actions against the test project.
 ## Git Workflow
 
 This repo uses a **fork-based PR model**. `origin` points to the upstream
-`SatcherInstitute/health-equity-tracker`; each contributor pushes feature branches
-to their own fork remote, then opens a PR from there.
+`SatcherInstitute/health-equity-tracker`. Each contributor has their own fork
+added as a personal remote. Push feature branches to your fork, then open a PR
+from there against `origin/main`.
 
 ```bash
-# Push a feature branch to your fork (creates the branch on your fork)
-git push ben <branch-name>
+# Check your remotes — your fork should be listed alongside origin
+git remote -v
+
+# Push a feature branch to your own fork remote (not origin)
+git push <your-fork-remote> <branch-name>
 
 # Open a PR from the GitHub URL printed in the push output, or via gh:
-gh pr create --base main --head benhammondmusic:<branch-name>
+gh pr create --base main --head <your-github-username>:<branch-name>
 ```
-
-`ben` is the remote name for `https://github.com/benhammondmusic/health-equity-tracker.git`.
-Other team members use their own remote names (`ali`, `eric`, `jc`, etc.) — see `git remote -v`.
 
 **Never push feature branches directly to `origin`** (`SatcherInstitute`). The one
 exception is the shared backend test branch:
@@ -61,7 +62,7 @@ exception is the shared backend test branch:
 git push origin HEAD:infra-test -f   # backend GCP deploy only
 ```
 
-See `README.md` for the full fork setup steps.
+See `README.md` for full fork setup steps including how to add your fork as a remote.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,32 @@ git push origin HEAD:infra-test -f
 
 Then run the relevant DAG workflow from GitHub Actions against the test project.
 
+## Git Workflow
+
+This repo uses a **fork-based PR model**. `origin` points to the upstream
+`SatcherInstitute/health-equity-tracker`; each contributor pushes feature branches
+to their own fork remote, then opens a PR from there.
+
+```bash
+# Push a feature branch to your fork (creates the branch on your fork)
+git push ben <branch-name>
+
+# Open a PR from the GitHub URL printed in the push output, or via gh:
+gh pr create --base main --head benhammondmusic:<branch-name>
+```
+
+`ben` is the remote name for `https://github.com/benhammondmusic/health-equity-tracker.git`.
+Other team members use their own remote names (`ali`, `eric`, `jc`, etc.) — see `git remote -v`.
+
+**Never push feature branches directly to `origin`** (`SatcherInstitute`). The one
+exception is the shared backend test branch:
+
+```bash
+git push origin HEAD:infra-test -f   # backend GCP deploy only
+```
+
+See `README.md` for the full fork setup steps.
+
 ## Commands
 
 Frontend commands run from `frontend/` — see `frontend/CLAUDE.md`.


### PR DESCRIPTION
## Summary

- Documents the fork-based PR push workflow in root `CLAUDE.md` so all contributors (and Claude Code) know to push feature branches to their personal fork remote rather than directly to `origin`
- Fixes a race condition in the `E2E_DEV` CI workflow where E2E tests were running concurrently with the deploy, hitting the old dev site and failing on any newly-added behavior tests

## Changes

**`CLAUDE.md`** — new Git Workflow section explaining the fork model, with generic placeholders (`<your-fork-remote>`, `<your-github-username>`) and a pointer to `README.md` for full setup. Notes the `infra-test` exception.

**`.github/workflows/e2eDev.yml`** — switches trigger from `push` to `workflow_run` so E2E tests only start after `DEPLOY MAIN CODE TO INFRA-TEST GCP (DEV SITE)` completes successfully. `workflow_dispatch` guard kept for manual runs.

## Test plan

- [ ] Merge a future commit to `main` and confirm `RUN Frontend E2Es Against Dev Site` starts only after the deploy job finishes
- [ ] Manually trigger `RUN Frontend E2Es Against Dev Site` via `workflow_dispatch` to confirm the guard works

🤖 Generated with [Claude Code](https://claude.com/claude-code)