### PR TITLE
fix(pr-skill): preserve bot review blocks when rewriting PR body

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -268,7 +268,9 @@ Use this template:
 - 3–5 bullets maximum; each one line
 - Omit "Root Cause / Motivation" unless the why is genuinely non-obvious to a reviewer reading the diff
 
-Write the body to `/tmp/pr-body.md`, then apply:
+Before writing the body, fetch the current PR body and check for any auto-generated bot sections (CodeRabbit "Summary by CodeRabbit", or similar blocks appended by review bots). These are delimited by HTML comments like `<!-- This is an auto-generated comment: ... -->`. **Preserve them verbatim** — append them after your written body so they survive the `--body-file` overwrite.
+
+Write the body to `/tmp/pr-body.md`, appending any bot-generated blocks after the human-authored content, then apply:
 
 ```bash
 gh pr edit --title "<new title>" --body-file /tmp/pr-body.md


### PR DESCRIPTION
When `/pr` rewrites the PR description via `gh pr edit --body-file`, it silently overwrites any auto-generated content that review bots (CodeRabbit, etc.) have appended. This updates the skill to fetch the existing body first, extract any bot-generated blocks (delimited by `<!-- ... -->` HTML comments), and re-append them after the human-authored content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated PR skill instructions to preserve auto-generated bot sections when updating PR bodies, ensuring bot-created content remains intact during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->