### PR TITLE
perf(deps): remove data-forge, replace with native array operations

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7744,6 +7744,27 @@
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
 			}
+		},
+		"node_modules/@emnapi/core": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.1",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
 		}
 	}
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,6 @@
 				"@tanstack/react-query": "^5.101.0",
 				"@tanstack/react-table": "^8.21.3",
 				"d3": "^7.9.0",
-				"data-forge": "^1.10.3",
 				"dom-to-image-more": "^3.7.1",
 				"geojson": "^0.5.0",
 				"jotai": "^2.19.1",
@@ -165,6 +164,7 @@
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"devOptional": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
 				"@babel/generator": "^7.29.0",
@@ -371,6 +371,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
 			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.28.6",
 				"@babel/parser": "^7.28.6",
@@ -774,7 +775,8 @@
 			"resolved": "https://registry.npmjs.org/@cspell/dict-css/-/dict-css-4.1.1.tgz",
 			"integrity": "sha512-y/Vgo6qY08e1t9OqR56qjoFLBCpi4QfWMf2qzD1l9omRZwvSMQGRPz4x0bxkkkU4oocMAeztjzCsmLew//c/8w==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cspell/dict-dart": {
 			"version": "2.3.2",
@@ -914,14 +916,16 @@
 			"resolved": "https://registry.npmjs.org/@cspell/dict-html/-/dict-html-4.0.15.tgz",
 			"integrity": "sha512-GJYnYKoD9fmo2OI0aySEGZOjThnx3upSUvV7mmqUu8oG+mGgzqm82P/f7OqsuvTaInZZwZbo+PwJQd/yHcyFIw==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cspell/dict-html-symbol-entities": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/@cspell/dict-html-symbol-entities/-/dict-html-symbol-entities-4.0.5.tgz",
 			"integrity": "sha512-429alTD4cE0FIwpMucvSN35Ld87HCyuM8mF731KU5Rm4Je2SG6hmVx7nkBsLyrmH3sQukTcr1GaiZsiEg8svPA==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cspell/dict-java": {
 			"version": "5.0.12",
@@ -1119,7 +1123,8 @@
 			"resolved": "https://registry.npmjs.org/@cspell/dict-typescript/-/dict-typescript-3.2.3.tgz",
 			"integrity": "sha512-zXh1wYsNljQZfWWdSPYwQhpwiuW0KPW1dSd8idjMRvSD0aSvWWHoWlrMsmZeRl4qM4QCEAjua8+cjflm41cQBg==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"peer": true
 		},
 		"node_modules/@cspell/dict-vue": {
 			"version": "3.0.5",
@@ -1260,6 +1265,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			},
@@ -1283,35 +1289,9 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/@data-forge/serialization": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@data-forge/serialization/-/serialization-1.0.1.tgz",
-			"integrity": "sha512-EP7IWimh5JcDOISVoXvNIjUAqcPN1FkNWvuvjY3uzcswErxB8j93ldlUBvgvGEszqFRwMM3fpMF0HrISg5iBSQ==",
-			"license": "MIT"
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -1382,6 +1362,7 @@
 			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
 			"integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -1425,6 +1406,7 @@
 			"resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
 			"integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.18.3",
 				"@emotion/babel-plugin": "^11.13.5",
@@ -1969,6 +1951,7 @@
 			"integrity": "sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -2060,6 +2043,7 @@
 			"resolved": "https://registry.npmjs.org/@mui/material/-/material-9.0.1.tgz",
 			"integrity": "sha512-voyCpeUxcSWLN7KPZuq0pGCIt726T9K6kiVM3XUcywZDAlZSarLHaUxJVQpospbjjOzN53hwyjo8s6KoWl6utw==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/runtime": "^7.29.2",
 				"@mui/core-downloads-tracker": "^9.0.1",
@@ -2400,9 +2384,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2420,9 +2401,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2440,9 +2418,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2460,9 +2435,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2480,9 +2452,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2500,9 +2469,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3281,6 +3247,7 @@
 			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
@@ -3704,6 +3671,7 @@
 			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -3725,6 +3693,7 @@
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
 			"integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"csstype": "^3.0.2"
 			}
@@ -3735,6 +3704,7 @@
 			"integrity": "sha512-/EEvYBdT3BflCWvTMO7YkYBHVE9Ci6XdqZciZANQgKpaiDRGOLIlRo91jbTNRQjgPFWVaRxcYc0luVNFitz57A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"peerDependencies": {
 				"@types/react": "^19.2.0"
 			}
@@ -3846,6 +3816,7 @@
 			"integrity": "sha512-36l628fQ/9a/8ihy97eOtEnvWQEdqULQOJtcaxtoNq0G1w3Mxd4szSahOaMM9/NGyZ+hyKcMtIW/WIxq0XQViQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.6",
@@ -4135,6 +4106,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"baseline-browser-mapping": "^2.10.12",
 				"caniuse-lite": "^1.0.30001782",
@@ -4252,16 +4224,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/clone": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-			"integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/clsx": {
@@ -4920,6 +4882,7 @@
 			"resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
 			"integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
 			"license": "ISC",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			}
@@ -5004,21 +4967,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/data-forge": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/data-forge/-/data-forge-1.10.5.tgz",
-			"integrity": "sha512-wl21hTydikjm1O2w/vTu0CW4ReMpdcJJx9+xfaGoe0EQa1P5VMl1c6j/5Mfy2X8P19ltC62cAx/66OAMrVkAmA==",
-			"license": "MIT",
-			"dependencies": {
-				"@data-forge/serialization": "^1.0.0",
-				"dayjs": "^1.8.12",
-				"easy-table": "1.1.0",
-				"json5": "^2.1.0",
-				"numeral": "^2.0.6",
-				"papaparse": "5.2.0",
-				"typy": "^3.0.1"
-			}
-		},
 		"node_modules/data-urls": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -5032,12 +4980,6 @@
 			"engines": {
 				"node": ">=18"
 			}
-		},
-		"node_modules/dayjs": {
-			"version": "1.11.20",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-			"integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
-			"license": "MIT"
 		},
 		"node_modules/debug": {
 			"version": "4.4.3",
@@ -5077,19 +5019,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/defaults": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
-			"integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"clone": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/delaunator": {
@@ -5153,15 +5082,6 @@
 			"dependencies": {
 				"no-case": "^3.0.4",
 				"tslib": "^2.0.3"
-			}
-		},
-		"node_modules/easy-table": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
-			"integrity": "sha512-oq33hWOSSnl2Hoh00tZWaIPi1ievrD9aFG82/IgjlycAnW9hHx5PkJiXpxPsgEE+H7BsbVQXFVFST8TEXS6/pA==",
-			"license": "MIT",
-			"optionalDependencies": {
-				"wcwidth": ">=1.0.1"
 			}
 		},
 		"node_modules/electron-to-chromium": {
@@ -5801,6 +5721,7 @@
 			"resolved": "https://registry.npmjs.org/jotai/-/jotai-2.20.0.tgz",
 			"integrity": "sha512-b5GAqgmXmXzB4WPaTH26ppk9Sl7AA9WSQX7yfdM+gJ1rFROiWcVbi97gFuN/yVCojOcbcvop2sfLL+fjxW0JVg==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12.20.0"
 			},
