### PR TITLE
chore: add CodeRabbit config to replace Gemini Code Assist

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -34,7 +34,6 @@ reviews:
         This is a health equity data pipeline. Focus on:
         - Statistical accuracy: numerators and denominators must cover the same population, geography, and time window
         - Race/ethnicity labels must match HET standard labels defined in ingestion/standardized_columns.py (Race enum); non-standard labels silently produce null joins
-        - Suppression: counts below 100 should be suppressed before percent calculations
         - Percent metric type (pct_share vs pct_rate vs pct_rel_inequity) must match the denominator used
         - Time period alignment: datasets joined across years need explicit handling
         - Person-first language in any user-facing strings or methodology text
@@ -62,7 +61,10 @@ reviews:
         - WCAG 2.1 AA: color contrast >= 4.5:1 for text; no color-only encoding in charts
         - Interactive elements need visible focus rings and accessible names (aria-label or visible text)
         - New charts need an accessible text alternative (summary description or data table)
-        - Use HET design tokens (het-teal, het-purple, het-grey, etc.), not raw hex values
+        - Design tokens are in `src/styles/tokens/colors.ts` (JS: `colors.altGreen`) and
+          generated as Tailwind utilities (CSS: `bg-alt-green`, `text-secondary-dark`).
+          Never use raw hex values or default Tailwind color classes (`text-zinc-500`, `bg-gray-100`).
+          To pick a color, consult `frontend/tokens/colors.tokens.json`.
         - New metric configs belong in MetricConfig<Topic>.ts
         - New providers extend VariableProvider and register in VariableProviderMap.ts
         - Person-first language in all UI strings; avoid "vulnerable populations", "at-risk" without qualification

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,12 +4,13 @@
 language: "en-US"
 
 tone_instructions: >
+  Be brief. Lead each finding with a priority label: [HIGH], [MEDIUM], or [LOW].
+  Only flag real bugs, data errors, or security issues at [HIGH].
   Be constructive and welcoming to new contributors.
-  Flag health data accuracy issues strictly.
-  Skip suggestions that do not improve correctness or maintainability.
+  Skip [LOW] findings unless trivially fixable.
 
 reviews:
-  profile: "assertive"
+  profile: "chill"
   poem: false
   high_level_summary: true
   auto_review:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,6 +17,7 @@ reviews:
     base_branches:
       - main
   path_filters:
+    - "**"
     # Source data files: large CSVs committed for pipeline reference, not code
     - "!data/**"
     # Test golden data: auto-generated expected output, not hand-written code

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,73 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "en-US"
+
+tone_instructions: >
+  Be constructive and welcoming to new contributors.
+  Flag health data accuracy issues strictly.
+  Skip suggestions that do not improve correctness or maintainability.
+
+reviews:
+  profile: "assertive"
+  poem: false
+  high_level_summary: true
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    base_branches:
+      - main
+  path_filters:
+    # Source data files: large CSVs committed for pipeline reference, not code
+    - "!data/**"
+    # Test golden data: auto-generated expected output, not hand-written code
+    - "!python/tests/**/golden_data/**"
+    # Lock files and build output
+    - "!package-lock.json"
+    - "!frontend/dist/**"
+    - "!**/__pycache__/**"
+  path_instructions:
+    - path: "python/datasources/**"
+      instructions: |
+        This is a health equity data pipeline. Focus on:
+        - Statistical accuracy: numerators and denominators must cover the same population, geography, and time window
+        - Race/ethnicity labels must match HET standard labels defined in ingestion/standardized_columns.py (Race enum); non-standard labels silently produce null joins
+        - Suppression: counts below 100 should be suppressed before percent calculations
+        - Percent metric type (pct_share vs pct_rate vs pct_rel_inequity) must match the denominator used
+        - Time period alignment: datasets joined across years need explicit handling
+        - Person-first language in any user-facing strings or methodology text
+        - AIAN/NHPI grouping: verify logic matches add_aian_api and the Race enum
+        - Hardcoded years should reference shared constants (ACS_EARLIEST_YEAR, ACS_CURRENT_YEAR)
+
+    - path: "python/ingestion/**"
+      instructions: |
+        Shared ingestion utilities used by all data sources. Focus on:
+        - Backwards compatibility: changes here affect every DataSource subclass
+        - Type safety with het_types.py definitions
+        - GCS/BQ utility functions should handle both string and numeric FIPS codes safely
+
+    - path: "python/tests/**"
+      instructions: |
+        Data pipeline tests. Focus on:
+        - Mocks should be faithful to the real API signature; a mock that accepts bad input and returns good output is worse than no test
+        - Golden data CSVs should be regenerated when output table shape changes
+        - Integration tests that exercise the full write_to_bq path catch join and aggregation bugs that unit tests miss
+        - Fixture files belong in python/tests/data/<source>/, not in the repo-root data/ directory
+
+    - path: "frontend/src/**"
+      instructions: |
+        React/TypeScript frontend using MUI, Tailwind, D3, and Jotai. Focus on:
+        - WCAG 2.1 AA: color contrast >= 4.5:1 for text; no color-only encoding in charts
+        - Interactive elements need visible focus rings and accessible names (aria-label or visible text)
+        - New charts need an accessible text alternative (summary description or data table)
+        - Use HET design tokens (het-teal, het-purple, het-grey, etc.), not raw hex values
+        - New metric configs belong in MetricConfig<Topic>.ts
+        - New providers extend VariableProvider and register in VariableProviderMap.ts
+        - Person-first language in all UI strings; avoid "vulnerable populations", "at-risk" without qualification
+        - Race/ethnicity labels must match HET standard display names
+
+    - path: ".github/workflows/dag*.yml"
+      instructions: |
+        Data pipeline DAG workflows. Focus on:
+        - Workflow must include a failure notification step
+        - New workflows should follow the infra-test pattern used by other DAG workflows
+        - Secrets references should use existing org/repo secrets, not new ad hoc ones

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,4 @@
+# CodeRabbit configuration — see https://docs.coderabbit.ai
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 
 language: "en-US"


### PR DESCRIPTION
## Summary

- Adds `.coderabbit.yaml` to replace Gemini Code Assist, which sunsets July 17, 2026
- CodeRabbit is free for public OSS repos with no seat limit; runs as a GitHub App, no workflow changes needed
- Excludes `data/` and golden data CSVs from review scope (generated files, not code)
- Path-specific instructions for: data pipeline accuracy (HET race labels, suppression thresholds), frontend a11y (WCAG 2.1 AA, design tokens), test quality, and DAG workflows
- Fixed `path_filters` to include `"**"` wildcard before negation patterns per CodeRabbit glob behavior

## Test plan

- [x] Install CodeRabbit GitHub App on the repo
- [x] Confirm CodeRabbit auto-posts a review on this PR after install

Closes #4785

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CodeRabbit configuration file (configuration-only, no runtime changes). It sets English and a concise review tone, enables automatic incremental reviews on main, and includes broad path filters plus path-specific instructions covering Python ingestion/tests, frontend accessibility/design tokens, and workflow notification/secret-handling expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->