### PR TITLE
fix(ui): clipboard focus, error toast color, map card layout tweaks

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,11 +9,10 @@ tone_instructions: >
   Only flag genuine bugs, data errors, or security issues.
   Skip style, naming, and refactor suggestions entirely.
 
-pre_merge_checks:
-  docstrings:
-    mode: "off"
-
 reviews:
+  pre_merge_checks:
+    docstrings:
+      mode: "off"
   profile: "chill"
   poem: false
   high_level_summary: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,6 +9,10 @@ tone_instructions: >
   Only flag genuine bugs, data errors, or security issues.
   Skip style, naming, and refactor suggestions entirely.
 
+pre_merge_checks:
+  docstrings:
+    mode: "off"
+
 reviews:
   profile: "chill"
   poem: false

--- a/frontend/src/cards/ChartTitle.tsx
+++ b/frontend/src/cards/ChartTitle.tsx
@@ -11,7 +11,7 @@ export default function ChartTitle(props: ChartTitleProps) {
         {props.title}
       </h2>
       {props.subtitle && (
-        <h3 className='m-0 p-0 text-center font-normal text-small italic'>
+        <h3 className='m-0 mt-2 p-0 text-center font-normal text-small italic'>
           {props.subtitle}
         </h3>
       )}

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -629,12 +629,12 @@ function MapCardWithKey(props: MapCardProps) {
                   onClick={() => {
                     setMultimapOpen(true)
                   }}
-                  className='flex items-center'
+                  className='flex items-start'
                   ariaLabel={`Launch multiple maps view with side-by-side maps of each ${prettyDemoType} group`}
                 >
-                  <GridView />
-                  <span className='mt-1 px-1 text-alt-green'>
-                    View {prettyDemoType} disparties across multiple small maps
+                  <GridView className='mt-0.5 shrink-0' />
+                  <span className='px-1 text-left text-alt-green'>
+                    View small multiples
                   </span>
                 </HetLinkButton>
               </div>

--- a/frontend/src/cards/ui/CopyCardImageToClipboardButton.tsx
+++ b/frontend/src/cards/ui/CopyCardImageToClipboardButton.tsx
@@ -56,7 +56,7 @@ export function CopyCardImageToClipboardButton(
           </div>
         )}
       </HetSnackbar>
-      <HetSnackbar open={errorOpen} handleClose={handleClose}>
+      <HetSnackbar open={errorOpen} handleClose={handleClose} severity='error'>
         Unable to copy image. Please keep this tab focused and try again.
       </HetSnackbar>
     </>

--- a/frontend/src/charts/choroplethMap/LegendItem.tsx
+++ b/frontend/src/charts/choroplethMap/LegendItem.tsx
@@ -11,7 +11,7 @@ export default function LegendItem({ color, label }: LegendItemProps) {
       <svg width={SWATCH_SIZE} height={SWATCH_SIZE} className='shrink-0'>
         <rect width={SWATCH_SIZE} height={SWATCH_SIZE} fill={color} />
       </svg>
-      <span className='text-smallest'>{label}</span>
+      <span className='whitespace-nowrap text-smallest'>{label}</span>
     </div>
   )
 }

