### PR TITLE
chore(skills/pr): always include Netlify preview URL, drop pending placeholder

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -235,9 +235,7 @@ Rewrite the PR title (under 70 chars) and body. Keep the description **short and
 Use this template:
 
 ```markdown
-**Preview:** [<short label>](<netlify-url>/<route>?<params>) · [<label 2>](<netlify-url>/<route2>?<params>)
-
-*(Preview URL pending deploy)* — replace the line above once Netlify posts its comment.
+**Preview:** [<short label>](<netlify-url>/<route>?<params>)
 
 ## Summary
 
@@ -253,9 +251,8 @@ Use this template:
 
 **Preview line rules:**
 - Always the first line of the body so reviewers can click straight to the feature
-- If the Netlify URL is not yet available, write `*(Preview URL pending deploy)*` as a single line placeholder — do not invent a URL
-- Include 1–3 deep links with the URL params needed to see the feature immediately (e.g. `?mls=1.hiv-3.06&mlp=disparity` to land on a specific report)
-- Remove the placeholder line and replace with real links once the URL is known
+- The PR number is always known at this point — construct the URL as `https://deploy-preview-{number}--health-equity-tracker.netlify.app`; never omit it or use a placeholder
+- One deep link with the URL params needed to land directly on the changed UI (e.g. `?mls=1.hiv-3.06&mlp=disparity`)
 
 **Summary rules:**
 - 3–5 bullets maximum; each one line

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -17,14 +17,24 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
 
+  // MUI Autocomplete groupBy requires options sorted by their group key so groups
+  // are contiguous. Sort by an explicit priority prefix rather than FIPS code
+  // length so the requirement holds after any filtering the user triggers.
+  const groupSortKey = (fips: Fips): string => {
+    if (fips.isUsa()) return `0`
+    if (fips.isState()) return `1`
+    if (fips.isTerritory()) return `2`
+    return `3_${fips.getFipsCategory()}`
+  }
+
   const options = Object.keys(props.phraseSegment)
-    .sort((a: string, b: string) => {
-      if (a.length === b.length) {
-        return a.localeCompare(b)
-      }
-      return b.length > a.length ? -1 : 1
-    })
     .map((fipsCode) => new Fips(fipsCode))
