### PR TITLE
fix(e2e): unblock WebKit and Firefox nightly matrix failures

### DIFF
--- a/frontend/playwright-tests/navigation.ci.spec.ts
+++ b/frontend/playwright-tests/navigation.ci.spec.ts
@@ -318,7 +318,10 @@ test('Default reset from Compare Topics mode creates one history entry; back ret
 
   // One back-press should return to the comparevars report, not stay on /exploredata.
   // A double-pushState bug would leave the previous comparevars state unreachable.
-  await page.goBack({ waitUntil: 'commit' })
+  // Use history.back() instead of page.goBack(): Firefox flakes with
+  // NS_BINDING_ABORTED when goBack's navigation-wait races the SPA's URL writes.
+  await page.waitForLoadState('networkidle')
+  await page.evaluate(() => window.history.back())
   await expect(page).toHaveURL(/mlp=comparevars/)
 })
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -58,17 +58,17 @@ const config: PlaywrightTestConfig = {
       testMatch: /.*mobile\.spec\.ts/,
       use: { ...devices['iPad (gen 7)'] },
     },
+    // Firefox and WebKit reject clipboard-* permissions at context/page
+    // creation, and no .ci spec uses the clipboard, so grant none here.
     {
       name: 'FIREFOX_NIGHTLY',
       testMatch: /.*\.ci\.spec\.ts/,
-      // Firefox's Playwright driver rejects clipboard-* permissions at context
-      // creation, and no .ci spec uses the clipboard, so grant none here.
       use: { browserName: 'firefox', permissions: [] },
     },
     {
       name: 'WEBKIT_NIGHTLY',
       testMatch: /.*\.ci\.spec\.ts/,
-      use: { browserName: 'webkit' },
+      use: { browserName: 'webkit', permissions: [] },
     },
   ],
 }


### PR DESCRIPTION
## Summary

- Follow-up to #4908: with the Firefox clipboard error fixed, the nightly run got past `maxFailures: 2` and exposed two more matrix failures.
- WebKit rejects `clipboard-write` at page creation the same way Firefox rejects `clipboard-read`, so `WEBKIT_NIGHTLY` now also overrides `permissions: []` (no `.ci` spec uses the clipboard).
- The compare-mode back-navigation test flaked on Firefox with `NS_BINDING_ABORTED` (~20-40% reproducible locally): `page.goBack()`'s navigation-wait races the SPA's URL writes. It now triggers `window.history.back()` in-page and relies on the auto-retrying URL assertion.

## Test plan

- [x] Firefox: navigation test 10/10 passing in parallel against prod (previously 2-4 failures per 10)
- [x] WebKit: `ami.ci` and `asthma.ci` both pass against prod (previously died at page creation)
- [x] Chromium: changed navigation test 5/5 passing (runs on every PR via E2E_CI)
- [ ] Next nightly E2E run (e2eScheduled.yml) goes fully green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
