### PR TITLE
fix(e2e): drop clipboard permissions for Firefox nightly project

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -61,7 +61,9 @@ const config: PlaywrightTestConfig = {
     {
       name: 'FIREFOX_NIGHTLY',
       testMatch: /.*\.ci\.spec\.ts/,
-      use: { browserName: 'firefox' },
+      // Firefox's Playwright driver rejects clipboard-* permissions at context
+      // creation, and no .ci spec uses the clipboard, so grant none here.
+      use: { browserName: 'firefox', permissions: [] },
     },
     {
       name: 'WEBKIT_NIGHTLY',


### PR DESCRIPTION
## Summary

- The nightly E2E workflow has failed every night since #4863 added global clipboard-read/clipboard-write permissions: the Playwright Firefox driver rejects those permissions at context creation, so both FIREFOX_NIGHTLY specs (ami, asthma) died before loading a page.
- Overrides `permissions: []` on the FIREFOX_NIGHTLY project only. Chromium projects keep the global grant, which the Share-this-report nightly spec needs. No `.ci` spec touches the clipboard, so Firefox loses nothing.

## Test plan

- [x] Ran `asthma.ci.spec.ts` locally under FIREFOX_NIGHTLY: the clipboard-read context error is gone and the browser now loads pages (identical behavior to a Chromium baseline run)
- [ ] Next scheduled nightly E2E run (e2eScheduled.yml) goes green on the Firefox matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
