### PR TITLE
fix(chlp-banner): restore spaces and block layout on Open CHLP Maps button

### DIFF
--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -21,8 +21,8 @@ export default function CHLPMapsBanner() {
           onClick={() => setModalIsOpen(true)}
         >
           <span className='font-semibold'>
-            Open <span className='sm:hidden'>CHLP</span>
-            <span className='hidden sm:inline'>
+            Open <span className='font-semibold sm:hidden'>CHLP</span>
+            <span className='hidden font-semibold sm:inline'>
               Center for HIV Law and Policy (CHLP)
             </span>{' '}
             Maps

--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -20,9 +20,9 @@ export default function CHLPMapsBanner() {
           className='font-semibold text-alt-black hover:translate-x-1 hover:transition-transform hover:duration-300'
           onClick={() => setModalIsOpen(true)}
         >
-          <span>
-            Open <span className='font-semibold sm:hidden'>CHLP</span>
-            <span className='hidden font-semibold sm:inline'>
+          <span className='font-semibold'>
+            Open <span className='sm:hidden'>CHLP</span>
+            <span className='hidden sm:inline'>
               Center for HIV Law and Policy (CHLP)
             </span>{' '}
             Maps

--- a/frontend/src/reports/ui/CHLPMapsBanner.tsx
+++ b/frontend/src/reports/ui/CHLPMapsBanner.tsx
@@ -15,16 +15,20 @@ export default function CHLPMapsBanner() {
       Many states criminalize people living with HIV for conduct that is either
       not criminalized or criminalized less severely for people not living with
       HIV.
-      <HetLinkButton
-        className='font-semibold text-alt-black hover:translate-x-1 hover:transition-transform hover:duration-300'
-        onClick={() => setModalIsOpen(true)}
-      >
-        Open <span className='font-semibold sm:hidden'>CHLP</span>
-        <span className='hidden font-semibold sm:inline'>
-          Center for HIV Law and Policy (CHLP)
-        </span>{' '}
-        Maps
-      </HetLinkButton>
+      <div className='mt-2'>
+        <HetLinkButton
+          className='font-semibold text-alt-black hover:translate-x-1 hover:transition-transform hover:duration-300'
+          onClick={() => setModalIsOpen(true)}
+        >
+          <span>
+            Open <span className='font-semibold sm:hidden'>CHLP</span>
+            <span className='hidden font-semibold sm:inline'>
+              Center for HIV Law and Policy (CHLP)
+            </span>{' '}
+            Maps
+          </span>
+        </HetLinkButton>
+      </div>
     </HetNotice>
   )
 }


### PR DESCRIPTION
## Summary

- MUI `Button` renders children in an `inline-flex` container, which silently drops whitespace text nodes. The "Open CHLP Maps" button was rendering as "OpenCHLPMaps" with no spaces.
- Wrapping all button content in a single `<span>` makes it one flex child; inside that span, normal inline text rules apply and the spaces between "Open", the conditional name, and "Maps" are preserved.
- Adds `<div className='mt-2'>` wrapper so the button renders on its own line below the paragraph instead of flowing inline with it.
- Keeps `text-alt-black` color (unchanged from current main).

## Test plan

- [ ] Mobile: button reads "Open CHLP Maps" on its own line below the paragraph
- [ ] Desktop: button reads "Open Center for HIV Law and Policy (CHLP) Maps" on its own line
- [ ] Clicking the button opens the CHLP Maps modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)