### PR TITLE
fix: sync ErrorBoundaryDropParams import; increase LRU cache limits

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import {
   Routes,
   useLocation,
 } from 'react-router'
+import ErrorBoundaryDropParams from './ErrorBoundaryDropParams'
 import { methodologyRouteConfigs } from './pages/Methodology/methodologyContent/methodologyRouteConfigs'
 import { policyRouteConfigs } from './pages/Policy/policyContent/policyRouteConfigs'
 import { wiheConfigs } from './pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu'
@@ -52,9 +53,6 @@ const AboutUsPage = React.lazy(
 )
 const WhatIsHealthEquityPage = React.lazy(
   async () => await import('./pages/WhatIsHealthEquity/WhatIsHealthEquityPage'),
-)
-const ErrorBoundaryDropParams = React.lazy(
-  async () => await import('./ErrorBoundaryDropParams'),
 )
 const ExploreDataFallback = React.lazy(
   async () => await import('./pages/ExploreData/ExploreDataFallback'),

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -19,8 +19,8 @@ import VariableProviderMap from './VariableProviderMap'
 // 2. The total site memory usage is reasonable. This is a bit of a judgement
 //    call, but it should be comparable with other applications. This can be
 //    viewed in the browser task manager.
-const MAX_CACHE_SIZE_DATASETS = 1_000_000
-const MAX_CACHE_SIZE_QUERIES = 100_000
+const MAX_CACHE_SIZE_DATASETS = 500_000
+const MAX_CACHE_SIZE_QUERIES = 50_000
 
 // We only expect one metadata entry so we can set cache size to 1.
 const MAX_CACHE_SIZE_METADATA = 1

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -19,8 +19,8 @@ import VariableProviderMap from './VariableProviderMap'
 // 2. The total site memory usage is reasonable. This is a bit of a judgement
 //    call, but it should be comparable with other applications. This can be
 //    viewed in the browser task manager.
-const MAX_CACHE_SIZE_DATASETS = 100_000
-const MAX_CACHE_SIZE_QUERIES = 10_000
+const MAX_CACHE_SIZE_DATASETS = 1_000_000
+const MAX_CACHE_SIZE_QUERIES = 100_000
 
 // We only expect one metadata entry so we can set cache size to 1.
 const MAX_CACHE_SIZE_METADATA = 1


### PR DESCRIPTION
## Summary

- Fixes #4725: `ErrorBoundaryDropParams` was lazy-loaded via `React.lazy()`, preventing it from catching errors thrown during Suspense. Changed to a synchronous import.
- Fixes #4726: LRU cache sized by row count caused premature eviction of large datasets. Increased `MAX_CACHE_SIZE_DATASETS` to 500k and `MAX_CACHE_SIZE_QUERIES` to 50k (from 100k / 10k).

## Root Cause / Motivation

React error boundaries must be synchronously present in the tree before any components they protect. A lazy-loaded boundary cannot catch errors thrown during its own Suspense loading phase.

The LRU cache budget meant a single large dataset (~50k rows) consumed 50% of the allowance, causing a second large dataset to evict the first immediately. The new limits let ~10 large datasets coexist in cache while staying well within mobile memory budgets.

## Test plan

- [x] Explore Data page loads normally (Playwright)
- [x] Error boundary fallback renders on bad URL params (Playwright)
- [x] TypeScript type check passes (tsc --noEmit)
- [x] Biome lint/format passes (npm run cleanup)
- [x] Navigate between several topics/geographies and verify datasets are not silently re-fetched

🤖 Generated with [Claude Code](https://claude.com/claude-code)
