### PR TITLE
fix(frontend_server): proxy auth broken by http-proxy-middleware v3+

### DIFF
--- a/frontend_server/server.js
+++ b/frontend_server/server.js
@@ -78,7 +78,7 @@ app.use('/api', (req, _res, next) => {
     const targetUrl = assertEnvVar('DATA_SERVER_URL')
     getIamToken(metadataServerTokenURL + targetUrl)
       .then((token) => {
-        req.headers['Authorization_DataServer'] = `bearer ${token}`
+        req.dataServerToken = token
         next()
       })
       .catch(next)
@@ -91,12 +91,15 @@ const apiProxyOptions = {
   target: assertEnvVar('DATA_SERVER_URL'),
   changeOrigin: true,
   pathRewrite: { '^/api': '' },
-  onProxyReq: (proxyReq) => {
-    proxyReq.setHeader(
-      'Authorization',
-      proxyReq.getHeader('Authorization_DataServer'),
-    )
-    proxyReq.removeHeader('Authorization_DataServer')
+  // http-proxy-middleware v3+ only fires handlers registered under `on:` —
+  // a top-level onProxyReq is silently ignored, which sends the request with
+  // no Authorization header and gets a 403 from Cloud Run IAM.
+  on: {
+    proxyReq: (proxyReq, req) => {
+      if (req.dataServerToken) {
+        proxyReq.setHeader('Authorization', `bearer ${req.dataServerToken}`)
+      }
+    },
   },
 }
 const apiProxy = createProxyMiddleware(apiProxyOptions)


### PR DESCRIPTION
## Summary

- The dependabot bump of http-proxy-middleware 3.0.5 -> 4.x (#4756, #4856) silently broke the legacy frontend's authenticated proxy: v3+ only fires handlers registered under `on:`, so the top-level `onProxyReq` was ignored and `/api` requests reached the data server with no Authorization header, returning 403 from Cloud Run IAM
- Stashes the IAM token on the request object and sets the Authorization header from the `on.proxyReq` event (the v3+/v4 API), which also stops relaying the token through a synthetic request header
- This is what actually caused the 403 smoke tests previously attributed to the recreated-SA quirk; prod is unaffected today (it runs a pre-v3 release) but the next prod release would ship the broken proxy, so this must land before the cutover release (#4900)

Verified locally end to end with stub metadata and data servers: the proxied request arrives with `bearer <token>` and no leaked internal headers.

## Test plan

- [x] Local stub verification: `/api/dataset` proxies with correct Authorization header and `^/api` path rewrite
- [ ] After merge, on infra-test: `https://frontend-service-zarv4pcejq-uc.a.run.app/api/dataset?name=geographies.json` returns 200 through the proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)
