### PR TITLE
fix(a11y): remove tabIndex=-1 from scroll targets; suppress dialog/drawer focus ring

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -66,7 +66,6 @@ function CardWrapper(props: {
     <div
       className={`relative m-2 flex justify-center rounded bg-alt-white p-3 shadow-raised ${props.className}`}
       style={{ minHeight: props.minHeight }}
-      tabIndex={-1}
     >
       <CircularProgress aria-label='loading' />
     </div>

--- a/frontend/src/reports/CustomUnknownMap.tsx
+++ b/frontend/src/reports/CustomUnknownMap.tsx
@@ -27,7 +27,6 @@ const CustomUnknownMap: React.FC<CustomUnknownMapProps> = ({
 
   return (
     <div
-      tabIndex={-1}
       className='w-full'
       id='unknown-demographic-map'
       style={{

--- a/frontend/src/reports/Report.tsx
+++ b/frontend/src/reports/Report.tsx
@@ -168,7 +168,6 @@ export function Report(props: ReportProps) {
               >
                 {/* 100k MAP CARD */}
                 <div
-                  tabIndex={-1}
                   id='rate-map'
                   // NOTE: use inline styles to set dynamic scroll margin based on MadLib header height
                   style={{
@@ -192,7 +191,6 @@ export function Report(props: ReportProps) {
                 {/* RATE TRENDS LINE CHART CARD */}
                 {rateMetricConfig?.timeSeriesCadence && (
                   <div
-                    tabIndex={-1}
                     className='w-full scroll-m-0 md:scroll-mt-24'
                     id='rates-over-time'
                   >
@@ -207,7 +205,6 @@ export function Report(props: ReportProps) {
 
                 {/* 100K BAR CHART CARD */}
                 <div
-                  tabIndex={-1}
                   className='w-full'
                   id='rate-chart'
                   style={{
@@ -224,7 +221,6 @@ export function Report(props: ReportProps) {
 
                 {/* UNKNOWNS MAP CARD */}
                 <div
-                  tabIndex={-1}
                   className='w-full'
                   id='unknown-demographic-map'
                   style={{
@@ -250,7 +246,6 @@ export function Report(props: ReportProps) {
                 {/* SHARE TRENDS LINE CHART CARD */}
                 {inequityOverTimeConfig?.timeSeriesCadence && (
                   <div
-                    tabIndex={-1}
                     id='inequities-over-time'
                     className='w-full scroll-m-0 md:scroll-mt-24'
                   >
@@ -267,7 +262,6 @@ export function Report(props: ReportProps) {
 
                 {/* DISPARITY BAR CHART COMPARE VS POPULATION */}
                 <div
-                  tabIndex={-1}
                   className='w-full'
                   id='population-vs-distribution'
                   style={{
@@ -288,7 +282,6 @@ export function Report(props: ReportProps) {
 
                 {/* DATA TABLE CARD */}
                 <div
-                  tabIndex={-1}
                   className='w-full'
                   id='data-table'
                   style={{
@@ -306,7 +299,6 @@ export function Report(props: ReportProps) {
                 {/* AGE ADJUSTED TABLE CARD */}
                 {resolvedConfig.metrics?.age_adjusted_ratio && (
                   <div
-                    tabIndex={-1}
                     className='w-full'
                     id='age-adjusted-ratios'
                     style={{

--- a/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
+++ b/frontend/src/reports/RowOfTwoOptionalMetrics.tsx
@@ -43,7 +43,6 @@ export default function RowOfTwoOptionalMetrics(
   return (
     <div id={`${props.id}-row`} className='flex w-full flex-wrap'>
       <div
-        tabIndex={-1}
         className={`w-full gap-2 lg:gap-3 ${props.hideSecondCard ? '' : 'md:w-1/2'}`}
         id={props.id}
         // NOTE: use inline styles to set dynamic scroll margin based on MadLib header height
@@ -63,7 +62,6 @@ export default function RowOfTwoOptionalMetrics(
       </div>
       {!props.hideSecondCard && (
         <div
-          tabIndex={-1}
           className='w-full md:w-1/2'
           id={`${props.id}2`}
           style={{ scrollMarginTop: props.headerScrollMargin }}

--- a/frontend/src/styles/theme/muiTheme.tsx
+++ b/frontend/src/styles/theme/muiTheme.tsx
@@ -79,6 +79,24 @@ const muiTheme = extendTheme({
         },
       },
     },
+    MuiDialog: {
+      styleOverrides: {
+        paper: {
+          '&:focus, &:focus-visible': {
+            outline: 'none',
+          },
+        },
+      },
+    },
+    MuiDrawer: {
+      styleOverrides: {
+        paper: {
+          '&:focus, &:focus-visible': {
+            outline: 'none',
+          },
+        },
+      },
+    },
     MuiInputBase: {
       styleOverrides: {
         sizeSmall: {


### PR DESCRIPTION
## Summary

- Remove `tabIndex={-1}` from scroll-target container divs in `CardWrapper`, `Report`, `RowOfTwoOptionalMetrics`, and `CustomUnknownMap`. These divs are observed by `IntersectionObserver` and scrolled to via `scrollIntoView()` — neither requires focusability. The attributes were leftover from an earlier approach and had no purpose except making non-interactive containers inadvertently focusable (and subject to a browser focus ring).
- Add `MuiDialog` and `MuiDrawer` paper overrides in `muiTheme.tsx` to suppress the blue focus outline. MUI's `FocusTrap` hard-codes `tabIndex: -1` on those paper elements internally and calls `element.focus()` programmatically when a modal opens. Modern browsers (Chrome 67+) classify programmatic `element.focus()` as `:focus-visible`, producing a visible ring even though no keyboard navigation occurred. A theme override on `:focus, :focus-visible` is the correct fix; the Gemini suggestion of `:focus:not(:focus-visible)` would not suppress a programmatic focus event.

## Root Cause / Motivation

Blue focus rings were appearing on non-interactive containers: card section wrappers, the `CardWrapper` loading placeholder, and Dialog/Drawer paper elements. The rings on the scroll-target divs existed because `tabIndex={-1}` made them focusable even though the scroll system (`useStepObserver`) only uses `scrollIntoView()` and never calls `.focus()`. The rings on dialog/drawer paper are a MUI internal behavior that requires a theme override to suppress.

## Test plan

- [x] Biome (`npm run cleanup`) — no changes
- [x] TypeScript (`npx tsc --noEmit`) — no errors
- [x] Playwright: report section divs (`#rate-map`, `#rate-chart`, `#data-table`) no longer have `tabindex="-1"` attribute
- [x] Playwright: table of contents sidebar sections remain attached in DOM after tabIndex removal
- [ ] Manual: open a Dialog/Drawer and verify no blue focus ring appears on the paper container
- [ ] Manual: tab through the explore data page and verify all interactive elements (buttons, links, inputs) still show focus rings normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)
