### PR TITLE
docs(conventions): never put issue number in PR title

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -232,6 +232,10 @@ git diff origin/main -- frontend/src/
 
 Rewrite the PR title (under 70 chars) and body. Keep the description **short and focused** — a few tight bullets, no padding. The test plan is the audited behavioral checklist from Step 5 only (no static tooling items).
 
+**Title rules:**
+- Under 70 chars
+- **Never include an issue number in the title** — no `(#1234)` suffix. It looks like a PR number at a glance and makes titles hard to scan. `Closes #NNNN` belongs in the body only.
+
 Use this template:
 
 ```markdown

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,8 @@ git push origin HEAD:infra-test -f   # backend GCP deploy only
 
 See `README.md` for full fork setup steps including how to add your fork as a remote.
 
+**PR title convention:** Never put an issue number in the PR title (no `(#1234)` suffix). It is visually indistinguishable from a PR number at a glance. Use `Closes #NNNN` in the PR body instead.
+
 ## Commands
 
 Frontend commands run from `frontend/` — see `frontend/CLAUDE.md`.


### PR DESCRIPTION
## Summary

- Adds explicit rule to root \`CLAUDE.md\` and \`.claude/skills/pr/SKILL.md\`: no issue number in the PR title
- \`(#1234)\` suffixes look like PR numbers at a glance and make the list hard to scan
- \`Closes #NNNN\` belongs in the PR body only

🤖 Generated with [Claude Code](https://claude.com/claude-code)