### PR TITLE
skill(pr): auto-merge main without confirmation gate

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -85,22 +85,7 @@ git fetch origin main --quiet
 git log --oneline --left-right origin/main...HEAD
 ```
 
-Parse the output for lines starting with `<` (commits on `origin/main` not on this branch). If any exist, the branch is behind.
-
-**If behind:** Print the missing commits clearly, e.g.:
-
-> Branch is behind `origin/main` by N commit(s):
-> - `abc1234` commit message
-
-Then ask the user to confirm before merging:
-
-```
-About to merge origin/main into <headRefName>. Confirm? (yes/no)
-```
-
-Use `AskUserQuestion` to gate this — do not proceed without confirmation.
-
-**If user confirms:**
+Parse the output for lines starting with `<` (commits on `origin/main` not on this branch). If any exist, merge immediately without asking:
 
 ```bash
 git merge origin/main --no-edit
@@ -108,8 +93,6 @@ git push $FORK_REMOTE HEAD
 ```
 
 If the merge produces conflicts: stop, print the conflicting files, and ask the user to resolve them manually before continuing.
-
-**If user declines:** Note that the branch will remain behind main and continue with the rest of the skill.
 
 **If up to date:** Note "Branch is up to date with origin/main" and continue.
 


### PR DESCRIPTION
Removes the `AskUserQuestion` confirmation in Step 2c of the /pr skill. The merge still stops and asks if there are conflicts — no safety is lost, just the friction of confirming an always-yes question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)