### PR TITLE
feat(/pr skill): add critical review evaluation and reply step

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge
-description: Force-merge an open PR to main (bypassing review requirements), delete the local branch, pull the updated main, and push it to the ben remote (personal fork). Use when the user wants to close out a PR without waiting for review, or run /merge.
+description: Force-merge an open PR to main (bypassing review requirements), delete the local branch, pull the updated main, and push it to the personal fork remote. Use when the user wants to close out a PR without waiting for review, or run /merge.
 ---
 
 # /merge
@@ -11,7 +11,7 @@ The user may pass a PR number as an argument (e.g. `/merge 4764`). If none is gi
 
 ---
 
-## Step 1 — Identify the PR
+## Step 1 — Identify the PR and derive fork remote
 
 ```bash
 gh pr view [<number>] --json number,title,headRefName,baseRefName,state
@@ -22,6 +22,15 @@ Confirm:
 - `baseRefName` is `main`
 
 If the PR is already merged or closed: print a message and stop.
+
+Derive the personal fork remote:
+
+```bash
+GH_USER=$(gh api user -q .login)
+FORK_REMOTE=$(git remote -v | grep -i "github.com[/:]${GH_USER}/" | head -1 | awk '{print $1}')
+```
+
+If `FORK_REMOTE` is empty, print a warning and ask the user to identify their fork remote with `git remote -v`.
 
 Print the PR title and number, then ask the user to confirm before merging:
 > "About to force-merge PR #<number>: '<title>'. Confirm? (yes/no)"
@@ -87,17 +96,17 @@ After a squash merge, local main always diverges (N commits become 1 on origin),
 ## Step 5 — Push main to personal fork
 
 ```bash
-git push ben main --force
+git push $FORK_REMOTE main --force
 ```
 
-Force-push is required after a squash merge because `ben/main` still has the pre-squash commits.
+Force-push is required after a squash merge because the fork's main still has the pre-squash commits.
 
 ---
 
 ## Step 6 — Confirm
 
 Print a summary:
-> "Merged PR #<number>. Local main is up to date with origin/main and pushed to ben/main."
+> "Merged PR #<number>. Local main is up to date with origin/main and pushed to $FORK_REMOTE/main."
 
 ---
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -11,13 +11,26 @@ The user may pass a PR number as an argument (e.g. `/pr 4764`). If none is given
 
 ---
 
-## Step 1 — Identify the PR
+## Step 1 — Identify the PR and derive context
 
 ```bash
 gh pr view --json number,title,body,headRefName,baseRefName
 ```
 
 If no open PR is found: print an error and stop.
+
+Then derive two variables used throughout the remaining steps:
+
+```bash
+# Upstream repo (e.g. SatcherInstitute/health-equity-tracker)
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+
+# Personal fork remote — the remote whose URL contains the current GitHub user's login
+GH_USER=$(gh api user -q .login)
+FORK_REMOTE=$(git remote -v | grep -i "github.com[/:]${GH_USER}/" | head -1 | awk '{print $1}')
+```
+
+If `FORK_REMOTE` is empty, print a warning and ask the user to identify their fork remote with `git remote -v`, then continue using that name.
 
 ---
 
@@ -46,10 +59,10 @@ If any check fails: report the failure with the full error, fix it, re-run, and 
 Fetch all reviews and inline comments on the PR:
 
 ```bash
-gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/reviews \
+gh api repos/$REPO/pulls/<number>/reviews \
   --jq '[.[] | {user: .user.login, state: .state, body: .body}]'
 
-gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments \
+gh api repos/$REPO/pulls/<number>/comments \
   --jq '[.[] | {user: .user.login, path: .path, line: .line, body: .body, id: .id}]'
 ```
 
@@ -70,11 +83,11 @@ Then act:
   ```bash
   git add <files>
   git commit -m "address review: <short description>"
-  git push ben HEAD
+  git push $FORK_REMOTE HEAD
   ```
   Reply with one short sentence — what you did and why, nothing more:
   ```bash
-  gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+  gh api repos/$REPO/pulls/<number>/comments/<comment_id>/replies \
     -f body="Fixed — <one line>."
   ```
   Then resolve the thread via GraphQL (requires the thread `node_id` from the comment object):
@@ -83,7 +96,7 @@ Then act:
   ```
 - **Decline it**: reply with one sentence explaining why, then leave the thread open:
   ```bash
-  gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+  gh api repos/$REPO/pulls/<number>/comments/<comment_id>/replies \
     -f body="Not changing — <one line reason>."
   ```
 
