### PR TITLE
chore(skills): add /pre-pr; update /pr and /screenshot-pr

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -41,6 +41,7 @@ If `FORK_REMOTE` is empty, print a warning and ask the user to identify their fo
 Run Biome and tsc from `frontend/`. Biome auto-fixes files (CI runs `biome ci` which only reports); tsc is fast and catches type errors before the push:
 
 ```bash
+cd frontend
 npm run cleanup
 npx tsc --noEmit
 ```
@@ -164,8 +165,12 @@ cd frontend
 lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1
 npm run dev > /tmp/het-dev-server.log 2>&1 &
 DEV_PID=$!
-# Poll until the server responds rather than sleeping a fixed amount
-until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done
+# Poll until the server responds (timeout after 60s)
+TIMEOUT=60
+until curl -s http://localhost:3000 > /dev/null 2>&1; do
+  if [ $TIMEOUT -le 0 ]; then echo "Dev server failed to start" >&2; kill $DEV_PID 2>/dev/null; exit 1; fi
+  sleep 1; TIMEOUT=$((TIMEOUT - 1))
+done
 ```
 
 **Write a temp test file** at `frontend/playwright-tests/_pr_verify.spec.ts`. Each test should correspond to one checklist item — use a descriptive test name that matches the checklist wording so results map back clearly. Example structure:

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pr
-description: Run all frontend checks, update CLAUDE.md and README docs as needed, then update the open PR's title and description to accurately reflect the changes. Use when the user wants to close out a PR, verify it's ready for review, or run /pr.
+description: Run Biome auto-fix (cleanup only — tsc and Vitest run in CI, not locally), address any open review comments, update CLAUDE.md docs if stale, verify the test plan with Playwright against a local dev server (live backend + feature flags), then update the open PR title and description. Use when the user wants to close out a PR, verify it's ready for review, or run /pr.
 ---
 
 # /pr
 
-Run all checks, update docs, and polish the open PR so it's ready for human review.
+Polish the open PR so it's ready for human review: auto-fix formatting, address review comments, update docs, verify tests, and rewrite the PR description.
 
 The user may pass a PR number as an argument (e.g. `/pr 4764`). If none is given, detect the open PR from the current branch.
 
@@ -34,23 +34,31 @@ If `FORK_REMOTE` is empty, print a warning and ask the user to identify their fo
 
 ---
 
-## Step 2 — Run all checks
+## Step 2 — Run Biome auto-fix and type check
 
-Run these from `frontend/` in parallel — they are independent:
+`npm run test` (Vitest) runs in CI — do NOT run it locally here.
 
-```bash
-npx tsc --noEmit
-```
-
-```bash
-npm run test
-```
+Run Biome and tsc from `frontend/`. Biome auto-fixes files (CI runs `biome ci` which only reports); tsc is fast and catches type errors before the push:
 
 ```bash
 npm run cleanup
+npx tsc --noEmit
 ```
 
-If any check fails: report the failure with the full error, fix it, re-run, and only continue once all three pass. Stage and commit any files that `cleanup` modified automatically.
+If cleanup modifies any files, stage and commit them before the tsc run:
+
+```bash
+git add -p   # review what changed
+git commit -m "style: biome auto-fix"
+```
+
+If tsc exits non-zero: fix all errors before continuing — do not push with type errors.
+
+After both pass, push:
+
+```bash
+git push $FORK_REMOTE HEAD
+```
 
 ---
 
@@ -148,22 +156,24 @@ Remove or rewrite any items that refer to code that was removed or refactored.
 
 For every remaining unchecked item that describes a browser interaction (URL params, navigation behavior, UI state, link resolution), write and run a targeted Playwright test.
 
-**Start the preview server** (build first if no server is already running):
+**Start the dev server** (connects to the live dev GCP backend — no build step needed, data fetches work):
 
 ```bash
 cd frontend
-npm run build 2>&1 | tail -5
-npx vite preview --port 4173 &
-PREVIEW_PID=$!
-sleep 3  # wait for server to be ready
+# Kill any leftover dev server so we always land on port 3000
+lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1
+npm run dev > /tmp/het-dev-server.log 2>&1 &
+DEV_PID=$!
+# Poll until the server responds rather than sleeping a fixed amount
+until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done
 ```
 
 **Write a temp test file** at `frontend/playwright-tests/_pr_verify.spec.ts`. Each test should correspond to one checklist item — use a descriptive test name that matches the checklist wording so results map back clearly. Example structure:
 
 ```ts
