### PR TITLE
style: biome formatting cleanup from #4853 merge

### DIFF
--- a/frontend/src/cards/ui/CopyCardImageToClipboardButton.tsx
+++ b/frontend/src/cards/ui/CopyCardImageToClipboardButton.tsx
@@ -16,16 +16,16 @@ export function CopyCardImageToClipboardButton(
   props: CopyCardImageToClipboardButtonProps,
 ) {
   const {
-  cardName,
-  isThinking,
-  setIsThinking,
-  imgDataUrl,
-  confirmationOpen,
-  errorOpen,
-  handleCopyImgToClipboard,
-  handleCopyRowImgToClipboard,
-  handleClose,
-} = useCardImage(props.popover, props.scrollToHash)
+    cardName,
+    isThinking,
+    setIsThinking,
+    imgDataUrl,
+    confirmationOpen,
+    errorOpen,
+    handleCopyImgToClipboard,
+    handleCopyRowImgToClipboard,
+    handleClose,
+  } = useCardImage(props.popover, props.scrollToHash)
 
   const isCompareMode = window.location.href.includes('compare')
   const imgTerm = isCompareMode ? 'Side-by-Side Images' : 'Image'

--- a/frontend/src/utils/hooks/useCardImage.tsx
+++ b/frontend/src/utils/hooks/useCardImage.tsx
@@ -20,8 +20,8 @@ export function useCardImage(
   const cardUrlWithHash = `${urlWithoutHash}#${scrollToHash}`
 
   const handleImageAction = async (
-  destination: 'clipboard' | 'download',
-  isRowOfTwo: boolean = false,
+    destination: 'clipboard' | 'download',
+    isRowOfTwo: boolean = false,
   ) => {
     if (destination === 'clipboard') {
       setConfirmationOpen(false)
@@ -41,10 +41,10 @@ export function useCardImage(
           setErrorOpen(false)
           setImgDataUrl(result)
           setConfirmationOpen(true)
-          } else {
-              setConfirmationOpen(false)
-              setErrorOpen(true)
-          }
+        } else {
+          setConfirmationOpen(false)
+          setErrorOpen(true)
+        }
       }
       if (destination === 'download') {
         cardMenuPopover?.close()
@@ -73,11 +73,11 @@ export function useCardImage(
       }
     },
     handleClose: () => {
-    setIsThinking(false)
-    setConfirmationOpen(false)
-    setErrorOpen(false)
-    cardMenuPopover.close()
-    setImgDataUrl(null)
+      setIsThinking(false)
+      setConfirmationOpen(false)
+      setErrorOpen(false)
+      cardMenuPopover.close()
+      setImgDataUrl(null)
     },
   }
 }


### PR DESCRIPTION
Applies the Biome auto-formatting that was missed in #4853 (external contributor PR). Two files had indentation nits that CI flagged but the PR was merged before they were fixed.

Closes #4853 follow-up cleanup — no logic changes, formatting only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)