### PR TITLE
fix(chlp): improve banner button and modal attribution

### DIFF
--- a/frontend/src/pages/ExploreData/CHLPMapsModal.tsx
+++ b/frontend/src/pages/ExploreData/CHLPMapsModal.tsx
@@ -85,14 +85,17 @@ export default function CHLPMapsModal() {
       </div>
 
       <div className='mb-6 text-center'>
-        <a
-          href='https://www.hivlawandpolicy.org/maps'
-          target='_blank'
-          rel='noopener noreferrer'
-          className='rounded px-4 py-2 text-dark-green hover:underline'
-        >
-          Learn more at hivlawandpolicy.org
-        </a>
+        <p>Maps from Center for HIV Law and Policy (CHLP)</p>
+        <p>
+          <a
+            href='https://www.hivlawandpolicy.org/maps'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='rounded px-4 py-2 text-dark-green hover:underline'
+          >
+            Learn more at hivlawandpolicy.org →
+          </a>
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -1,12 +1,10 @@
 import HetLinkButton from '../../styles/HetComponents/HetLinkButton'
 import HetNotice from '../../styles/HetComponents/HetNotice'
-import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
 import { useParamState } from '../../utils/hooks/useParamState'
 import { CHLP_MAPS_PARAM_KEY } from '../../utils/urlutils'
 
 export default function CHLPMapsBanner() {
   const [_, setModalIsOpen] = useParamState(CHLP_MAPS_PARAM_KEY)
-  const isSmAndUp = useIsBreakpointAndUp('sm')
 
   return (
     <HetNotice
@@ -21,7 +19,11 @@ export default function CHLPMapsBanner() {
         className='block py-1 font-semibold text-alt-green text-smallest hover:translate-x-1 hover:transition-transform hover:duration-300'
         onClick={() => setModalIsOpen(true)}
       >
-        Open {isSmAndUp ? 'Center for HIV Law and Policy (CHLP)' : 'CHLP'} Maps
+        Open <span className='sm:hidden'>CHLP</span>
+        <span className='hidden sm:inline'>
+          Center for HIV Law and Policy (CHLP)
+        </span>{' '}
+        Maps
       </HetLinkButton>
     </HetNotice>
   )

--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -1,10 +1,12 @@
 import HetLinkButton from '../../styles/HetComponents/HetLinkButton'
 import HetNotice from '../../styles/HetComponents/HetNotice'
+import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
 import { useParamState } from '../../utils/hooks/useParamState'
 import { CHLP_MAPS_PARAM_KEY } from '../../utils/urlutils'
 
 export default function CHLPMapsBanner() {
   const [_, setModalIsOpen] = useParamState(CHLP_MAPS_PARAM_KEY)
+  const isSmAndUp = useIsBreakpointAndUp('sm')
 
   return (
     <HetNotice
@@ -16,15 +18,10 @@ export default function CHLPMapsBanner() {
       not criminalized or criminalized less severely for people not living with
       HIV.
       <HetLinkButton
-        className='font-semibold text-alt-black hover:translate-x-1 hover:transition-transform hover:duration-300'
+        className='block py-1 font-semibold text-alt-green text-smallest hover:translate-x-1 hover:transition-transform hover:duration-300'
         onClick={() => setModalIsOpen(true)}
       >
-        {/* Mobile */}
-        <span className='text-smallest sm:hidden'>View CHLP maps →</span>
-        {/* Tablet/Desktop */}
-        <span className='hidden sm:inline'>
-          → View Center for HIV Law and Policy (CHLP) Maps
-        </span>
+        Open {isSmAndUp ? 'Center for HIV Law and Policy (CHLP)' : 'CHLP'} Maps
       </HetLinkButton>
     </HetNotice>
   )


### PR DESCRIPTION
## Summary

- **CHLPMapsBanner:** Replaces JS-based `useIsBreakpointAndUp` hook with Tailwind breakpoint spans (`sm:hidden` / `hidden sm:inline`) for mobile vs. desktop label; changes button color from `text-alt-black` to `text-alt-green`; adds `block py-1` spacing
- **CHLPMapsModal:** Adds an explicit "Maps from Center for HIV Law and Policy (CHLP)" attribution paragraph above the learn-more link; appends `→` to the link label

## Merge order

**Merge this PR BEFORE the parent tooltip refactor PR.**
The parent branch (`refactor/unified-chart-tooltips`) has these files reverted to main; once this lands, rebase or merge main into the parent branch to restore them.

## Test plan

- [x] Banner renders short label ("CHLP") on mobile viewport (Playwright)
- [x] Banner long label span is present in DOM on desktop viewport (Playwright)
- [x] Modal opens from banner button click (Playwright)
- [x] Modal shows "Maps from Center for HIV Law and Policy (CHLP)" attribution paragraph (Playwright)
- [x] Modal shows "Learn more at hivlawandpolicy.org" link (Playwright)
- [x] TypeScript — no errors (`tsc --noEmit`)
- [x] Biome formatting — clean (`npm run cleanup`)

## Screenshots

### HIV Report Page (banner visible)

**Mobile (375px)**
![HIV report mobile](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/exploredata-375px.png?v=1780940414)

**Tablet (768px)**
![HIV report tablet](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/exploredata-768px.png?v=1780940414)

**Desktop (1280px)**
![HIV report desktop](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/exploredata-1280px.png?v=1780940414)

---

### CHLP Maps Modal

**Mobile (375px)**
![CHLP modal mobile](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/dialog-chlp-maps-mobile.png?v=1780940414)

**Tablet (768px)**
![CHLP modal tablet](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/dialog-chlp-maps-tablet.png?v=1780940414)

**Desktop (1280px)**
![CHLP modal desktop](https://storage.googleapis.com/het-pr-screenshots/pr-4786/chlp-banner-modal-tweaks/dialog-chlp-maps-desktop.png?v=1780940414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
