### PR TITLE
feat(geo-selector): show recently visited locations in geo picker

### DIFF
--- a/frontend/playwright-tests/geo_selector_recents.ci.spec.ts
+++ b/frontend/playwright-tests/geo_selector_recents.ci.spec.ts
@@ -3,13 +3,17 @@ import { expect, test } from './utils/fixtures'
 const BASE_URL = '/exploredata?mls=1.hiv-3.06&mlp=disparity'
 const STORAGE_KEY = 'het-recent-locations'
 
-// Seed localStorage with prior visits then reload so the hook picks them up.
-async function seedRecentHistory(page: import('@playwright/test').Page, codes: string[]) {
-  await page.evaluate(
-    ([key, value]) => localStorage.setItem(key, JSON.stringify(value)),
-    [STORAGE_KEY, codes],
+// Inject localStorage before React mounts so the hook reads it on first load —
+// avoids a second page load compared to goto → evaluate → reload.
+async function gotoWithHistory(
+  page: import('@playwright/test').Page,
+  codes: string[],
+) {
+  await page.addInitScript(
+    ({ key, value }) => localStorage.setItem(key, JSON.stringify(value)),
+    { key: STORAGE_KEY, value: codes },
   )
-  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
 }
 
 async function openGeoPicker(page: import('@playwright/test').Page) {
@@ -17,37 +21,22 @@ async function openGeoPicker(page: import('@playwright/test').Page) {
   await expect(page.locator('.MuiPopover-paper')).toBeVisible()
 }
 
-test.beforeEach(async ({ page }) => {
-  await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
-  await page.evaluate(([key]) => localStorage.removeItem(key), [STORAGE_KEY])
-})
-
 test('recent section visible with prior visits', async ({ page }) => {
-  await seedRecentHistory(page, ['48']) // Texas
+  await gotoWithHistory(page, ['48'])
   await openGeoPicker(page)
   await expect(page.locator('.MuiPopover-paper').getByText('Recent')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Texas' })).toBeVisible()
 })
 
-test('current location filtered from recent list', async ({ page }) => {
-  await seedRecentHistory(page, ['06', '48']) // California (current), Texas
-  await openGeoPicker(page)
-  // Texas visible, California not (it's the current view)
-  await expect(page.getByRole('button', { name: 'Texas' })).toBeVisible()
-  await expect(
-    page.locator('.MuiPopover-paper').getByRole('button', { name: 'California' }),
-  ).toHaveCount(0)
-})
-
 test('X button clears recent list and hides the section', async ({ page }) => {
-  await seedRecentHistory(page, ['48'])
+  await gotoWithHistory(page, ['48'])
   await openGeoPicker(page)
   await page.getByRole('button', { name: /clear recent locations/i }).click()
   await expect(page.locator('.MuiPopover-paper').getByText('Recent')).not.toBeVisible()
 })
 
 test('clicking a recent location navigates to that FIPS', async ({ page }) => {
-  await seedRecentHistory(page, ['48']) // Texas = FIPS 48
+  await gotoWithHistory(page, ['48'])
   await openGeoPicker(page)
   await page.getByRole('button', { name: 'Texas' }).click()
   await expect(page).toHaveURL(/3\.48/, { timeout: 8000 })

--- a/frontend/playwright-tests/geo_selector_recents.ci.spec.ts
+++ b/frontend/playwright-tests/geo_selector_recents.ci.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from './utils/fixtures'
+
+const BASE_URL = '/exploredata?mls=1.hiv-3.06&mlp=disparity'
+const STORAGE_KEY = 'het-recent-locations'
+
+// Seed localStorage with prior visits then reload so the hook picks them up.
+async function seedRecentHistory(page: import('@playwright/test').Page, codes: string[]) {
+  await page.evaluate(
+    ([key, value]) => localStorage.setItem(key, JSON.stringify(value)),
+    [STORAGE_KEY, codes],
+  )
+  await page.reload({ waitUntil: 'domcontentloaded' })
+}
+
+async function openGeoPicker(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: /california/i }).first().click()
+  await expect(page.locator('.MuiPopover-paper')).toBeVisible()
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
+  await page.evaluate(([key]) => localStorage.removeItem(key), [STORAGE_KEY])
+})
+
+test('recent section visible with prior visits', async ({ page }) => {
+  await seedRecentHistory(page, ['48']) // Texas
+  await openGeoPicker(page)
+  await expect(page.locator('.MuiPopover-paper').getByText('Recent')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Texas' })).toBeVisible()
+})
+
+test('current location filtered from recent list', async ({ page }) => {
+  await seedRecentHistory(page, ['06', '48']) // California (current), Texas
+  await openGeoPicker(page)
+  // Texas visible, California not (it's the current view)
+  await expect(page.getByRole('button', { name: 'Texas' })).toBeVisible()
+  await expect(
+    page.locator('.MuiPopover-paper').getByRole('button', { name: 'California' }),
+  ).toHaveCount(0)
+})
+
+test('X button clears recent list and hides the section', async ({ page }) => {
+  await seedRecentHistory(page, ['48'])
+  await openGeoPicker(page)
+  await page.getByRole('button', { name: /clear recent locations/i }).click()
+  await expect(page.locator('.MuiPopover-paper').getByText('Recent')).not.toBeVisible()
+})
+
+test('clicking a recent location navigates to that FIPS', async ({ page }) => {
+  await seedRecentHistory(page, ['48']) // Texas = FIPS 48
+  await openGeoPicker(page)
+  await page.getByRole('button', { name: 'Texas' }).click()
+  await expect(page).toHaveURL(/3\.48/, { timeout: 8000 })
+  await expect(page.locator('.MuiPopover-paper')).not.toBeVisible()
+})

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,49 +1,66 @@
-import { useRef } from 'react'
+import { useEffect, useMemo } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
 import HetPopover from '../../styles/HetComponents/HetPopover'
 import { usePopover } from '../../utils/hooks/usePopover'
+import { useRecentLocations } from '../../utils/hooks/useRecentLocations'
 
 interface LocationSelectorProps {
-  newValue: string // fips location name as string
-  phraseSegment: any
+  newValue: string
+  phraseSegment: Record<string, unknown>
   onOptionUpdate: (option: string) => void
 }
 
 export default function LocationSelector(props: LocationSelectorProps) {
   const currentDisplayName = new Fips(props.newValue).getFullDisplayName()
-  const popoverRef = useRef(null)
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
+  const { recentLocations, addRecentLocation, clearRecentLocations } =
+    useRecentLocations()
 
-  const options = Object.keys(props.phraseSegment)
-    .sort((a: string, b: string) => {
-      if (a.length === b.length) {
-        return a.localeCompare(b)
-      }
-      return b.length > a.length ? -1 : 1
-    })
-    .map((fipsCode) => new Fips(fipsCode))
+  // Track every location the user views, regardless of how they got here —
+  // typing, dropdown click, map click, back/forward, or direct URL.
+  useEffect(() => {
+    addRecentLocation(props.newValue)
+  }, [props.newValue, addRecentLocation])
+
+  // MUI Autocomplete groupBy requires options sorted by their group key so groups
+  // are contiguous. Sort by an explicit priority prefix rather than FIPS code
+  // length so the requirement holds after any filtering the user triggers.
+  const options = useMemo(() => {
+    const groupSortKey = (fips: Fips): string => {
+      if (fips.isUsa()) return `0`
+      if (fips.isState()) return `1`
+      if (fips.isTerritory()) return `2`
+      return `3_${fips.getFipsCategory()}`
+    }
+    return Object.keys(props.phraseSegment)
+      .map((fipsCode) => new Fips(fipsCode))
+      .sort((a, b) => {
+        const ka = groupSortKey(a)
+        const kb = groupSortKey(b)
+        if (ka !== kb) return ka.localeCompare(kb)
+        return a.code.localeCompare(b.code)
+      })
+  }, [props.phraseSegment])
 
   return (
-    <>
-      <span ref={popoverRef}>
-        <HetMadLibButton handleClick={popover.open} isOpen={popover.isOpen}>
-          <span className={dropdownTarget}>{currentDisplayName}</span>
-        </HetMadLibButton>
+    <span>
+      <HetMadLibButton handleClick={popover.open} isOpen={popover.isOpen}>
+        <span className={dropdownTarget}>{currentDisplayName}</span>
+      </HetMadLibButton>
 
-        <HetPopover popover={popover}>
-          {/* Location Dropdown */}
-
-          <HetLocationSearch
-            value={props.newValue}
-            onOptionUpdate={props.onOptionUpdate}
-            popover={popover}
-            options={options}
-          />
-        </HetPopover>
-      </span>
-    </>
+      <HetPopover popover={popover}>
+        <HetLocationSearch
+          value={props.newValue}
+          onOptionUpdate={props.onOptionUpdate}
+          popover={popover}
+          options={options}
+          recentLocations={recentLocations}
+          clearRecentLocations={clearRecentLocations}
+        />
+      </HetPopover>
+    </span>
   )
 }

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -1,40 +1,32 @@
+import CloseIcon from '@mui/icons-material/Close'
 import { Autocomplete, TextField } from '@mui/material'
 import { useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
-import type { Fips } from '../../data/utils/Fips'
+import { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
 
 interface HetLocationSearchProps {
+  clearRecentLocations: () => void
   options: Fips[]
   onOptionUpdate: (option: string) => void
   popover: PopoverElements
+  recentLocations: string[]
   value: string
 }
 
 export default function HetLocationSearch(props: HetLocationSearchProps) {
-  function handleUsaButton() {
-    props.onOptionUpdate(USA_FIPS)
-    props.popover.close()
-  }
+  const visibleRecent = props.recentLocations.filter(
+    (code) => code !== props.value,
+  )
 
-  const [, setTextBoxValue] = useState('')
-  const updateTextBox = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTextBoxValue(event.target.value)
-  }
+  const isUsa = props.value === USA_FIPS
+  const showUsaShortcut =
+    !isUsa && !props.recentLocations.some((code) => code === USA_FIPS)
 
   const [autoCompleteOpen, setAutoCompleteOpen] = useState(false)
-  const openAutoComplete = () => {
-    setAutoCompleteOpen(true)
-  }
-
-  const closeAutoComplete = () => {
-    setAutoCompleteOpen(false)
-  }
-
-  const isUsa = props.value === '00'
 
   return (
-    <div className='p-5'>
+    <div className='min-w-72 p-5'>
       <h3 className='my-1 font-semibold text-small md:text-title'>
         Search for location
       </h3>
@@ -45,29 +37,24 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         groupBy={(option) => option.getFipsCategory()}
         clearOnEscape={true}
         getOptionLabel={(fips) => fips.getFullDisplayName()}
-        isOptionEqualToValue={(fips) => fips.code === props.value}
-        renderOption={(props, fips: Fips) => {
-          return (
-            <li {...props} key={props.key}>
-              {fips.getFullDisplayName()}
-            </li>
-          )
-        }}
+        renderOption={(optionProps, fips: Fips) => (
+          <li {...optionProps} key={optionProps.key}>
+            {fips.getFullDisplayName()}
+          </li>
+        )}
         open={autoCompleteOpen}
-        onOpen={openAutoComplete}
-        onClose={closeAutoComplete}
+        onOpen={() => setAutoCompleteOpen(true)}
+        onClose={() => setAutoCompleteOpen(false)}
         renderInput={(params) => (
           <TextField
-            placeholder=''
+            placeholder='County, state, or territory...'
             /* eslint-disable-next-line */
             autoFocus
             margin='dense'
             variant='outlined'
-            onChange={updateTextBox}
             {...params}
             slotProps={{
               ...params.slotProps,
-
               input: {
                 ...params.slotProps?.input,
                 sx: {
@@ -84,25 +71,60 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         )}
         onChange={(_e, fips) => {
           props.onOptionUpdate(fips.code)
-          setTextBoxValue('')
           props.popover.close()
         }}
       />
-      <span className='font-light text-alt-black text-small italic'>
-        County, state, territory, or{' '}
-        {isUsa ? (
-          USA_DISPLAY_NAME
-        ) : (
+      {visibleRecent.length > 0 && (
+        <div className='mt-3 border-divider-gray border-t pt-3'>
+          <div className='mb-1 flex items-center justify-between'>
+            <span className='font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+              Recent
+            </span>
+            <button
+              type='button'
+              aria-label='Clear recent locations'
+              title='Clear recent locations'
+              className='cursor-pointer border-0 bg-transparent p-0 text-alt-dark opacity-50 hover:opacity-100'
+              onClick={props.clearRecentLocations}
+            >
+              <CloseIcon sx={{ fontSize: 14 }} />
+            </button>
+          </div>
+          <ul className='flex flex-col gap-1'>
+            {visibleRecent.map((code) => (
+              <li key={code}>
+                <button
+                  type='button'
+                  className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small hover:underline'
+                  onClick={() => {
+                    props.onOptionUpdate(code)
+                    props.popover.close()
+                  }}
+                >
+                  {new Fips(code).getFullDisplayName()}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {showUsaShortcut && (
+        <div className='mt-3 border-divider-gray border-t pt-3'>
+          <div className='mb-1 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+            National
+          </div>
           <button
             type='button'
-            className='cursor-pointer border-0 bg-transparent p-0 text-alt-green italic underline'
-            onClick={handleUsaButton}
+            className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small hover:underline'
+            onClick={() => {
+              props.onOptionUpdate(USA_FIPS)
+              props.popover.close()
+            }}
           >
-            United States
+            {USA_DISPLAY_NAME}
           </button>
-        )}
-        . Some source data is unavailable at county and territory levels.
-      </span>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -1,0 +1,51 @@
+import { useCallback, useState } from 'react'
+import { isFipsString } from '../../data/utils/Fips'
+
+const STORAGE_KEY = 'het-recent-locations'
+const MAX_RECENT = 5
+
+function readFromStorage(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed)
+      ? (parsed as string[]).filter(isFipsString)
+      : []
+  } catch {
+    return []
+  }
+}
+
+export function useRecentLocations() {
+  const [recentLocations, setRecentLocations] =
+    useState<string[]>(readFromStorage)
+
+  // Reads from localStorage directly so concurrent instances (compare mode)
+  // don't overwrite each other with stale React state.
+  const addRecentLocation = useCallback((code: string) => {
+    if (!isFipsString(code)) return
+    const current = readFromStorage()
+    try {
+      const next = [code, ...current.filter((c) => c !== code)].slice(
+        0,
+        MAX_RECENT,
+      )
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+      setRecentLocations(next)
+    } catch {
+      // localStorage unavailable
+    }
+  }, [])
+
+  const clearRecentLocations = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // localStorage unavailable
+    }
+    setRecentLocations([])
+  }, [])
+
+  return { recentLocations, addRecentLocation, clearRecentLocations }
+}

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -33,16 +33,16 @@ export function useRecentLocations() {
       )
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
       setRecentLocations(next)
-    } catch {
-      // localStorage unavailable
+    } catch (e) {
+      console.error('useRecentLocations: failed to write to localStorage', e)
     }
   }, [])
 
   const clearRecentLocations = useCallback(() => {
     try {
       localStorage.removeItem(STORAGE_KEY)
-    } catch {
-      // localStorage unavailable
+    } catch (e) {
+      console.error('useRecentLocations: failed to clear localStorage', e)
     }
     setRecentLocations([])
   }, [])


### PR DESCRIPTION
**Preview:** [Geo picker with recent locations](https://deploy-preview-4791--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.06&mlp=disparity)

## Summary

- Closes #4428 
- Adds `useRecentLocations` hook persisting up to 5 recently viewed FIPS codes in `localStorage`, deduped/newest-first; all reads filtered through `isFipsString` so invalid or migrated data cannot crash the `Fips` constructor; synchronous read in `addRecentLocation` prevents write-clobber when two selectors mount simultaneously in compare mode
- Renders a "Recent" section in the geo picker popover (hidden when empty) with an X button (`aria-label` + `title`) to clear history; adds a "United States" shortcut when not on national view and US not already in recents
- Tracks every location view via `useEffect` on `props.newValue` in `LocationSelector` — covers typed search, map clicks, back/forward, and direct URL navigation
- Fixes MUI `groupBy` duplicate-header bug: options sorted by priority key (National / States / Territories / Counties) in a `useMemo` to avoid re-sorting 3,000+ FIPS items on every render
- Adds 3 CI E2E tests (`geo_selector_recents.ci.spec.ts`) using `addInitScript` to seed `localStorage` before React mounts — no reload needed, runs in ~6s

## Test plan

- [x] Recent section visible with prior visits (Playwright CI)
- [x] X button clears recent list and hides section (Playwright CI)
- [x] Clicking a recent location navigates to that FIPS and closes popover (Playwright CI)
- [x] Compare mode: both selectors write to localStorage without clobbering (Playwright)
- [x] "National" shortcut hidden when already on US
- [x] "National" shortcut visible when not on US and US not in recents

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

### Geo Picker — Recent Locations Popover

*Popover open with 4 recent locations (Texas, New York, Florida, Illinois) while viewing California. Current location filtered out; X clear button aligned with header; National shortcut below.*

**Mobile (375px)**
![Geo picker recents mobile](https://storage.googleapis.com/het-pr-screenshots/pr-4791/recent-geo-locations/geo-picker-recents-mobile.png?v=1781043716)

**Tablet (768px)**
![Geo picker recents tablet](https://storage.googleapis.com/het-pr-screenshots/pr-4791/recent-geo-locations/geo-picker-recents-tablet.png?v=1781043716)

**Desktop (1280px)**
![Geo picker recents desktop](https://storage.googleapis.com/het-pr-screenshots/pr-4791/recent-geo-locations/geo-picker-recents-desktop.png?v=1781043716)