-import { test, expect } from '@playwright/test'
+import { test, expect } from './utils/fixtures'
 
-const BASE = 'http://localhost:4173'
+const BASE = 'http://localhost:3000'
 
 test('atl and extremes cleared after mode switch', async ({ page }) => {
   await page.goto(`${BASE}/exploredata?mls=1.hiv-3.00&mlp=disparity&atl=true&extremes=true`)
@@ -173,11 +183,11 @@ test('atl and extremes cleared after mode switch', async ({ page }) => {
 })
 ```
 
-**Run only the temp file** against the `chromium` project:
+**Run only the temp file** against the `E2E_NIGHTLY` project (Chromium, no testMatch restriction):
 
 ```bash
 cd frontend
-npx playwright test playwright-tests/_pr_verify.spec.ts --project=chromium --reporter=line 2>&1
+E2E_BASE_URL=http://localhost:3000 npx playwright test playwright-tests/_pr_verify.spec.ts --project=E2E_NIGHTLY --reporter=line 2>&1
 ```
 
 **Map results back to checklist:**
@@ -188,7 +198,7 @@ npx playwright test playwright-tests/_pr_verify.spec.ts --project=chromium --rep
 **Clean up** after all tests run:
 
 ```bash
-kill $PREVIEW_PID 2>/dev/null
+kill $DEV_PID 2>/dev/null
 rm frontend/playwright-tests/_pr_verify.spec.ts
 ```
 

--- a/.claude/skills/pre-pr/SKILL.md
+++ b/.claude/skills/pre-pr/SKILL.md
@@ -186,13 +186,11 @@ Pre-PR #<N> is open as a draft at <url>.
 Next steps:
 1. Review the pre-PR diff — it should contain only the extracted files
 2. Mark it ready for review and merge it
-3. After it merges, update your feature branch:
+3. After it merges, pull main into your feature branch and resolve any conflicts:
 
    git fetch origin main
-   git rebase origin/main
-   git push <fork-remote> HEAD --force-with-lease
-
-The rebase will be clean because the feature branch already has those files reverted.
+   git merge origin/main
+   git push <fork-remote> HEAD
 ```
 
 ---

--- a/.claude/skills/pre-pr/SKILL.md
+++ b/.claude/skills/pre-pr/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: pre-pr
+description: Scan the current PR for tangential changes that can be extracted into a smaller prerequisite PR. Use when the user wants to split out unrelated cleanup, bug fixes, or refactors from a feature branch so reviewers see a focused diff.
+---
+
+# /pre-pr
+
+Scan the current PR's full diff for **topic-based clusters of file changes** that are unrelated to the PR's main purpose and safe to extract. Extraction works at the file level — not the commit level — so it handles changes spread across many commits or mixed with feature work. The extracted changes become a standalone pre-PR that merges first; the feature branch then has those files reverted back to main, keeping both diffs clean.
+
+---
+
+## Step 1 — Get PR context
+
+```bash
+gh pr view --json number,title,body,headRefName,baseRefName
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+GH_USER=$(gh api user -q .login)
+FORK_REMOTE=$(git remote -v | grep -i "github.com[/:]${GH_USER}/" | head -1 | awk '{print $1}')
+FEATURE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+If no open PR: print an error and stop.
+
+---
+
+## Step 2 — Read the full diff
+
+```bash
+git diff origin/main --name-only
+git diff origin/main --stat
+git diff origin/main
+```
+
+Read every changed file's diff in full. Also read the PR title and body to understand the stated purpose.
+
+---
+
+## Step 3 — Identify tangential file clusters
+
+Group the changed files by topic. For each group, ask:
+
+**1. Is this topic independent of the PR's stated purpose?**
+The changes should address something the PR wasn't trying to do. Strong candidates:
+- Removing dead code or unnecessary attributes noticed during the work (e.g. unused `tabIndex`, stale JSDoc)
+- Fixing an unrelated bug or UX issue discovered while working
+- Updating a skill, config, or doc file unrelated to the feature
+- Broad cleanup (removing a pattern across many files) that doesn't set up the feature
+
+**2. Can these files be reverted on the feature branch without breaking anything?**
+Read the feature branch's remaining changed files. If reverting the tangential files to main leaves the feature branch compiling and logically correct — extraction is safe. If the feature code imports or depends on the tangential changes, it is NOT safe to extract.
+
+**3. Does the extracted state apply cleanly to main?**
+The tangential files' current state on the feature branch must be a valid, standalone improvement over main — not a halfway step that only makes sense combined with other feature changes.
+
+**Mixed files**: if a single file contains both tangential changes (lines A-B) and feature changes (lines C-D), it cannot be cleanly extracted at the file level. Flag it and skip it — do not attempt to construct a partial patch.
+
+---
+
+## Step 4 — Present findings
+
+Print a clear, scannable summary. For each candidate cluster, explain WHY it's tangential in one sentence, list the files, and confirm that reverting them on the feature branch is safe.
+
+```
+## Tangential change clusters found
+
+### 1. <short cluster name>
+Why: <one sentence — what this is and why it's unrelated to the PR's purpose>
+Files:
+  - path/to/file1.tsx
+  - path/to/file2.tsx
+Safe to extract: yes — reverting these files on the feature branch leaves the remaining diff intact and compilable.
+
+### 2. <short cluster name>
+...
+
+## Cannot extract (mixed files)
+- path/to/mixed.tsx — contains both <tangential change> and <feature change> in the same file
+
+## Nothing found
+(only if truly nothing qualifies — explain why)
+```
+
+If nothing qualifies, say so directly and explain why each changed file area is too coupled to the PR's purpose.
+
+---
+
+## Step 5 — Confirm with user
+
+Summarize the proposed extraction and ask for confirmation before touching any branches:
+
+> "I found [N] extractable cluster(s). I'll:
+> 1. Create `<pre-branch>` from main and apply the tangential file versions from your feature branch
+> 2. Commit, push, and open a draft pre-PR
+> 3. Revert those same files on `<feature-branch>` back to main and commit
+>
+> Both branches will compile cleanly. Proceed?"
+
+Wait for explicit confirmation. Respect any adjustments to which clusters to extract.
+
+---
+
+## Step 6 — Create the pre-PR branch
+
+Derive a branch name from the cluster description: slugify it, prefix with `refactor/`, `fix/`, or `chore/` based on the nature of the changes.
+
+```bash
+PRE_BRANCH="<prefix>/<slug>"
+
+# Branch from main — never from the feature branch
+git fetch origin main
+git checkout -b $PRE_BRANCH origin/main
+
+# Pull the tangential file versions from the feature branch
+git checkout $FEATURE_BRANCH -- path/to/file1.tsx path/to/file2.tsx ...
+
+# Commit
+git commit -m "<short description of what the extracted change does>"
+
+# Push to fork
+git push $FORK_REMOTE $PRE_BRANCH
+
+# Return to feature branch
+git checkout $FEATURE_BRANCH
+```
+
+If any step fails: stop, explain what went wrong, and do not proceed to revert the feature branch.
+
+---
+
+## Step 7 — Revert the extracted files on the feature branch
+
+Now that the pre-PR branch holds those changes, revert the same files on the feature branch back to their state on main:
+
+```bash
+git checkout origin/main -- path/to/file1.tsx path/to/file2.tsx ...
+git commit -m "revert <description> to main — extracted to pre-PR #<pre-pr-number>"
+git push $FORK_REMOTE HEAD
+```
+
+After this commit, the feature branch diff no longer includes those files. The two PRs are cleanly separated.
+
+If the feature branch no longer compiles after the revert: something was coupled that wasn't caught in Step 3. Stop, explain the issue, and undo the revert commit with `git revert HEAD`. Do not push a broken state.
+
+---
+
+## Step 8 — Open the pre-PR
+
+```bash
+gh pr create \
+  --base main \
+  --head "${GH_USER}:${PRE_BRANCH}" \
+  --draft \
+  --title "<concise title under 60 chars>" \
+  --body-file /tmp/pre-pr-body.md
+```
+
+Body template (write to `/tmp/pre-pr-body.md` first):
+
+```markdown
+## Summary
+
+- <bullet: what each file change does>
+
+## Why a separate PR
+
+<One sentence: why these changes are independent of the parent PR's purpose.>
+
+## Parent PR
+
+Extracted from #<number>. This should merge first; the parent PR already has these files reverted to main.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Open as **draft** so the user can verify before requesting review.
+
+---
+
+## Step 9 — Advise on next steps
+
+Print:
+
+```
+Pre-PR #<N> is open as a draft at <url>.
+
+Next steps:
+1. Review the pre-PR diff — it should contain only the extracted files
+2. Mark it ready for review and merge it
+3. After it merges, update your feature branch:
+
+   git fetch origin main
+   git rebase origin/main
+   git push <fork-remote> HEAD --force-with-lease
+
+The rebase will be clean because the feature branch already has those files reverted.
+```
+
+---
+
+## Notes
+
+- **File-level extraction, not commit-level.** This handles changes spread across multiple commits or mixed with feature work. It copies the file's final state from the feature branch, not a diff of one commit.
+- **Compilation safety is the hard gate.** If reverting the extracted files would break the feature branch, do not extract. Flag the coupling and move on.
+- **Never push a broken state.** If anything goes wrong during the revert step, undo immediately and explain.
+- **Draft by default.** Pre-PRs open as draft so the user can sanity-check before review.
+- **Topical, not cosmetic.** The bar for extraction is "meaningfully independent" — not "happened to touch a different file." Refactors that set up the feature (new shared components, type changes that feature code imports) stay in the main PR.

--- a/.claude/skills/pre-pr/SKILL.md
+++ b/.claude/skills/pre-pr/SKILL.md
@@ -106,6 +106,11 @@ Derive a branch name from the cluster description: slugify it, prefix with `refa
 ```bash
 PRE_BRANCH="<prefix>/<slug>"
 
+# Abort if there are uncommitted changes — they would bleed into the new branch
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: uncommitted changes present. Commit or stash before extracting." >&2; exit 1
+fi
+
 # Branch from main — never from the feature branch
 git fetch origin main
 git checkout -b $PRE_BRANCH origin/main
@@ -132,7 +137,13 @@ If any step fails: stop, explain what went wrong, and do not proceed to revert t
 Now that the pre-PR branch holds those changes, revert the same files on the feature branch back to their state on main:
 
 ```bash
-git checkout origin/main -- path/to/file1.tsx path/to/file2.tsx ...
+for file in path/to/file1.tsx path/to/file2.tsx ...; do
+  if git show origin/main:"$file" > /dev/null 2>&1; then
+    git checkout origin/main -- "$file"   # file existed on main: restore it
+  else
+    git rm -f "$file"                     # file is new: remove it entirely
+  fi
+done
 git commit -m "revert <description> to main — extracted to pre-PR #<pre-pr-number>"
 git push $FORK_REMOTE HEAD
 ```

--- a/.claude/skills/screenshot-pr/SKILL.md
+++ b/.claude/skills/screenshot-pr/SKILL.md
@@ -82,9 +82,14 @@ If not `200`: start it automatically:
 
 ```bash
 lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1
+cd frontend
 npm run dev > /tmp/het-dev-server.log 2>&1 &
 DEV_PID=$!
-until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done
+TIMEOUT=60
+until curl -s http://localhost:3000 > /dev/null 2>&1; do
+  if [ $TIMEOUT -le 0 ]; then echo "Dev server failed to start" >&2; kill $DEV_PID 2>/dev/null; exit 1; fi
+  sleep 1; TIMEOUT=$((TIMEOUT - 1))
+done
 echo "Server ready"
 ```
 

--- a/.claude/skills/screenshot-pr/SKILL.md
+++ b/.claude/skills/screenshot-pr/SKILL.md
@@ -5,7 +5,7 @@ description: Take responsive screenshots of the current branch's frontend work a
 
 # /screenshot-pr
 
-Take responsive screenshots of the current branch's frontend work and embed them into the open PR's `## Screenshots` section. Screenshots are uploaded to a public GCS bucket and linked as markdown images.
+Take responsive screenshots of the current branch's frontend work — both page-level views and open dialogs/drawers — and embed them into the open PR's `## Screenshots` section. Screenshots are uploaded to a public GCS bucket and linked as markdown images. Re-running this skill always **replaces** the existing Screenshots section with fresh images.
 
 The user may pass explicit routes as arguments (e.g. `/screenshot-pr /datacatalog /exploredata`). If no routes are given, infer them from changed files and always confirm before proceeding.
 
@@ -25,17 +25,17 @@ Extract: `number` (PR number), `headRefName` (branch name), `body` (current PR b
 
 ## Step 2 — Derive slugs
 
-- **Feature slug**: take the branch name, strip a leading `feature/` prefix, replace `/` and non-alphanumeric characters with `-`, lowercase, collapse consecutive `-`.
-  - Example: `feature/datacatalog-topic-tags` → `datacatalog-topic-tags`
+- **Feature slug**: take the branch name, strip a leading `feat/`, `fix/`, `feature/`, or `chore/` prefix, replace `/` and non-alphanumeric characters with `-`, lowercase, collapse consecutive `-`.
+  - Example: `feat/mobile-bottom-sheet-and-e2e-matrix` → `mobile-bottom-sheet-and-e2e-matrix`
 - **Output dir**: `/tmp/het-screenshots/pr-{number}/{feature-slug}`
 - **GCS upload prefix**: `pr-{number}/{feature-slug}/`
 - **Public URL base**: `https://storage.googleapis.com/het-pr-screenshots/pr-{number}/{feature-slug}/`
 
 ---
 
-## Step 3 — Determine routes
+## Step 3 — Determine routes and dialogs
 
-**If the user passed routes as arguments** (e.g. `/screenshot-pr /datacatalog`): use those routes. Skip inference. Still confirm briefly ("I'll screenshot `/datacatalog` — proceed?") before continuing.
+**If the user passed routes as arguments** (e.g. `/screenshot-pr /datacatalog`): use those routes. Skip inference.
 
 **If no routes were given**: infer from changed files:
 
@@ -56,44 +56,144 @@ Apply these heuristics (first match wins per file; collect all unique routes):
 | `src/styles/**` or design tokens (`tokens/*.json`) | `/` |
 | `src/data/providers/**`, `src/data/config/**` | `/exploredata` |
 
-If multiple routes are inferred, list them all.
+**Dialog detection**: also scan the changed files for modal/dialog components. If any of the following patterns appear in the diff, add dialog screenshots too (see Step 5b):
 
-If the changed files don't map clearly to any route (e.g. pure utility/infra changes), explain this to the user and ask them to specify routes manually.
+| Changed file pattern | Dialogs to screenshot |
+|---|---|
+| `*Modal.tsx` or `*Dialog.tsx` or `HetResponsiveDialog.tsx` | Detect URL-param key from the file name or by grepping for `useParamState` calls; ask the user to confirm which ones to include |
 
-**Always ask for confirmation before proceeding**, even when inference is confident. Show the inferred routes and the reasoning, then wait for the user to confirm or adjust.
+If the changed files contain modal components, list the detected dialogs and ask for confirmation in the same message as the page routes.
+
+If the changed files don't map clearly to any route, explain this and ask the user to specify routes manually.
+
+**Always confirm before proceeding** — show inferred routes (and dialogs, if any) and wait for user confirmation.
 
 ---
 
-## Step 4 — Check local dev server
+## Step 4 — Ensure dev server is running
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
 ```
 
-If the result is not `200`: tell the user to start the dev server first:
-> "The dev server isn't running. Start it with `npm run localhost` (or `npm run start:deploy_preview`) from the `frontend/` directory, then re-run `/screenshot-pr`."
+If the result is `200`: server is ready, continue.
 
-Stop here and wait. Do not proceed without a running server.
+If not `200`: start it automatically:
+
+```bash
+lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1
+npm run dev > /tmp/het-dev-server.log 2>&1 &
+DEV_PID=$!
+until curl -s http://localhost:3000 > /dev/null 2>&1; do sleep 1; done
+echo "Server ready"
+```
+
+Track `$DEV_PID` so you can kill it in Step 9 cleanup.
 
 ---
 
-## Step 5 — Run the screenshot script
+## Step 5a — Page-level screenshots
 
-Build the command with one `--routes` flag per route:
+For each confirmed route, run the screenshot script from the `frontend/` directory:
 
 ```bash
-cd frontend && npm run screenshots -- \
+cd /path/to/frontend  # use the absolute path to frontend/
+npx tsx scripts/take-screenshots.ts \
   --base-url "http://localhost:3000" \
   --output-dir "/tmp/het-screenshots/pr-{number}/{feature-slug}" \
   --routes /route1 \
   --routes /route2
 ```
 
-(Add one `--routes <path>` flag for each confirmed route.)
+Run via `npx tsx /absolute/path/to/frontend/scripts/take-screenshots.ts` — do NOT use `cd frontend &&` (shell working directory may already be inside `frontend/`). Use the absolute path.
 
 The script saves files named `{page-slug}-{width}px.png` in the output dir:
 - `/` → `home-375px.png`, `home-768px.png`, `home-1280px.png`
 - `/datacatalog` → `datacatalog-375px.png`, etc.
+
+---
+
+## Step 5b — Dialog/drawer screenshots (when modals changed)
+
+When the PR includes changed modal or dialog components, write a temporary Playwright script to capture each dialog open at each viewport. Write it to `frontend/scripts/_dialog-screenshots.ts` (with the leading `_` so it's clearly temporary), then run it with an absolute path.
+
+**Viewport heights:** use `844` for mobile, `1024` for tablet, `900` for desktop.
+
+**Key considerations:**
+- Some modals only mount below a breakpoint (e.g. `InsightReportModal` uses `!isDesktopLayout` which is `md` = 900px, so it never mounts at 1280px). Add a `maxWidth` guard per dialog and log a skip message rather than failing.
+- Wait for `[role="dialog"]` to appear (up to 15s) before screenshotting. If it never appears, log a warning and move on.
+- Disable animations with an injected style tag before screenshotting.
+- Use `{ waitUntil: 'networkidle' }` on `page.goto` since the dev server fetches real data from GCP.
+- Create a fresh browser context per dialog+viewport so sessions don't bleed.
+- Use `fullPage: false` to capture only the visible viewport (dialog + dimmed background).
+
+**Example script structure** (adapt params/dialogs as needed):
+
+```ts
+import { chromium } from '@playwright/test'
+import { mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const BASE = 'http://localhost:3000'
+const OUT  = '/tmp/het-screenshots/pr-{number}/{feature-slug}'
+const HET_PARAMS = 'mls=1.hiv-3.00&mlp=disparity'  // adjust per topic
+
+const VIEWPORTS = [
+  { width: 375,  height: 844,  label: 'mobile'  },
+  { width: 768,  height: 1024, label: 'tablet'  },
+  { width: 1280, height: 900,  label: 'desktop' },
+]
+
+const DIALOGS = [
+  { name: 'topic-info',     param: 'topic-info',    maxWidth: Infinity },
+  { name: 'chlp-maps',      param: 'chlp-maps',     maxWidth: Infinity },
+  { name: 'report-insight', param: 'report-insight', maxWidth: 899 },  // mobile/tablet only
+  { name: 'multiple-maps',  param: 'multiple-maps', maxWidth: Infinity },
+  { name: 'vote-dot-org',   param: 'vote-dot-org',  maxWidth: Infinity },
+]
+
+mkdirSync(OUT, { recursive: true })
+const browser = await chromium.launch()
+
+for (const dialog of DIALOGS) {
+  for (const vp of VIEWPORTS) {
+    if (vp.width > dialog.maxWidth) {
+      console.info(`  [skip] ${dialog.name} @ ${vp.width}px (not mounted)`)
+      continue
+    }
+    const ctx  = await browser.newContext({ viewport: { width: vp.width, height: vp.height } })
+    const page = await ctx.newPage()
+    await page.goto(`${BASE}/exploredata?${HET_PARAMS}&${dialog.param}=true`, { waitUntil: 'networkidle' })
+    await page.addStyleTag({ content: '*, *::before, *::after { animation: none !important; transition: none !important; }' })
+    try {
+      await page.waitForSelector('[role="dialog"]', { timeout: 15000 })
+      await page.waitForTimeout(600)
+    } catch {
+      console.warn(`  [warn] no dialog: ${dialog.name} @ ${vp.width}px`)
+      await ctx.close()
+      continue
+    }
+    const filename = `dialog-${dialog.name}-${vp.label}.png`
+    await page.screenshot({ fullPage: false, path: join(OUT, filename) })
+    console.info(`  [${vp.label}] ${filename}`)
+    await ctx.close()
+  }
+}
+
+await browser.close()
+```
+
+Run it:
+
+```bash
+npx tsx /absolute/path/to/frontend/scripts/_dialog-screenshots.ts
+```
+
+After all screenshots are captured, delete the temp script:
+
+```bash
+rm /absolute/path/to/frontend/scripts/_dialog-screenshots.ts
+```
 
 ---
 
@@ -107,92 +207,95 @@ gsutil -m cp \
 
 Public read is granted at the bucket level via Terraform IAM (`allUsers:objectViewer`), so no per-object ACL flag is needed.
 
-If this fails with an authentication error: tell the user to run `gcloud auth application-default login` and retry. Write access requires an authenticated `msm.edu` Google account.
+After upload, verify the count:
 
-If `het-pr-screenshots` doesn't exist yet: it is provisioned via Terraform. The user should push to `infra-test` and trigger the deploy workflow, or run `terraform apply` locally against `het-infra-test-05` using the config in `config/`.
+```bash
+gsutil ls gs://het-pr-screenshots/pr-{number}/{feature-slug}/*.png | wc -l
+```
+
+If the count is less than the number of files captured, upload missing files individually with `gsutil cp`.
+
+If this fails with an authentication error: tell the user to run `gcloud auth application-default login` and retry.
 
 ---
 
 ## Step 7 — Build the Screenshots markdown
 
-For each route, derive a human-readable page name:
-- `/` → `Home`
-- `/exploredata` → `Explore Data`
-- `/datacatalog` → `Data Catalog`
-- `/aboutus` → `About Us`
-- General rule: split on `-` and `/`, title-case each word, join with spaces.
+### Page-level screenshots
 
-The public URL for each file: `https://storage.googleapis.com/het-pr-screenshots/pr-{number}/{feature-slug}/{page-slug}-{width}px.png`
-
-Build the section as stacked breakpoints — one block per route, separated by `---`:
+For each page route, derive a human-readable name (split on `-`/`/`, title-case, join with spaces). Group by page:
 
 ```markdown
-## Screenshots
-
 ### {Page Name}
 
-**Mobile — 375px**
-![{Page Name} mobile screenshot]({url}/{slug}-375px.png)
+**Mobile (375px)**
+![{Page Name} mobile]({url}/{slug}-375px.png)
 
-**Tablet — 768px**
-![{Page Name} tablet screenshot]({url}/{slug}-768px.png)
+**Tablet (768px)**
+![{Page Name} tablet]({url}/{slug}-768px.png)
 
-**Desktop — 1280px**
-![{Page Name} desktop screenshot]({url}/{slug}-1280px.png)
-
----
-
-### {Next Page Name}
-
-**Mobile — 375px**
-...
+**Desktop (1280px)**
+![{Page Name} desktop]({url}/{slug}-1280px.png)
 ```
 
-(Omit the trailing `---` after the last route.)
+### Dialog screenshots
+
+For each dialog, group by modal name. Note which breakpoints show a drawer vs a dialog. If a modal is mobile/tablet-only, add a note explaining why (e.g. "*(Desktop: rendered inline in sidebar)*"):
+
+```markdown
+### {Modal Name}
+
+**Mobile (375px) — bottom-sheet drawer**
+![{name} mobile]({url}/dialog-{name}-mobile.png)
+
+**Tablet (768px) — bottom-sheet drawer**
+![{name} tablet]({url}/dialog-{name}-tablet.png)
+
+**Desktop (1280px) — dialog**
+![{name} desktop]({url}/dialog-{name}-desktop.png)
+```
+
+Separate each modal block with `---`. Omit the trailing `---` after the last block.
 
 ---
 
-## Step 8 — Update the PR body
+## Step 8 — Update the PR body (always replaces)
 
-1. Get the current body:
-   ```bash
-   gh pr view --json body --jq '.body'
-   ```
+1. Get the current body (already fetched in Step 1, or re-fetch if needed).
 
 2. Locate the `## Screenshots` section in the body:
-   - **Found**: replace everything from `## Screenshots` up to (but not including) the next `## ` heading, or to the end of the string if there's no next `##` heading.
-   - **Not found**: append the full section (including the `## Screenshots` heading) to the end of the body, separated by a blank line. This ensures a subsequent re-run can locate the section to replace rather than appending a second copy.
+   - **Found**: replace everything from `## Screenshots` to the end of the string (Screenshots is always the last section). Write the full updated body to `/tmp/het-screenshots/pr-{number}/body.md` and apply it.
+   - **Not found**: append `\n\n## Screenshots\n\n{content}` to the end of the body.
 
-3. Write the updated body to a temp file:
-   ```bash
-   # (Write new body content to this path)
-   /tmp/het-screenshots/pr-{number}/body.md
-   ```
+3. Write to temp file and apply:
 
-4. Apply the update:
-   ```bash
-   gh pr edit --body-file /tmp/het-screenshots/pr-{number}/body.md
-   ```
-   Using `--body-file` avoids shell quoting issues with long markdown content.
+```bash
+gh pr edit {number} --body-file /tmp/het-screenshots/pr-{number}/body.md
+```
+
+Using `--body-file` avoids shell quoting issues with long markdown content.
 
 ---
 
 ## Step 9 — Cleanup and confirm
 
 ```bash
+kill $DEV_PID 2>/dev/null   # only if we started the server in Step 4
 rm -rf /tmp/het-screenshots/pr-{number}
 ```
 
 Print a summary:
 > "✓ {count} screenshots embedded in PR #{number}: {PR URL}"
 
-List the public URLs of the uploaded images so the user can verify them in a browser before pushing.
+List the public URLs so the user can verify them in a browser.
 
 ---
 
 ## Notes
 
-- **GCS bucket**: `het-pr-screenshots` — public read, 90-day auto-delete lifecycle. A GitHub Actions workflow (`cleanup-pr-screenshots.yml`) also deletes the folder when the PR closes.
-- **Breakpoints**: 375px (mobile), 768px (tablet), 1280px (desktop) — matches the project's `sm`, `smplus`, and `lg` design tokens.
-- **Script location**: `frontend/scripts/take-screenshots.ts` — run via `npm run screenshots` from `frontend/`.
+- **GCS bucket**: `het-pr-screenshots` — public read, 90-day auto-delete lifecycle.
+- **Breakpoints**: 375px (mobile), 768px (tablet), 1280px (desktop).
+- **Page screenshot script**: `frontend/scripts/take-screenshots.ts` — always run via `npx tsx /absolute/path` to avoid CJS/ESM issues.
+- **Dialog screenshots**: write a fresh `_dialog-screenshots.ts` script each time; delete it after use.
+- **Re-running**: always replaces the `## Screenshots` section — never appends a second copy.
 - **If Playwright browsers aren't installed**: run `npx playwright install chromium` from `frontend/`.


### PR DESCRIPTION
## Summary

- Add `/pre-pr` skill — scans a PR diff for topic-based clusters of tangential file changes, extracts them to a standalone pre-PR branch from main, reverts those files on the feature branch, and opens a draft PR. Handles newly-created files (uses `git rm` for files not on main), guards against uncommitted-change bleed with a clean workdir check, and advises `git merge` (not rebase) after the pre-PR lands.
- Update `/pr` skill: Step 2 now runs `cd frontend && npm run cleanup` then `npx tsc --noEmit` sequentially with a push after both pass; drops Vitest (CI only); switches Playwright verification from `vite preview` to the dev server on port 3000 and from the `chromium` project to `E2E_NIGHTLY`. Dev server poll has a 60-second timeout.
- Update `/screenshot-pr` skill: handles `feat/`/`fix/`/`chore/` slug prefixes; adds Step 5b for dialog/drawer screenshots via a temporary Playwright script; auto-starts dev server (with `cd frontend` and 60-second timeout) if not running; always replaces the `## Screenshots` section rather than appending.

## Why a separate PR

These are dev-tooling documentation changes to Claude Code skills — independent of the mobile bottom-sheet dialog feature in the parent PR (#4773).

## Parent PR

Extracted from #4773. This should merge first; the parent PR already has these files reverted to main.

## Test plan

- [x] All skill prose and code blocks reviewed against actual usage in prior sessions
- [x] `cd frontend` present in Step 2 of `/pr` and Step 4 auto-start of `/screenshot-pr`
- [x] Dev server poll loops have 60-second timeout with error exit in both `/pr` and `/screenshot-pr`
- [x] `/pre-pr` Step 6 aborts on uncommitted changes before creating the branch
- [x] `/pre-pr` Step 7 uses `git show origin/main:$file` to detect new files and falls back to `git rm`
- [x] `/pre-pr` Step 9 advises `git merge origin/main` (not rebase) after the pre-PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
