### PR TITLE
Fix mobile map bottom clipping and remove stray server binary

### DIFF
--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -38,12 +38,10 @@ jobs:
 
       # --- CODE QUALITY (fails fast) ---
 
-      - name: Setup Biome
-        uses: biomejs/setup-biome@v2
-        with:
-          version: 2.2.5
+      # Use the Biome version from package.json (installed by npm ci) so CI
+      # can't drift from the version the pre-commit hook runs locally
       - name: Run Biome
-        run: biome ci src/
+        run: npx @biomejs/biome ci src/
 
       - name: Run Vitest unit tests
         run: npm test

--- a/frontend/src/cards/ui/IncarceratedChildrenShortAlert.tsx
+++ b/frontend/src/cards/ui/IncarceratedChildrenShortAlert.tsx
@@ -31,7 +31,12 @@ function IncarceratedChildrenShortAlert(
       </strong>{' '}
       confined in {adultFacilities} in{' '}
       <span>{props.fips.getSentenceDisplayName()}</span>.{' '}
-      <a href={urlMap.childrenInPrison}>Learn more.</a>
+      <a
+        href={urlMap.childrenInPrison}
+        aria-label='Learn more about children confined in adult facilities'
+      >
+        Learn more.
+      </a>
     </HetNotice>
   )
 }

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -22,6 +22,9 @@ import type {
 } from './types'
 
 const MARGIN = { top: 0, right: 0, bottom: 0, left: 0 }
+// Extra downward nudge of the map group on mobile; must also be subtracted
+// from the projection fit height or the bottom of the map clips off the SVG
+const MOBILE_TOP_OFFSET = 10
 
 export const renderMap = (options: RenderMapOptions) => {
   const {
@@ -51,7 +54,8 @@ export const renderMap = (options: RenderMapOptions) => {
   const territoryHeight = fips.isUsa()
     ? TERRITORIES.marginTop + TERRITORIES.radius * 2
     : 0
-  const mapHeight = height - territoryHeight
+  const mapHeight =
+    height - territoryHeight - (isMobile ? MOBILE_TOP_OFFSET : 0)
 
   const { mapGroup } = initializeSvg({
     svgRef: svgRef,
@@ -162,6 +166,9 @@ const initializeSvg = (options: InitializeSvgOptions) => {
     mapGroup: svg
       .append('g')
       .attr('class', 'map-container')
-      .attr('transform', `translate(${left}, ${isMobile ? top + 10 : top})`),
+      .attr(
+        'transform',
+        `translate(${left}, ${isMobile ? top + MOBILE_TOP_OFFSET : top})`,
+      ),
   }
 }

--- a/frontend/src/styles/HetComponents/HetCarouselCard.tsx
+++ b/frontend/src/styles/HetComponents/HetCarouselCard.tsx
@@ -118,6 +118,7 @@ export function HetCarouselCard({
                   </div>
                   {readMoreHref && (
                     <div className='mb-4 flex w-full flex-row items-center justify-start gap-2 py-0'>
+                      {/* biome-ignore lint/a11y/noAmbiguousAnchorText: accessible name comes from the dynamic aria-label, which Biome can't evaluate statically */}
                       <a
                         target='_blank'
                         rel='noopener noreferrer'
@@ -167,6 +168,7 @@ export function HetCarouselCard({
                   </div>
                   {readMoreHref && (
                     <div className='mb-4 flex w-full flex-row items-center justify-start gap-2 py-0'>
+                      {/* biome-ignore lint/a11y/noAmbiguousAnchorText: accessible name comes from the dynamic aria-label, which Biome can't evaluate statically */}
                       <a
                         className='ml-auto font-medium text-small leading-some-space no-underline'
                         aria-label={`Learn more about ${ariaLabel}`}


### PR DESCRIPTION
**Preview:** [Colorado HIV county map (view at mobile width)](https://deploy-preview-4896--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.08&mlp=disparity&group1=All)

## Summary

- Fix mobile-only clipping of the bottom 10px of every state/county choropleth map: the map group is nudged down 10px on mobile but the projection was fitted to the full SVG height, so the lowest geography (e.g. Colorado's SE corner) rendered below the SVG edge and was cut off
- Remove the accidentally committed 50MB compiled Go binary `server/server` (slipped into main via #4889; `server/.gitignore` covers it once untracked)
- Fix three `noAmbiguousAnchorText` a11y lint errors newly flagged by Biome 2.5 that were blocking all frontend commits: add a static aria-label to the incarcerated-children alert link, suppress false positives on carousel links that already have descriptive dynamic aria-labels

## Test plan

- [x] Playwright at 375px viewport: Colorado county map southern border renders fully to the SE corner (content bottom = SVG height exactly; was 10px past it)
- [x] Desktop rendering unchanged (offset only applies on mobile)
- [ ] Spot-check another state map on a real phone via the deploy preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)