@@ -109,7 +122,7 @@ If updates are needed: edit the relevant docs, then commit:
 ```bash
 git add frontend/CLAUDE.md CLAUDE.md README.md   # only files actually changed
 git commit -m "docs: update CLAUDE.md to reflect <what changed>"
-git push ben main
+git push $FORK_REMOTE HEAD
 ```
 
 ---
@@ -161,6 +174,6 @@ Print the updated PR URL when done.
 
 ## Notes
 
-- Never push directly to `origin` (SatcherInstitute). Always push to `ben` (personal fork).
+- Never push directly to `origin` (SatcherInstitute). Always push to `$FORK_REMOTE` (your personal fork).
 - All test failures must be fixed before proceeding — do not skip or suppress them.
 - Doc updates should reflect durable invariants, not ephemeral task details.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -66,19 +66,17 @@ Do not copy the reviewer's proposed solution verbatim. Read the surrounding code
 
 Then act:
 
-- **Address it**: implement the fix your way, commit, push:
+- **Address it**: implement the fix your way, commit, and push:
   ```bash
   git add <files>
   git commit -m "address review: <short description>"
   git push ben HEAD
   ```
-- **Decline it**: reply explaining why the concern doesn't apply or why the change would be worse.
-
-Reply to each comment to close the loop:
-```bash
-gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
-  -f body="<your response>"
-```
+  Then resolve the thread via GraphQL (requires the thread `node_id` from the comment object):
+  ```bash
+  gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<node_id>"}) { thread { isResolved } } }'
+  ```
+- **Decline it**: leave the thread open for the human reviewer to dismiss.
 
 If there are no unresolved reviews or comments, note that and continue.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -70,13 +70,13 @@ Then act:
   ```bash
   git add <files>
   git commit -m "address review: <short description>"
-  git push ben main
+  git push ben HEAD
   ```
 - **Decline it**: reply explaining why the concern doesn't apply or why the change would be worse.
 
 Reply to each comment to close the loop:
 ```bash
-gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+gh api repos/SatcherInstitute/health-equity-tracker/pulls/comments/<comment_id>/replies \
   -f body="<your response>"
 ```
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -41,7 +41,39 @@ If any check fails: report the failure with the full error, fix it, re-run, and 
 
 ---
 
-## Step 3 — Assess doc freshness
+## Step 3 — Address code review feedback
+
+Fetch all reviews and inline comments on the PR:
+
+```bash
+gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/reviews \
+  --jq '[.[] | {user: .user.login, state: .state, body: .body}]'
+
+gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments \
+  --jq '[.[] | {user: .user.login, path: .path, line: .line, body: .body}]'
+```
+
+For each review or inline comment that is not purely informational:
+
+1. **Read the concern** — understand what the reviewer is asking.
+2. **Decide**: address it, push back with a reason, or mark it as won't-fix with an explanation.
+3. **If addressing**: make the code change, then commit and push:
+   ```bash
+   git add <files>
+   git commit -m "address review: <short description>"
+   git push ben main
+   ```
+4. **Reply to the comment** on GitHub to close the loop:
+   ```bash
+   gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+     -f body="<your response>"
+   ```
+
+If there are no unresolved reviews or comments, note that and continue.
+
+---
+
+## Step 4 — Assess doc freshness
 
 Read the current `frontend/CLAUDE.md` and (if relevant) the root `CLAUDE.md` and `README.md`.
 
@@ -64,7 +96,7 @@ git push ben main
 
 ---
 
-## Step 4 — Update the PR title and description
+## Step 5 — Update the PR title and description
 
 Get the full diff to understand what actually changed:
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -41,7 +41,7 @@ If any check fails: report the failure with the full error, fix it, re-run, and 
 
 ---
 
-## Step 3 — Address code review feedback
+## Step 3 — Evaluate and address code review feedback
 
 Fetch all reviews and inline comments on the PR:
 
@@ -50,24 +50,35 @@ gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/reviews \
   --jq '[.[] | {user: .user.login, state: .state, body: .body}]'
 
 gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments \
