### PR TITLE
fix(choropleth): use threshold scale for discrete data

### DIFF
--- a/frontend/src/charts/choroplethMap/colorSchemes.ts
+++ b/frontend/src/charts/choroplethMap/colorSchemes.ts
@@ -179,6 +179,19 @@ export function createColorScale(options: CreateColorScaleOptions): ColorScale {
       .range(colorArray)
   }
 
+  const uniqueDomainValues = [...new Set(domain)].sort((a, b) => a - b)
+  if (
+    uniqueDomainValues.length > 0 &&
+    uniqueDomainValues.length <= colorArray.length
+  ) {
+    // Discrete data: use threshold scale so each distinct value gets its own
+    // color bucket rather than letting quantile over-represent common values
+    // (e.g. CAWP county percentages where most counties share a single value).
+    return scaleThreshold<number, string>()
+      .domain(uniqueDomainValues)
+      .range(colorArray.slice(0, uniqueDomainValues.length + 1))
+  }
+
   return scaleQuantile<string, number>().domain(domain).range(colorArray)
 }
 

--- a/frontend/src/charts/choroplethMap/colorSchemes.ts
+++ b/frontend/src/charts/choroplethMap/colorSchemes.ts
@@ -182,7 +182,7 @@ export function createColorScale(options: CreateColorScaleOptions): ColorScale {
   const uniqueDomainValues = [...new Set(domain)].sort((a, b) => a - b)
   if (
     uniqueDomainValues.length > 0 &&
-    uniqueDomainValues.length <= colorArray.length
+    uniqueDomainValues.length < colorArray.length
   ) {
     // Discrete data: use threshold scale so each distinct value gets its own
     // color bucket rather than letting quantile over-represent common values


### PR DESCRIPTION
**Preview:** [Georgia — Women in US Congress (county)](https://deploy-preview-4862--health-equity-tracker.netlify.app/exploredata?mls=1.women_in_gov-3.13&group1=All&dt1=women_in_us_congress)

## Summary

- When a choropleth dataset has < N distinct non-zero values (N = color palette size, typically 6), switch from `scaleQuantile` to `scaleThreshold` using those values as explicit breakpoints
- `scaleQuantile` distributes colors by population rank, not value: if 60% of counties share a value (e.g. 33% for Women in Congress), quantile assigns 3-4 colors to that cluster and squeezes rarer high values into a single shared color, producing legend entries with no corresponding map color
- `scaleThreshold` gives each distinct value its own color bucket regardless of how many observations share it
- The legend's existing `else` fallback in `legendDataProcessor.ts` (calls `createLegendForSmallDataset`) already handles non-quantile scales correctly — no legend code changes needed
- Continuous health metrics (HIV rates, CHR scores, etc.) have far more than 6 distinct values per geography and stay on the quantile path unchanged

## Test plan

- [x] Georgia CAWP state map legend shows only values that appear on the map (no empty buckets)
- [x] National CAWP map — same check
- [x] HIV map — legend still shows full quantile range (>6 distinct values, unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
