### PR TITLE
fix(het-table): restore metric label on All column header in alt table views

### DIFF
--- a/frontend/src/cards/ui/AltTableView.tsx
+++ b/frontend/src/cards/ui/AltTableView.tsx
@@ -68,8 +68,9 @@ export default function AltTableView(props: AltTableViewProps) {
     const isUnknownPctCol = key.includes('with unknown ')
 
     let header: React.ReactNode = key.replaceAll('_', ' ')
-    if (!isTimeCol && key !== ALL && !isUnknownPctCol) {
-      header = `${optionalAgesPrefix}${key.replaceAll('_', ' ')} ${dataColumnLabel}`
+    if (!isTimeCol && !isUnknownPctCol) {
+      const prefix = key !== ALL ? optionalAgesPrefix : ''
+      header = `${prefix}${key.replaceAll('_', ' ')} ${dataColumnLabel}`
     } else if (isTimeCol) {
       header = `${key.replaceAll('_', ' ')} (${earliestTimePeriod} - ${latestTimePeriod})`
     }

--- a/frontend/src/reports/CustomAltTable.tsx
+++ b/frontend/src/reports/CustomAltTable.tsx
@@ -91,8 +91,9 @@ export default function CustomAltTable(props: CustomAltTableProps) {
           const isUnknownPctCol = key.includes('with unknown ')
 
           let header: React.ReactNode = key.replaceAll('_', ' ')
-          if (!isTimeCol && key !== ALL && !isUnknownPctCol) {
-            header = `${optionalAgesPrefix}${key.replaceAll('_', ' ')} ${dataColumnLabel}`
+          if (!isTimeCol && !isUnknownPctCol) {
+            const prefix = key !== ALL ? optionalAgesPrefix : ''
+            header = `${prefix}${key.replaceAll('_', ' ')} ${dataColumnLabel}`
           } else if (isTimeCol) {
             header = `${key.replaceAll('_', ' ')} (${earliestTimePeriod} - ${latestTimePeriod})`
           }


### PR DESCRIPTION
## Summary

- Fixes E2E regression introduced by the HetTable migration (#4889)
- `AltTableView` and `CustomAltTable` were not appending the metric label (e.g. `% PrEP coverage`) to the "All" group column header
- Old code: `!isTimeCol && !isUnknownPctCol` (included All) — new code incorrectly used `!isTimeCol && key !== ALL && !isUnknownPctCol` (excluded All)
- Fix: drop `key !== ALL` from the metric-label condition; keep it only as a guard for the ages prefix

Fixes `hiv_prep.spec.ts › HIV PrEP: Rates Over Time` E2E failure on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)