+    .sort((a, b) => {
+      const ka = groupSortKey(a)
+      const kb = groupSortKey(b)
+      if (ka !== kb) return ka.localeCompare(kb)
+      return a.code.localeCompare(b.code)
+    })
 
   return (
     <>

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,9 +1,10 @@
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
 import HetPopover from '../../styles/HetComponents/HetPopover'
 import { usePopover } from '../../utils/hooks/usePopover'
+import { useRecentLocations } from '../../utils/hooks/useRecentLocations'
 
 interface LocationSelectorProps {
   newValue: string // fips location name as string
@@ -16,6 +17,13 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const popoverRef = useRef(null)
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
+  const { recentLocations, addRecentLocation } = useRecentLocations()
+
+  // Track every location the user views, regardless of how they got here —
+  // typing, dropdown click, map click, back/forward, or direct URL.
+  useEffect(() => {
+    addRecentLocation(props.newValue, currentDisplayName)
+  }, [props.newValue, addRecentLocation, currentDisplayName])
 
   // MUI Autocomplete groupBy requires options sorted by their group key so groups
   // are contiguous. Sort by an explicit priority prefix rather than FIPS code
@@ -51,6 +59,7 @@ export default function LocationSelector(props: LocationSelectorProps) {
             onOptionUpdate={props.onOptionUpdate}
             popover={popover}
             options={options}
+            recentLocations={recentLocations}
           />
         </HetPopover>
       </span>

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { Fips } from '../../data/utils/Fips'
 import HetLocationSearch from '../../styles/HetComponents/HetLocationSearch'
 import HetMadLibButton from '../../styles/HetComponents/HetMadLibButton'
@@ -28,21 +28,22 @@ export default function LocationSelector(props: LocationSelectorProps) {
   // MUI Autocomplete groupBy requires options sorted by their group key so groups
   // are contiguous. Sort by an explicit priority prefix rather than FIPS code
   // length so the requirement holds after any filtering the user triggers.
-  const groupSortKey = (fips: Fips): string => {
-    if (fips.isUsa()) return `0`
-    if (fips.isState()) return `1`
-    if (fips.isTerritory()) return `2`
-    return `3_${fips.getFipsCategory()}`
-  }
-
-  const options = Object.keys(props.phraseSegment)
-    .map((fipsCode) => new Fips(fipsCode))
-    .sort((a, b) => {
-      const ka = groupSortKey(a)
-      const kb = groupSortKey(b)
-      if (ka !== kb) return ka.localeCompare(kb)
-      return a.code.localeCompare(b.code)
-    })
+  const options = useMemo(() => {
+    const groupSortKey = (fips: Fips): string => {
+      if (fips.isUsa()) return `0`
+      if (fips.isState()) return `1`
+      if (fips.isTerritory()) return `2`
+      return `3_${fips.getFipsCategory()}`
+    }
+    return Object.keys(props.phraseSegment)
+      .map((fipsCode) => new Fips(fipsCode))
+      .sort((a, b) => {
+        const ka = groupSortKey(a)
+        const kb = groupSortKey(b)
+        if (ka !== kb) return ka.localeCompare(kb)
+        return a.code.localeCompare(b.code)
+      })
+  }, [props.phraseSegment])
 
   return (
     <>

--- a/frontend/src/pages/ExploreData/LocationSelector.tsx
+++ b/frontend/src/pages/ExploreData/LocationSelector.tsx
@@ -17,7 +17,8 @@ export default function LocationSelector(props: LocationSelectorProps) {
   const popoverRef = useRef(null)
   const popover = usePopover()
   const dropdownTarget = `${props.newValue}-dropdown-fips`
-  const { recentLocations, addRecentLocation } = useRecentLocations()
+  const { recentLocations, addRecentLocation, clearRecentLocations } =
+    useRecentLocations()
 
   // Track every location the user views, regardless of how they got here —
   // typing, dropdown click, map click, back/forward, or direct URL.
@@ -61,6 +62,7 @@ export default function LocationSelector(props: LocationSelectorProps) {
             popover={popover}
             options={options}
             recentLocations={recentLocations}
+            clearRecentLocations={clearRecentLocations}
           />
         </HetPopover>
       </span>

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -3,23 +3,22 @@ import { useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import type { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
-import { useRecentLocations } from '../../utils/hooks/useRecentLocations'
+import type { RecentLocation } from '../../utils/hooks/useRecentLocations'
 
 interface HetLocationSearchProps {
   options: Fips[]
   onOptionUpdate: (option: string) => void
   popover: PopoverElements
+  recentLocations: RecentLocation[]
   value: string
 }
 
 export default function HetLocationSearch(props: HetLocationSearchProps) {
-  const { recentLocations, addRecentLocation } = useRecentLocations()
-  const visibleRecent = recentLocations.filter(
+  const visibleRecent = props.recentLocations.filter(
     (loc) => loc.code !== props.value,
   )
 
   function handleUsaButton() {
-    addRecentLocation(USA_FIPS, USA_DISPLAY_NAME)
     props.onOptionUpdate(USA_FIPS)
     props.popover.close()
   }
@@ -38,9 +37,9 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
     setAutoCompleteOpen(false)
   }
 
-  const isUsa = props.value === '00'
+  const isUsa = props.value === USA_FIPS
   const showUsaShortcut =
-    !isUsa && !recentLocations.some((loc) => loc.code === USA_FIPS)
+    !isUsa && !props.recentLocations.some((loc) => loc.code === USA_FIPS)
 
   return (
     <div className='min-w-72 p-5'>
@@ -91,7 +90,6 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           />
         )}
         onChange={(_e, fips) => {
-          addRecentLocation(fips.code, fips.getFullDisplayName())
           props.onOptionUpdate(fips.code)
           setTextBoxValue('')
           props.popover.close()
@@ -130,7 +128,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
             className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
             onClick={handleUsaButton}
           >
-            United States
+            {USA_DISPLAY_NAME}
           </button>
         </div>
       )}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import type { Fips } from '../../data/utils/Fips'
 import type { PopoverElements } from '../../utils/hooks/usePopover'
+import { useRecentLocations } from '../../utils/hooks/useRecentLocations'
 
 interface HetLocationSearchProps {
   options: Fips[]
@@ -12,7 +13,13 @@ interface HetLocationSearchProps {
 }
 
 export default function HetLocationSearch(props: HetLocationSearchProps) {
+  const { recentLocations, addRecentLocation } = useRecentLocations()
+  const visibleRecent = recentLocations.filter(
+    (loc) => loc.code !== props.value,
+  )
+
   function handleUsaButton() {
+    addRecentLocation(USA_FIPS, USA_DISPLAY_NAME)
     props.onOptionUpdate(USA_FIPS)
     props.popover.close()
   }
@@ -83,12 +90,36 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           />
         )}
         onChange={(_e, fips) => {
+          addRecentLocation(fips.code, fips.getFullDisplayName())
           props.onOptionUpdate(fips.code)
           setTextBoxValue('')
           props.popover.close()
         }}
       />
-      <span className='font-light text-alt-black text-small italic'>
+      {visibleRecent.length > 0 && (
+        <div className='mt-3 border-divider-gray border-t pt-3'>
+          <p className='mb-1 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+            Recent
+          </p>
+          <ul className='flex flex-col gap-1'>
+            {visibleRecent.map((loc) => (
+              <li key={loc.code}>
+                <button
+                  type='button'
+                  className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
+                  onClick={() => {
+                    props.onOptionUpdate(loc.code)
+                    props.popover.close()
+                  }}
+                >
+                  {loc.displayName}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <p className='mt-3 font-light text-alt-black text-small italic'>
         County, state, territory, or{' '}
         {isUsa ? (
           USA_DISPLAY_NAME
@@ -101,8 +132,8 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
             United States
           </button>
         )}
-        . Some source data is unavailable at county and territory levels.
-      </span>
+        . Some data unavailable at county and territory levels.
+      </p>
     </div>
   )
 }

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -52,7 +52,6 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         groupBy={(option) => option.getFipsCategory()}
         clearOnEscape={true}
         getOptionLabel={(fips) => fips.getFullDisplayName()}
-        isOptionEqualToValue={(fips) => fips.code === props.value}
         renderOption={(props, fips: Fips) => {
           return (
             <li {...props} key={props.key}>
@@ -65,7 +64,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         onClose={closeAutoComplete}
         renderInput={(params) => (
           <TextField
-            placeholder=''
+            placeholder='County, state, or territory...'
             /* eslint-disable-next-line */
             autoFocus
             margin='dense'
@@ -120,19 +119,20 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
         </div>
       )}
       <p className='mt-3 font-light text-alt-black text-small italic'>
-        County, state, territory, or{' '}
         {isUsa ? (
-          USA_DISPLAY_NAME
+          'Showing United States'
         ) : (
-          <button
-            type='button'
-            className='cursor-pointer border-0 bg-transparent p-0 text-alt-green italic underline'
-            onClick={handleUsaButton}
-          >
-            United States
-          </button>
+          <>
+            Or jump to{' '}
+            <button
+              type='button'
+              className='cursor-pointer border-0 bg-transparent p-0 text-alt-green italic underline'
+              onClick={handleUsaButton}
+            >
+              United States
+            </button>
+          </>
         )}
-        . Some data unavailable at county and territory levels.
       </p>
     </div>
   )

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -6,6 +6,7 @@ import type { PopoverElements } from '../../utils/hooks/usePopover'
 import type { RecentLocation } from '../../utils/hooks/useRecentLocations'
 
 interface HetLocationSearchProps {
+  clearRecentLocations: () => void
   options: Fips[]
   onOptionUpdate: (option: string) => void
   popover: PopoverElements
@@ -97,9 +98,18 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
       />
       {visibleRecent.length > 0 && (
         <div className='mt-3 border-divider-gray border-t pt-3'>
-          <p className='mb-1 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
-            Recent
-          </p>
+          <div className='mb-1 flex items-center justify-between'>
+            <p className='font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+              Recent
+            </p>
+            <button
+              type='button'
+              className='cursor-pointer border-0 bg-transparent p-0 text-alt-dark text-xs hover:text-alt-black hover:underline'
+              onClick={props.clearRecentLocations}
+            >
+              Clear
+            </button>
+          </div>
           <ul className='flex flex-col gap-1'>
             {visibleRecent.map((loc) => (
               <li key={loc.code}>

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -105,7 +105,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
               <li key={loc.code}>
                 <button
                   type='button'
-                  className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
+                  className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small hover:underline'
                   onClick={() => {
                     props.onOptionUpdate(loc.code)
                     props.popover.close()

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -106,6 +106,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
             <button
               type='button'
               aria-label='Clear recent locations'
+              title='Clear recent locations'
               className='cursor-pointer border-0 bg-transparent p-0 text-alt-dark opacity-50 hover:opacity-100'
               onClick={props.clearRecentLocations}
             >

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -1,3 +1,4 @@
+import CloseIcon from '@mui/icons-material/Close'
 import { Autocomplete, TextField } from '@mui/material'
 import { useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
@@ -98,16 +99,17 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
       />
       {visibleRecent.length > 0 && (
         <div className='mt-3 border-divider-gray border-t pt-3'>
-          <div className='mb-1 flex items-center justify-between'>
+          <div className='mb-2 flex items-center justify-between'>
             <p className='font-semibold text-alt-dark text-xs uppercase tracking-wide'>
               Recent
             </p>
             <button
               type='button'
-              className='cursor-pointer border-0 bg-transparent p-0 text-alt-dark text-xs hover:text-alt-black hover:underline'
+              aria-label='Clear recent locations'
+              className='cursor-pointer border-0 bg-transparent p-0 text-alt-dark opacity-50 hover:opacity-100'
               onClick={props.clearRecentLocations}
             >
-              Clear
+              <CloseIcon sx={{ fontSize: 14 }} />
             </button>
           </div>
           <ul className='flex flex-col gap-1'>
@@ -130,7 +132,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
       )}
       {showUsaShortcut && (
         <div className='mt-3 border-divider-gray border-t pt-3'>
-          <p className='mb-1 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+          <p className='mb-2 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
             National
           </p>
           <button

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -125,7 +125,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           </p>
           <button
             type='button'
-            className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
+            className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small hover:underline'
             onClick={handleUsaButton}
           >
             {USA_DISPLAY_NAME}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -130,7 +130,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
             className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
             onClick={handleUsaButton}
           >
-            the United States
+            United States
           </button>
         </div>
       )}

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -39,9 +39,11 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
   }
 
   const isUsa = props.value === '00'
+  const showUsaShortcut =
+    !isUsa && !recentLocations.some((loc) => loc.code === USA_FIPS)
 
   return (
-    <div className='p-5'>
+    <div className='min-w-72 p-5'>
       <h3 className='my-1 font-semibold text-small md:text-title'>
         Search for location
       </h3>
@@ -118,22 +120,20 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
           </ul>
         </div>
       )}
-      <p className='mt-3 font-light text-alt-black text-small italic'>
-        {isUsa ? (
-          'Showing United States'
-        ) : (
-          <>
-            Or jump to{' '}
-            <button
-              type='button'
-              className='cursor-pointer border-0 bg-transparent p-0 text-alt-green italic underline'
-              onClick={handleUsaButton}
-            >
-              United States
-            </button>
-          </>
-        )}
-      </p>
+      {showUsaShortcut && (
+        <div className='mt-3 border-divider-gray border-t pt-3'>
+          <p className='mb-1 font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+            National
+          </p>
+          <button
+            type='button'
+            className='cursor-pointer border-0 bg-transparent p-0 text-left text-alt-green text-small underline hover:no-underline'
+            onClick={handleUsaButton}
+          >
+            the United States
+          </button>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -99,10 +99,10 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
       />
       {visibleRecent.length > 0 && (
         <div className='mt-3 border-divider-gray border-t pt-3'>
-          <div className='mb-2 flex items-center justify-between'>
-            <p className='font-semibold text-alt-dark text-xs uppercase tracking-wide'>
+          <div className='mb-1 flex items-center justify-between'>
+            <span className='font-semibold text-alt-dark text-xs uppercase tracking-wide'>
               Recent
-            </p>
+            </span>
             <button
               type='button'
               aria-label='Clear recent locations'

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -47,5 +47,14 @@ export function useRecentLocations() {
     }
   }, [])
 
-  return { recentLocations, addRecentLocation }
+  const clearRecentLocations = useCallback(() => {
+    try {
+      localStorage.removeItem(STORAGE_KEY)
+    } catch {
+      // localStorage unavailable
+    }
+    setRecentLocations([])
+  }, [])
+
+  return { recentLocations, addRecentLocation, clearRecentLocations }
 }

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 
 const STORAGE_KEY = 'het-recent-locations'
 const MAX_RECENT = 5
 
-interface RecentLocation {
+export interface RecentLocation {
   code: string
   displayName: string
 }
@@ -20,18 +20,23 @@ export function useRecentLocations() {
     },
   )
 
-  function addRecentLocation(code: string, displayName: string) {
-    const next = [
-      { code, displayName },
-      ...recentLocations.filter((loc) => loc.code !== code),
-    ].slice(0, MAX_RECENT)
+  // Reads from localStorage directly so concurrent instances (compare mode)
+  // don't overwrite each other with stale React state.
+  const addRecentLocation = useCallback((code: string, displayName: string) => {
     try {
+      const current = JSON.parse(
+        localStorage.getItem(STORAGE_KEY) ?? '[]',
+      ) as RecentLocation[]
+      const next = [
+        { code, displayName },
+        ...current.filter((loc) => loc.code !== code),
+      ].slice(0, MAX_RECENT)
       localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+      setRecentLocations(next)
     } catch {
       // localStorage unavailable
     }
-    setRecentLocations(next)
-  }
+  }, [])
 
   return { recentLocations, addRecentLocation }
 }

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -21,18 +21,16 @@ export function useRecentLocations() {
   )
 
   function addRecentLocation(code: string, displayName: string) {
-    setRecentLocations((prev) => {
-      const next = [
-        { code, displayName },
-        ...prev.filter((loc) => loc.code !== code),
-      ].slice(0, MAX_RECENT)
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
-      } catch {
-        // localStorage unavailable
-      }
-      return next
-    })
+    const next = [
+      { code, displayName },
+      ...recentLocations.filter((loc) => loc.code !== code),
+    ].slice(0, MAX_RECENT)
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+    } catch {
+      // localStorage unavailable
+    }
+    setRecentLocations(next)
   }
 
   return { recentLocations, addRecentLocation }

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react'
+
+const STORAGE_KEY = 'het-recent-locations'
+const MAX_RECENT = 5
+
+interface RecentLocation {
+  code: string
+  displayName: string
+}
+
+export function useRecentLocations() {
+  const [recentLocations, setRecentLocations] = useState<RecentLocation[]>(
+    () => {
+      try {
+        const raw = localStorage.getItem(STORAGE_KEY)
+        return raw ? (JSON.parse(raw) as RecentLocation[]) : []
+      } catch {
+        return []
+      }
+    },
+  )
+
+  function addRecentLocation(code: string, displayName: string) {
+    setRecentLocations((prev) => {
+      const next = [
+        { code, displayName },
+        ...prev.filter((loc) => loc.code !== code),
+      ].slice(0, MAX_RECENT)
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next))
+      } catch {
+        // localStorage unavailable
+      }
+      return next
+    })
+  }
+
+  return { recentLocations, addRecentLocation }
+}

--- a/frontend/src/utils/hooks/useRecentLocations.tsx
+++ b/frontend/src/utils/hooks/useRecentLocations.tsx
@@ -13,7 +13,9 @@ export function useRecentLocations() {
     () => {
       try {
         const raw = localStorage.getItem(STORAGE_KEY)
-        return raw ? (JSON.parse(raw) as RecentLocation[]) : []
+        if (!raw) return []
+        const parsed = JSON.parse(raw)
+        return Array.isArray(parsed) ? (parsed as RecentLocation[]) : []
       } catch {
         return []
       }
@@ -23,10 +25,17 @@ export function useRecentLocations() {
   // Reads from localStorage directly so concurrent instances (compare mode)
   // don't overwrite each other with stale React state.
   const addRecentLocation = useCallback((code: string, displayName: string) => {
+    let current: RecentLocation[] = []
     try {
-      const current = JSON.parse(
-        localStorage.getItem(STORAGE_KEY) ?? '[]',
-      ) as RecentLocation[]
+      const raw = localStorage.getItem(STORAGE_KEY)
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed)) current = parsed as RecentLocation[]
+      }
+    } catch {
+      // corrupted storage — start fresh
+    }
+    try {
       const next = [
         { code, displayName },
         ...current.filter((loc) => loc.code !== code),


### PR DESCRIPTION
## Summary

- PR number is always known when `/pr` runs, so the Netlify URL is always derivable -- remove the `*(Preview URL pending deploy)*` placeholder line entirely
- Clarify: never omit the preview URL or fall back to a placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)