--- a/frontend/src/charts/choroplethMap/RateMapLegend.tsx
+++ b/frontend/src/charts/choroplethMap/RateMapLegend.tsx
@@ -92,19 +92,19 @@ export default function RateMapLegend(props: RateMapLegendProps) {
 
           <div
             // all views
-            className={`${LEGEND_ITEMS_BOX_CLASS} grid w-2/3 grid-cols-1 tiny:grid-cols-2 gap-x-3 gap-y-1.5 border-0 border-gray-grid-color-darker border-t border-solid px-4 pt-4 ${
+            className={`${LEGEND_ITEMS_BOX_CLASS} w-2/3 columns-1 tiny:columns-2 gap-x-3 space-y-1.5 border-0 border-gray-grid-color-darker border-t border-solid px-4 pt-4 ${
               props.isMulti
                 ? // multimap only
-                  'sm:grid-cols-3 lg:grid-cols-4'
+                  'columns-auto sm:columns-3 lg:columns-4'
                 : props.isCompareMode
                   ? // compare mode only
-                    'smplus:grid-cols-3 md:grid-cols-2 lg:grid-cols-3'
+                    'smplus:columns-3 md:columns-2 lg:columns-3'
                   : // non-compare mode only
-                    'sm:grid-cols-1'
+                    'sm:columns-1'
             }`}
           >
             {legendItems.map((item) => (
-              <div key={item.label}>
+              <div key={item.label} className='break-inside-avoid'>
                 <LegendItem color={item.color} label={item.label} />
               </div>
             ))}

--- a/frontend/src/charts/choroplethMap/RateMapLegend.tsx
+++ b/frontend/src/charts/choroplethMap/RateMapLegend.tsx
@@ -92,19 +92,19 @@ export default function RateMapLegend(props: RateMapLegendProps) {
 
           <div
             // all views
-            className={`${LEGEND_ITEMS_BOX_CLASS} w-2/3 columns-1 tiny:columns-2 gap-1 space-y-1 border-0 border-gray-grid-color-darker border-t border-solid px-4 pt-4 ${
+            className={`${LEGEND_ITEMS_BOX_CLASS} grid w-2/3 grid-cols-1 tiny:grid-cols-2 gap-x-3 gap-y-1.5 border-0 border-gray-grid-color-darker border-t border-solid px-4 pt-4 ${
               props.isMulti
                 ? // multimap only
-                  'columns-auto sm:columns-3 lg:columns-4'
+                  'sm:grid-cols-3 lg:grid-cols-4'
                 : props.isCompareMode
                   ? // compare mode only
-                    'smplus:columns-3 md:columns-2 lg:columns-3'
+                    'smplus:grid-cols-3 md:grid-cols-2 lg:grid-cols-3'
                   : // non-compare mode only
-                    'sm:columns-1'
+                    'sm:grid-cols-1'
             }`}
           >
             {legendItems.map((item) => (
-              <div key={item.label} className='mb-1 break-inside-avoid'>
+              <div key={item.label}>
                 <LegendItem color={item.color} label={item.label} />
               </div>
             ))}

--- a/frontend/src/charts/rateBarChart/EndOfRateBarLabel.tsx
+++ b/frontend/src/charts/rateBarChart/EndOfRateBarLabel.tsx
@@ -17,7 +17,7 @@ export default function EndOfRateBarLabel(props: EndOfRateBarLabelProps) {
     <text
       x={props.shouldLabelBeInside ? props.barWidth - 5 : props.barWidth + 5}
       y={props.yScale.bandwidth() / 2}
-      dy='1.3em'
+      dy='0.35em'
       textAnchor={props.shouldLabelBeInside ? 'end' : 'start'}
       className={`text-smallest ${props.barLabelColor}`}
       aria-hidden='true'

--- a/frontend/src/charts/rateBarChart/RoundedBarsWithLabels.tsx
+++ b/frontend/src/charts/rateBarChart/RoundedBarsWithLabels.tsx
@@ -49,7 +49,9 @@ export default function RoundedBarsWithLabels({
 
   return processedData.map((d, index) => {
     const barWidth = xScale(d[metricConfig.metricId]) || 0
-    const shouldLabelBeInside = d[metricConfig.metricId] > barLabelBreakpoint
+    const shouldLabelBeInside =
+      d[metricConfig.metricId] > barLabelBreakpoint ||
+      hitAreaWidth - barWidth < 90
     const yPosition = getYPosition(index, d[demographicType])
     const topGap =
       normalGap +

--- a/frontend/src/charts/rateBarChart/RoundedBarsWithLabels.tsx
+++ b/frontend/src/charts/rateBarChart/RoundedBarsWithLabels.tsx
@@ -49,9 +49,7 @@ export default function RoundedBarsWithLabels({
 
   return processedData.map((d, index) => {
     const barWidth = xScale(d[metricConfig.metricId]) || 0
-    const shouldLabelBeInside =
-      d[metricConfig.metricId] > barLabelBreakpoint ||
-      hitAreaWidth - barWidth < 90
+    const shouldLabelBeInside = d[metricConfig.metricId] > barLabelBreakpoint
     const yPosition = getYPosition(index, d[demographicType])
     const topGap =
       normalGap +

--- a/frontend/src/styles/HetComponents/HetBreadcrumbs.tsx
+++ b/frontend/src/styles/HetComponents/HetBreadcrumbs.tsx
@@ -24,60 +24,56 @@ export default function HetBreadcrumbs(props: {
   )
 
   return (
-    <Breadcrumbs
-      className='mx-3 my-1 justify-center'
-      separator='›'
-      aria-label={`Breadcrumb navigation for ${
-        props.ariaLabel ?? 'data'
-      } in ${props.fips.getDisplayName()} report`}
-    >
-      <Crumb
-        text={USA_DISPLAY_NAME}
-        isClickable={!props.fips.isUsa()}
-        onClick={() => {
-          props.updateFipsCallback(new Fips(USA_FIPS))
-          location.hash = `#${props.scrollToHashId}`
-        }}
-      />
-      {!props.fips.isUsa() && !props.isAtlantaMode && (
+    <div className='mx-3 my-1'>
+      <Breadcrumbs
+        separator='›'
+        aria-label={`Breadcrumb navigation for ${
+          props.ariaLabel ?? 'data'
+        } in ${props.fips.getDisplayName()} report`}
+      >
         <Crumb
-          text={props.fips.getStateDisplayName()}
-          isClickable={!props.fips.isStateOrTerritory()}
+          text={USA_DISPLAY_NAME}
+          isClickable={!props.fips.isUsa()}
           onClick={() => {
-            props.updateFipsCallback(props.fips.getParentFips())
+            props.updateFipsCallback(new Fips(USA_FIPS))
             location.hash = `#${props.scrollToHashId}`
           }}
         />
-      )}
-      {props.isAtlantaMode && (
-        <Crumb
-          text={'Georgia'}
-          isClickable={true}
-          onClick={() => {
-            setIsAtlantaMode(false)
-          }}
-        />
-      )}
-      {props.fips.isCounty() && (
-        <Crumb text={props.fips.getDisplayName()} isClickable={false} />
-      )}
+        {!props.fips.isUsa() && !props.isAtlantaMode && (
+          <Crumb
+            text={props.fips.getStateDisplayName()}
+            isClickable={!props.fips.isStateOrTerritory()}
+            onClick={() => {
+              props.updateFipsCallback(props.fips.getParentFips())
+              location.hash = `#${props.scrollToHashId}`
+            }}
+          />
+        )}
+        {props.isAtlantaMode && (
+          <Crumb
+            text={'Georgia'}
+            isClickable={true}
+            onClick={() => {
+              setIsAtlantaMode(false)
+            }}
+          />
+        )}
+        {props.fips.isCounty() && (
+          <Crumb text={props.fips.getDisplayName()} isClickable={false} />
+        )}
+      </Breadcrumbs>
 
-      {props.totalPopulationPhrase && (
-        <Crumb
-          text={props.totalPopulationPhrase}
-          isClickable={false}
-          isNote={true}
-        />
+      {(props.totalPopulationPhrase || props.subPopulationPhrase) && (
+        <div className='px-1 text-left text-alt-black text-smallest'>
+          {props.totalPopulationPhrase && (
+            <p className='my-0.5'>{props.totalPopulationPhrase}</p>
+          )}
+          {props.subPopulationPhrase && (
+            <p className='my-0.5'>{props.subPopulationPhrase}</p>
+          )}
+        </div>
       )}
-
-      {props.subPopulationPhrase && (
-        <Crumb
-          text={props.subPopulationPhrase}
-          isClickable={false}
-          isNote={true}
-        />
-      )}
-    </Breadcrumbs>
+    </div>
   )
 }
 

--- a/frontend/src/styles/HetComponents/HetSnackbar.tsx
+++ b/frontend/src/styles/HetComponents/HetSnackbar.tsx
@@ -5,6 +5,7 @@ interface HetSnackbarProps {
   children?: ReactNode
   open: boolean
   handleClose: () => void
+  severity?: 'success' | 'error' | 'warning' | 'info'
 }
 export default function HetSnackbar(props: HetSnackbarProps) {
   return (
@@ -19,6 +20,7 @@ export default function HetSnackbar(props: HetSnackbarProps) {
     >
       <Alert
         onClose={props.handleClose}
+        severity={props.severity ?? 'success'}
         className='border border-bar-chart-light border-solid'
         role='alert'
       >

--- a/frontend/src/utils/cardImageExportUtils.ts
+++ b/frontend/src/utils/cardImageExportUtils.ts
@@ -64,6 +64,7 @@ async function dataURLtoBlob(dataURL: string): Promise<Blob> {
 async function handleDestination(dataUrl: string, options: SaveImageOptions) {
   if (options.destination === 'clipboard') {
     try {
+      window.focus()
       const blob = await dataURLtoBlob(dataUrl)
 
       await navigator.clipboard.write([


### PR DESCRIPTION
**Preview:** [Rate map card - HIV at national level](https://deploy-preview-4864--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity)

## Summary

- Add `window.focus()` before `navigator.clipboard.write()` to fix clipboard permission error when `SimpleBackdrop` overlay takes focus during image capture
- Add `severity` prop to `HetSnackbar` and pass `severity='error'` on clipboard error toast so it renders red instead of green
- Shorten small multiples link text to "View small multiples" and fix alignment
- Add `mt-2` to `ChartTitle` subtitle for breathing room between title and subtitle
- Add `whitespace-nowrap` to `LegendItem` label to prevent mid-phrase line breaks
- Move population phrases out of MUI `Breadcrumbs` flex container into plain `<p>` elements below, fixing the `›` separator appearing on its own line
- Fix `EndOfRateBarLabel` `dy` from `1.3em` to `0.35em` so numeric labels are vertically centered within the bar on narrow charts
- Disable CodeRabbit docstring pre-merge check (TypeScript codebase has no JSDoc requirement)

## Test plan

- [x] Small multiples link shows short text "View small multiples" (Playwright)
- [x] Card subtitle has visible top margin below the title (Playwright)
- [x] Breadcrumb population phrases render as `<p>` elements below navigation crumbs (Playwright)
- [ ] Copy map card image to clipboard: image copies successfully without error toast
- [ ] Error toast shows red when clipboard copy fails (keep tab unfocused during capture)
- [ ] Legend items stay on one line without wrapping (requires map card to load in browser)
- [ ] Bar chart numeric label centered within bar on HIV county view (narrow bar scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
