### PR TITLE
fix: card export bgcolor white, HIV prevalence label

### DIFF
--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -190,7 +190,7 @@ export const HIV_DISEASE_METRICS: DataTypeConfig[] = [
         type: 'per100k',
         rateNumeratorMetric: {
           metricId: 'hiv_prevalence',
-          shortLabel: 'Individuals living with HIV',
+          shortLabel: 'Living with HIV',
           chartTitle: '',
           type: 'count',
         },

--- a/frontend/src/utils/cardImageExportUtils.ts
+++ b/frontend/src/utils/cardImageExportUtils.ts
@@ -8,6 +8,7 @@ type DomToImage = typeof domToImageMore
 
 import { CITATION_APA } from '../cards/ui/SourcesHelpers'
 import { LEGEND_ITEMS_BOX_CLASS } from '../charts/choroplethMap/RateMapLegend'
+import { colors } from '../styles/tokens/colors'
 import type { ScrollableHashId } from './hooks/useStepObserver'
 
 // Constants
@@ -34,6 +35,7 @@ interface DomToImageOptions {
   filter: (node: HTMLElement) => boolean
   width?: number
   height?: number
+  bgcolor?: string
 }
 
 // Utility functions
@@ -337,6 +339,7 @@ async function captureAndSaveImage(
       filter: hideElementsForScreenshot,
       width: width,
       height: height,
+      bgcolor: colors.altWhite,
     }
 
     // Get all node elements including the card node itself


### PR DESCRIPTION
## Summary

- **Card export dark mode fix:** pass `bgcolor: colors.altWhite` to `dom-to-image-more` so exported card images always have a white background regardless of OS dark mode — previously the transparent canvas rendered black in dark mode
- **HIV prevalence label:** shorten `rateNumeratorMetric.shortLabel` from `"Individuals living with HIV"` to `"Living with HIV"` for better fit in constrained chart label space

## Root Cause / Motivation

`dom-to-image-more` respects a `bgcolor` option; without it the captured canvas is transparent, which browsers composite as white in light mode and black in dark mode. The fix passes the design token white explicitly so the export is always light regardless of user preference.

## Test plan

- [x] TypeScript passes (`npx tsc --noEmit`)
- [x] Biome passes (`npm run cleanup`)
- [ ] Card export: use "Copy screenshot" on a card while OS is in dark mode — verify the clipboard image has a white background
- [ ] HIV prevalence chart: confirm "Living with HIV" label renders without truncation in the rate bar chart numerator chip

## Merge order

**Merge this PR BEFORE #4778.**
The parent PR has these files reverted to main; once this lands, merge main into the parent branch to restore them.

## Parent PR

Extracted from #4778 as a prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
