### PR TITLE
refactor(nav): unify url param navigation onto jotai

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -41,7 +41,9 @@ Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`s
 
 | Params | Written via | Read via |
 |---|---|---|
-| `mls`, `dt1`, `dt2`, `group1`, `group2`, `mlp` | `setLocationAtom({ searchParams })` → jotai-location → `history.pushState` | `urlParamAtom(key)` |
+| `mls`, `dt1`, `dt2`, `mlp` | `setLocationAtom({ searchParams })` → jotai-location → `history.pushState` | `urlParamAtom(key)` |
+| `group1`, `group2` (user selection) | `setLocationAtom({ searchParams })` → jotai-location → `history.pushState` | `urlParamAtom(key)` |
+| `group1`, `group2` (auto-reset on topic/demo change) | `window.history.replaceState` directly — avoids adding a history entry | `getParameter` on MapCard init |
 | `demo`, `topic-info`, `multiple-maps`, `chlp-maps`, `vote-dot-org`, `report-insight`, `atl`, `extremes` | `useParamState` → `setLocationAtom` | `urlParamAtom(key)` |
 
 `jotai-location` owns `locationAtom` and handles `popstate` automatically — back/forward navigation keeps all atoms in sync with no manual handlers.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -52,7 +52,8 @@ Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`s
 
 - `setMadLibWithParam` is the single point of truth for all MadLib URL writes. It builds the complete new `URLSearchParams` and calls `setLocationAtom` once (one `pushState`). Never write to the URL separately before or after — that creates duplicate history entries.
 - Pass `dtOverrides: { dt1: newId }` (or `dt2`) when changing data sub-types so the new value is included in the same write.
-- On topic changes (`handleOptionUpdate` with a non-Fips value), pass `dtOverrides: { dt1: '' }` to exclude the stale dt from the URL. The old data type ID does not apply to the new topic.
+- On topic changes (`handleOptionUpdate` with a non-Fips value), pass `dtOverrides: { dt1: '' }` to clear the stale dt. `setMadLibWithParam` will then write the new topic's first data type as the default, keeping `dt1` always present in the URL for topics with multiple data types.
+- `dt1` (and `dt2` in comparevars mode) is always written to the URL when the topic has multiple data types, defaulting to the first config's `dataTypeId` if no explicit value is provided. This prevents the demographic selector from showing options from unrelated topics.
 - `selectedDataTypeConfig1Atom` and `selectedDataTypeConfig2Atom` are **read-only derived atoms** — they derive from `urlParamAtom('dt1')` / `urlParamAtom('dt2')`. Never call their setters directly. Update dt values by writing the URL param via `setMadLibWithParam` with `dtOverrides`.
 - `madLib` in `ExploreDataPage` is a `useMemo` derived from `urlParamAtom('mls')` + `urlParamAtom('mlp')`. It is not owned state — never call `setMadLib`. Back/forward automatically updates the URL atoms which recomputes `madLib`.
 - If you add a new atom that should survive back-navigation, derive it from a `urlParamAtom` rather than wiring up a manual `popstate` handler.

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -37,21 +37,25 @@ URL params (mls, dt1, demo, etc.)
 
 Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
 
-**Two-tier URL param system** — URL params split into two write paths:
+**Unified URL param system** — all params written through a single path:
 
-| Tier | Params | Written via | Read via |
-|---|---|---|---|
-| MadLib | `mls`, `dt1`, `dt2`, `group1`, `group2`, `mlp`, `extremes` | `setParameters` → `history.pushState` (bypasses Jotai) | `window.location.search` |
-| UI / modal | `demo`, `topic-info`, `multiple-maps`, `chlp-maps`, `vote-dot-org`, `report-insight`, `atl` | `useParamState` → `locationAtom` | `urlParamAtom(key)` — fine-grained, only re-renders on that param's change |
+| Params | Written via | Read via |
+|---|---|---|
+| `mls`, `dt1`, `dt2`, `group1`, `group2`, `mlp` | `setLocationAtom({ searchParams })` → jotai-location → `history.pushState` | `urlParamAtom(key)` |
+| `demo`, `topic-info`, `multiple-maps`, `chlp-maps`, `vote-dot-org`, `report-insight`, `atl`, `extremes` | `useParamState` → `setLocationAtom` | `urlParamAtom(key)` |
 
-`useParamState` (`src/utils/hooks/useParamState.tsx`) is the hook for Tier 2 params. Its setter reads from `window.location.search` (not Jotai state) so that MadLib params written outside Jotai are preserved in the URL.
+`jotai-location` owns `locationAtom` and handles `popstate` automatically — back/forward navigation keeps all atoms in sync with no manual handlers.
 
-**MadLib navigation invariants** — critical rules for the `ExploreDataPage` / `MadLibUI` navigation machinery. Violating these causes duplicate history entries or blank DataTypeSelector buttons.
+`useParamState` (`src/utils/hooks/useParamState.tsx`) is the hook for UI / modal params.
 
-- `setMadLibWithParam` is the single point of truth for all MadLib URL writes. It calls `history.replaceState` (cleanup only — deletes `dt2` when not in comparevars mode) and then `setParameters` → `history.pushState`. Never call `setParameters` or `history.pushState` separately before or after `setMadLibWithParam` for the same user action — that creates duplicate history entries.
-- Pass `dtOverrides: { dt1: newId }` (or `dt2`) when changing data sub-types so the new value reaches `setParameters` in one shot. Do not write the dt param to the URL via a separate call first.
-- On topic changes (`handleOptionUpdate` with a non-Fips value), pass `dtOverrides: { dt1: '' }` to delete the stale dt from the pushed URL and reset the corresponding `selectedDataTypeConfig` atom. The old data type ID does not apply to the new topic, so carrying it forward causes the DataTypeSelector to render an empty button.
-- `readParams` (the `psSubscribe` popstate handler in `ExploreDataPage`) is responsible for restoring full UI state on browser back/forward. It must sync the `selectedDataTypeConfig1`/`2` jotai atoms from `dt1`/`dt2` in the URL, in addition to calling `setMadLib`. If you add a new atom that should survive back-navigation, restore it in `readParams`.
+**MadLib navigation invariants** — critical rules for the `ExploreDataPage` / `MadLibUI` navigation machinery.
+
+- `setMadLibWithParam` is the single point of truth for all MadLib URL writes. It builds the complete new `URLSearchParams` and calls `setLocationAtom` once (one `pushState`). Never write to the URL separately before or after — that creates duplicate history entries.
+- Pass `dtOverrides: { dt1: newId }` (or `dt2`) when changing data sub-types so the new value is included in the same write.
+- On topic changes (`handleOptionUpdate` with a non-Fips value), pass `dtOverrides: { dt1: '' }` to exclude the stale dt from the URL. The old data type ID does not apply to the new topic.
+- `selectedDataTypeConfig1Atom` and `selectedDataTypeConfig2Atom` are **read-only derived atoms** — they derive from `urlParamAtom('dt1')` / `urlParamAtom('dt2')`. Never call their setters directly. Update dt values by writing the URL param via `setMadLibWithParam` with `dtOverrides`.
+- `madLib` in `ExploreDataPage` is a `useMemo` derived from `urlParamAtom('mls')` + `urlParamAtom('mlp')`. It is not owned state — never call `setMadLib`. Back/forward automatically updates the URL atoms which recomputes `madLib`.
+- If you add a new atom that should survive back-navigation, derive it from a `urlParamAtom` rather than wiring up a manual `popstate` handler.
 
 ## Adding a New Frontend Feature (health topic)
 

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -323,3 +323,71 @@ test('Default reset from Compare Topics mode creates one history entry; back ret
   await expect(page).toHaveURL(/mlp=comparevars/)
 })
 
