### PR TITLE
fix(pr-skill): look up routes from internalRoutes.ts, never guess

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -70,6 +70,12 @@ https://deploy-preview-{number}--health-equity-tracker.netlify.app
 
 Identify the single most useful deep-link route that shows the core feature. Append URL params so the reviewer lands directly on the changed UI. Record the full URL for Step 6.
 
+**Never guess route strings.** All app routes are defined as constants in `frontend/src/utils/internalRoutes.ts`. Look up the correct path there before constructing the URL:
+
+```bash
+grep -n "PAGE_LINK\|_PATH\|_ROUTE" frontend/src/utils/internalRoutes.ts
+```
+
 ---
 
 ## Step 3 — Evaluate and address code review feedback


### PR DESCRIPTION
Prevents hallucinated preview link routes by requiring a grep of `internalRoutes.ts` before constructing the Netlify deep-link URL.

Caught when `/whatishet` was used instead of the real route `/whatishealthequity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)