### PR TITLE
fix(ux): guard configsContainsMatchingId against empty configs

### DIFF
--- a/frontend/src/reports/reportUtils.test.ts
+++ b/frontend/src/reports/reportUtils.test.ts
@@ -1,3 +1,4 @@
+import { HIV_DISEASE_METRICS } from '../data/config/MetricConfigHivCategory'
 import {
   VOTER_PARTICIPATION_METRICS,
   WOMEN_IN_GOV_METRICS,
@@ -80,6 +81,16 @@ describe('Test configsContainsMatchingId()', () => {
       ),
     ).toBe(false)
   })
+
+  test('empty configs with bothNeedToMatch returns false, not vacuous true', () => {
+    expect(
+      configsContainsMatchingId(
+        /* configs */ [],
+        /* ids */ ['voter_participation' as DataTypeId],
+        /* bothNeedToMatch? */ true,
+      ),
+    ).toBe(false)
+  })
 })
 
 describe('Test getAllDemographicOptions()', () => {
@@ -99,5 +110,28 @@ describe('Test getAllDemographicOptions()', () => {
       ['Age', 'unavailable for Women in elective office topics'],
       ['Sex', 'unavailable for Women in elective office topics'],
     ])
+  })
+
+  test('null config (no dt1 in URL) returns standard options, not PHRMA income/insurance', () => {
+    const { enabledDemographicOptionsMap: opts } = getAllDemographicOptions(
+      null,
+      new Fips('00'),
+    )
+    expect(opts).toEqual({
+      'Race/Ethnicity': 'race_and_ethnicity',
+      'Sex at Birth': 'sex',
+      Age: 'age',
+    })
+    expect(Object.values(opts)).not.toContain('income')
+    expect(Object.values(opts)).not.toContain('insurance_status')
+  })
+
+  test('HIV config returns standard options without income or insurance', () => {
+    const { enabledDemographicOptionsMap: opts } = getAllDemographicOptions(
+      HIV_DISEASE_METRICS[0],
+      new Fips('00'),
+    )
+    expect(Object.values(opts)).not.toContain('income')
+    expect(Object.values(opts)).not.toContain('insurance_status')
   })
 })

--- a/frontend/src/reports/reportUtils.ts
+++ b/frontend/src/reports/reportUtils.ts
@@ -125,7 +125,8 @@ export function configsContainsMatchingId(
   bothNeedToMatch?: boolean,
 ) {
   return bothNeedToMatch
-    ? configs.every((config) => ids.includes(config.dataTypeId))
+    ? configs.length > 0 &&
+        configs.every((config) => ids.includes(config.dataTypeId))
     : configs.some((config) => ids.includes(config.dataTypeId))
 }
 


### PR DESCRIPTION
## Summary

`Array.every()` on an empty array returns `true` (vacuous truth). When both `selectedDataTypeConfig1Atom` and `selectedDataTypeConfig2Atom` are null (no topic selected, or initial render before atoms populate), `getAllDemographicOptions` receives empty `configs`. Every `bothNeedToMatch=true` condition fires in sequence, and the last one — the PHRMA BRFSS check — sets `enabledDemographicOptionsMap` to a map containing `income` and `insurance_status`. Those then appear as demographic options for unrelated topics like HIV.

**Fix:** add `configs.length > 0 &&` before `configs.every(...)` so an empty array returns `false` instead of vacuously `true`.

## Root cause

Pre-existing on `main` — visible as a brief flash of wrong demographic options on initial page load (before the old writable atoms were populated by `readParams` effects). Surfaces more clearly after the jotai refactor which removed the effect-based population.

## Test plan

- [x] `configsContainsMatchingId([], [...], true)` now returns `false`
- [x] `getAllDemographicOptions(null, fips)` returns standard Race/Ethnicity, Sex, Age — no income or insurance
- [x] HIV config returns same standard options
- [x] All 15 `reportUtils` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)