-  --jq '[.[] | {user: .user.login, path: .path, line: .line, body: .body}]'
+  --jq '[.[] | {user: .user.login, path: .path, line: .line, body: .body, id: .id}]'
 ```
 
-For each review or inline comment that is not purely informational:
+For each review or inline comment, work through three questions before touching any code:
 
-1. **Read the concern** — understand what the reviewer is asking.
-2. **Decide**: address it, push back with a reason, or mark it as won't-fix with an explanation.
-3. **If addressing**: make the code change, then commit and push:
-   ```bash
-   git add <files>
-   git commit -m "address review: <short description>"
-   git push ben main
-   ```
-4. **Reply to the comment** on GitHub to close the loop:
-   ```bash
-   gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
-     -f body="<your response>"
-   ```
+**1. Is the concern actually valid?**
+Read the flagged code in context. Check whether the reviewer's premise is correct — automated reviewers (Gemini, CodeRabbit, etc.) frequently misread control flow, miss surrounding context, or flag patterns that are intentional. If the concern is based on a misunderstanding, it is not valid regardless of who raised it.
+
+**2. Is it worth addressing?**
+A valid concern still may not warrant a change. Consider: is this a real bug or a hypothetical edge case that can't happen? Does it conflict with an existing project convention? Is the suggested change more complex than the problem it solves? Cosmetic style suggestions that contradict the project's existing patterns are generally not worth addressing.
+
+**3. If worth addressing — what is the right fix for *this* codebase?**
+Do not copy the reviewer's proposed solution verbatim. Read the surrounding code, check how similar patterns are handled elsewhere in the project, and implement the fix in a way that matches the codebase's conventions. The reviewer's suggestion is a starting point for understanding the problem, not a diff to apply.
+
+Then act:
+
+- **Address it**: implement the fix your way, commit, push:
+  ```bash
+  git add <files>
+  git commit -m "address review: <short description>"
+  git push ben main
+  ```
+- **Decline it**: reply explaining why the concern doesn't apply or why the change would be worse.
+
+Reply to each comment to close the loop:
+```bash
+gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+  -f body="<your response>"
+```
 
 If there are no unresolved reviews or comments, note that and continue.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -76,7 +76,7 @@ Then act:
 
 Reply to each comment to close the loop:
 ```bash
-gh api repos/SatcherInstitute/health-equity-tracker/pulls/comments/<comment_id>/replies \
+gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
   -f body="<your response>"
 ```
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -72,11 +72,20 @@ Then act:
   git commit -m "address review: <short description>"
   git push ben HEAD
   ```
+  Reply with one short sentence — what you did and why, nothing more:
+  ```bash
+  gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+    -f body="Fixed — <one line>."
+  ```
   Then resolve the thread via GraphQL (requires the thread `node_id` from the comment object):
   ```bash
   gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<node_id>"}) { thread { isResolved } } }'
   ```
-- **Decline it**: leave the thread open for the human reviewer to dismiss.
+- **Decline it**: reply with one sentence explaining why, then leave the thread open:
+  ```bash
+  gh api repos/SatcherInstitute/health-equity-tracker/pulls/<number>/comments/<comment_id>/replies \
+    -f body="Not changing — <one line reason>."
+  ```
 
 If there are no unresolved reviews or comments, note that and continue.
 


### PR DESCRIPTION
## Summary

- Adds a review evaluation step to the `/pr` skill with a three-question gate: is the concern valid? is it worth addressing? what is the right fix for *this* codebase?
- Adds terse one-sentence replies per comment (addressed or declined) so decisions are visible without noise
- Resolves addressed threads via `gh api graphql resolveReviewThread`; leaves declined threads open for the human reviewer
- Uses `git push ben HEAD` instead of hardcoded `main` for robustness

## Motivation

The original `/pr` skill had no review step. Adding one naively risks blindly applying automated suggestions that misread context or conflict with project conventions. The three-question gate ensures each concern is evaluated on its merits before any code is touched. Reviewer suggestions are a starting point for understanding the problem, not a diff to apply.

## Test plan

- [ ] Running `/pr` on a PR with Gemini comments fetches, evaluates, and replies to each one
- [ ] Addressed threads are resolved; declined threads stay open
- [ ] No changes are made based solely on a reviewer's suggested code without critical evaluation first

🤖 Generated with [Claude Code](https://claude.com/claude-code)
