### PR TITLE
fix(map): gradient legend accuracy, tooltip units, alert padding

### DIFF
--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -193,7 +193,7 @@ export const formatMetricValue = (
   }
 
   if (isPctType(metricConfig.type)) {
-    return `${format('d')(value)}%`
+    return `${format('.1~f')(value)}%`
   }
 
   return format(',.2r')(value)

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -156,12 +156,7 @@ export const createDataMap = (
       {
         [tooltipLabel]:
           d[metric.metricId] != null
-            ? // Keys starting with '% unknown' are formatted manually in
-              // buildTooltipEntries (appends "% of ... data missing"), so pass
-              // the raw number to avoid double-% and integer rounding.
-              tooltipLabel.startsWith('% unknown')
-              ? d[metric.metricId]
-              : formatMetricValue(d[metric.metricId], metric)
+            ? formatMetricValue(d[metric.metricId], metric)
             : undefined,
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -156,7 +156,12 @@ export const createDataMap = (
       {
         [tooltipLabel]:
           d[metric.metricId] != null
-            ? formatMetricValue(d[metric.metricId], metric)
+            ? // Keys starting with '% unknown' are formatted manually in
+              // buildTooltipEntries (appends "% of ... data missing"), so pass
+              // the raw number to avoid double-% and integer rounding.
+              tooltipLabel.startsWith('% unknown')
+              ? d[metric.metricId]
+              : formatMetricValue(d[metric.metricId], metric)
             : undefined,
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -154,7 +154,10 @@ export const createDataMap = (
     dataWithHighestLowest.map((d) => [
       d.fips,
       {
-        [tooltipLabel]: d[metric.metricId],
+        [tooltipLabel]:
+          d[metric.metricId] != null
+            ? formatMetricValue(d[metric.metricId], metric)
+            : null,
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {
           [`# ${numeratorPhrase}`]:

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -157,7 +157,7 @@ export const createDataMap = (
         [tooltipLabel]:
           d[metric.metricId] != null
             ? formatMetricValue(d[metric.metricId], metric)
-            : null,
+            : undefined,
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {
           [`# ${numeratorPhrase}`]:

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.ts
@@ -88,12 +88,12 @@ export function createUnknownLegend(
     Number.isInteger(val) ? val.toString() : val.toFixed(1)
 
   // Always label the actual min/max bounds; add any intermediate nice ticks
-  // that are far enough from the boundaries to avoid overlapping labels.
-  const middleTicks = ticks.filter(
-    (tick) =>
-      tick > legendLowerBound + range * 0.2 &&
-      tick < legendUpperBound - range * 0.2,
-  )
+  // that are at least 30px from either boundary to avoid overlapping labels.
+  const minPixelGap = 30
+  const middleTicks = ticks.filter((tick) => {
+    const position = ((tick - legendLowerBound) / range) * gradientLength
+    return position > minPixelGap && position < gradientLength - minPixelGap
+  })
   const constrainedTicks = [
     { label: formatLabel(legendLowerBound), position: 0 },
     ...middleTicks.map((label) => ({

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.ts
@@ -17,6 +17,11 @@ export function createUnknownLegend(
   const gradientLength = width * 0.35
   const legendHeight = 15
   const [legendLowerBound, legendUpperBound] = colorScale.domain()
+  const range = legendUpperBound - legendLowerBound
+
+  // Skip gradient when all values are identical (no meaningful range to display)
+  if (range === 0) return
+
   const tickCount = 2
   const ticks = scaleLinear()
     .domain([legendLowerBound, legendUpperBound])
@@ -34,17 +39,13 @@ export function createUnknownLegend(
     .attr('x1', '0%')
     .attr('x2', '100%')
 
+  // Fix stops at 0%/100% so the gradient matches the actual map color range
   gradient
     .selectAll('stop')
-    .data(
-      ticks.map((value) => ({
-        offset: `${
-          ((value - legendLowerBound) / (legendUpperBound - legendLowerBound)) *
-          100
-        }%`,
-        color: colorScale(value),
-      })),
-    )
+    .data([
+      { offset: '0%', color: colorScale(legendLowerBound) },
+      { offset: '100%', color: colorScale(legendUpperBound) },
+    ])
     .join('stop')
     .attr('offset', (d) => d.offset)
     .attr('stop-color', (d) => d.color)
@@ -74,24 +75,21 @@ export function createUnknownLegend(
 
   const labelGroup = legendContainer
     .append('g')
-    .attr('transform', `translate(50, ${legendHeight + 10})`) // Align to gradient start
+    .attr('transform', `translate(50, ${legendHeight + 10})`)
 
-  const constrainedTicks = ticks.map((label) => {
-    // Constrain the positions of ticks to the gradient length
-    const position =
-      ((label - legendLowerBound) / (legendUpperBound - legendLowerBound)) *
-      gradientLength
+  // Only label ticks within the actual data range to avoid out-of-bounds positions
+  const constrainedTicks = ticks
+    .filter((tick) => tick >= legendLowerBound && tick <= legendUpperBound)
+    .map((label) => {
+      const position = ((label - legendLowerBound) / range) * gradientLength
+      const clampedPosition = Math.min(Math.max(position, 10), gradientLength)
+      return { label, position: clampedPosition }
+    })
 
-    // Clamp positions to the gradient bounds
-    const clampedPosition = Math.min(Math.max(position, 10), gradientLength)
-    return { label, position: clampedPosition }
-  })
-
-  // Add labels
   constrainedTicks.forEach(({ label, position }) => {
     labelGroup
       .append('text')
-      .attr('x', position) // Correctly aligned within gradient bounds
+      .attr('x', position)
       .attr('text-anchor', 'middle')
       .style('font', '10px sans-serif')
       .text(`${label}%`)

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.ts
@@ -39,13 +39,20 @@ export function createUnknownLegend(
     .attr('x1', '0%')
     .attr('x2', '100%')
 
-  // Fix stops at 0%/100% so the gradient matches the actual map color range
+  // Use 10 evenly-spaced stops so multi-hue scales (greenblue, viridis, etc.)
+  // render all intermediate hues, not just a linear RGB blend of the endpoints.
+  const stopCount = 10
+  const stops = Array.from({ length: stopCount }, (_, i) => {
+    const t = i / (stopCount - 1)
+    return {
+      offset: `${t * 100}%`,
+      color: colorScale(legendLowerBound + t * range),
+    }
+  })
+
   gradient
     .selectAll('stop')
-    .data([
-      { offset: '0%', color: colorScale(legendLowerBound) },
-      { offset: '100%', color: colorScale(legendUpperBound) },
-    ])
+    .data(stops)
     .join('stop')
     .attr('offset', (d) => d.offset)
     .attr('stop-color', (d) => d.color)
@@ -77,14 +84,24 @@ export function createUnknownLegend(
     .append('g')
     .attr('transform', `translate(50, ${legendHeight + 10})`)
 
-  // Only label ticks within the actual data range to avoid out-of-bounds positions
-  const constrainedTicks = ticks
-    .filter((tick) => tick >= legendLowerBound && tick <= legendUpperBound)
-    .map((label) => {
-      const position = ((label - legendLowerBound) / range) * gradientLength
-      const clampedPosition = Math.min(Math.max(position, 10), gradientLength)
-      return { label, position: clampedPosition }
-    })
+  const formatLabel = (val: number) =>
+    Number.isInteger(val) ? val.toString() : val.toFixed(1)
+
+  // Always label the actual min/max bounds; add any intermediate nice ticks
+  // that are far enough from the boundaries to avoid overlapping labels.
+  const middleTicks = ticks.filter(
+    (tick) =>
+      tick > legendLowerBound + range * 0.2 &&
+      tick < legendUpperBound - range * 0.2,
+  )
+  const constrainedTicks = [
+    { label: formatLabel(legendLowerBound), position: 0 },
+    ...middleTicks.map((label) => ({
+      label: formatLabel(label),
+      position: ((label - legendLowerBound) / range) * gradientLength,
+    })),
+    { label: formatLabel(legendUpperBound), position: gradientLength },
+  ]
 
   constrainedTicks.forEach(({ label, position }) => {
     labelGroup

--- a/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
+++ b/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
@@ -37,7 +37,7 @@ function buildTooltipEntries(
         const demoLabel = demographicType
           ? DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType]
           : 'demographic'
-        return { label: '', value: `${rawValue}% of ${demoLabel} data missing` }
+        return { label: '', value: `${rawValue} of ${demoLabel} data missing` }
       }
       return {
         label: key,

--- a/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
+++ b/frontend/src/charts/choroplethMap/mouseEventHandlers.ts
@@ -37,7 +37,13 @@ function buildTooltipEntries(
         const demoLabel = demographicType
           ? DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType]
           : 'demographic'
-        return { label: '', value: `${rawValue} of ${demoLabel} data missing` }
+        return {
+          label: '',
+          value:
+            rawValue != null
+              ? `${rawValue} of ${demoLabel} data missing`
+              : missingDataValue,
+        }
       }
       return {
         label: key,

--- a/frontend/src/reports/ui/IncarceratedChildrenLongAlert.tsx
+++ b/frontend/src/reports/ui/IncarceratedChildrenLongAlert.tsx
@@ -6,26 +6,23 @@ import { PDOH_LINK } from '../../utils/internalRoutes'
 
 function IncarceratedChildrenLongAlert() {
   return (
-    <div>
-      <HetNotice
-        title='Children in Adult Jails and Prisons'
-        kind='health-crisis'
-        className='m-2 border border-report-alert text-left'
-      >
-        <p>
-          Despite criminal justice distinctions between adults and children,
-          some states have laws that remove children from these protections and{' '}
-          <a target='_blank' rel='noreferrer' href={urlMap.prisonPolicy}>
-            enable the incarceration of children in adult institutions
-          </a>
-          . These children are more exposed to physical and sexual abuse, fewer
-          age-appropriate services, and worse health outcomes. Below, we
-          highlight the <HetTerm>total number of confined children</HetTerm> in
-          adult facilities; read more in{' '}
-          <Link to={PDOH_LINK}>our methodology</Link>.
-        </p>
-      </HetNotice>
-    </div>
+    <HetNotice
+      title='Children in Adult Jails and Prisons'
+      kind='health-crisis'
+      className='border border-report-alert text-left'
+    >
+      <p>
+        Despite criminal justice distinctions between adults and children, some
+        states have laws that remove children from these protections and{' '}
+        <a target='_blank' rel='noreferrer' href={urlMap.prisonPolicy}>
+          enable the incarceration of children in adult institutions
+        </a>
+        . These children are more exposed to physical and sexual abuse, fewer
+        age-appropriate services, and worse health outcomes. Below, we highlight
+        the <HetTerm>total number of confined children</HetTerm> in adult
+        facilities; read more in <Link to={PDOH_LINK}>our methodology</Link>.
+      </p>
+    </HetNotice>
   )
 }
 


### PR DESCRIPTION
**Preview:** [Medicare HIV diagnoses map](https://deploy-preview-4809--health-equity-tracker.netlify.app/exploredata?mls=1.medicare_hiv-3.00&mlp=disparity&dt1=medicare_hiv)

## Summary

- Fixes SVG NaN console errors on the unknown map gradient legend when all unknowns values are identical (zero-range domain causes `0/0`) — closes #4808 root cause
- Fixes unknown map legend darkest color being darker than the darkest state: 10 evenly-spaced gradient stops across actual data bounds preserve all intermediate hues on multi-hue scales — closes #4808
- Always labels the actual min/max data bounds on the gradient; intermediate nice ticks filtered by pixel gap (30px) to avoid overlap on narrow screens
- Formats map hover tooltip values via `formatMetricValue` so per-100k metrics show the unit suffix and pct values preserve one decimal place (`5.7%` not `6%`) — closes #4807
- Reduces excessive padding on Children in Adult Jails and Prisons alert by removing redundant outer `<div>` and double `m-2` — closes #4806

## Test plan

- [x] Load Medicare HIV diagnoses unknowns map — no NaN SVG errors in console (Playwright)
- [x] Hover a state on HIV diagnoses rate map — tooltip shows "per 100k" suffix (Playwright)
- [x] Hover a state on incarceration map — tooltip has no double-%% (Playwright)
- [x] Children in Adult Jails alert — no extra `m-2` class on rendered element (Playwright)
- [x] Visually confirm unknown map gradient legend darkest color matches darkest state on map

Closes #4806
Closes #4807
Closes #4808

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Screenshots

### Tooltip with per-100k units (fix #4807)

**Tablet (768px)**
![Tooltip per-100k tablet](https://storage.googleapis.com/het-pr-screenshots/pr-4809/map-bugs/tooltip-per100k-tablet.png?v=1781218382)

**Desktop (1280px)**
![Tooltip per-100k desktop](https://storage.googleapis.com/het-pr-screenshots/pr-4809/map-bugs/tooltip-per100k-desktop.png?v=1781218382)

---

### Children in Adult Jails alert — reduced padding (fix #4806)

**Mobile (375px)**
![Alert padding mobile](https://storage.googleapis.com/het-pr-screenshots/pr-4809/map-bugs/alert-padding-mobile.png?v=1781218382)

**Tablet (768px)**
![Alert padding tablet](https://storage.googleapis.com/het-pr-screenshots/pr-4809/map-bugs/alert-padding-tablet.png?v=1781218382)

**Desktop (1280px)**
![Alert padding desktop](https://storage.googleapis.com/het-pr-screenshots/pr-4809/map-bugs/alert-padding-desktop.png?v=1781218382)

---

### Fixed Unknown Maps Gradient

<img width="3702" height="3447" alt="image" src="https://github.com/user-attachments/assets/7db27323-eb6f-4098-b5f9-f7e8bf06d238" />

<img width="1560" height="2235" alt="image" src="https://github.com/user-attachments/assets/6b29d22d-546c-48cb-812f-c295eaa8ade2" />

