### PR TITLE
fix(e2e): grant clipboard permissions in Playwright config

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -30,6 +30,7 @@ const config: PlaywrightTestConfig = {
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    permissions: ['clipboard-read', 'clipboard-write'],
   },
 
   projects: [


### PR DESCRIPTION
**Preview:** N/A (Playwright config change — no UI to preview)

## Summary

- PR #4853 added error handling for clipboard failures: `confirmationOpen` is only set on success, `errorOpen` on failure
- Headless Chromium denies `clipboard-write` by default, so `navigator.clipboard.write([new ClipboardItem(...)])` throws a `NotAllowedError` in CI
- `save_card_image.spec.ts` then times out waiting for "Copied Rate map Image to" which never appears
- Granting `clipboard-read` + `clipboard-write` in the global Playwright `use` block lets the image clipboard write succeed in headless mode, restoring the success snackbar

## Test plan

- [x] `e2eDev` workflow should pass `save_card_image.spec.ts` once merged

Fixes #4853 regression (e2eDev failing since 2026-06-22 16:49)

🤖 Generated with [Claude Code](https://claude.com/claude-code)