### PR TITLE
feat(cawp): register congressional_districts as a proper MetricId

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -247,7 +247,10 @@ function MapCardWithKey(props: MapCardProps) {
   const subPopulationId = metricConfig?.rateDenominatorMetric?.metricId
   if (subPopulationId) initialMetridIds.push(subPopulationId)
 
-  if (props.dataTypeConfig.dataTypeId === 'women_in_us_congress') {
+  if (
+    props.dataTypeConfig.dataTypeId === 'women_in_us_congress' &&
+    !props.fips.isUsa()
+  ) {
     initialMetridIds.push('congressional_districts')
   }
 

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -247,6 +247,10 @@ function MapCardWithKey(props: MapCardProps) {
   const subPopulationId = metricConfig?.rateDenominatorMetric?.metricId
   if (subPopulationId) initialMetridIds.push(subPopulationId)
 
+  if (props.dataTypeConfig.dataTypeId === 'women_in_us_congress') {
+    initialMetridIds.push('congressional_districts')
+  }
+
   const queries = [
     metricQuery(
       initialMetridIds,

--- a/frontend/src/data/config/MetricConfigPDOH.ts
+++ b/frontend/src/data/config/MetricConfigPDOH.ts
@@ -46,6 +46,7 @@ export type PDOHMetricId =
   | 'voter_participation_pct_share'
   | 'women_state_leg_pct_relative_inequity'
   | 'women_this_race_state_leg_count'
+  | 'congressional_districts'
   | 'women_this_race_us_congress_count'
   | 'women_this_race_us_congress_names'
   | 'women_us_congress_pct_relative_inequity'

--- a/frontend/src/data/providers/CawpProvider.test.ts
+++ b/frontend/src/data/providers/CawpProvider.test.ts
@@ -107,4 +107,46 @@ describe('CAWP Unit Tests', () => {
       'rate-map',
     )
   })
+
+  test('congressional_districts flows through to query response when requested', async () => {
+    const cawpProvider = new CawpProvider()
+    const breakdowns = Breakdowns.forChildrenFips(new Fips('06')).addBreakdown(
+      RACE,
+    )
+    const datasetId = 'cawp_data-race_and_ethnicity_county_current-06'
+    dataFetcher.setFakeDatasetLoaded(datasetId, [
+      {
+        county_fips: '06001',
+        county_name: 'Alameda',
+        state_fips: '06',
+        fips: '06001',
+        fips_name: 'Alameda',
+        race_and_ethnicity: 'All',
+        pct_share_of_us_congress: 10,
+        congressional_districts: '13,14',
+      },
+      {
+        county_fips: '06003',
+        county_name: 'Alpine',
+        state_fips: '06',
+        fips: '06003',
+        fips_name: 'Alpine',
+        race_and_ethnicity: 'All',
+        pct_share_of_us_congress: 5,
+        congressional_districts: '4',
+      },
+    ])
+
+    const response = await cawpProvider.getData(
+      new MetricQuery(
+        ['pct_share_of_us_congress', 'congressional_districts'],
+        breakdowns,
+        'women_in_us_congress',
+        'current',
+      ),
+    )
+
+    const districts = response.data.map((row) => row.congressional_districts)
+    expect(districts).toEqual(['13,14', '4'])
+  })
 })

--- a/frontend/src/data/providers/CawpProvider.ts
+++ b/frontend/src/data/providers/CawpProvider.ts
@@ -31,6 +31,7 @@ const CAWP_CONGRESS_COUNTS: MetricId[] = [
 
 const CAWP_CONGRESS_METRICS: MetricId[] = [
   'cawp_population_pct', // needed for pct_share disparity comparison at county level
+  'congressional_districts',
   'pct_share_of_us_congress',
   'pct_share_of_women_us_congress',
   'women_us_congress_pct_relative_inequity',
@@ -44,6 +45,7 @@ const CAWP_STLEG_COUNTS: MetricId[] = [
 
 export const CAWP_METRICS: MetricId[] = [
   'cawp_population_pct',
+  'congressional_districts',
   'pct_share_of_state_leg',
   'pct_share_of_women_state_leg',
   'women_state_leg_pct_relative_inequity',
@@ -147,16 +149,7 @@ class CawpProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      const hasDistricts =
-        breakdowns.geography === 'county' &&
-        df.getColumnNames().includes('congressional_districts')
-      const districtSeries = hasDistricts
-        ? df.getSeries('congressional_districts')
-        : null
       df = this.removeUnrequestedColumns(df, metricQuery)
-      if (districtSeries) {
-        df = df.withSeries('congressional_districts', districtSeries)
-      }
     }
     return new MetricQueryResponse(df.toArray(), consumedDatasetIds)
   }


### PR DESCRIPTION
**Preview:** [Women in US Congress county view](https://deploy-preview-4878--health-equity-tracker.netlify.app/exploredata?mls=1.women_in_gov-3.37&mlp=disparity&dt1=women_in_us_congress)

## Summary

- Registers `congressional_districts` as a proper `MetricId` in `PDOHMetricId`, following the same pattern as `confined_children_estimated_total` and `GENDER_METRICS`
- Adds it to `CAWP_CONGRESS_METRICS` (county validation) and `CAWP_METRICS` (provider routing)
- `MapCard` pushes it onto `metricIdsToFetch` when `dataTypeId === 'women_in_us_congress'` and geography is not national, so `removeUnrequestedColumns` preserves it automatically
- Removes the capture-reattach workaround in `CawpProvider` (12 lines gone)
- Adds a unit test verifying `congressional_districts` survives the provider pipeline end-to-end

## Test plan

- [x] Unit test: `congressional_districts` flows through to response when included in metricIds
- [x] Women in US Congress county-level map loads without error (Playwright)
- [x] National-level map loads without error and does not request county-only field (Playwright)
- [x] Manual: county map shows correct district labels in the multi-district alert when hovering/clicking a multi-district county

Closes #4870

🤖 Generated with [Claude Code](https://claude.com/claude-code)
