### PR TITLE
fix(cards): guard extremes displayData inline; hide insight btn in screenshots

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -101,6 +101,23 @@ interface MapCardProps {
   trackerMode: MadLibId
 }
 
+function ExtremesResetGuard({
+  dataLength,
+  isExtremesMode,
+  setIsExtremesMode,
+}: {
+  dataLength: number
+  isExtremesMode: boolean
+  setIsExtremesMode: (val: boolean) => void
+}) {
+  useEffect(() => {
+    if (isExtremesMode && dataLength <= 1) {
+      setIsExtremesMode(false)
+    }
+  }, [dataLength, isExtremesMode, setIsExtremesMode])
+  return null
+}
+
 // This wrapper ensures the proper key is set to create a new instance when required (when
 // the props change and the state needs to be reset) rather than relying on the card caller.
 export default function MapCard(props: MapCardProps) {
@@ -510,8 +527,6 @@ function MapCardWithKey(props: MapCardProps) {
 
         const mapConfig = props.dataTypeConfig.mapConfig
 
-        if (dataForActiveDemographicGroup?.length <= 1) setIsExtremesMode(false)
-
         const hasMapData =
           !!dataForActiveDemographicGroup?.length && !!metricConfig
         overrideCardHasData?.(hasMapData)
@@ -519,6 +534,11 @@ function MapCardWithKey(props: MapCardProps) {
         if (!hasMapData)
           return (
             <>
+              <ExtremesResetGuard
+                dataLength={dataForActiveDemographicGroup?.length ?? 0}
+                isExtremesMode={isExtremesMode}
+                setIsExtremesMode={setIsExtremesMode}
+              />
               <div className='w-full'>
                 <ChartTitle
                   title={'Rate map unavailable: ' + title}
@@ -575,6 +595,11 @@ function MapCardWithKey(props: MapCardProps) {
 
         return (
           <>
+            <ExtremesResetGuard
+              dataLength={dataForActiveDemographicGroup?.length ?? 0}
+              isExtremesMode={isExtremesMode}
+              setIsExtremesMode={setIsExtremesMode}
+            />
             <MultiMapDialog
               dataTypeConfig={props.dataTypeConfig}
               demographicType={demographicType}

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -101,23 +101,6 @@ interface MapCardProps {
   trackerMode: MadLibId
 }
 
-function ExtremesResetGuard({
-  dataLength,
-  isExtremesMode,
-  setIsExtremesMode,
-}: {
-  dataLength: number
-  isExtremesMode: boolean
-  setIsExtremesMode: (val: boolean) => void
-}) {
-  useEffect(() => {
-    if (isExtremesMode && dataLength <= 1) {
-      setIsExtremesMode(false)
-    }
-  }, [dataLength, isExtremesMode, setIsExtremesMode])
-  return null
-}
-
 // This wrapper ensures the proper key is set to create a new instance when required (when
 // the props change and the state needs to be reset) rather than relying on the card caller.
 export default function MapCard(props: MapCardProps) {
@@ -515,9 +498,10 @@ function MapCardWithKey(props: MapCardProps) {
           })
         }
 
-        const displayData = isExtremesMode
-          ? highestValues.concat(lowestValues)
-          : dataForActiveDemographicGroup
+        const displayData =
+          isExtremesMode && dataForActiveDemographicGroup.length > 1
+            ? highestValues.concat(lowestValues)
+            : dataForActiveDemographicGroup
 
         const isPhrmaAdherence =
           PHRMA_METRICS.includes(metricId) && metricConfig.type === 'pct_rate'
@@ -534,11 +518,6 @@ function MapCardWithKey(props: MapCardProps) {
         if (!hasMapData)
           return (
             <>
-              <ExtremesResetGuard
-                dataLength={dataForActiveDemographicGroup?.length ?? 0}
-                isExtremesMode={isExtremesMode}
-                setIsExtremesMode={setIsExtremesMode}
-              />
               <div className='w-full'>
                 <ChartTitle
                   title={'Rate map unavailable: ' + title}
@@ -595,11 +574,6 @@ function MapCardWithKey(props: MapCardProps) {
 
         return (
           <>
-            <ExtremesResetGuard
-              dataLength={dataForActiveDemographicGroup?.length ?? 0}
-              isExtremesMode={isExtremesMode}
-              setIsExtremesMode={setIsExtremesMode}
-            />
             <MultiMapDialog
               dataTypeConfig={props.dataTypeConfig}
               demographicType={demographicType}

--- a/frontend/src/cards/ui/InsightVisualizationButton.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationButton.tsx
@@ -24,17 +24,14 @@ export default function InsightVisualizationButton({
   return (
     <Tooltip title={isOpen ? 'Clear insight' : 'Generate AI insight'}>
       <IconButton
+        className='hide-on-screenshot remove-height-on-screenshot'
         onClick={() =>
           setCardInsightOpen((prev) => ({ ...prev, [openKey]: !isOpen }))
         }
         aria-label={isOpen ? 'Clear insight' : 'Generate insight'}
         size='small'
       >
-        {isOpen ? (
-          <DeleteForever className='hide-on-screenshot remove-height-on-screenshot' />
-        ) : (
-          <AutoAwesome className='text-base' />
-        )}
+        {isOpen ? <DeleteForever /> : <AutoAwesome className='text-base' />}
       </IconButton>
     </Tooltip>
   )


### PR DESCRIPTION
## Summary

- Closes #4735 -- `setIsExtremesMode(false)` was called inside `CardWrapper`'s render prop, updating URL state (via `jotai-location`) during the render phase. Fix: guard `displayData` inline with `isExtremesMode && dataForActiveDemographicGroup.length > 1`. The URL param is never cleared, so state -> county -> state navigation preserves extremes mode.
- Closes #4736 -- `AutoAwesome` (sparkle) icon was missing `hide-on-screenshot`, so it appeared in card image exports. Moved `hide-on-screenshot` and `remove-height-on-screenshot` to the `IconButton` wrapper, covering both icon states (sparkle and delete) uniformly.

## Root Cause / Motivation

The original `if (dataLength <= 1) setIsExtremesMode(false)` call during render was introduced to prevent `displayData` from using `highestValues.concat(lowestValues)` on a single-row dataset. But it was destructive: it cleared the URL param, so navigating state -> county -> state silently turned extremes off. `ExtremesListBox` already has its own `length > 1` guard, so applying the same guard to `displayData` is sufficient. No state mutation needed, no new component, and the param survives navigation.

## Test plan

- [x] `extremes` param is preserved when navigating to a county-level report (Playwright, dev server)
- [x] `extremes` param survives on a national-level report with many data rows (Playwright, dev server)
- [x] Back/forward navigation works correctly on a page with `extremes` param (Playwright, dev server)
- [x] Insight button wrapper has `hide-on-screenshot` on the `<button>` element (Playwright, dev server with `SHOW_INSIGHT_GENERATION=1`)
- [x] Insight button keeps `hide-on-screenshot` after toggling to delete (clear) state (Playwright, dev server)
- [x] tsc, Vitest (318 tests), Biome all pass (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