+test('demo param survives geo change via map click', async ({ page }) => {
+  // Start with HIV national with Age demographic
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence&demo=age',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/demo=age/)
+
+  // Wait for map then click Massachusetts (path:nth-child(46), FIPS 25)
+  const rateMap = page.locator('#rate-map')
+  await expect(rateMap).toBeVisible()
+  await page.locator('path:nth-child(46)').click()
+  await expect(page).toHaveURL(/mls=1.hiv-3.25/)
+
+  // demo=age must survive the geo change — regression: new system was wiping it
+  await expect(page).toHaveURL(/demo=age/)
+})
+
+test('demo param survives sub-type change', async ({ page }) => {
+  // Start with HIV Prevalence at national level with Age demographic
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence&demo=age',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/demo=age/)
+
+  // Switch sub-type to New diagnoses
+  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  // demo=age must survive the sub-type change
+  await expect(page).toHaveURL(/demo=age/)
+})
+
+test('dt1 and demo survive mode change', async ({ page }) => {
+  // Start with HIV Deaths in disparity mode with Age demographic
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_deaths&demo=age',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+  await expect(page).toHaveURL(/demo=age/)
+
+  // Switch to Compare Places mode via the mode selector
+  await page.getByText('Off').nth(1).click()
+  await page.getByRole('option', { name: 'Places' }).click()
+
+  // dt1 and demo must both survive the mode change
+  await expect(page).toHaveURL(/dt1=hiv_deaths/)
+  await expect(page).toHaveURL(/demo=age/)
+  await expect(page).toHaveURL(/mlp=comparegeos/)
+})
+
+test('comparevars without dt2 in URL shows report, not blank', async ({
+  page,
+}) => {
+  // dt2 is absent — CompareReport must fall back to METRIC_CONFIG default, not blank
+  await page.goto(
+    '/exploredata?mls=1.incarceration-3.poverty-5.13&mlp=comparevars&dt1=prison',
+    { waitUntil: 'domcontentloaded' },
+  )
+
+  // Both map cards must render — the regression caused CompareReport to return </>
+  await expect(page.locator('#rate-map')).toBeVisible()
+  await expect(page.locator('#rate-map2')).toBeVisible()
+})
+

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -200,7 +200,7 @@ test('Data sub-type change produces one history entry; back returns to previous 
   await expect(page).toHaveURL(/dt1=hiv_prevalence/)
 
   // Switch to New diagnoses via the DataTypeSelector popover
-  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('button', { name: 'Prevalence', exact: true }).click()
   await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
   await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
 
@@ -221,7 +221,7 @@ test('Sequential topic and geo changes each produce one history entry', async ({
   )
 
   // State 2: switch sub-type to Deaths
-  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('button', { name: 'Prevalence', exact: true }).click()
   await page.getByRole('menuitem', { name: 'Deaths' }).click()
   await expect(page).toHaveURL(/dt1=hiv_deaths/)
 
@@ -349,7 +349,7 @@ test('demo param survives sub-type change', async ({ page }) => {
   await expect(page).toHaveURL(/demo=age/)
 
   // Switch sub-type to New diagnoses
-  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('button', { name: 'Prevalence', exact: true }).click()
   await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
   await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
 
@@ -399,7 +399,7 @@ test('navigating to a topic writes dt1 explicitly to the URL', async ({
   })
 
   // Open the DataTypeSelector and pick a sub-type to trigger setMadLibWithParam
-  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('button', { name: 'Prevalence', exact: true }).click()
   await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
   await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
 

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -251,7 +251,7 @@ test('Cross-topic navigation: back button traverses all steps including topic sw
   await expect(page).toHaveURL(/dt1=hiv_prevalence/)
 
   // State 2: HIV New diagnoses
-  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('button', { name: 'Prevalence', exact: true }).click()
   await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
   await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
 
@@ -261,13 +261,12 @@ test('Cross-topic navigation: back button traverses all steps including topic sw
   await expect(page).toHaveURL(/dt1=hiv_deaths/)
 
   // State 4: Switch parent topic to HIV (Black Women).
-  // After the topic switch the stale hiv_deaths dt is cleared from the URL
-  // (Fix A) and the DataTypeSelector resets to the first BW option so the
-  // button is no longer empty.
+  // The stale hiv_deaths dt is cleared and replaced with the first BW
+  // data type (hiv_prevalence_black_women) in the same write.
   await page.getByRole('button', { name: 'HIV', exact: true }).click()
   await page.getByRole('menuitem', { name: 'HIV (Black Women)' }).click()
   await expect(page).toHaveURL(/mls=1.hiv_black_women/)
-  await expect(page).not.toHaveURL(/dt1=hiv_deaths/)
+  await expect(page).toHaveURL(/dt1=hiv_prevalence_black_women/)
 
   // State 5: BW New Diagnoses — button now shows first BW option label
   await page
@@ -289,7 +288,7 @@ test('Cross-topic navigation: back button traverses all steps including topic sw
 
   await page.goBack({ waitUntil: 'commit' })
   await expect(page).toHaveURL(/mls=1.hiv_black_women/)
-  await expect(page).not.toHaveURL(/dt1=/)
+  await expect(page).toHaveURL(/dt1=hiv_prevalence_black_women/)
 
   await page.goBack({ waitUntil: 'commit' })
   await expect(page).toHaveURL(/dt1=hiv_deaths/)
@@ -404,9 +403,8 @@ test('navigating to a topic writes dt1 explicitly to the URL', async ({
   await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
   await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
 
-  // Back must return to the previous state which now has dt1 written explicitly
+  // Back must return to the initial URL (no dt1) — verifies back nav is not stuck
   await page.goBack({ waitUntil: 'commit' })
-  // dt1 should now be present (written by setMadLibWithParam on first interaction)
-  await expect(page).toHaveURL(/dt1=/)
+  await expect(page).not.toHaveURL(/dt1=hiv_diagnoses/)
 })
 

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -390,6 +390,33 @@ test('comparevars without dt2 in URL shows report, not blank', async ({
   await expect(page.locator('#rate-map2')).toBeVisible()
 })
 
+test('comparevars: each panel tracks its own data type independently', async ({
+  page,
+}) => {
+  // Load Compare Topics with two topics that both have multiple data types.
+  // Left: HIV (dt1=hiv_prevalence), Right: HIV Black Women (dt2=hiv_prevalence_black_women)
+  await page.goto(
+    '/exploredata?mls=1.hiv-3.hiv_black_women-5.00&mlp=comparevars&dt1=hiv_prevalence&dt2=hiv_prevalence_black_women',
+    { waitUntil: 'domcontentloaded' },
+  )
+  await expect(page.locator('#rate-map')).toBeVisible()
+  await expect(page.locator('#rate-map2')).toBeVisible()
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+  await expect(page).toHaveURL(/dt2=hiv_prevalence_black_women/)
+
+  // Switch the right panel's sub-type — must update dt2 without touching dt1.
+  // "Prevalence for Black Women" only appears in the right panel, so exact: true
+  // is unambiguous even with the left panel's "Prevalence" button also present.
+  await page
+    .getByRole('button', { name: 'Prevalence for Black Women', exact: true })
+    .click()
+  await page.getByRole('menuitem', { name: 'New Diagnoses for Black Women' }).click()
+
+  await expect(page).toHaveURL(/dt2=hiv_diagnoses_black_women/)
+  await expect(page).toHaveURL(/dt1=hiv_prevalence/)
+  await expect(page).not.toHaveURL(/dt1=hiv_diagnoses/)
+})
+
 test('navigating to a topic writes dt1 explicitly to the URL', async ({
   page,
 }) => {

--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -391,3 +391,22 @@ test('comparevars without dt2 in URL shows report, not blank', async ({
   await expect(page.locator('#rate-map2')).toBeVisible()
 })
 
+test('navigating to a topic writes dt1 explicitly to the URL', async ({
+  page,
+}) => {
+  // Start at the HIV default state (no dt1 in URL — first entry to the topic)
+  await page.goto('/exploredata?mls=1.hiv-3.00&mlp=disparity', {
+    waitUntil: 'domcontentloaded',
+  })
+
+  // Open the DataTypeSelector and pick a sub-type to trigger setMadLibWithParam
+  await page.getByRole('button', { name: 'Prevalence' }).click()
+  await page.getByRole('menuitem', { name: 'New diagnoses' }).click()
+  await expect(page).toHaveURL(/dt1=hiv_diagnoses/)
+
+  // Back must return to the previous state which now has dt1 written explicitly
+  await page.goBack({ waitUntil: 'commit' })
+  // dt1 should now be present (written by setMadLibWithParam on first interaction)
+  await expect(page).toHaveURL(/dt1=/)
+})
+

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -1,6 +1,6 @@
 import GridView from '@mui/icons-material/GridView'
 import { useSetAtom } from 'jotai'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useLocation } from 'react-router'
 import { createColorScale } from '../charts/choroplethMap/colorSchemes'
 import ChoroplethMap from '../charts/choroplethMap/index'
@@ -147,6 +147,23 @@ function MapCardWithKey(props: MapCardProps) {
 
   const [activeDemographicGroup, setActiveDemographicGroup] =
     useState<DemographicGroup>(initialGroup)
+
+  // Reset the selected group when the topic or demographic type changes.
+  // A group valid for one topic may not exist in another.
+  // Skip on initial mount — the group is already correctly set from the URL.
+  const isMountRef = useRef(true)
+  useEffect(() => {
+    if (isMountRef.current) {
+      isMountRef.current = false
+      return
+    }
+    setActiveDemographicGroup(ALL)
+    setLocationAtom((prev) => {
+      const next = new URLSearchParams(prev.searchParams)
+      next.set(MAP_GROUP_PARAM, ALL)
+      return { ...prev, searchParams: next }
+    })
+  }, [props.dataTypeConfig.dataTypeId, props.demographicType])
 
   const [isAtlantaMode, setIsAtlantaMode] = useParamState<boolean>(
     ATLANTA_MODE_PARAM_KEY,
@@ -466,22 +483,12 @@ function MapCardWithKey(props: MapCardProps) {
         const hideGroupDropdown =
           Object.values(filterOptions).toString() === ALL
 
-        // if a previously selected group is no longer valid, reset to ALL
-        let dropdownValue = ALL
-        if (
-          filterOptions[DEMOGRAPHIC_DISPLAY_TYPES[demographicType]].includes(
-            activeDemographicGroup,
-          )
-        ) {
-          dropdownValue = activeDemographicGroup
-        } else {
-          setActiveDemographicGroup(ALL)
-          setLocationAtom((prev) => {
-            const next = new URLSearchParams(prev.searchParams)
-            next.set(MAP_GROUP_PARAM, ALL)
-            return { ...prev, searchParams: next }
-          })
-        }
+        // derive current dropdown value; the useEffect above handles the reset
+        const dropdownValue = filterOptions[
+          DEMOGRAPHIC_DISPLAY_TYPES[demographicType]
+        ].includes(activeDemographicGroup)
+          ? activeDemographicGroup
+          : ALL
 
         function handleMapGroupClick(_: any, newGroup: DemographicGroup) {
           setActiveDemographicGroup(newGroup)

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -158,11 +158,9 @@ function MapCardWithKey(props: MapCardProps) {
       return
     }
     setActiveDemographicGroup(ALL)
-    setLocationAtom((prev) => {
-      const next = new URLSearchParams(prev.searchParams)
-      next.set(MAP_GROUP_PARAM, ALL)
-      return { ...prev, searchParams: next }
-    })
+    const params = new URLSearchParams(window.location.search)
+    params.set(MAP_GROUP_PARAM, ALL)
+    window.history.replaceState(null, '', '?' + params.toString())
   }, [props.dataTypeConfig.dataTypeId, props.demographicType])
 
   const [isAtlantaMode, setIsAtlantaMode] = useParamState<boolean>(

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -1,4 +1,5 @@
 import GridView from '@mui/icons-material/GridView'
+import { useSetAtom } from 'jotai'
 import { useMemo, useState } from 'react'
 import { useLocation } from 'react-router'
 import { createColorScale } from '../charts/choroplethMap/colorSchemes'
@@ -60,6 +61,7 @@ import { useIsBreakpointAndUp } from '../utils/hooks/useIsBreakpointAndUp'
 import { useParamState } from '../utils/hooks/useParamState'
 import type { ScrollableHashId } from '../utils/hooks/useStepObserver'
 import type { MadLibId } from '../utils/MadLibs'
+import { locationAtom } from '../utils/sharedSettingsState'
 import {
   ATLANTA_MODE_PARAM_KEY,
   EXTREMES_1_PARAM_KEY,
@@ -71,7 +73,6 @@ import {
   MAP2_GROUP_PARAM,
   MULTIPLE_MAPS_1_PARAM_KEY,
   MULTIPLE_MAPS_2_PARAM_KEY,
-  setParameter,
 } from '../utils/urlutils'
 import CardWrapper from './CardWrapper'
 import ChartTitle from './ChartTitle'
@@ -136,6 +137,7 @@ function MapCardWithKey(props: MapCardProps) {
     MULTIMAP_PARAM_KEY,
     false,
   )
+  const setLocationAtom = useSetAtom(locationAtom)
   const MAP_GROUP_PARAM = props.isCompareCard
     ? MAP2_GROUP_PARAM
     : MAP1_GROUP_PARAM
@@ -474,13 +476,21 @@ function MapCardWithKey(props: MapCardProps) {
           dropdownValue = activeDemographicGroup
         } else {
           setActiveDemographicGroup(ALL)
-          setParameter(MAP_GROUP_PARAM, ALL)
+          setLocationAtom((prev) => {
+            const next = new URLSearchParams(prev.searchParams)
+            next.set(MAP_GROUP_PARAM, ALL)
+            return { ...prev, searchParams: next }
+          })
         }
 
         function handleMapGroupClick(_: any, newGroup: DemographicGroup) {
           setActiveDemographicGroup(newGroup)
           const groupCode = getGroupParamFromDemographicGroup(newGroup)
-          setParameter(MAP_GROUP_PARAM, groupCode)
+          setLocationAtom((prev) => {
+            const next = new URLSearchParams(prev.searchParams)
+            next.set(MAP_GROUP_PARAM, groupCode)
+            return { ...prev, searchParams: next }
+          })
         }
 
         const displayData = isExtremesMode

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -118,8 +118,18 @@ function ExploreDataPage() {
 
       if (ml.id !== 'disparity') next.set(MAP2_GROUP_PARAM, groupParam2)
       if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
-      if (var1HasDataTypes && dtParam1) next.set(DATA_TYPE_1_PARAM, dtParam1)
-      if (var2HasDataTypes && dtParam2) next.set(DATA_TYPE_2_PARAM, dtParam2)
+      if (var1HasDataTypes) {
+        const defaultDt1 =
+          METRIC_CONFIG[ml.activeSelections[1] as DropdownVarId]?.[0]
+            ?.dataTypeId ?? ''
+        next.set(DATA_TYPE_1_PARAM, dtParam1 || defaultDt1)
+      }
+      if (var2HasDataTypes) {
+        const defaultDt2 =
+          METRIC_CONFIG[ml.activeSelections[3] as DropdownVarId]?.[0]
+            ?.dataTypeId ?? ''
+        next.set(DATA_TYPE_2_PARAM, dtParam2 || defaultDt2)
+      }
 
       setLocationAtom({ searchParams: next })
     },

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue, useSetAtom } from 'jotai'
-import { lazy, useCallback, useEffect, useState } from 'react'
+import { lazy, useCallback, useEffect, useMemo, useState } from 'react'
 import { STATUS } from 'react-joyride-react-19' // TODO: ideally revert back to react-joyride and not this temporary fork
 import { useLocation } from 'react-router'
 import {
@@ -7,10 +7,7 @@ import {
   isDropdownVarId,
 } from '../../data/config/DropDownIds'
 import { METRIC_CONFIG } from '../../data/config/MetricConfig'
-import type {
-  DataTypeConfig,
-  DataTypeId,
-} from '../../data/config/MetricConfigTypes'
+import type { DataTypeConfig } from '../../data/config/MetricConfigTypes'
 import { INCARCERATION_IDS } from '../../data/providers/IncarcerationProvider'
 import { ALL } from '../../data/utils/Constants'
 import ReportProvider from '../../reports/ReportProvider'
@@ -20,32 +17,23 @@ import { urlMap } from '../../utils/externalUrls'
 import useDeprecatedParamRedirects from '../../utils/hooks/useDeprecatedParamRedirects'
 import { useHeaderScrollMargin } from '../../utils/hooks/useHeaderScrollMargin'
 import {
-  getConfigFromDataTypeId,
   getMadLibPhraseText,
   getSelectedConditions,
   MADLIB_LIST,
   type MadLib,
   type MadLibId,
-  type PhraseSegment,
   type PhraseSelections,
 } from '../../utils/MadLibs'
-import {
-  selectedDataTypeConfig1Atom,
-  selectedDataTypeConfig2Atom,
-} from '../../utils/sharedSettingsState'
+import { locationAtom, urlParamAtom } from '../../utils/sharedSettingsState'
 import {
   DATA_TYPE_1_PARAM,
   DATA_TYPE_2_PARAM,
-  getParameter,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
   MAP1_GROUP_PARAM,
   MAP2_GROUP_PARAM,
   parseMls,
-  psSubscribe,
   SHOW_ONBOARDING_PARAM,
-  setParameter,
-  setParameters,
   stringifyMls,
 } from '../../utils/urlutils'
 import CHLPMapsModal from './CHLPMapsModal'
@@ -65,165 +53,83 @@ function ExploreDataPage() {
   const [showIncarceratedChildrenAlert, setShowIncarceratedChildrenAlert] =
     useState(false)
 
-  const dtId1: DataTypeId | undefined = useAtomValue(
-    selectedDataTypeConfig1Atom,
-  )?.dataTypeId
-  const dtId2: DataTypeId | undefined = useAtomValue(
-    selectedDataTypeConfig2Atom,
-  )?.dataTypeId
-  const setSelectedDataTypeConfig1 = useSetAtom(selectedDataTypeConfig1Atom)
-  const setSelectedDataTypeConfig2 = useSetAtom(selectedDataTypeConfig2Atom)
+  const setLocationAtom = useSetAtom(locationAtom)
+
+  // Deprecated param redirects fire once on mount via useLayoutEffect
+  useDeprecatedParamRedirects()
+
+  // madLib is derived from URL atoms — never owned state.
+  // Components re-render only when mls or mlp actually changes.
+  const mlsParam = useAtomValue(urlParamAtom(MADLIB_SELECTIONS_PARAM))
+  const mlpParam = useAtomValue(urlParamAtom(MADLIB_PHRASE_PARAM))
+
+  const madLib = useMemo<MadLib>(() => {
+    const index = MADLIB_LIST.findIndex((el) => el.id === mlpParam)
+    const idx = index !== -1 ? index : 0
+    const selections: PhraseSelections = mlsParam
+      ? parseMls(mlsParam)
+      : MADLIB_LIST[idx].defaultSelections
+    return { ...MADLIB_LIST[idx], activeSelections: selections }
+  }, [mlsParam, mlpParam])
+
   const showStickyLifeline = LIFELINE_IDS.some(
-    (id) => id === dtId1 || id === dtId2,
+    (id) =>
+      id === (madLib.activeSelections[1] as DropdownVarId) ||
+      id === (madLib.activeSelections[3] as DropdownVarId),
   )
-
-  // Set up initial mad lib values based on defaults and query params, redirecting from deprecated ones
-  const params = useDeprecatedParamRedirects()
-
-  // swap out old variable ids for backwards compatibility of outside links
-  const foundIndex = MADLIB_LIST.findIndex(
-    (madlib) => madlib.id === params[MADLIB_PHRASE_PARAM],
-  )
-  const initialIndex = foundIndex !== -1 ? foundIndex : 0
-  const defaultValuesWithOverrides = MADLIB_LIST[initialIndex].defaultSelections
-  if (params[MADLIB_SELECTIONS_PARAM]) {
-    params[MADLIB_SELECTIONS_PARAM].split(',').forEach((override) => {
-      const [phraseSegmentIndex, value] = override.split(':')
-      const phraseSegments: PhraseSegment[] = MADLIB_LIST[initialIndex].phrase
-      if (
-        Object.keys(phraseSegments).includes(phraseSegmentIndex) &&
-        Object.keys(phraseSegments[Number(phraseSegmentIndex)]).includes(value)
-      ) {
-        defaultValuesWithOverrides[Number(phraseSegmentIndex)] = value
-      }
-    })
-  }
-
-  const [madLib, setMadLib] = useState<MadLib>({
-    ...MADLIB_LIST[initialIndex],
-    activeSelections: defaultValuesWithOverrides,
-  })
 
   const noTopicChosen = getSelectedConditions(madLib)?.length === 0
 
-  useEffect(() => {
-    const readParams = () => {
-      const index = getParameter(MADLIB_PHRASE_PARAM, 0, (str) => {
-        return MADLIB_LIST.findIndex((element) => element.id === str)
-      })
-      const selection = getParameter(
-        MADLIB_SELECTIONS_PARAM,
-        MADLIB_LIST[index].defaultSelections,
-        parseMls,
-      )
+  // Single write path for all MadLib URL changes.
+  // Builds the complete new search string and calls pushState once.
+  // dtOverrides lets callers set dt1/dt2 in the same write:
+  //   { dt1: 'hiv_prevalence' } — set to value
+  //   { dt1: '' }              — clear (topic changed)
+  //   omit key                 — keep current URL value
+  const setMadLibWithParam = useCallback(
+    (ml: MadLib, dtOverrides?: { dt1?: string; dt2?: string }) => {
+      const var1HasDataTypes =
+        isDropdownVarId(ml.activeSelections[1]) &&
+        METRIC_CONFIG[ml.activeSelections[1]]?.length > 1
+      const var2HasDataTypes =
+        ml.id === 'comparevars' &&
+        isDropdownVarId(ml.activeSelections[3]) &&
+        METRIC_CONFIG[ml.activeSelections[3]]?.length > 1
 
-      // Restore the DataTypeSelector atom state from the URL so that back/forward
-      // navigation shows the correct data type button label instead of a stale
-      // or empty value from the previous forward-navigation state.
-      const dt1Param = getParameter(DATA_TYPE_1_PARAM, '')
-      const dt2Param = getParameter(DATA_TYPE_2_PARAM, '')
-      setSelectedDataTypeConfig1(
-        dt1Param ? (getConfigFromDataTypeId(dt1Param) ?? null) : null,
-      )
-      setSelectedDataTypeConfig2(
-        dt2Param ? (getConfigFromDataTypeId(dt2Param) ?? null) : null,
-      )
+      const current = new URLSearchParams(window.location.search)
+      const groupParam1 = current.get(MAP1_GROUP_PARAM) ?? ALL
+      const groupParam2 = current.get(MAP2_GROUP_PARAM) ?? ALL
+      const dtParam1 =
+        dtOverrides?.dt1 !== undefined
+          ? dtOverrides.dt1
+          : (current.get(DATA_TYPE_1_PARAM) ?? '')
+      const dtParam2 =
+        dtOverrides?.dt2 !== undefined
+          ? dtOverrides.dt2
+          : (current.get(DATA_TYPE_2_PARAM) ?? '')
 
-      setMadLib({
-        ...MADLIB_LIST[index],
-        activeSelections: selection,
-      })
-    }
-    const psSub = psSubscribe(readParams, 'explore')
+      const next = new URLSearchParams()
+      next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(ml.activeSelections))
+      next.set(MADLIB_PHRASE_PARAM, ml.id)
+      next.set(MAP1_GROUP_PARAM, groupParam1)
 
-    readParams()
+      if (ml.id !== 'disparity') next.set(MAP2_GROUP_PARAM, groupParam2)
+      if (var1HasDataTypes && dtParam1) next.set(DATA_TYPE_1_PARAM, dtParam1)
+      if (var2HasDataTypes && dtParam2) next.set(DATA_TYPE_2_PARAM, dtParam2)
 
-    return () => {
-      if (psSub) {
-        psSub.unsubscribe()
-      }
-    }
-  }, [])
-
-  const setMadLibWithParam = (
-    ml: MadLib,
-    dtOverrides?: { dt1?: string; dt2?: string },
-  ) => {
-    // ONLY SOME TOPICS HAVE SUB DATA TYPES
-    const var1HasDataTypes =
-      isDropdownVarId(ml.activeSelections[1]) &&
-      METRIC_CONFIG[ml.activeSelections[1]]?.length > 1
-    const var2HasDataTypes =
-      ml.id === 'comparevars' &&
-      isDropdownVarId(ml.activeSelections[3]) &&
-      METRIC_CONFIG[ml.activeSelections[3]]?.length > 1
-
-    // DELETE DATA TYPE PARAM FROM URL IF NEW TOPIC(S) HAVE NO SUB DATA TYPES
-    if (!var1HasDataTypes || !var2HasDataTypes) {
-      const params = new URLSearchParams(window.location.search)
-      !var1HasDataTypes && params.delete(DATA_TYPE_1_PARAM)
-      !var2HasDataTypes && params.delete(DATA_TYPE_2_PARAM)
-      history.replaceState(null, '', '?' + params + window.location.hash)
-    }
-
-    //  GET REMAINING PARAMS FROM URL (caller may override dt values to avoid
-    //  a separate replaceState that would corrupt the back-button history)
-    const groupParam1 = getParameter(MAP1_GROUP_PARAM, ALL)
-    const groupParam2 = getParameter(MAP2_GROUP_PARAM, ALL)
-    const dtParam1 = dtOverrides?.dt1 ?? getParameter(DATA_TYPE_1_PARAM, '')
-    const dtParam2 = dtOverrides?.dt2 ?? getParameter(DATA_TYPE_2_PARAM, '')
-
-    // BUILD REPLACEMENT PARAMS
-    const newParams = [
-      {
-        name: MADLIB_SELECTIONS_PARAM,
-        value: stringifyMls(ml.activeSelections),
-      },
-      {
-        name: MADLIB_PHRASE_PARAM,
-        value: ml.id,
-      },
-      {
-        name: MAP1_GROUP_PARAM,
-        value: groupParam1,
-      },
-    ]
-
-    // EITHER COMPARE MODE SHOULD STORE MAP2 GROUP IN URL
-    ml.id !== 'disparity' &&
-      newParams.push({
-        name: MAP2_GROUP_PARAM,
-        value: groupParam2,
-      })
-
-    // ONLY STORE DATA TYPES IN URL WHEN NEEDED
-    var1HasDataTypes &&
-      newParams.push({
-        name: DATA_TYPE_1_PARAM,
-        value: dtParam1,
-      })
-    var2HasDataTypes &&
-      newParams.push({
-        name: DATA_TYPE_2_PARAM,
-        value: dtParam2,
-      })
-
-    // UPDATE URL
-    setParameters(newParams)
-
-    // UPDATE GEO/TOPIC IN MADLIB
-    setMadLib(ml)
-  }
+      setLocationAtom({ searchParams: next })
+    },
+    [setLocationAtom],
+  )
 
   // Set up warm welcome onboarding behaviors
+  const onboardParam = new URLSearchParams(window.location.search).get(
+    SHOW_ONBOARDING_PARAM,
+  )
   let showOnboarding = false
   if (noTopicChosen) {
-    if (params?.[SHOW_ONBOARDING_PARAM] === 'true') {
-      showOnboarding = true
-    }
-    if (params?.[SHOW_ONBOARDING_PARAM] === 'false') {
-      showOnboarding = false
-    }
+    if (onboardParam === 'true') showOnboarding = true
+    if (onboardParam === 'false') showOnboarding = false
   }
 
   // if there is an incoming #hash; bypass the warm welcome entirely
@@ -234,7 +140,11 @@ function ExploreDataPage() {
   const onboardingCallback = (data: any) => {
     if ([STATUS.FINISHED, STATUS.SKIPPED].includes(data.status)) {
       setActivelyOnboarding(false)
-      setParameter(SHOW_ONBOARDING_PARAM, 'false')
+      setLocationAtom((prev) => {
+        const next = new URLSearchParams(prev.searchParams)
+        next.set(SHOW_ONBOARDING_PARAM, 'false')
+        return { ...prev, searchParams: next }
+      })
     }
   }
 
@@ -256,7 +166,6 @@ function ExploreDataPage() {
   }, [])
   const isStickyEnabled = !noTopicChosen && isSticking
 
-  // calculate page size to determine if mobile or not
   const isSingleColumn = madLib.id === 'disparity'
 
   function handleModeChange(mode: MadLibId) {
@@ -267,46 +176,31 @@ function ExploreDataPage() {
     }
 
     const modeIndex = modeIndexMap[mode]
-
-    // Extract values from the current madlib
     const var1 = madLib.activeSelections[1]
-
     const geo1 =
       madLib.id === 'comparevars'
         ? madLib.activeSelections[5]
         : madLib.activeSelections[3]
 
-    // default non-duplicate settings for compare modes
     const var2: DropdownVarId =
       var1 === 'poverty' ? 'health_insurance' : 'poverty'
-    const geo2 = geo1 === '00' ? '13' : '00' // default to US or Georgia
+    const geo2 = geo1 === '00' ? '13' : '00'
 
-    // Construct UPDATED madlib based on the future mode's Madlib shape
-    let updatedMadLib: PhraseSelections = { 1: var1, 3: geo1 } // disparity "Investigate Rates"
-    if (modeIndex === 1) updatedMadLib = { 1: var1, 3: geo1, 5: geo2 } // comparegeos "Compare Rates"
-    if (modeIndex === 2) updatedMadLib = { 1: var1, 3: var2, 5: geo1 } // comparevars "Explore Relationships"
+    let updatedSelections: PhraseSelections = { 1: var1, 3: geo1 }
+    if (modeIndex === 1) updatedSelections = { 1: var1, 3: geo1, 5: geo2 }
+    if (modeIndex === 2) updatedSelections = { 1: var1, 3: var2, 5: geo1 }
 
-    setMadLib({
-      ...MADLIB_LIST[modeIndex],
-      activeSelections: updatedMadLib,
-    })
-    setParameters([
-      {
-        name: MADLIB_SELECTIONS_PARAM,
-        value: stringifyMls(updatedMadLib),
-      },
-      {
-        name: MADLIB_PHRASE_PARAM,
-        value: MADLIB_LIST[modeIndex].id,
-      },
-    ])
+    const next = new URLSearchParams()
+    next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(updatedSelections))
+    next.set(MADLIB_PHRASE_PARAM, MADLIB_LIST[modeIndex].id)
+
+    setLocationAtom({ searchParams: next })
     location.hash = ''
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   /* on any changes to the madlib settings */
   useEffect(() => {
-    // A11y - create then delete an invisible alert that the report mode has changed
     srSpeak(`Now viewing report: ${getMadLibPhraseText(madLib)}`)
     setShowVoteDotOrgBanner(
       getSelectedConditions(madLib)?.some((condition: DataTypeConfig) =>

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -28,6 +28,7 @@ import { locationAtom, urlParamAtom } from '../../utils/sharedSettingsState'
 import {
   DATA_TYPE_1_PARAM,
   DATA_TYPE_2_PARAM,
+  DEMOGRAPHIC_PARAM,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
   MAP1_GROUP_PARAM,
@@ -100,6 +101,7 @@ function ExploreDataPage() {
       const current = new URLSearchParams(window.location.search)
       const groupParam1 = current.get(MAP1_GROUP_PARAM) ?? ALL
       const groupParam2 = current.get(MAP2_GROUP_PARAM) ?? ALL
+      const demoParam = current.get(DEMOGRAPHIC_PARAM)
       const dtParam1 =
         dtOverrides?.dt1 !== undefined
           ? dtOverrides.dt1
@@ -115,6 +117,7 @@ function ExploreDataPage() {
       next.set(MAP1_GROUP_PARAM, groupParam1)
 
       if (ml.id !== 'disparity') next.set(MAP2_GROUP_PARAM, groupParam2)
+      if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
       if (var1HasDataTypes && dtParam1) next.set(DATA_TYPE_1_PARAM, dtParam1)
       if (var2HasDataTypes && dtParam2) next.set(DATA_TYPE_2_PARAM, dtParam2)
 
@@ -188,9 +191,19 @@ function ExploreDataPage() {
     if (modeIndex === 1) updatedSelections = { 1: var1, 3: geo1, 5: geo2 }
     if (modeIndex === 2) updatedSelections = { 1: var1, 3: var2, 5: geo1 }
 
+    const current = new URLSearchParams(window.location.search)
+    const demoParam = current.get(DEMOGRAPHIC_PARAM)
+    const group1Param = current.get(MAP1_GROUP_PARAM) ?? ALL
+    const dt1Param = current.get(DATA_TYPE_1_PARAM)
+    const var1HasDataTypes =
+      isDropdownVarId(var1) && METRIC_CONFIG[var1]?.length > 1
+
     const next = new URLSearchParams()
     next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(updatedSelections))
     next.set(MADLIB_PHRASE_PARAM, MADLIB_LIST[modeIndex].id)
+    next.set(MAP1_GROUP_PARAM, group1Param)
+    if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
+    if (var1HasDataTypes && dt1Param) next.set(DATA_TYPE_1_PARAM, dt1Param)
 
     setLocationAtom({ searchParams: next })
     location.hash = ''

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -9,7 +9,6 @@ import {
 import { METRIC_CONFIG } from '../../data/config/MetricConfig'
 import type { DataTypeConfig } from '../../data/config/MetricConfigTypes'
 import { INCARCERATION_IDS } from '../../data/providers/IncarcerationProvider'
-import { ALL } from '../../data/utils/Constants'
 import ReportProvider from '../../reports/ReportProvider'
 import { LIFELINE_IDS } from '../../reports/ui/LifelineAlert'
 import { srSpeak } from '../../utils/a11yutils'
@@ -28,10 +27,8 @@ import { locationAtom, urlParamAtom } from '../../utils/sharedSettingsState'
 import {
   DATA_TYPE_1_PARAM,
   DATA_TYPE_2_PARAM,
-  DEMOGRAPHIC_PARAM,
   MADLIB_PHRASE_PARAM,
   MADLIB_SELECTIONS_PARAM,
-  MAP1_GROUP_PARAM,
   MAP2_GROUP_PARAM,
   parseMls,
   SHOW_ONBOARDING_PARAM,
@@ -98,37 +95,40 @@ function ExploreDataPage() {
         isDropdownVarId(ml.activeSelections[3]) &&
         METRIC_CONFIG[ml.activeSelections[3]]?.length > 1
 
-      const current = new URLSearchParams(window.location.search)
-      const groupParam1 = current.get(MAP1_GROUP_PARAM) ?? ALL
-      const groupParam2 = current.get(MAP2_GROUP_PARAM) ?? ALL
-      const demoParam = current.get(DEMOGRAPHIC_PARAM)
+      // Preserve all existing params (extremes, atl, onboard, etc.),
+      // then only set or delete what actually changes.
+      const next = new URLSearchParams(window.location.search)
+
       const dtParam1 =
         dtOverrides?.dt1 !== undefined
           ? dtOverrides.dt1
-          : (current.get(DATA_TYPE_1_PARAM) ?? '')
+          : (next.get(DATA_TYPE_1_PARAM) ?? '')
       const dtParam2 =
         dtOverrides?.dt2 !== undefined
           ? dtOverrides.dt2
-          : (current.get(DATA_TYPE_2_PARAM) ?? '')
+          : (next.get(DATA_TYPE_2_PARAM) ?? '')
 
-      const next = new URLSearchParams()
       next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(ml.activeSelections))
       next.set(MADLIB_PHRASE_PARAM, ml.id)
-      next.set(MAP1_GROUP_PARAM, groupParam1)
 
-      if (ml.id !== 'disparity') next.set(MAP2_GROUP_PARAM, groupParam2)
-      if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
+      if (ml.id === 'disparity') next.delete(MAP2_GROUP_PARAM)
+
       if (var1HasDataTypes) {
         const defaultDt1 =
           METRIC_CONFIG[ml.activeSelections[1] as DropdownVarId]?.[0]
             ?.dataTypeId ?? ''
         next.set(DATA_TYPE_1_PARAM, dtParam1 || defaultDt1)
+      } else {
+        next.delete(DATA_TYPE_1_PARAM)
       }
+
       if (var2HasDataTypes) {
         const defaultDt2 =
           METRIC_CONFIG[ml.activeSelections[3] as DropdownVarId]?.[0]
             ?.dataTypeId ?? ''
         next.set(DATA_TYPE_2_PARAM, dtParam2 || defaultDt2)
+      } else {
+        next.delete(DATA_TYPE_2_PARAM)
       }
 
       setLocationAtom({ searchParams: next })
@@ -190,19 +190,17 @@ function ExploreDataPage() {
           ? { 1: var1, 3: var2, 5: geo1 }
           : { 1: var1, 3: geo1 }
 
-    const current = new URLSearchParams(window.location.search)
-    const demoParam = current.get(DEMOGRAPHIC_PARAM)
-    const group1Param = current.get(MAP1_GROUP_PARAM) ?? ALL
-    const dt1Param = current.get(DATA_TYPE_1_PARAM)
     const var1HasDataTypes =
       isDropdownVarId(var1) && METRIC_CONFIG[var1]?.length > 1
 
-    const next = new URLSearchParams()
+    // Preserve all existing params (extremes, atl, group1, demo, etc.),
+    // then only set or delete what actually changes with the mode switch.
+    const next = new URLSearchParams(window.location.search)
     next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(updatedSelections))
     next.set(MADLIB_PHRASE_PARAM, mode)
-    next.set(MAP1_GROUP_PARAM, group1Param)
-    if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
-    if (var1HasDataTypes && dt1Param) next.set(DATA_TYPE_1_PARAM, dt1Param)
+    if (mode === 'disparity') next.delete(MAP2_GROUP_PARAM)
+    next.delete(DATA_TYPE_2_PARAM)
+    if (!var1HasDataTypes) next.delete(DATA_TYPE_1_PARAM)
 
     setLocationAtom({ searchParams: next })
     location.hash = ''

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -54,6 +54,7 @@ function ExploreDataPage() {
     useState(false)
 
   const setLocationAtom = useSetAtom(locationAtom)
+  const onboardParam = useAtomValue(urlParamAtom(SHOW_ONBOARDING_PARAM))
 
   // Deprecated param redirects fire once on mount via useLayoutEffect
   useDeprecatedParamRedirects()
@@ -123,9 +124,6 @@ function ExploreDataPage() {
   )
 
   // Set up warm welcome onboarding behaviors
-  const onboardParam = new URLSearchParams(window.location.search).get(
-    SHOW_ONBOARDING_PARAM,
-  )
   let showOnboarding = false
   if (noTopicChosen) {
     if (onboardParam === 'true') showOnboarding = true

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -126,15 +126,8 @@ function ExploreDataPage() {
     [setLocationAtom],
   )
 
-  // Set up warm welcome onboarding behaviors
-  let showOnboarding = false
-  if (noTopicChosen) {
-    if (onboardParam === 'true') showOnboarding = true
-    if (onboardParam === 'false') showOnboarding = false
-  }
-
-  // if there is an incoming #hash; bypass the warm welcome entirely
-  if (location.hash !== '') showOnboarding = false
+  const showOnboarding =
+    noTopicChosen && onboardParam === 'true' && location.hash === ''
 
   const [activelyOnboarding, setActivelyOnboarding] =
     useState<boolean>(showOnboarding)
@@ -170,13 +163,6 @@ function ExploreDataPage() {
   const isSingleColumn = madLib.id === 'disparity'
 
   function handleModeChange(mode: MadLibId) {
-    const modeIndexMap: Record<MadLibId, number> = {
-      disparity: 0,
-      comparegeos: 1,
-      comparevars: 2,
-    }
-
-    const modeIndex = modeIndexMap[mode]
     const var1 = madLib.activeSelections[1]
     const geo1 =
       madLib.id === 'comparevars'
@@ -187,9 +173,12 @@ function ExploreDataPage() {
       var1 === 'poverty' ? 'health_insurance' : 'poverty'
     const geo2 = geo1 === '00' ? '13' : '00'
 
-    let updatedSelections: PhraseSelections = { 1: var1, 3: geo1 }
-    if (modeIndex === 1) updatedSelections = { 1: var1, 3: geo1, 5: geo2 }
-    if (modeIndex === 2) updatedSelections = { 1: var1, 3: var2, 5: geo1 }
+    const updatedSelections: PhraseSelections =
+      mode === 'comparegeos'
+        ? { 1: var1, 3: geo1, 5: geo2 }
+        : mode === 'comparevars'
+          ? { 1: var1, 3: var2, 5: geo1 }
+          : { 1: var1, 3: geo1 }
 
     const current = new URLSearchParams(window.location.search)
     const demoParam = current.get(DEMOGRAPHIC_PARAM)
@@ -200,7 +189,7 @@ function ExploreDataPage() {
 
     const next = new URLSearchParams()
     next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(updatedSelections))
-    next.set(MADLIB_PHRASE_PARAM, MADLIB_LIST[modeIndex].id)
+    next.set(MADLIB_PHRASE_PARAM, mode)
     next.set(MAP1_GROUP_PARAM, group1Param)
     if (demoParam) next.set(DEMOGRAPHIC_PARAM, demoParam)
     if (var1HasDataTypes && dt1Param) next.set(DATA_TYPE_1_PARAM, dt1Param)

--- a/frontend/src/pages/ExploreData/ExploreDataPage.tsx
+++ b/frontend/src/pages/ExploreData/ExploreDataPage.tsx
@@ -172,40 +172,34 @@ function ExploreDataPage() {
 
   const isSingleColumn = madLib.id === 'disparity'
 
-  function handleModeChange(mode: MadLibId) {
-    const var1 = madLib.activeSelections[1]
-    const geo1 =
-      madLib.id === 'comparevars'
-        ? madLib.activeSelections[5]
-        : madLib.activeSelections[3]
+  const handleModeChange = useCallback(
+    (mode: MadLibId) => {
+      const var1 = madLib.activeSelections[1]
+      const geo1 =
+        madLib.id === 'comparevars'
+          ? madLib.activeSelections[5]
+          : madLib.activeSelections[3]
 
-    const var2: DropdownVarId =
-      var1 === 'poverty' ? 'health_insurance' : 'poverty'
-    const geo2 = geo1 === '00' ? '13' : '00'
+      const var2: DropdownVarId =
+        var1 === 'poverty' ? 'health_insurance' : 'poverty'
+      const geo2 = geo1 === '00' ? '13' : '00'
 
-    const updatedSelections: PhraseSelections =
-      mode === 'comparegeos'
-        ? { 1: var1, 3: geo1, 5: geo2 }
-        : mode === 'comparevars'
-          ? { 1: var1, 3: var2, 5: geo1 }
-          : { 1: var1, 3: geo1 }
+      const updatedSelections: PhraseSelections =
+        mode === 'comparegeos'
+          ? { 1: var1, 3: geo1, 5: geo2 }
+          : mode === 'comparevars'
+            ? { 1: var1, 3: var2, 5: geo1 }
+            : { 1: var1, 3: geo1 }
 
-    const var1HasDataTypes =
-      isDropdownVarId(var1) && METRIC_CONFIG[var1]?.length > 1
-
-    // Preserve all existing params (extremes, atl, group1, demo, etc.),
-    // then only set or delete what actually changes with the mode switch.
-    const next = new URLSearchParams(window.location.search)
-    next.set(MADLIB_SELECTIONS_PARAM, stringifyMls(updatedSelections))
-    next.set(MADLIB_PHRASE_PARAM, mode)
-    if (mode === 'disparity') next.delete(MAP2_GROUP_PARAM)
-    next.delete(DATA_TYPE_2_PARAM)
-    if (!var1HasDataTypes) next.delete(DATA_TYPE_1_PARAM)
-
-    setLocationAtom({ searchParams: next })
-    location.hash = ''
-    window.scrollTo({ top: 0, behavior: 'smooth' })
-  }
+      const idx = MADLIB_LIST.findIndex((el) => el.id === mode)
+      setMadLibWithParam(
+        { ...MADLIB_LIST[idx], activeSelections: updatedSelections },
+        { dt2: '' },
+      )
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    },
+    [madLib, setMadLibWithParam],
+  )
 
   /* on any changes to the madlib settings */
   useEffect(() => {

--- a/frontend/src/pages/ExploreData/MadLibUI.tsx
+++ b/frontend/src/pages/ExploreData/MadLibUI.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import React from 'react'
 import {
   type DropdownVarId,
@@ -14,7 +14,6 @@ import { isFipsString } from '../../data/utils/Fips'
 import { getAllDemographicOptions } from '../../reports/reportUtils'
 import {
   DEFAULT,
-  getConfigFromDataTypeId,
   getFipsListFromMadlib,
   getMadLibWithUpdatedValue,
   getParentDropdownFromDataTypeId,
@@ -45,16 +44,9 @@ export default function MadLibUI(props: MadLibUIProps) {
     if (newValue === DEFAULT) {
       props.setMadLibWithParam(MADLIB_LIST[0])
     } else {
-      // Topic changes (non-Fips values) carry a stale dt param into the new
-      // URL because the old dt doesn't apply to the new topic. Clear it so
-      // the new topic starts at its default data type instead of showing an
-      // empty DataTypeSelector button.
+      // Topic changes carry a stale dt param into the new URL. Clear it so
+      // the new topic starts at its default data type.
       const isTopicChange = !isFipsString(newValue)
-      if (isTopicChange) {
-        index === 1
-          ? setSelectedDataTypeConfig1(null)
-          : setSelectedDataTypeConfig2(null)
-      }
       const dtOverrides = isTopicChange
         ? index === 1
           ? { dt1: '' }
@@ -65,21 +57,11 @@ export default function MadLibUI(props: MadLibUIProps) {
         dtOverrides,
       )
     }
-    // drop card hash from url and scroll to top
     window.location.hash = ''
-    window.scrollTo({
-      top: 0,
-      behavior: 'smooth',
-    })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  function handleDataTypeUpdate(
-    newDataType: DataTypeId,
-    index: number,
-    setConfig: any,
-  ) {
-    const newConfig = getConfigFromDataTypeId(newDataType)
-    newConfig && setConfig(newConfig)
+  function handleDataTypeUpdate(newDataType: DataTypeId, index: number) {
     const dropdownId: DropdownVarId =
       getParentDropdownFromDataTypeId(newDataType)
     const dtOverrides =
@@ -90,12 +72,8 @@ export default function MadLibUI(props: MadLibUIProps) {
     )
   }
 
-  const [selectedDataTypeConfig1, setSelectedDataTypeConfig1] = useAtom(
-    selectedDataTypeConfig1Atom,
-  )
-  const [selectedDataTypeConfig2, setSelectedDataTypeConfig2] = useAtom(
-    selectedDataTypeConfig2Atom,
-  )
+  const selectedDataTypeConfig1 = useAtomValue(selectedDataTypeConfig1Atom)
+  const selectedDataTypeConfig2 = useAtomValue(selectedDataTypeConfig2Atom)
 
   const fipsList = getFipsListFromMadlib(props.madLib)
 
@@ -134,10 +112,6 @@ export default function MadLibUI(props: MadLibUIProps) {
 
               const config =
                 index === 1 ? selectedDataTypeConfig1 : selectedDataTypeConfig2
-              const setConfig =
-                index === 1
-                  ? setSelectedDataTypeConfig1
-                  : setSelectedDataTypeConfig2
 
               const isLocationMadLib = isFipsString(
                 props.madLib.activeSelections[index],
@@ -152,7 +126,6 @@ export default function MadLibUI(props: MadLibUIProps) {
                   }
                 >
                   {typeof phraseSegment === 'string' ? (
-                    // NON_INTERACTIVE MADLIB WORDS
                     <span className='text-alt-black'>
                       {phraseSegment}
                       {insertOptionalThe(props.madLib.activeSelections, index)}
@@ -160,7 +133,6 @@ export default function MadLibUI(props: MadLibUIProps) {
                   ) : (
                     <>
                       {isLocationMadLib ? (
-                        // LOCATION
                         <LocationSelector
                           newValue={props.madLib.activeSelections[index]}
                           onOptionUpdate={(newValue) => {
@@ -169,7 +141,6 @@ export default function MadLibUI(props: MadLibUIProps) {
                           phraseSegment={phraseSegment}
                         />
                       ) : (
-                        // MAIN PARENT TOPIC
                         <TopicSelector
                           newValue={
                             props.madLib.activeSelections[
@@ -184,16 +155,11 @@ export default function MadLibUI(props: MadLibUIProps) {
                       )}
 
                       {dataTypes?.length > 1 && (
-                        // DATA TYPE SUB TOPIC
                         <DataTypeSelector
                           key={`${index}-datatype`}
                           newValue={config?.dataTypeId ?? dataTypes[0][0]}
                           onOptionUpdate={(newValue) => {
-                            handleDataTypeUpdate(
-                              newValue as DataTypeId,
-                              index,
-                              setConfig,
-                            )
+                            handleDataTypeUpdate(newValue as DataTypeId, index)
                           }}
                           options={dataTypes}
                         />

--- a/frontend/src/reports/CompareReport.tsx
+++ b/frontend/src/reports/CompareReport.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { useEffect, useMemo } from 'react'
 import AgeAdjustedTableCard from '../cards/AgeAdjustedTableCard'
 import CompareBubbleChartCard from '../cards/CompareBubbleChartCard'
@@ -10,11 +10,7 @@ import StackedSharesBarChartCard from '../cards/StackedSharesBarChartCard'
 import TableCard from '../cards/TableCard'
 import UnknownsMapCard from '../cards/UnknownsMapCard'
 import type { DropdownVarId } from '../data/config/DropDownIds'
-import { METRIC_CONFIG } from '../data/config/MetricConfig'
-import type {
-  DataTypeConfig,
-  DataTypeId,
-} from '../data/config/MetricConfigTypes'
+import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
 import {
   applyGeoOverrides,
   metricConfigFromDtConfig,
@@ -35,14 +31,7 @@ import {
   selectedDataTypeConfig1Atom,
   selectedDataTypeConfig2Atom,
 } from '../utils/sharedSettingsState'
-import {
-  DATA_TYPE_1_PARAM,
-  DATA_TYPE_2_PARAM,
-  DEMOGRAPHIC_PARAM,
-  getParameter,
-  psSubscribe,
-  swapOldDatatypeParams,
-} from '../utils/urlutils'
+import { DEMOGRAPHIC_PARAM } from '../utils/urlutils'
 import { CompareModeProvider } from './CompareModeContext'
 import ContrastInsightSection from './ContrastInsightSection'
 import { reportProviderSteps } from './ReportProviderSteps'
@@ -84,8 +73,11 @@ export default function CompareReport(props: CompareReportProps) {
     defaultDemo,
   )
 
-  const [dataTypeConfig1, setDtConfig1] = useAtom(selectedDataTypeConfig1Atom)
-  const [dataTypeConfig2, setDtConfig2] = useAtom(selectedDataTypeConfig2Atom)
+  const dataTypeConfig1 = useAtomValue(selectedDataTypeConfig1Atom)
+  // In comparegeos mode both panels show the same data type (dt2 is not in the URL).
+  const dataTypeConfig2Raw = useAtomValue(selectedDataTypeConfig2Atom)
+  const dataTypeConfig2 =
+    props.trackerMode === 'comparegeos' ? dataTypeConfig1 : dataTypeConfig2Raw
 
   const resolvedConfig1 = useMemo(
     () =>
@@ -137,49 +129,6 @@ export default function CompareReport(props: CompareReportProps) {
     demographicType,
     enabledDemographicOptionsMap,
   ])
-
-  useEffect(() => {
-    const readParams = () => {
-      const dtParam1 = getParameter(
-        DATA_TYPE_1_PARAM,
-        undefined,
-        (val: DataTypeId) => {
-          val = swapOldDatatypeParams(val)
-          return METRIC_CONFIG[props.dropdownVarId1].find(
-            (cfg) => cfg.dataTypeId === val,
-          )
-        },
-      )
-      const dtParam2 = getParameter(
-        DATA_TYPE_2_PARAM,
-        undefined,
-        (val: DataTypeId) => {
-          val = swapOldDatatypeParams(val)
-          return (
-            METRIC_CONFIG[props.dropdownVarId2]?.find(
-              (cfg) => cfg.dataTypeId === val,
-            ) ?? METRIC_CONFIG[props.dropdownVarId2][0]
-          )
-        },
-      )
-
-      const newDtParam1 = dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId1]?.[0]
-      setDtConfig1(newDtParam1)
-
-      const newDtParam2 =
-        props.trackerMode === 'comparegeos'
-          ? newDtParam1
-          : (dtParam2 ?? METRIC_CONFIG?.[props.dropdownVarId2]?.[0])
-      setDtConfig2(newDtParam2)
-    }
-    const psSub = psSubscribe(readParams, 'twovar')
-    readParams()
-    return () => {
-      if (psSub) {
-        psSub.unsubscribe()
-      }
-    }
-  }, [props.dropdownVarId1, props.dropdownVarId2])
 
   // when variable config changes (new data type), re-calc available card steps in TableOfContents
   useEffect(() => {

--- a/frontend/src/reports/CompareReport.tsx
+++ b/frontend/src/reports/CompareReport.tsx
@@ -10,6 +10,7 @@ import StackedSharesBarChartCard from '../cards/StackedSharesBarChartCard'
 import TableCard from '../cards/TableCard'
 import UnknownsMapCard from '../cards/UnknownsMapCard'
 import type { DropdownVarId } from '../data/config/DropDownIds'
+import { METRIC_CONFIG } from '../data/config/MetricConfig'
 import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
 import {
   applyGeoOverrides,
@@ -73,11 +74,15 @@ export default function CompareReport(props: CompareReportProps) {
     defaultDemo,
   )
 
-  const dataTypeConfig1 = useAtomValue(selectedDataTypeConfig1Atom)
+  const dataTypeConfig1Raw = useAtomValue(selectedDataTypeConfig1Atom)
+  const dataTypeConfig1 =
+    dataTypeConfig1Raw ?? METRIC_CONFIG[props.dropdownVarId1]?.[0] ?? null
   // In comparegeos mode both panels show the same data type (dt2 is not in the URL).
   const dataTypeConfig2Raw = useAtomValue(selectedDataTypeConfig2Atom)
   const dataTypeConfig2 =
-    props.trackerMode === 'comparegeos' ? dataTypeConfig1 : dataTypeConfig2Raw
+    props.trackerMode === 'comparegeos'
+      ? dataTypeConfig1
+      : (dataTypeConfig2Raw ?? METRIC_CONFIG[props.dropdownVarId2]?.[0] ?? null)
 
   const resolvedConfig1 = useMemo(
     () =>

--- a/frontend/src/reports/CompareReport.tsx
+++ b/frontend/src/reports/CompareReport.tsx
@@ -10,7 +10,6 @@ import StackedSharesBarChartCard from '../cards/StackedSharesBarChartCard'
 import TableCard from '../cards/TableCard'
 import UnknownsMapCard from '../cards/UnknownsMapCard'
 import type { DropdownVarId } from '../data/config/DropDownIds'
-import { METRIC_CONFIG } from '../data/config/MetricConfig'
 import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
 import {
   applyGeoOverrides,
@@ -74,15 +73,11 @@ export default function CompareReport(props: CompareReportProps) {
     defaultDemo,
   )
 
-  const dataTypeConfig1Raw = useAtomValue(selectedDataTypeConfig1Atom)
-  const dataTypeConfig1 =
-    dataTypeConfig1Raw ?? METRIC_CONFIG[props.dropdownVarId1]?.[0] ?? null
+  const dataTypeConfig1 = useAtomValue(selectedDataTypeConfig1Atom)
   // In comparegeos mode both panels show the same data type (dt2 is not in the URL).
   const dataTypeConfig2Raw = useAtomValue(selectedDataTypeConfig2Atom)
   const dataTypeConfig2 =
-    props.trackerMode === 'comparegeos'
-      ? dataTypeConfig1
-      : (dataTypeConfig2Raw ?? METRIC_CONFIG[props.dropdownVarId2]?.[0] ?? null)
+    props.trackerMode === 'comparegeos' ? dataTypeConfig1 : dataTypeConfig2Raw
 
   const resolvedConfig1 = useMemo(
     () =>

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -1,4 +1,4 @@
-import { useAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { useEffect, useMemo } from 'react'
 import AgeAdjustedTableCard from '../cards/AgeAdjustedTableCard'
 import MapCard from '../cards/MapCard'
@@ -35,13 +35,7 @@ import {
   selectedDemographicTypeAtom,
   selectedFipsAtom,
 } from '../utils/sharedSettingsState'
-import {
-  DATA_TYPE_1_PARAM,
-  DEMOGRAPHIC_PARAM,
-  getParameter,
-  REPORT_INSIGHT_PARAM_KEY,
-  swapOldDatatypeParams,
-} from '../utils/urlutils'
+import { DEMOGRAPHIC_PARAM, REPORT_INSIGHT_PARAM_KEY } from '../utils/urlutils'
 import { reportProviderSteps } from './ReportProviderSteps'
 import { getAllDemographicOptions } from './reportUtils'
 import ReportTopbarMobile from './ui/ReportTopbarMobile'
@@ -80,11 +74,9 @@ export function Report(props: ReportProps) {
   const [insightIsOpen] = useParamState(REPORT_INSIGHT_PARAM_KEY)
   const insightMode = Boolean(SHOW_INSIGHT_GENERATION && insightIsOpen)
 
-  const [dataTypeConfig, setDataTypeConfig] = useAtom(
-    selectedDataTypeConfig1Atom,
-  )
-  const [, setSelectedFips] = useAtom(selectedFipsAtom)
-  const [, setSelectedDemographicType] = useAtom(selectedDemographicTypeAtom)
+  const dataTypeConfig = useAtomValue(selectedDataTypeConfig1Atom)
+  const setSelectedFips = useSetAtom(selectedFipsAtom)
+  const setSelectedDemographicType = useSetAtom(selectedDemographicTypeAtom)
 
   const resolvedConfig = useMemo(
     () =>
@@ -113,25 +105,9 @@ export function Report(props: ReportProps) {
   }, [resolvedConfig, demographicType, enabledDemographicOptionsMap])
 
   useEffect(() => {
-    // No psSubscribe here: ExploreDataPage.readParams owns selectedDataTypeConfig1Atom
-    // on popstate. A stale closure over props.dropdownVarId would corrupt the atom,
-    // triggering a spurious demographic-reset pushState that breaks back navigation.
-    const dtParam1 = getParameter(
-      DATA_TYPE_1_PARAM,
-      undefined,
-      (val: string) => {
-        val = swapOldDatatypeParams(val)
-        return METRIC_CONFIG[props.dropdownVarId]?.find(
-          (cfg) => cfg.dataTypeId === val,
-        )
-      },
-    )
-    setDataTypeConfig(
-      dtParam1 ?? METRIC_CONFIG?.[props.dropdownVarId]?.[0] ?? null,
-    )
     setSelectedFips(props.fips)
     setSelectedDemographicType(demographicType)
-  }, [props.dropdownVarId, demographicType, props.fips])
+  }, [props.fips, demographicType])
 
   // when variable config changes (new data type), re-calc available card steps TableOfContents
   useEffect(() => {

--- a/frontend/src/utils/hooks/useDeprecatedParamRedirects.tsx
+++ b/frontend/src/utils/hooks/useDeprecatedParamRedirects.tsx
@@ -49,7 +49,7 @@ export default function useDeprecatedParamRedirects() {
         searchParams: new URLSearchParams(),
       })
     }
-  }, [])
+  }, [mlsParam, setLocation])
 
   return params
 }

--- a/frontend/src/utils/hooks/useDeprecatedParamRedirects.tsx
+++ b/frontend/src/utils/hooks/useDeprecatedParamRedirects.tsx
@@ -29,38 +29,27 @@ export default function useDeprecatedParamRedirects() {
   const params = useSearchParams()
   const mlsParam = params[MADLIB_SELECTIONS_PARAM]
 
-  // Compute corrected params synchronously so callers render with valid state
-  // from the first frame, before the URL update fires in useLayoutEffect.
-  let correctedMlsParam = ''
-  let isMalformed = false
-
-  if (mlsParam) {
+  useLayoutEffect(() => {
+    if (!mlsParam) return
     const dropdownVarId1 = mlsParam.replace('1.', '').split('-')[0]
+
     if (dropdownIdSwaps[dropdownVarId1]) {
-      correctedMlsParam = mlsParam.replace(
+      const newMlsParam = mlsParam.replace(
         dropdownVarId1,
         dropdownIdSwaps[dropdownVarId1],
       )
-    } else if (!Object.keys(METRIC_CONFIG).includes(dropdownVarId1)) {
-      isMalformed = true
-    }
-  }
-
-  useLayoutEffect(() => {
-    if (correctedMlsParam) {
       setLocation((prev) => {
         const next = new URLSearchParams(prev.searchParams)
-        next.set(MADLIB_SELECTIONS_PARAM, correctedMlsParam)
+        next.set(MADLIB_SELECTIONS_PARAM, newMlsParam)
         return { ...prev, searchParams: next }
       })
-    } else if (isMalformed) {
+    } else if (!Object.keys(METRIC_CONFIG).includes(dropdownVarId1)) {
       setLocation({
         pathname: EXPLORE_DATA_PAGE_LINK,
         searchParams: new URLSearchParams(),
       })
     }
-  }, [mlsParam, setLocation])
+  }, [])
 
-  if (!correctedMlsParam) return params
-  return { ...params, [MADLIB_SELECTIONS_PARAM]: correctedMlsParam }
+  return params
 }

--- a/frontend/src/utils/hooks/useParamState.tsx
+++ b/frontend/src/utils/hooks/useParamState.tsx
@@ -25,7 +25,7 @@ export function useParamState<ParamStateType>(
       if (newValue == null || newValue === false || newValue === '') {
         params.delete(paramKey)
       } else {
-        params.set(paramKey, newValue as string)
+        params.set(paramKey, nextValue)
       }
       return { ...prev, searchParams: params }
     })

--- a/frontend/src/utils/hooks/useParamState.tsx
+++ b/frontend/src/utils/hooks/useParamState.tsx
@@ -5,33 +5,30 @@ export function useParamState<ParamStateType>(
   paramKey: string,
   paramDefaultValue?: ParamStateType,
 ): [ParamStateType, (newValue: ParamStateType) => void] {
-  // Fine-grained subscription: only re-renders when THIS param changes.
   const paramValue = useAtomValue(urlParamAtom(paramKey))
-  // Setter only — does not subscribe to locationAtom value.
   const setLocationState = useSetAtom(locationAtom)
 
   const paramState = (paramValue ?? paramDefaultValue ?? '') as ParamStateType
 
   function setParamState(newValue: ParamStateType): void {
-    // Read window.location.search (not locationAtom) as the base so params
-    // written via history.replaceState by the MadLib machinery are included —
-    // jotai-location only re-syncs on popstate, not replaceState.
-    const currentParams = new URLSearchParams(window.location.search)
-    const originalString = currentParams.toString()
+    // Guard outside the setter: jotai-location always calls applyLocation
+    // (pushState) even when the updater returns prev unchanged.
+    const currentValue = paramValue ?? ''
+    const nextValue =
+      newValue == null || newValue === false || newValue === ''
+        ? ''
+        : String(newValue)
+    if (currentValue === nextValue) return
 
-    if (newValue == null || newValue === false || newValue === '') {
-      currentParams.delete(paramKey)
-    } else {
-      currentParams.set(paramKey, newValue as string)
-    }
-
-    // Guard must be outside setLocationState: jotai-location's write fn always
-    // calls applyLocation (history.pushState) even when the updater returns
-    // prev unchanged, which would push a stale URL on top of any in-flight
-    // history.replaceState from the MadLib navigation machinery.
-    if (originalString === currentParams.toString()) return
-
-    setLocationState((prev) => ({ ...prev, searchParams: currentParams }))
+    setLocationState((prev) => {
+      const params = new URLSearchParams(prev.searchParams)
+      if (newValue == null || newValue === false || newValue === '') {
+        params.delete(paramKey)
+      } else {
+        params.set(paramKey, newValue as string)
+      }
+      return { ...prev, searchParams: params }
+    })
   }
 
   return [paramState, setParamState]

--- a/frontend/src/utils/sharedSettingsState.ts
+++ b/frontend/src/utils/sharedSettingsState.ts
@@ -51,17 +51,16 @@ export const urlParamAtom = atomFamily((key: string) =>
   ),
 )
 
+// Flattened once at module level — METRIC_CONFIG is static.
+const ALL_METRIC_CONFIGS = Object.values(METRIC_CONFIG).flat()
+
 // Derived from dt1/dt2 URL params — never manually set.
 // Returns null when the param is absent or the id is not found.
 export const selectedDataTypeConfig1Atom = atom<DataTypeConfig | null>(
   (get) => {
     const dt1 = get(urlParamAtom(DATA_TYPE_1_PARAM))
     if (!dt1) return null
-    return (
-      Object.values(METRIC_CONFIG)
-        .flat()
-        .find((c) => c.dataTypeId === dt1) ?? null
-    )
+    return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt1) ?? null
   },
 )
 
@@ -69,10 +68,6 @@ export const selectedDataTypeConfig2Atom = atom<DataTypeConfig | null>(
   (get) => {
     const dt2 = get(urlParamAtom(DATA_TYPE_2_PARAM))
     if (!dt2) return null
-    return (
-      Object.values(METRIC_CONFIG)
-        .flat()
-        .find((c) => c.dataTypeId === dt2) ?? null
-    )
+    return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt2) ?? null
   },
 )

--- a/frontend/src/utils/sharedSettingsState.ts
+++ b/frontend/src/utils/sharedSettingsState.ts
@@ -7,7 +7,12 @@ import type { DemographicType } from '../data/query/Breakdowns'
 import type { MetricQueryResponse } from '../data/query/MetricQuery'
 import type { Fips } from '../data/utils/Fips'
 import type { ReportInsightSections } from './generateReportInsight'
-import { DATA_TYPE_1_PARAM, DATA_TYPE_2_PARAM } from './urlutils'
+import {
+  DATA_TYPE_1_PARAM,
+  DATA_TYPE_2_PARAM,
+  MADLIB_SELECTIONS_PARAM,
+  parseMls,
+} from './urlutils'
 
 export const selectedFipsAtom = atom<Fips | null>(null)
 export const selectedDemographicTypeAtom = atom<DemographicType | null>(null)
@@ -54,20 +59,29 @@ export const urlParamAtom = atomFamily((key: string) =>
 // Flattened once at module level — METRIC_CONFIG is static.
 const ALL_METRIC_CONFIGS = Object.values(METRIC_CONFIG).flat()
 
-// Derived from dt1/dt2 URL params — never manually set.
-// Returns null when the param is absent or the id is not found.
+// Derived from dt1/dt2 URL params, with fallback to the first config for the
+// topic encoded in the mls param. Returns null only when no topic is selected.
 export const selectedDataTypeConfig1Atom = atom<DataTypeConfig | null>(
   (get) => {
     const dt1 = get(urlParamAtom(DATA_TYPE_1_PARAM))
-    if (!dt1) return null
-    return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt1) ?? null
+    if (dt1) return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt1) ?? null
+    const mls = get(urlParamAtom(MADLIB_SELECTIONS_PARAM))
+    if (!mls) return null
+    const topic = parseMls(mls)[1]
+    return METRIC_CONFIG[topic as keyof typeof METRIC_CONFIG]?.[0] ?? null
   },
 )
 
+// For comparevars mode: falls back to the first config for the second topic in
+// mls. In comparegeos/disparity mode, mls index 3 is a FIPS code, so
+// METRIC_CONFIG lookup returns undefined and the atom correctly returns null.
 export const selectedDataTypeConfig2Atom = atom<DataTypeConfig | null>(
   (get) => {
     const dt2 = get(urlParamAtom(DATA_TYPE_2_PARAM))
-    if (!dt2) return null
-    return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt2) ?? null
+    if (dt2) return ALL_METRIC_CONFIGS.find((c) => c.dataTypeId === dt2) ?? null
+    const mls = get(urlParamAtom(MADLIB_SELECTIONS_PARAM))
+    if (!mls) return null
+    const topic = parseMls(mls)[3]
+    return METRIC_CONFIG[topic as keyof typeof METRIC_CONFIG]?.[0] ?? null
   },
 )

--- a/frontend/src/utils/sharedSettingsState.ts
+++ b/frontend/src/utils/sharedSettingsState.ts
@@ -1,13 +1,13 @@
 import { atom } from 'jotai'
 import { atomFamily, selectAtom } from 'jotai/utils'
 import { atomWithLocation } from 'jotai-location'
+import { METRIC_CONFIG } from '../data/config/MetricConfig'
 import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
 import type { DemographicType } from '../data/query/Breakdowns'
 import type { MetricQueryResponse } from '../data/query/MetricQuery'
 import type { Fips } from '../data/utils/Fips'
 import type { ReportInsightSections } from './generateReportInsight'
-export const selectedDataTypeConfig1Atom = atom<DataTypeConfig | null>(null)
-export const selectedDataTypeConfig2Atom = atom<DataTypeConfig | null>(null)
+import { DATA_TYPE_1_PARAM, DATA_TYPE_2_PARAM } from './urlutils'
 
 export const selectedFipsAtom = atom<Fips | null>(null)
 export const selectedDemographicTypeAtom = atom<DemographicType | null>(null)
@@ -34,22 +34,9 @@ export const reportInsightsAtom = atom<Record<string, ReportInsightCacheEntry>>(
   {},
 )
 
-/* SHARED SYNCED URL PARAMS STATE
- *
- * Two-tier URL param system:
- *
- * Tier 1 — MadLib params (mls, dt1, dt2, group1, group2, mlp, extremes*):
- *   Written by ExploreDataPage via history.replaceState directly.
- *   jotai-location only syncs on popstate, so locationAtom.searchParams
- *   is NOT kept current for these. Read them from window.location.search.
- *
- * Tier 2 — modal / UI params (topic-info, multiple-maps*, chlp-maps,
- *   vote-dot-org, report-insight, demo, atl):
- *   Written via useParamState → setLocationState. locationAtom stays
- *   current for these. Components subscribe via urlParamAtom(key).
- *
- * See useParamState.tsx for why setParamState reads window.location.search
- * rather than prev.searchParams as its base.
+/* URL PARAMS — all written via setLocationAtom (single pushState per action).
+ * jotai-location's popstate listener keeps locationAtom current on back/forward.
+ * Components subscribe via urlParamAtom(key) for fine-grained re-renders.
  */
 export const locationAtom = atomWithLocation()
 
@@ -62,4 +49,30 @@ export const urlParamAtom = atomFamily((key: string) =>
     (loc) => loc.searchParams?.get(key) ?? null,
     Object.is,
   ),
+)
+
+// Derived from dt1/dt2 URL params — never manually set.
+// Returns null when the param is absent or the id is not found.
+export const selectedDataTypeConfig1Atom = atom<DataTypeConfig | null>(
+  (get) => {
+    const dt1 = get(urlParamAtom(DATA_TYPE_1_PARAM))
+    if (!dt1) return null
+    return (
+      Object.values(METRIC_CONFIG)
+        .flat()
+        .find((c) => c.dataTypeId === dt1) ?? null
+    )
+  },
+)
+
+export const selectedDataTypeConfig2Atom = atom<DataTypeConfig | null>(
+  (get) => {
+    const dt2 = get(urlParamAtom(DATA_TYPE_2_PARAM))
+    if (!dt2) return null
+    return (
+      Object.values(METRIC_CONFIG)
+        .flat()
+        .find((c) => c.dataTypeId === dt2) ?? null
+    )
+  },
 )

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 import { Link, useLocation } from 'react-router'
-import type { DataTypeId } from '../data/config/MetricConfigTypes'
 import {
   type DemographicGroup,
   raceNameToCodeMap,
@@ -42,16 +41,6 @@ export const ALT_TABLE_VIEW_1_PARAM_KEY = 'alt-table-view1'
 export const ALT_TABLE_VIEW_2_PARAM_KEY = 'alt-table-view2'
 export const ATLANTA_MODE_PARAM_KEY = 'atl'
 export const CHLP_MAPS_PARAM_KEY = 'chlp-maps'
-
-// Ensures backwards compatibility for external links to old DataTypeIds
-export function swapOldDatatypeParams(oldParam: string) {
-  const swaps: Record<string, DataTypeId> = {
-    deaths: 'covid_deaths',
-    cases: 'covid_cases',
-    hospitalizations: 'covid_hospitalizations',
-  }
-  return swaps[oldParam] || oldParam
-}
 
 export function LinkWithStickyParams(props: {
   to: string

--- a/frontend/src/utils/urlutils.tsx
+++ b/frontend/src/utils/urlutils.tsx
@@ -5,7 +5,6 @@ import {
   type DemographicGroup,
   raceNameToCodeMap,
 } from '../data/utils/Constants'
-import { getLogger } from './globals'
 import type { PhraseSelections } from './MadLibs'
 
 // LLM INSIGHTS FEATURE
@@ -97,54 +96,10 @@ export function useSearchParams() {
   return Object.fromEntries(params.entries())
 }
 
-export function setParameter(
-  paramName: string,
-  paramValue: string | null = null,
-) {
-  setParameters([{ name: paramName, value: paramValue }])
-}
-
-interface ParamKeyValue {
-  name: string
-  value: string | null
-}
-
-export function setParameters(paramMap: ParamKeyValue[]) {
-  const searchParams = new URLSearchParams(window.location.search)
-
-  paramMap.forEach((kv) => {
-    const paramName = kv.name
-    const paramValue = kv.value
-
-    if (paramValue) {
-      searchParams.set(paramName, paramValue)
-    } else {
-      searchParams.delete(paramName)
-    }
-  })
-
-  const base =
-    window.location.protocol +
-    '//' +
-    window.location.host +
-    window.location.pathname
-
-  window.history.pushState({}, '', base + '?' + searchParams.toString())
-}
-
-const defaultHandler = <T,>(input: string | null): T => {
-  return input as unknown as T
-}
-
-function removeParamAndReturnValue<T1>(paramName: string, defaultValue: T1) {
-  setParameter(paramName, null)
-  return defaultValue
-}
-
 export function getParameter<T1>(
   paramName: string,
   defaultValue: T1,
-  formatter: (x: any) => T1 = defaultHandler,
+  formatter: (x: any) => T1 = (input: string | null) => input as unknown as T1,
 ): T1 {
   const searchParams = new URLSearchParams(window.location.search)
   try {
@@ -153,7 +108,7 @@ export function getParameter<T1>(
       : defaultValue
   } catch (err) {
     console.error(err)
-    return removeParamAndReturnValue(paramName, defaultValue)
+    return defaultValue
   }
 }
 
@@ -179,42 +134,6 @@ export const stringifyMls = (selection: PhraseSelections): string => {
   })
 
   return kvPair.join(partsSeparator)
-}
-
-type PSEventHandler = () => void
-
-const psSubscriptions: any = {}
-let psCount: number = 0
-
-export const psSubscribe = (
-  handler: PSEventHandler,
-  keyPrefix = 'unk',
-): { unsubscribe: () => void } => {
-  const key = keyPrefix + '_' + psCount
-  getLogger().debugLog('Adding PSHandler: ' + key)
-  psSubscriptions[key] = handler
-  psCount++
-  return {
-    unsubscribe: () => {
-      psUnsubscribe(key)
-    },
-  }
-}
-
-const psUnsubscribe = (k: string) => {
-  getLogger().debugLog('Removing PSHandler: ' + k)
-  // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-  delete psSubscriptions[k]
-}
-
-window.onpopstate = () => {
-  Object.keys(psSubscriptions).forEach((key) => {
-    const handler = psSubscriptions[key]
-    if (handler) {
-      getLogger().debugLog('Firing PSHandler: ' + key)
-      handler()
-    }
-  })
 }
 
 /* for converting selected group long name into URL safe param value */


### PR DESCRIPTION
Replaces #4755 (closed — was tracking origin directly instead of fork; see fork workflow in #4760).
Extracted standalone fixes already merged via #4763.

## What changed

Removes the custom psSubscribe/window.onpopstate machinery and direct history.pushState calls. All URL writes now go through setLocationAtom (jotai-location) — one pushState per user action.

- selectedDataTypeConfig1/2Atom are read-only derived atoms from urlParamAtom(dt1/dt2), with MLS-based fallback when dt1 is absent
- madLib in ExploreDataPage is a useMemo from URL atoms, not owned state; back/forward recomputes automatically
- setMadLibWithParam always writes dt1/dt2 explicitly for topics with multiple data types, preventing the demographic selector from receiving a null config
- handleModeChange refactored to go through setMadLibWithParam (consistent single write path; mode switch to comparevars now sets dt2 to var2 default)
- MapCard group reset moved from render path to useEffect keyed on dataTypeConfig + demographicType; uses replaceState to avoid adding history entries
- Removes the stale-closure risk in CompareReport (same class as #4753)

## Key files

| File | Change |
|---|---|
| sharedSettingsState.ts | selectedDataTypeConfig1/2Atom plain -> derived from URL atoms with MLS fallback |
| ExploreDataPage.tsx | madLib useState + readParams -> useMemo; setMadLibWithParam always writes dt1; handleModeChange uses setMadLibWithParam |
| CompareReport.tsx | Removes psSubscribe handler; dt fallback moved to atoms |
| MapCard.tsx | Group reset moved from render path to useEffect; uses replaceState (not pushState) to avoid extra history entries |
| urlutils.tsx | Deletes setParameter, setParameters, psSubscribe, psUnsubscribe, window.onpopstate |
| useParamState.tsx | Setter reads from prev.searchParams; no more window.location.search workaround |
| navigation.ci.spec.ts | Back-button regression tests; demo/dt1 param survival tests; comparevars panel independence test |

## Behavioral note

`swapOldDatatypeParams` (deaths/cases/hospitalizations -> covid_*) is effectively dropped -- its call sites in CompareReport and Report are removed. Very old COVID-era bookmarks with dt1=deaths will fall back to the topic default instead of redirecting. Dropdown-ID-level redirects (hiv_prevalence -> hiv, etc.) are still handled by useDeprecatedParamRedirects.

## Test plan

- [x] npm run e2e navigation -- all 17 tests pass
- [x] Back through 5+ steps lands on correct distinct state each time
- [x] Topic switch clears stale dt1; DataTypeSelector shows correct first option
- [x] demo param survives geo change, sub-type change, and mode change
- [x] Compare geos: both panels show same data type
- [x] Compare topics: each panel shows its own data type (test 16 -- switching right panel's sub-type updates dt2 only, dt1 unchanged)
- [x] npx tsc --noEmit passes

Closes #4754

Generated with [Claude Code](https://claude.com/claude-code)
