### PR TITLE
fix(e2e): update population phrase selectors from li to p

### DIFF
--- a/frontend/playwright-tests/bb_ami.spec.ts
+++ b/frontend/playwright-tests/bb_ami.spec.ts
@@ -38,7 +38,7 @@ test('PHRMA: Beta Blockers after Heart Attack (AMI)', async ({ page }) => {
       expect
         .soft(
           page
-            .locator('li')
+            .locator('p')
             .filter({ hasText: 'Total population of Medicare Beta-Blocker' })
             .first(),
         )

--- a/frontend/playwright-tests/maternal_mortality.spec.ts
+++ b/frontend/playwright-tests/maternal_mortality.spec.ts
@@ -11,7 +11,7 @@ test('Maternal Mortality', async ({ page }) => {
     .getByRole('heading', { name: 'New Mothers, Ages 10-' })
     .click()
   await page
-    .locator('li')
+    .locator('p')
     .filter({ hasText: 'Total population of New' })
     .click()
   await page

--- a/frontend/playwright-tests/medicare_hiv.spec.ts
+++ b/frontend/playwright-tests/medicare_hiv.spec.ts
@@ -12,7 +12,7 @@ test('PHRMA HIV conditions and medication adherence', async ({ page }) => {
     .getByRole('heading', { name: 'Medicare ARV Beneficiaries,' })
     .click()
   await page
-    .getByRole('listitem')
+    .locator('p')
     .filter({ hasText: 'Total population of Medicare' })
     .click()
   await page

--- a/frontend/playwright-tests/medicare_schizophrenia.spec.ts
+++ b/frontend/playwright-tests/medicare_schizophrenia.spec.ts
@@ -13,7 +13,7 @@ test('PHRMA MENTAL HEALTH conditions and medication adherence', async ({
     .getByRole('heading', { name: 'Medicare beneficiaries with' })
     .click()
   await page
-    .getByRole('listitem')
+    .locator('p')
     .filter({ hasText: 'Total population of Medicare' })
     .click()
   await page


### PR DESCRIPTION
## Summary

- Four nightly E2E tests broke after `ee5538b21` moved `totalPopulationPhrase` / `subPopulationPhrase` from MUI `Breadcrumbs` `<li>` elements into plain `<p>` tags in `HetBreadcrumbs.tsx`
- Tests were selecting `locator('li')` / `getByRole('listitem')` filtered by `'Total population of...'` text, which no longer matches the DOM
- Updated all four selectors to `locator('p')` to match the new element type

Closes #4866

## Test plan

- [x] `bb_ami.spec.ts` - locator updated from `li` to `p`
- [x] `maternal_mortality.spec.ts` - locator updated from `li` to `p`
- [x] `medicare_hiv.spec.ts` - locator updated from `getByRole('listitem')` to `locator('p')`
- [x] `medicare_schizophrenia.spec.ts` - locator updated from `getByRole('listitem')` to `locator('p')`

🤖 Generated with [Claude Code](https://claude.com/claude-code)