### PR TITLE
fix: make policy/methodology sidebar rows navigate on first click

### DIFF
--- a/frontend/src/styles/HetComponents/HetCardMenu.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenu.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router'
+import { useLocation } from 'react-router'
 import type { RouteConfig } from '../../pages/sharedTypes'
 import HetDivider from './HetDivider'
 import HetListItemButton from './HetListItemButton'
@@ -10,6 +10,8 @@ interface HetCardMenuProps {
 }
 
 export default function HetCardMenu(props: HetCardMenuProps) {
+  const location = useLocation()
+
   return (
     <nav
       role='menu'
@@ -17,7 +19,11 @@ export default function HetCardMenu(props: HetCardMenuProps) {
       className={`ml-0 flex flex-col rounded-sm py-0 pl-0 tracking-normal shadow-raised-tighter ${props.className ?? ''} `}
     >
       {props.routeConfigs.map((config) => (
-        <HetDesktopMenuItem key={config.path} routeConfig={config} />
+        <HetDesktopMenuItem
+          key={config.path}
+          routeConfig={config}
+          selected={location.pathname === config.path}
+        />
       ))}
     </nav>
   )
@@ -25,6 +31,7 @@ export default function HetCardMenu(props: HetCardMenuProps) {
 
 interface HetDesktopMenuItemProps {
   routeConfig: RouteConfig
+  selected: boolean
 }
 
 function HetDesktopMenuItem(props: HetDesktopMenuItemProps) {
@@ -37,14 +44,13 @@ function HetDesktopMenuItem(props: HetDesktopMenuItemProps) {
       )}
 
       <HetListItemButton
+        to={props.routeConfig.path}
         className='mx-2 pl-2 font-roboto'
-        selected={window.location.pathname === props.routeConfig.path}
-        aria-label={props.routeConfig.label}
+        selected={props.selected}
+        ariaLabel={props.routeConfig.label}
         option={props.routeConfig.isTopLevel ? 'boldGreenCol' : 'normalBlack'}
       >
-        <Link className='no-underline' to={props.routeConfig.path}>
-          {props.routeConfig.label}
-        </Link>
+        {props.routeConfig.label}
       </HetListItemButton>
     </>
   )

--- a/frontend/src/styles/HetComponents/HetCardMenuMobile.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenuMobile.tsx
@@ -1,6 +1,6 @@
 import { FormControl, InputLabel, MenuItem, Select } from '@mui/material'
 import Toolbar from '@mui/material/Toolbar'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 
 interface HetCardMenuMobileProps {
   className?: string
@@ -10,6 +10,7 @@ interface HetCardMenuMobileProps {
 
 export default function HetCardMenuMobile(props: HetCardMenuMobileProps) {
   const navigate = useNavigate()
+  const location = useLocation()
 
   const handleSelected = (event: any) => {
     navigate(event.target.value)
@@ -27,7 +28,7 @@ export default function HetCardMenuMobile(props: HetCardMenuMobileProps) {
             <InputLabel id='context-select-label'>{props.label}</InputLabel>
             <Select
               labelId='context-select-label'
-              value={window.location.pathname}
+              value={location.pathname}
               onChange={handleSelected}
               label={props.label}
             >

--- a/frontend/src/styles/HetComponents/HetListItemButton.tsx
+++ b/frontend/src/styles/HetComponents/HetListItemButton.tsx
@@ -1,11 +1,13 @@
 import { ListItemButton } from '@mui/material'
 import type { ReactNode } from 'react'
+import { Link } from 'react-router'
 
 type HetListItemButtonOptionType = 'boldGreenCol' | 'normalBlack'
 
 interface HetListItemButtonProps {
   children: ReactNode
   onClick?: () => void
+  to?: string
   id?: string
   className?: string
   ariaLabel?: string
@@ -17,26 +19,51 @@ interface HetListItemButtonProps {
 
 const optionsToClasses: Record<HetListItemButtonOptionType, string> = {
   boldGreenCol: 'py-2 pl-0 font-sans-title text-small font-medium no-underline',
-  normalBlack: 'py-1 pl-2 text-small font-light text-alt-black',
+  normalBlack: 'py-1 pl-2 text-small font-light',
 }
 
 export default function HetListItemButton(props: HetListItemButtonProps) {
+  const inner = (
+    <span
+      className={`${optionsToClasses[props.option ?? 'boldGreenCol']} ${
+        props.className ?? ''
+      }`}
+    >
+      {props.children}
+    </span>
+  )
+
+  const sharedClassName = `mx-auto px-0 text-alt-green no-underline ${
+    props.selected ? 'bg-hover-alt-green' : 'bg-alt-white'
+  }`
+
+  // When `to` is set, the whole row IS the router link — a single interactive
+  // element so a click anywhere on the row navigates (no tiny nested anchor).
+  if (props.to) {
+    return (
+      <ListItemButton
+        component={Link}
+        to={props.to}
+        className={sharedClassName}
+        aria-label={props.ariaLabel}
+        selected={props.selected}
+        role='menuitem'
+      >
+        {inner}
+      </ListItemButton>
+    )
+  }
+
   return (
     <ListItemButton
       tabIndex={props.onClick ? undefined : -1}
-      className={`mx-auto px-0 ${props.selected ? 'bg-hover-alt-green' : 'bg-alt-white'}`}
+      className={sharedClassName}
       onClick={props.onClick}
       aria-label={props.ariaLabel}
       selected={props.selected}
       role='menuitem'
     >
-      <span
-        className={`${optionsToClasses[props.option ?? 'boldGreenCol']} ${
-          props.className ?? ''
-        }`}
-      >
-        {props.children}
-      </span>
+      {inner}
     </ListItemButton>
   )
 }

--- a/frontend/src/styles/HetComponents/HetListItemButton.tsx
+++ b/frontend/src/styles/HetComponents/HetListItemButton.tsx
@@ -45,6 +45,9 @@ export default function HetListItemButton(props: HetListItemButtonProps) {
         component={Link}
         to={props.to}
         className={sharedClassName}
+        id={props.id}
+        style={props.style}
+        onClick={props.onClick}
         aria-label={props.ariaLabel}
         selected={props.selected}
         role='menuitem'
@@ -58,6 +61,8 @@ export default function HetListItemButton(props: HetListItemButtonProps) {
     <ListItemButton
       tabIndex={props.onClick ? undefined : -1}
       className={sharedClassName}
+      id={props.id}
+      style={props.style}
       onClick={props.onClick}
       aria-label={props.ariaLabel}
       selected={props.selected}


### PR DESCRIPTION
## Summary

The policy and methodology sidebar rows required multiple clicks to change route. Each row rendered a full-width MUI `ListItemButton`, but the only actual navigation target was a small `<a>` wrapping the label text. Clicking anywhere else on the row — the whitespace beside the label, which still shows the full-row hover highlight — hit a non-interactive element and did nothing, so users had to click repeatedly.

### Fix
- Render the whole row as a single react-router `Link` (`ListItemButton component={Link}`) so a click anywhere on the row navigates. This also removes an invalid nested-interactive-element (`<a>` inside a `role="menuitem"` `ButtonBase`).
- Derive the `selected` state reactively from `useLocation()` instead of non-reactive `window.location.pathname`.
- Make the mobile `Select` value reactive as well.
- Restore the green link color (`text-alt-green`) since MUI's row styles otherwise override the global anchor color, and drop the now-dead `text-alt-black` so appearance is unchanged.

Shared component, so this fixes both the Policy and Methodology sidebars.

Closes #4883

## Test plan
- [x] `tsc --noEmit` passes
- [x] Biome clean
- [x] Verified in browser: clicking row whitespace navigates on the first click (policy + methodology)
- [x] Selected highlight updates correctly; each row is a single `<a>` with no nested anchors
- [x] Text color unchanged (green) across all items; mobile dropdown reflects the current route

🤖 Generated with [Claude Code](https://claude.com/claude-code)