### PR TITLE
obs(frontend-server): log IAM token fetch and failure events

### DIFF
--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -64,7 +64,7 @@ function getIamToken(fetchUrl) {
       return res.text()
     })
     .catch((err) => {
-      console.warn('[iam-token] fetch failed, clearing cache:', err.message)
+      console.warn('[iam-token] fetch failed, clearing cache:', err)
       _iamTokenPromise = null
       _iamTokenExpiry = 0
       throw err

--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -56,6 +56,7 @@ let _iamTokenExpiry = 0
 
 function getIamToken(fetchUrl) {
   if (_iamTokenPromise && Date.now() < _iamTokenExpiry) return _iamTokenPromise
+  console.info('[iam-token] fetching new token')
   _iamTokenExpiry = Date.now() + 55 * 60 * 1000
   _iamTokenPromise = fetch(fetchUrl, { headers: { 'Metadata-Flavor': 'Google' } })
     .then((res) => {
@@ -63,6 +64,7 @@ function getIamToken(fetchUrl) {
       return res.text()
     })
     .catch((err) => {
+      console.warn('[iam-token] fetch failed, clearing cache:', err.message)
       _iamTokenPromise = null
       _iamTokenExpiry = 0
       throw err


### PR DESCRIPTION
**Preview:** [HIV national](https://deploy-preview-4876--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&group1=All&dt1=hiv_prevalence&demo=race_and_ethnicity) *(server-only change — no UI diff)*

## Summary

- Logs `[iam-token] fetching new token` on cache miss so Cloud Run logs show exactly one entry per cold start and per 55-minute renewal
- Logs full `err` object (not just `err.message`) on token fetch failure, preserving stack trace

In production you should see exactly one `[iam-token] fetching new token` log line at cold start, then silence for 55 minutes. Makes it trivial to verify [#4867](https://github.com/SatcherInstitute/health-equity-tracker/issues/4867) behavior via `gcloud logging read`.

Part of the [perf: explore data page](https://github.com/SatcherInstitute/health-equity-tracker/milestone/6) milestone.

## Test plan

- [ ] After deploy, run: `gcloud logging read 'resource.labels.service_name="frontend-service" AND textPayload:"[iam-token]"' --project=het-infra-prod` and confirm exactly one `fetching new token` entry appears at cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)
