### PR TITLE
perf(frontend_server): cache IAM identity token for 55 minutes

### DIFF
--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -47,19 +47,24 @@ app.use('/api', (req, res, next) => {
 })
 
 // Add Authorization header for all requests proxied to the data server.
-// TODO: The token can be cached and only refreshed when needed
+// Token is cached for 55 minutes - Cloud Run identity tokens are valid for
+// 1 hour, and we refresh 5 minutes early to avoid serving an expiring token.
+let _iamToken = null
+let _iamTokenExpiry = 0
+
+async function getIamToken(fetchUrl) {
+  if (_iamToken && Date.now() < _iamTokenExpiry) return _iamToken
+  const res = await fetch(fetchUrl, { headers: { 'Metadata-Flavor': 'Google' } })
+  _iamToken = await res.text()
+  _iamTokenExpiry = Date.now() + 55 * 60 * 1000
+  return _iamToken
+}
+
 app.use('/api', (req, _res, next) => {
   if (assertEnvVar('NODE_ENV') === 'production') {
     const metadataServerTokenURL = assertEnvVar('METADATA_SERVER_TOKEN_URL')
     const targetUrl = assertEnvVar('DATA_SERVER_URL')
-    const fetchUrl = metadataServerTokenURL + targetUrl
-    const options = {
-      headers: {
-        'Metadata-Flavor': 'Google',
-      },
-    }
-    fetch(fetchUrl, options)
-      .then((res) => res.text())
+    getIamToken(metadataServerTokenURL + targetUrl)
       .then((token) => {
         req.headers['Authorization_DataServer'] = `bearer ${token}`
         next()

--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -49,15 +49,25 @@ app.use('/api', (req, res, next) => {
 // Add Authorization header for all requests proxied to the data server.
 // Token is cached for 55 minutes - Cloud Run identity tokens are valid for
 // 1 hour, and we refresh 5 minutes early to avoid serving an expiring token.
-let _iamToken = null
+// The promise itself is cached so concurrent requests during cold start or
+// expiry coalesce onto a single fetch rather than stampeding the metadata server.
+let _iamTokenPromise = null
 let _iamTokenExpiry = 0
 
-async function getIamToken(fetchUrl) {
-  if (_iamToken && Date.now() < _iamTokenExpiry) return _iamToken
-  const res = await fetch(fetchUrl, { headers: { 'Metadata-Flavor': 'Google' } })
-  _iamToken = await res.text()
+function getIamToken(fetchUrl) {
+  if (_iamTokenPromise && Date.now() < _iamTokenExpiry) return _iamTokenPromise
   _iamTokenExpiry = Date.now() + 55 * 60 * 1000
-  return _iamToken
+  _iamTokenPromise = fetch(fetchUrl, { headers: { 'Metadata-Flavor': 'Google' } })
+    .then((res) => {
+      if (!res.ok) throw new Error(`Metadata server returned ${res.status}`)
+      return res.text()
+    })
+    .catch((err) => {
+      _iamTokenPromise = null
+      _iamTokenExpiry = 0
+      throw err
+    })
+  return _iamTokenPromise
 }
 
 app.use('/api', (req, _res, next) => {


### PR DESCRIPTION
**Preview:** [HIV national – Explore Data](https://deploy-preview-4875--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&group1=All&dt1=hiv_prevalence&demo=race_and_ethnicity)

## Summary

- Caches the Cloud Run IAM identity token at module scope for 55 minutes instead of fetching a fresh one before every proxied `/api` request
- Caches the promise (not the resolved value) so concurrent requests during cold start coalesce onto a single metadata server fetch rather than stampeding it
- Validates `res.ok` before storing; on failure clears the cache so the next request retries rather than reusing an error response for 55 minutes

Closes #4867
Part of milestone: perf: explore data page

## Test plan

- [ ] Deploy to infra-test (auto-triggers on merge to main via `deployInfraTest.yml`) and verify `/api/dataset` requests succeed
- [ ] Check frontend_server Cloud Run logs: metadata server fetch should appear once per session rather than once per request

🤖 Generated with [Claude Code](https://claude.com/claude-code)
