### PR TITLE
fix(chlp): bold link spans and modal height overflow

### DIFF
--- a/frontend/src/pages/ExploreData/CHLPMapsModal.tsx
+++ b/frontend/src/pages/ExploreData/CHLPMapsModal.tsx
@@ -49,7 +49,7 @@ export default function CHLPMapsModal() {
 
   const galleryContent = (
     <div className='flex h-full w-full flex-col items-center justify-center'>
-      <div className='flex w-full grow flex-col items-center justify-center py-8'>
+      <div className='flex w-full grow flex-col items-center justify-center py-4'>
         <div className='relative flex w-full items-center justify-center'>
           <img
             src={mapData[currentMapIndex].imageUrl}
@@ -84,7 +84,7 @@ export default function CHLPMapsModal() {
         </div>
       </div>
 
-      <div className='mb-6 text-center'>
+      <div className='mb-3 text-center'>
         <p>Maps from Center for HIV Law and Policy (CHLP)</p>
         <p>
           <a

--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -19,8 +19,8 @@ export default function CHLPMapsBanner() {
         className='block py-1 font-semibold text-alt-green text-smallest hover:translate-x-1 hover:transition-transform hover:duration-300'
         onClick={() => setModalIsOpen(true)}
       >
-        Open <span className='sm:hidden'>CHLP</span>
-        <span className='hidden sm:inline'>
+        Open <span className='font-semibold sm:hidden'>CHLP</span>
+        <span className='hidden font-semibold sm:inline'>
           Center for HIV Law and Policy (CHLP)
         </span>{' '}
         Maps


### PR DESCRIPTION
## Summary

- Fix span font-weight not inheriting in CHLP banner link (MUI resets font-weight on children; each span now has `font-semibold` explicitly)
- Reduce vertical padding in CHLP modal to prevent bottom attribution link from overflowing off-screen on desktop

## Merge order

**Merge this PR AFTER #4786.**
These are visual polish fixes for the CHLP banner and modal introduced in #4786. #4786 is already merged; this PR applies cleanly on top of main.

## Parent PR

Follow-up to #4786 (CHLP banner + modal, already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)