@@ -5881,6 +5802,7 @@
 			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"cssstyle": "^4.2.1",
 				"data-urls": "^5.0.0",
@@ -5944,6 +5866,7 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"json5": "lib/cli.js"
@@ -6412,15 +6335,6 @@
 			"devOptional": true,
 			"license": "MIT"
 		},
-		"node_modules/numeral": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
-			"integrity": "sha512-qaKRmtYPZ5qdw4jWJD6bxEf1FJEqllJrwxCLIm0sQU/A7v2/czigzOb+C2uSiFsa9lBUzeH7M1oK+Q+OLxL3kA==",
-			"license": "MIT",
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/nwsapi": {
 			"version": "2.2.23",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -6446,12 +6360,6 @@
 				"https://github.com/sponsors/sxzz",
 				"https://opencollective.com/debug"
 			],
-			"license": "MIT"
-		},
-		"node_modules/papaparse": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz",
-			"integrity": "sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA==",
 			"license": "MIT"
 		},
 		"node_modules/parent-module": {
@@ -6574,6 +6482,7 @@
 			"integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -6675,6 +6584,7 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
 			"integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6697,6 +6607,7 @@
 			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
 			"integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"scheduler": "^0.27.0"
 			},
@@ -6830,6 +6741,7 @@
 			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
 			"integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"react-router": "7.16.0"
 			},
@@ -7396,6 +7308,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -7403,12 +7316,6 @@
 			"engines": {
 				"node": ">=14.17"
 			}
-		},
-		"node_modules/typy": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/typy/-/typy-3.3.0.tgz",
-			"integrity": "sha512-Du53deMF9X9pSM3gVXDjLBq14BUfZWSGKfmmR1kTlg953RaIZehfc8fQuoAiW+SRO6bJsP+59mv1tsH8vwKghg==",
-			"license": "MIT"
 		},
 		"node_modules/undici-types": {
 			"version": "6.21.0",
@@ -7454,6 +7361,7 @@
 			"integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -7562,6 +7470,7 @@
 			"integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.6",
 				"@vitest/mocker": "4.1.6",
@@ -7671,16 +7580,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/wcwidth": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-			"integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"defaults": "^1.0.3"
 			}
 		},
 		"node_modules/webidl-conversions": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,6 @@
 		"@tanstack/react-query": "^5.101.0",
 		"@tanstack/react-table": "^8.21.3",
 		"d3": "^7.9.0",
-		"data-forge": "^1.10.3",
 		"dom-to-image-more": "^3.7.1",
 		"geojson": "^0.5.0",
 		"jotai": "^2.19.1",

--- a/frontend/src/cards/CompareBubbleChartCard.tsx
+++ b/frontend/src/cards/CompareBubbleChartCard.tsx
@@ -110,7 +110,7 @@ export default function CompareBubbleChartCard(
           dataTopicY.map((row) => [
             row.fips +
               row.fips_name +
-              String(row.race_and_ethnicity ?? '').replace(' (NH)', ''),
+              String(row[props.demographicType] ?? '').replace(' (NH)', ''),
             row,
           ]),
         )
@@ -118,7 +118,7 @@ export default function CompareBubbleChartCard(
           const key =
             rowX.fips +
             rowX.fips_name +
-            String(rowX.race_and_ethnicity ?? '').replace(' (NH)', '')
+            String(rowX[props.demographicType] ?? '').replace(' (NH)', '')
           const rowY = yIndex.get(key)
           return rowY ? [{ ...rowX, ...rowY }] : []
         })

--- a/frontend/src/cards/CompareBubbleChartCard.tsx
+++ b/frontend/src/cards/CompareBubbleChartCard.tsx
@@ -1,4 +1,3 @@
-import { DataFrame } from 'data-forge'
 import CompareBubbleChart from '../charts/CompareBubbleChart'
 import type {
   DataTypeConfig,
@@ -107,40 +106,30 @@ export default function CompareBubbleChartCard(
 
         const dataPopRadius = rateQueryResponsePop.data
 
-        // Create DataFrames from your arrays
-        const df1 = new DataFrame(dataTopicX)
-        const df2 = new DataFrame(dataTopicY)
-        const dfPop = new DataFrame(dataPopRadius)
-
-        // Merge the DataFrames based on "fips" and "race_and_ethnicity"
-        const mergedXYData = df1.join(
-          df2,
-          (rowX) =>
+        const yIndex = new Map(
+          dataTopicY.map((row) => [
+            row.fips +
+              row.fips_name +
+              String(row.race_and_ethnicity ?? '').replace(' (NH)', ''),
+            row,
+          ]),
+        )
+        const mergedXY = dataTopicX.flatMap((rowX) => {
+          const key =
             rowX.fips +
             rowX.fips_name +
-            rowX.race_and_ethnicity?.replace(' (NH)', ''),
-          (rowY) =>
-            rowY.fips +
-            rowY.fips_name +
-            rowY.race_and_ethnicity?.replace(' (NH)', ''),
-          (leftRow, rightRow) => ({
-            ...leftRow, // Merge fields from df1
-            ...rightRow, // Merge fields from df2
-          }),
-        )
+            String(rowX.race_and_ethnicity ?? '').replace(' (NH)', '')
+          const rowY = yIndex.get(key)
+          return rowY ? [{ ...rowX, ...rowY }] : []
+        })
 
-        const mergedData = mergedXYData.join(
-          dfPop,
-          (row) => row.fips + row.fips_name,
-          (rowPop) => rowPop.fips + rowPop.fips_name,
-          (leftRow, rightRow) => ({
-            ...leftRow,
-            ...rightRow,
-          }),
+        const popIndex = new Map(
+          dataPopRadius.map((row) => [row.fips + row.fips_name, row]),
         )
-
-        // Convert the merged DataFrame back to an array of objects
-        const mergedArray = mergedData.toArray()
+        const mergedArray = mergedXY.flatMap((row) => {
+          const rowPop = popIndex.get(row.fips + row.fips_name)
+          return rowPop ? [{ ...row, ...rowPop }] : []
+        })
 
         const validXData = mergedArray.map((row) => ({
           fips: row.fips,

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -223,6 +223,11 @@ class MetricQueryCache extends ResourceCache<MetricQuery, MetricQueryResponse> {
     const uniqueConsumedDatasetIds = Array.from(new Set(consumedDatasetIds))
     // Each MetricQuery always resolves to a single provider — multi-provider
     // queries were removed when population data was baked into topic tables.
+    if (queryResponses.length !== 1) {
+      throw new Error(
+        `Expected exactly 1 provider response, got ${queryResponses.length}`,
+      )
+    }
     const resp = new MetricQueryResponse(
       queryResponses[0].data,
       uniqueConsumedDatasetIds,

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -1,4 +1,3 @@
-import { DataFrame, type IDataFrame } from 'data-forge'
 import { LRUCache } from 'lru-cache'
 import { getDataFetcher, getDataManager, getLogger } from '../../utils/globals'
 import type {
@@ -8,7 +7,6 @@ import type {
 import { type MetricQuery, MetricQueryResponse } from '../query/MetricQuery'
 import { DatasetOrganizer } from '../sorting/DatasetOrganizer'
 import { Dataset, type MapOfDatasetMetadata } from '../utils/DatasetTypes'
-import { joinOnCols } from '../utils/datasetutils'
 import VariableProviderMap from './VariableProviderMap'
 
 // Max size for the dataset and query cache is measured by number of rows in the
@@ -219,24 +217,14 @@ class MetricQueryCache extends ResourceCache<MetricQuery, MetricQueryResponse> {
       return potentialErrorResponse
     }
 
-    const dataframes: IDataFrame[] = queryResponses.map(
-      (response) => new DataFrame(response.data),
-    )
-
-    const joined = dataframes.reduce((prev, next) => {
-      return joinOnCols(prev, next, query.breakdowns.getJoinColumns(), 'outer')
-    })
-
-    const consumedDatasetIds = queryResponses.reduce(
-      (
-        accumulator: Array<DatasetId | DatasetIdWithStateFIPSCode>,
-        response: MetricQueryResponse,
-      ) => accumulator.concat(response.consumedDatasetIds),
-      [],
+    const consumedDatasetIds = queryResponses.flatMap(
+      (r) => r.consumedDatasetIds,
     )
     const uniqueConsumedDatasetIds = Array.from(new Set(consumedDatasetIds))
+    // Each MetricQuery always resolves to a single provider — multi-provider
+    // queries were removed when population data was baked into topic tables.
     const resp = new MetricQueryResponse(
-      joined.toArray(),
+      queryResponses[0].data,
       uniqueConsumedDatasetIds,
     )
 

--- a/frontend/src/data/providers/AcsConditionProvider.ts
+++ b/frontend/src/data/providers/AcsConditionProvider.ts
@@ -46,7 +46,7 @@ class AcsConditionProvider extends VariableProvider {
       : appendFipsIfNeeded(datasetId, breakdowns)
     const acsDataset = await getDataManager().loadDataset(specificDatasetId)
 
-    let df = acsDataset.toDataFrame()
+    let df = acsDataset.rows
 
     // If requested, filter geography by state or county level
     // We apply the geo filter right away to reduce subsequent calculation times
@@ -59,7 +59,7 @@ class AcsConditionProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df.toArray(), [datasetId])
+    return new MetricQueryResponse(df, [datasetId])
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/AhrProvider.ts
+++ b/frontend/src/data/providers/AhrProvider.ts
@@ -156,7 +156,7 @@ class AhrProvider extends VariableProvider {
       ? datasetId
       : appendFipsIfNeeded(datasetId, breakdowns)
     const ahr = await getDataManager().loadDataset(specificDatasetId)
-    let df = ahr.toDataFrame()
+    let df = ahr.rows
 
     const consumedDatasetIds = [datasetId]
 
@@ -170,7 +170,7 @@ class AhrProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds?: MetricId[]): boolean {

--- a/frontend/src/data/providers/CawpProvider.ts
+++ b/frontend/src/data/providers/CawpProvider.ts
@@ -150,14 +150,14 @@ class CawpProvider extends VariableProvider {
       const hasDistricts =
         breakdowns.geography === 'county' &&
         df.some((row) => 'congressional_districts' in row)
-      const districts = hasDistricts
-        ? df.map((row) => row.congressional_districts)
+      const districtsByFips = hasDistricts
+        ? new Map(df.map((row) => [row.fips, row.congressional_districts]))
         : null
       df = this.removeUnrequestedColumns(df, metricQuery)
-      if (districts) {
-        df = df.map((row, i) => ({
+      if (districtsByFips) {
+        df = df.map((row) => ({
           ...row,
-          congressional_districts: districts[i],
+          congressional_districts: districtsByFips.get(row.fips),
         }))
       }
     }

--- a/frontend/src/data/providers/CawpProvider.ts
+++ b/frontend/src/data/providers/CawpProvider.ts
@@ -108,7 +108,7 @@ class CawpProvider extends VariableProvider {
       ? datasetId
       : appendFipsIfNeeded(datasetId, breakdowns)
     const cawp = await getDataManager().loadDataset(specificDatasetId)
-    let df = cawp.toDataFrame()
+    let df = cawp.rows
 
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
@@ -149,16 +149,19 @@ class CawpProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       const hasDistricts =
         breakdowns.geography === 'county' &&
-        df.getColumnNames().includes('congressional_districts')
-      const districtSeries = hasDistricts
-        ? df.getSeries('congressional_districts')
+        df.some((row) => 'congressional_districts' in row)
+      const districts = hasDistricts
+        ? df.map((row) => row.congressional_districts)
         : null
       df = this.removeUnrequestedColumns(df, metricQuery)
-      if (districtSeries) {
-        df = df.withSeries('congressional_districts', districtSeries)
+      if (districts) {
+        df = df.map((row, i) => ({
+          ...row,
+          congressional_districts: districts[i],
+        }))
       }
     }
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds?: MetricId[]): boolean {

--- a/frontend/src/data/providers/CdcCancerProvider.ts
+++ b/frontend/src/data/providers/CdcCancerProvider.ts
@@ -85,7 +85,7 @@ class CdcCancerProvider extends VariableProvider {
       }
 
       const cancerData = await getDataManager().loadDataset(datasetId)
-      let df = cancerData.toDataFrame()
+      let df = cancerData.rows
 
       df = this.filterByGeo(df, breakdowns)
       df = this.renameGeoColumns(df, breakdowns)
@@ -97,7 +97,7 @@ class CdcCancerProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+      return new MetricQueryResponse(df, consumedDatasetIds)
     } catch (error) {
       console.error('Error fetching cancer data:', error)
       throw error

--- a/frontend/src/data/providers/CdcCovidProvider.ts
+++ b/frontend/src/data/providers/CdcCovidProvider.ts
@@ -66,11 +66,11 @@ class CdcCovidProvider extends VariableProvider {
       : appendFipsIfNeeded(datasetId, breakdowns)
     const covidDataset = await getDataManager().loadDataset(specificDatasetId)
     const consumedDatasetIds = [datasetId]
-    let df = covidDataset.toDataFrame()
+    let df = covidDataset.rows
 
     df = this.filterByGeo(df, breakdowns)
 
-    if (df.toArray().length === 0) {
+    if (df.length === 0) {
       return new MetricQueryResponse([], consumedDatasetIds)
     }
     df = this.renameGeoColumns(df, breakdowns)
@@ -133,7 +133,7 @@ class CdcCovidProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/GeoContextProvider.ts
+++ b/frontend/src/data/providers/GeoContextProvider.ts
@@ -32,7 +32,7 @@ class GeoContextProvider extends VariableProvider {
     const specificDatasetId = appendFipsIfNeeded(datasetId, breakdowns)
     const geoContext = await getDataManager().loadDataset(specificDatasetId)
 
-    let df = geoContext.toDataFrame()
+    let df = geoContext.rows
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
 
@@ -64,7 +64,7 @@ class GeoContextProvider extends VariableProvider {
       populationId && consumedDatasetIds.push(populationId)
     }
 
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
+++ b/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
@@ -48,7 +48,7 @@ class GunViolenceBlackMenProvider extends VariableProvider {
 
       const gunViolenceBlackMenData =
         await getDataManager().loadDataset(datasetId)
-      let df = gunViolenceBlackMenData.toDataFrame()
+      let df = gunViolenceBlackMenData.rows
 
       df = this.filterByGeo(df, breakdowns)
       df = this.renameGeoColumns(df, breakdowns)
@@ -60,7 +60,7 @@ class GunViolenceBlackMenProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+      return new MetricQueryResponse(df, consumedDatasetIds)
     } catch (error) {
       console.error('Error fetching gun homicides of Black men data:', error)
       throw error

--- a/frontend/src/data/providers/GunViolenceProvider.ts
+++ b/frontend/src/data/providers/GunViolenceProvider.ts
@@ -94,15 +94,22 @@ class GunViolenceProvider extends VariableProvider {
 
       const gunViolenceData =
         await getDataManager().loadDataset(specificDatasetId)
-      let df = gunViolenceData.toDataFrame()
+      let df = gunViolenceData.rows
 
       df = this.filterByGeo(df, breakdowns)
       df = this.renameGeoColumns(df, breakdowns)
       if (isChr) {
-        df = df.renameSeries({
-          chr_population_pct: 'fatal_population_pct',
-          chr_population_estimated_total: 'fatal_population',
-        })
+        df = df.map(
+          ({
+            chr_population_pct,
+            chr_population_estimated_total,
+            ...rest
+          }) => ({
+            ...rest,
+            fatal_population_pct: chr_population_pct,
+            fatal_population: chr_population_estimated_total,
+          }),
+        )
       }
       if (isFallbackId) {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
@@ -112,7 +119,7 @@ class GunViolenceProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+      return new MetricQueryResponse(df, consumedDatasetIds)
     } catch (error) {
       console.error('Error fetching gun deaths data:', error)
       throw error

--- a/frontend/src/data/providers/GunViolenceYouthProvider.ts
+++ b/frontend/src/data/providers/GunViolenceYouthProvider.ts
@@ -63,7 +63,7 @@ class GunViolenceYouthProvider extends VariableProvider {
       }
 
       const gunViolenceYouthData = await getDataManager().loadDataset(datasetId)
-      let df = gunViolenceYouthData.toDataFrame()
+      let df = gunViolenceYouthData.rows
 
       df = this.filterByGeo(df, breakdowns)
       df = this.renameGeoColumns(df, breakdowns)
@@ -75,7 +75,7 @@ class GunViolenceYouthProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+      return new MetricQueryResponse(df, consumedDatasetIds)
     } catch (error) {
       console.error('Error fetching gun deaths of youth data:', error)
       throw error

--- a/frontend/src/data/providers/HivBlackWomenProvider.ts
+++ b/frontend/src/data/providers/HivBlackWomenProvider.ts
@@ -64,7 +64,7 @@ class HivBlackWomenProvider extends VariableProvider {
       : appendFipsIfNeeded(datasetId, breakdowns)
 
     const hiv = await getDataManager().loadDataset(specificDatasetId)
-    let df = hiv.toDataFrame()
+    let df = hiv.rows
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
 
@@ -75,7 +75,7 @@ class HivBlackWomenProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, _metricIds: MetricId[]): boolean {

--- a/frontend/src/data/providers/HivProvider.ts
+++ b/frontend/src/data/providers/HivProvider.ts
@@ -108,7 +108,7 @@ class HivProvider extends VariableProvider {
       ? datasetId
       : appendFipsIfNeeded(datasetId, breakdowns)
     const hiv = await getDataManager().loadDataset(specificDatasetId)
-    let df = hiv.toDataFrame()
+    let df = hiv.rows
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
 
@@ -118,7 +118,7 @@ class HivProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds: MetricId[]): boolean {

--- a/frontend/src/data/providers/IncarcerationProvider.tsx
+++ b/frontend/src/data/providers/IncarcerationProvider.tsx
@@ -73,7 +73,7 @@ class IncarcerationProvider extends VariableProvider {
       ? datasetId
       : appendFipsIfNeeded(datasetId, breakdowns)
     const dataSource = await getDataManager().loadDataset(specificDatasetId)
-    let df = dataSource.toDataFrame()
+    let df = dataSource.rows
 
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
@@ -114,7 +114,7 @@ class IncarcerationProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/MaternalMortalityProvider.ts
+++ b/frontend/src/data/providers/MaternalMortalityProvider.ts
@@ -43,10 +43,10 @@ class MaternalMortalityProvider extends VariableProvider {
       const maternalMortalityDataset =
         await getDataManager().loadDataset(datasetId)
       const consumedDatasetIds = [datasetId]
-      let df = maternalMortalityDataset.toDataFrame()
+      let df = maternalMortalityDataset.rows
       df = this.filterByGeo(df, breakdowns)
 
-      if (df.toArray().length === 0) {
+      if (df.length === 0) {
         return new MetricQueryResponse([], consumedDatasetIds)
       }
       df = this.renameGeoColumns(df, breakdowns)
@@ -58,7 +58,7 @@ class MaternalMortalityProvider extends VariableProvider {
         df = this.removeUnrequestedColumns(df, metricQuery)
       }
 
-      return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+      return new MetricQueryResponse(df, consumedDatasetIds)
     } catch (error) {
       console.error('Error fetching maternal mortality data:', error)
       throw error

--- a/frontend/src/data/providers/PhrmaBrfssProvider.ts
+++ b/frontend/src/data/providers/PhrmaBrfssProvider.ts
@@ -93,7 +93,7 @@ class PhrmaBrfssProvider extends VariableProvider {
       : appendFipsIfNeeded(datasetId, breakdowns)
 
     const phrma = await getDataManager().loadDataset(specificDatasetId)
-    let df = phrma.toDataFrame()
+    let df = phrma.rows
 
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
@@ -106,7 +106,7 @@ class PhrmaBrfssProvider extends VariableProvider {
     }
 
     const consumedDatasetIds = [datasetId]
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/PhrmaProvider.ts
+++ b/frontend/src/data/providers/PhrmaProvider.ts
@@ -122,7 +122,7 @@ class PhrmaProvider extends VariableProvider {
       : appendFipsIfNeeded(datasetId, breakdowns)
 
     const phrma = await getDataManager().loadDataset(specificDatasetId)
-    let df = phrma.toDataFrame()
+    let df = phrma.rows
 
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
@@ -135,7 +135,7 @@ class PhrmaProvider extends VariableProvider {
     }
 
     const consumedDatasetIds = [datasetId]
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/VaccineProvider.ts
+++ b/frontend/src/data/providers/VaccineProvider.ts
@@ -53,7 +53,7 @@ class VaccineProvider extends VariableProvider {
       ? datasetId
       : appendFipsIfNeeded(datasetId, breakdowns)
     const vaxData = await getDataManager().loadDataset(specificDatasetId)
-    let df = vaxData.toDataFrame()
+    let df = vaxData.rows
 
     df = this.filterByGeo(df, breakdowns)
     df = this.renameGeoColumns(df, breakdowns)
@@ -81,7 +81,7 @@ class VaccineProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
+    return new MetricQueryResponse(df, consumedDatasetIds)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/VariableProvider.test.ts
+++ b/frontend/src/data/providers/VariableProvider.test.ts
@@ -8,7 +8,7 @@ import VariableProvider from './VariableProvider'
 // Minimal concrete subclass — only the abstract methods need stubs
 class TestProvider extends VariableProvider {
   constructor() {
-    super('acs_condition_provider', [])
+    super('test_provider' as any, [])
   }
 
   async getDataInternal() {

--- a/frontend/src/data/providers/VariableProvider.test.ts
+++ b/frontend/src/data/providers/VariableProvider.test.ts
@@ -8,7 +8,7 @@ import VariableProvider from './VariableProvider'
 // Minimal concrete subclass — only the abstract methods need stubs
 class TestProvider extends VariableProvider {
   constructor() {
-    super('test_provider', [])
+    super('acs_condition_provider', [])
   }
 
   async getDataInternal() {

--- a/frontend/src/data/providers/VariableProvider.test.ts
+++ b/frontend/src/data/providers/VariableProvider.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, it } from 'vitest'
+import { exclude } from '../query/BreakdownFilter'
+import { Breakdowns } from '../query/Breakdowns'
+import { MetricQuery } from '../query/MetricQuery'
+import { Fips } from '../utils/Fips'
+import VariableProvider from './VariableProvider'
+
+// Minimal concrete subclass — only the abstract methods need stubs
+class TestProvider extends VariableProvider {
+  constructor() {
+    super('test_provider', [])
+  }
+
+  async getDataInternal() {
+    return { data: [], consumedDatasetIds: [] } as any
+  }
+
+  allowsBreakdowns() {
+    return true
+  }
+}
+
+const provider = new TestProvider()
+
+// ---------------------------------------------------------------------------
+// filterByGeo
+// ---------------------------------------------------------------------------
+
+const NATIONAL_ROWS = [
+  { state_fips: '01', state_name: 'Alabama', value: 1 },
+  { state_fips: '02', state_name: 'Alaska', value: 2 },
+]
+
+const COUNTY_ROWS = [
+  { county_fips: '01001', county_name: 'Autauga', state_fips: '01', value: 1 },
+  { county_fips: '01003', county_name: 'Baldwin', state_fips: '01', value: 2 },
+  {
+    county_fips: '02013',
+    county_name: 'Aleutians East',
+    state_fips: '02',
+    value: 3,
+  },
+]
+
+describe('VariableProvider.filterByGeo', () => {
+  it('returns all rows when no filterFips is set', () => {
+    const breakdowns = Breakdowns.byState()
+    expect(provider.filterByGeo(NATIONAL_ROWS, breakdowns)).toEqual(
+      NATIONAL_ROWS,
+    )
+  })
+
+  it('filters state rows by state fips code', () => {
+    const breakdowns = Breakdowns.byState().withGeoFilter(new Fips('01'))
+    expect(provider.filterByGeo(NATIONAL_ROWS, breakdowns)).toEqual([
+      { state_fips: '01', state_name: 'Alabama', value: 1 },
+    ])
+  })
+
+  it('filters county rows by specific county fips code', () => {
+    const breakdowns = Breakdowns.byCounty().withGeoFilter(new Fips('01001'))
+    expect(provider.filterByGeo(COUNTY_ROWS, breakdowns)).toEqual([
+      {
+        county_fips: '01001',
+        county_name: 'Autauga',
+        state_fips: '01',
+        value: 1,
+      },
+    ])
+  })
+
+  it('filters county rows to all counties within a state when filterFips is a state', () => {
+    const breakdowns = Breakdowns.byCounty().withGeoFilter(new Fips('01'))
+    const result = provider.filterByGeo(COUNTY_ROWS, breakdowns)
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.county_fips)).toEqual(['01001', '01003'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// renameGeoColumns
+// ---------------------------------------------------------------------------
+
+const GEO_ROWS = [
+  {
+    state_fips: '01',
+    state_name: 'Alabama',
+    county_fips: '01001',
+    county_name: 'Autauga',
+    value: 10,
+  },
+]
+
+describe('VariableProvider.renameGeoColumns', () => {
+  it('maps state columns to fips/fips_name and drops county columns', () => {
+    const breakdowns = Breakdowns.byState()
+    expect(provider.renameGeoColumns(GEO_ROWS, breakdowns)).toEqual([
+      { fips: '01', fips_name: 'Alabama', value: 10 },
+    ])
+  })
+
+  it('maps county columns to fips/fips_name and drops state columns', () => {
+    const breakdowns = Breakdowns.byCounty()
+    expect(provider.renameGeoColumns(GEO_ROWS, breakdowns)).toEqual([
+      { fips: '01001', fips_name: 'Autauga', value: 10 },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// removeUnrequestedColumns
+// ---------------------------------------------------------------------------
+
+const WIDE_ROWS = [
+  {
+    fips: '01',
+    fips_name: 'Alabama',
+    race_and_ethnicity: 'White',
+    hiv_prevalence_per_100k: 5,
+    extra_column: 'drop me',
+    time_period: '2020',
+  },
+]
+
+describe('VariableProvider.removeUnrequestedColumns', () => {
+  it('keeps fips, fips_name, requested metric, and enabled demographic; drops the rest', () => {
+    const breakdowns = Breakdowns.byState().andRace()
+    const query = new MetricQuery(
+      ['hiv_prevalence_per_100k'],
+      breakdowns,
+      'hiv_prevalence',
+      'current',
+    )
+    expect(provider.removeUnrequestedColumns(WIDE_ROWS, query)).toEqual([
+      {
+        fips: '01',
+        fips_name: 'Alabama',
+        race_and_ethnicity: 'White',
+        hiv_prevalence_per_100k: 5,
+      },
+    ])
+  })
+
+  it('also keeps time_period for historical queries', () => {
+    const breakdowns = Breakdowns.byState().andRace()
+    const query = new MetricQuery(
+      ['hiv_prevalence_per_100k'],
+      breakdowns,
+      'hiv_prevalence',
+      'historical',
+    )
+    expect(provider.removeUnrequestedColumns(WIDE_ROWS, query)).toEqual([
+      {
+        fips: '01',
+        fips_name: 'Alabama',
+        race_and_ethnicity: 'White',
+        hiv_prevalence_per_100k: 5,
+        time_period: '2020',
+      },
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// applyDemographicBreakdownFilters
+// ---------------------------------------------------------------------------
+
+const RACE_ROWS = [
+  { fips: '01', race_and_ethnicity: 'White', value: 1 },
+  { fips: '01', race_and_ethnicity: 'Black or African American', value: 2 },
+  { fips: '01', race_and_ethnicity: 'All', value: 3 },
+]
+
+describe('VariableProvider.applyDemographicBreakdownFilters', () => {
+  it('returns all rows when the demographic breakdown has no filter', () => {
+    const breakdowns = Breakdowns.byState().andRace()
+    expect(
+      provider.applyDemographicBreakdownFilters(RACE_ROWS, breakdowns),
+    ).toEqual(RACE_ROWS)
+  })
+
+  it('includes only the specified values with an include filter', () => {
+    const breakdowns = Breakdowns.byState().andRace({
+      include: true,
+      values: ['White', 'Black or African American'],
+    })
+    const result = provider.applyDemographicBreakdownFilters(
+      RACE_ROWS,
+      breakdowns,
+    )
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.race_and_ethnicity)).toEqual([
+      'White',
+      'Black or African American',
+    ])
+  })
+
+  it('excludes the specified values with an exclude filter', () => {
+    const breakdowns = Breakdowns.byState().andRace(exclude('All'))
+    const result = provider.applyDemographicBreakdownFilters(
+      RACE_ROWS,
+      breakdowns,
+    )
+    expect(result).toHaveLength(2)
+    expect(result.map((r) => r.race_and_ethnicity)).not.toContain('All')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// castAllsAsRequestedDemographicBreakdown
+// ---------------------------------------------------------------------------
+
+const ALLS_ROWS = [
+  { fips: '01', value: 10 },
+  { fips: '02', value: 20 },
+]
+
+describe('VariableProvider.castAllsAsRequestedDemographicBreakdown', () => {
+  it('stamps "All" on the sole enabled demographic column for every row', () => {
+    const breakdowns = Breakdowns.byState().andRace()
+    const result = provider.castAllsAsRequestedDemographicBreakdown(
+      ALLS_ROWS,
+      breakdowns,
+    )
+    expect(result).toEqual([
+      { fips: '01', value: 10, race_and_ethnicity: 'All' },
+      { fips: '02', value: 20, race_and_ethnicity: 'All' },
+    ])
+  })
+
+  it('stamps "All" on the age column when age breakdown is requested', () => {
+    const breakdowns = Breakdowns.byState().andAge()
+    const result = provider.castAllsAsRequestedDemographicBreakdown(
+      ALLS_ROWS,
+      breakdowns,
+    )
+    expect(result).toEqual([
+      { fips: '01', value: 10, age: 'All' },
+      { fips: '02', value: 20, age: 'All' },
+    ])
+  })
+})

--- a/frontend/src/data/providers/VariableProvider.ts
+++ b/frontend/src/data/providers/VariableProvider.ts
@@ -1,4 +1,3 @@
-import type { IDataFrame } from 'data-forge'
 import type { MetricId } from '../config/MetricConfigTypes'
 import type { ProviderId } from '../loading/VariableProviderMap'
 import type { Breakdowns } from '../query/Breakdowns'
@@ -9,6 +8,7 @@ import {
 } from '../query/MetricQuery'
 import { DatasetOrganizer } from '../sorting/DatasetOrganizer'
 import { TIME_PERIOD } from '../utils/Constants'
+import type { HetRow } from '../utils/DatasetTypes'
 
 abstract class VariableProvider {
   readonly providerId: ProviderId
@@ -35,94 +35,74 @@ abstract class VariableProvider {
     return resp
   }
 
-  filterByGeo(df: IDataFrame, breakdowns: Breakdowns): IDataFrame {
-    const fipsColumn: string =
+  filterByGeo(rows: readonly HetRow[], breakdowns: Breakdowns): HetRow[] {
+    const fipsColumn =
       breakdowns.geography === 'county' ? 'county_fips' : 'state_fips'
-
     if (breakdowns.filterFips !== undefined) {
       const fips = breakdowns.filterFips
       if (fips.isStateOrTerritory() && breakdowns.geography === 'county') {
-        return df.where((row) => fips.isParentOf(row.county_fips)).resetIndex()
-      } else {
-        return df.where((row) => row[fipsColumn] === fips.code).resetIndex()
+        return rows.filter((row) => fips.isParentOf(row.county_fips))
       }
+      return rows.filter((row) => row[fipsColumn] === fips.code)
     }
-    return df
+    return rows as HetRow[]
   }
 
-  renameGeoColumns(df: IDataFrame, breakdowns: Breakdowns): IDataFrame {
-    let newDataframe = df
-    const [fipsColumn, geoNameColumn] =
-      breakdowns.geography === 'county'
-        ? ['county_fips', 'county_name']
-        : ['state_fips', 'state_name']
-
-    if (breakdowns.geography === 'county') {
-      newDataframe = newDataframe.dropSeries(['state_fips']).resetIndex()
-    }
-
-    return newDataframe
-      .renameSeries({
-        [fipsColumn]: 'fips',
-        [geoNameColumn]: 'fips_name',
-      })
-      .resetIndex()
+  renameGeoColumns(rows: readonly HetRow[], breakdowns: Breakdowns): HetRow[] {
+    const isCounty = breakdowns.geography === 'county'
+    return rows.map((row) => {
+      const { county_fips, county_name, state_fips, state_name, ...rest } = row
+      if (isCounty) {
+        return { ...rest, fips: county_fips, fips_name: county_name }
+      }
+      return { ...rest, fips: state_fips, fips_name: state_name }
+    })
   }
 
-  removeUnrequestedColumns(df: IDataFrame, metricQuery: MetricQuery) {
-    const dataFrame = df
-    let requestedColumns = ['fips', 'fips_name'].concat(metricQuery.metricIds)
-
+  removeUnrequestedColumns(
+    rows: readonly HetRow[],
+    metricQuery: MetricQuery,
+  ): HetRow[] {
+    let requestedColumns = ['fips', 'fips_name', ...metricQuery.metricIds]
     if (metricQuery.timeView === 'historical') {
       requestedColumns.push(TIME_PERIOD)
     }
-
-    // Add column names of enabled breakdowns
     requestedColumns = requestedColumns.concat(
-      Object.entries(metricQuery.breakdowns.demographicBreakdowns)
-        .filter(([_, breakdown]) => breakdown.enabled)
-        .map(([_, breakdown]) => breakdown.columnName),
+      Object.values(metricQuery.breakdowns.demographicBreakdowns)
+        .filter((breakdown) => breakdown.enabled)
+        .map((breakdown) => breakdown.columnName),
     )
-
-    const columnsToRemove = dataFrame
-      .getColumnNames()
-      .filter((column) => !requestedColumns.includes(column))
-
-    return dataFrame.dropSeries(columnsToRemove).resetIndex()
+    const colSet = new Set(requestedColumns)
+    return rows.map((row) =>
+      Object.fromEntries(
+        Object.entries(row).filter(([key]) => colSet.has(key)),
+      ),
+    )
   }
 
   applyDemographicBreakdownFilters(
-    df: IDataFrame,
+    rows: readonly HetRow[],
     breakdowns: Breakdowns,
-  ): IDataFrame {
-    let dataFrame = df
-    Object.values(breakdowns.demographicBreakdowns).forEach((demo) => {
+  ): HetRow[] {
+    let result: HetRow[] = rows as HetRow[]
+    for (const demo of Object.values(breakdowns.demographicBreakdowns)) {
       if (demo.enabled && demo.filter) {
-        const filter = demo.filter
-        dataFrame = dataFrame
-          .where((row) => {
-            const value = row[demo.columnName]
-            return filter.include === filter.values.includes(value)
-          })
-          .resetIndex()
+        const { include, values } = demo.filter
+        result = result.filter(
+          (row) => include === values.includes(row[demo.columnName]),
+        )
       }
-    })
-    return dataFrame
+    }
+    return result
   }
 
-  // add the requested demographic column to the ALLS df, with the value 'All' on each row
+  // Stamps 'All' onto the requested demographic column for every row in an alls dataset.
   castAllsAsRequestedDemographicBreakdown(
-    df: IDataFrame,
+    rows: readonly HetRow[],
     breakdowns: Breakdowns,
-  ): IDataFrame {
-    const requestedDemographic =
-      breakdowns.getSoleDemographicBreakdown().columnName
-    df = df.generateSeries((row) => {
-      row[requestedDemographic] = 'All'
-      return row
-    })
-
-    return df
+  ): HetRow[] {
+    const column = breakdowns.getSoleDemographicBreakdown().columnName
+    return rows.map((row) => ({ ...row, [column]: 'All' }))
   }
 
   abstract getDataInternal(

--- a/frontend/src/data/query/MetricQuery.ts
+++ b/frontend/src/data/query/MetricQuery.ts
@@ -81,11 +81,11 @@ export class MetricQueryResponse {
   readonly consumedDatasetIds: Array<DatasetId | DatasetIdWithStateFIPSCode>
 
   constructor(
-    data: HetRow[],
+    data: readonly HetRow[],
     consumedDatasetIds: Array<DatasetId | DatasetIdWithStateFIPSCode> = [],
     missingDataMessage: string | undefined = undefined,
   ) {
-    this.data = data
+    this.data = Array.from(data)
     this.consumedDatasetIds = consumedDatasetIds
     this.invalidValues = getInvalidValues(this.data)
     this.missingDataMessage = missingDataMessage // possibly undefined

--- a/frontend/src/data/utils/DatasetTimeUtils.test.ts
+++ b/frontend/src/data/utils/DatasetTimeUtils.test.ts
@@ -1,4 +1,3 @@
-import { DataFrame } from 'data-forge'
 import type { TrendsData } from '../../charts/trendsChart/types'
 import { METRIC_CONFIG } from '../config/MetricConfig'
 import {
@@ -249,33 +248,28 @@ describe('dropRecentPartialMonth', () => {
       { time_period: '2024-03', value: 30 },
     ]
 
-    const df = new DataFrame(data)
-    const result = dropRecentPartialMonth(df)
+    const result = dropRecentPartialMonth(data)
 
-    expect(result.toArray()).toEqual([
+    expect(result).toEqual([
       { time_period: '2024-01', value: 10 },
       { time_period: '2024-02', value: 20 },
     ])
   })
 
-  it('should handle an empty DataFrame', () => {
-    const df = new DataFrame([])
-    const result = dropRecentPartialMonth(df)
-
-    expect(result.toArray()).toEqual([])
+  it('should handle an empty array', () => {
+    expect(dropRecentPartialMonth([])).toEqual([])
   })
 
-  it('should handle a DataFrame with non-sequential time periods', () => {
+  it('should handle non-sequential time periods', () => {
     const data = [
       { time_period: '2023-12', value: 10 },
       { time_period: '2024-01', value: 20 },
       { time_period: '2024-03', value: 30 },
     ]
 
-    const df = new DataFrame(data)
-    const result = dropRecentPartialMonth(df)
+    const result = dropRecentPartialMonth(data)
 
-    expect(result.toArray()).toEqual([
+    expect(result).toEqual([
       { time_period: '2023-12', value: 10 },
       { time_period: '2024-01', value: 20 },
     ])

--- a/frontend/src/data/utils/DatasetTimeUtils.ts
+++ b/frontend/src/data/utils/DatasetTimeUtils.ts
@@ -1,4 +1,3 @@
-import type { IDataFrame } from 'data-forge'
 import type { TimeSeries, TrendsData } from '../../charts/trendsChart/types'
 import type { MetricConfig, MetricId } from '../config/MetricConfigTypes'
 import type { DemographicType } from '../query/Breakdowns'
@@ -294,24 +293,17 @@ export function getElectionYearData(data: HetRow[]): HetRow[] {
   return data
 }
 
-export function dropRecentPartialMonth(df: IDataFrame): IDataFrame {
-  const partialMonth = getMostRecentMonth(df)
-  return df.where((row) => row.time_period !== partialMonth)
+export function dropRecentPartialMonth(rows: readonly HetRow[]): HetRow[] {
+  const partialMonth = getMostRecentMonth(rows)
+  return rows.filter((row) => row.time_period !== partialMonth)
 }
 
-function getMostRecentMonth(df: IDataFrame): string {
-  // Convert YYYY-MM strings to Date objects
-  const dates = df
-    .getSeries('time_period')
-    .toArray()
-    .map((period) => new Date(`${period}-01`).getTime()) // Get timestamp
-
-  // Find the maximum date
-  const maxTimestamp = Math.max(...dates)
+function getMostRecentMonth(rows: readonly HetRow[]): string {
+  const maxTimestamp = Math.max(
+    ...rows.map((row) => new Date(`${row.time_period}-01`).getTime()),
+  )
   const maxDate = new Date(maxTimestamp)
-
-  // Convert the maximum date back to YYYY-MM format
   const year = maxDate.getUTCFullYear()
-  const month = String(maxDate.getUTCMonth() + 1).padStart(2, '0') // getUTCMonth is zero-indexed
+  const month = String(maxDate.getUTCMonth() + 1).padStart(2, '0')
   return `${year}-${month}`
 }

--- a/frontend/src/data/utils/DatasetTimeUtils.ts
+++ b/frontend/src/data/utils/DatasetTimeUtils.ts
@@ -299,9 +299,11 @@ export function dropRecentPartialMonth(rows: readonly HetRow[]): HetRow[] {
 }
 
 function getMostRecentMonth(rows: readonly HetRow[]): string {
-  const maxTimestamp = Math.max(
-    ...rows.map((row) => new Date(`${row.time_period}-01`).getTime()),
-  )
+  if (rows.length === 0) return ''
+  const maxTimestamp = rows.reduce((max, row) => {
+    const t = new Date(`${row.time_period}-01`).getTime()
+    return t > max ? t : max
+  }, Number.NEGATIVE_INFINITY)
   const maxDate = new Date(maxTimestamp)
   const year = maxDate.getUTCFullYear()
   const month = String(maxDate.getUTCMonth() + 1).padStart(2, '0')

--- a/frontend/src/data/utils/DatasetTypes.ts
+++ b/frontend/src/data/utils/DatasetTypes.ts
@@ -1,4 +1,3 @@
-import { DataFrame, type IDataFrame } from 'data-forge'
 import type { CategoryTypeId } from '../config/CategoryTypes'
 import type { DatasetId } from '../config/DatasetMetadata'
 import type { DataSourceId } from '../config/MetadataMap'
@@ -60,10 +59,6 @@ export class Dataset {
   constructor(rows: HetRow[], metadata: DatasetMetadata) {
     this.rows = rows
     this.metadata = metadata
-  }
-
-  toDataFrame(): IDataFrame | DataFrame {
-    return new DataFrame(this.rows)
   }
 
   getAllColumnNames(): string[] {

--- a/frontend/src/data/utils/datasetutils.ts
+++ b/frontend/src/data/utils/datasetutils.ts
@@ -1,4 +1,3 @@
-import type { IDataFrame } from 'data-forge'
 import type {
   DatasetId,
   DatasetIdWithStateFIPSCode,
@@ -56,42 +55,6 @@ import {
 import type { HetRow } from './DatasetTypes'
 import type { Fips } from './Fips'
 import type { StateFipsCode } from './FipsData'
-
-type JoinType = 'inner' | 'left' | 'outer'
-
-// TODO: consider finding different library for joins, or write our own. This
-// library doesn't support multi-col joins naturally, so this uses a workaround.
-// I've also seen occasional issues with the page hanging that have been
-// difficult to consistently reproduce.
-/**
- * Joins two data frames on the specified columns, keeping all the remaining
- * columns from both.
- */
-export function joinOnCols(
-  df1: IDataFrame,
-  df2: IDataFrame,
-  cols: DemographicType[],
-  joinType: JoinType = 'inner',
-): IDataFrame {
-  const keySelector = (row: any) => {
-    const keys = cols.map((col) => col + ': ' + row[col])
-    return keys.join(',')
-  }
-  const aggFn = (row1: any, row2: any) => ({ ...row2, ...row1 })
-  let joined
-  switch (joinType) {
-    case 'inner':
-      joined = df1.join(df2, keySelector, keySelector, aggFn)
-      break
-    case 'left':
-      joined = df1.joinOuterLeft(df2, keySelector, keySelector, aggFn)
-      break
-    case 'outer':
-      joined = df1.joinOuter(df2, keySelector, keySelector, aggFn)
-      break
-  }
-  return joined.resetIndex()
-}
 
 /*
 Returns the lowest `listSize` & highest `listSize` values, unless there are ties for first and/or last in which case the only the tied values are returned. If there is overlap, it is removed from the highest values.


### PR DESCRIPTION
**Preview:** [HIV Disparity Report](https://deploy-preview-4877--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity&dt1=hiv_prevalence)

## Summary

- Removes the 3.2MB `data-forge` dependency entirely from the frontend bundle
- Replaces all `IDataFrame` / `DataFrame` usage with plain `HetRow[]` array operations across 16 providers and 5 core data files
- Removes dead outer-join path in `DataManager` (confirmed unreachable: each `MetricQuery` always maps to exactly one provider); adds explicit invariant throw if violated
- Replaces `CompareBubbleChartCard` DataFrame joins with Map-based inner joins keyed on `props.demographicType` (feature-flagged, not on prod)
- Adds `VariableProvider.test.ts` with 13 unit tests covering all 5 rewritten methods
- Restores `@emnapi/core` and `@emnapi/runtime` lock file entries dropped by macOS `npm uninstall`; Linux CI needs these for the WASM fallback

## Test plan

- [x] HIV disparity report loads and renders all cards correctly (Playwright)
- [x] Time-series historical view loads correctly, tests `dropRecentPartialMonth` path (Playwright)
- [x] Women in US Congress county-level map loads (Playwright)
- [x] Gun deaths county-level map loads, tests GunViolenceProvider column rename path (Playwright)
- [x] Correlation bubble chart renders in compare topics mode (Playwright, requires `SHOW_CORRELATION_CARD` flag enabled in deploy preview)

Closes #4870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
