### PR TITLE
docs(skill): /pr waits for CI checks and reports pass/fail

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: pr
 model: haiku
-description: Run Biome auto-fix (cleanup only — tsc and Vitest run in CI, not locally), address any open review comments, update CLAUDE.md docs if stale, verify the test plan with Playwright against a local dev server (live backend + feature flags), then update the open PR title and description. Use when the user wants to close out a PR, verify it's ready for review, or run /pr.
+description: Run Biome auto-fix (cleanup only — tsc and Vitest run in CI, not locally), address any open review comments, update CLAUDE.md docs if stale, verify the test plan with Playwright against a local dev server (live backend + feature flags), update the open PR title and description, then watch CI until all checks pass (diagnosing and reporting any failures). Use when the user wants to close out a PR, verify it's ready for review, or run /pr.
 ---
 
 # /pr
 
-Polish the open PR so it's ready for human review: auto-fix formatting, address review comments, update docs, verify tests, and rewrite the PR description.
+Polish the open PR so it's ready for human review: auto-fix formatting, address review comments, update docs, verify tests, rewrite the PR description, then wait for all CI checks to pass and report the result.
 
 The user may pass a PR number as an argument (e.g. `/pr 4764`). If none is given, detect the open PR from the current branch.
 
@@ -319,6 +319,30 @@ gh pr edit --title "<new title>" --body-file /tmp/pr-body.md
 ```
 
 Print the updated PR URL when done.
+
+---
+
+## Step 7 — Wait for CI checks and report
+
+The skill is not done until CI has run on the final push. Watch the PR's checks until every one completes:
+
+```bash
+gh pr checks <number> --watch --interval 30
+```
+
+This blocks until all checks finish (exit code 0 = all passed, nonzero = at least one failed or was cancelled). Run it in the background with a generous timeout if the check suite is long; do not poll manually in a sleep loop.
+
+**If all checks pass:** report back to the user that the PR is polished and all CI checks are green. Done.
+
+**If any check fails:**
+
+1. Diagnose before touching anything. Pull the failing logs and read the actual error:
+   ```bash
+   gh pr checks <number> | grep -v pass
+   gh run view <run-id> --log-failed | tail -100
+   ```
+2. Determine the root cause: a real defect in this PR, a flaky/nondeterministic test, or a failure unrelated to the branch (e.g. broken main, expired secret, infra outage).
+3. Alert the user with a short diagnosis — which check failed, why, and what the fix would be — then **ask whether to push up a fix / keep working on it**. Do not push a fix, re-run the workflow, or dismiss the failure without the user's go-ahead.
 
 ---
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -327,18 +327,22 @@ Print the updated PR URL when done.
 The skill is not done until CI has run on the final push. Watch the PR's checks until every one completes:
 
 ```bash
-gh pr checks <number> --watch --interval 30
+gh pr checks <number> --watch --interval 30 --fail-fast
 ```
 
-This blocks until all checks finish (exit code 0 = all passed, nonzero = at least one failed or was cancelled). Run it in the background with a generous timeout if the check suite is long; do not poll manually in a sleep loop.
+This blocks until all checks finish (exit code 0 = all passed, nonzero = at least one failed or was cancelled); `--fail-fast` exits at the first failure so diagnosis can start immediately. Run it in the foreground with a generous timeout (10 minutes). If the suite outlasts the timeout, just re-run the same command — it is idempotent. Do not poll manually in a sleep loop.
 
 **If all checks pass:** report back to the user that the PR is polished and all CI checks are green. Done.
 
 **If any check fails:**
 
-1. Diagnose before touching anything. Pull the failing logs and read the actual error:
+1. Diagnose before touching anything. List the non-passing checks, then pull the failing run's logs:
    ```bash
-   gh pr checks <number> | grep -v pass
+   gh pr checks <number> --json name,bucket,link \
+     --jq '.[] | select(.bucket != "pass" and .bucket != "skipping")'
+
+   # run id is the number in the check's link after /runs/; or find it via:
+   gh run list --branch <headRefName> --limit 10
    gh run view <run-id> --log-failed | tail -100
    ```
 2. Determine the root cause: a real defect in this PR, a flaky/nondeterministic test, or a failure unrelated to the branch (e.g. broken main, expired secret, infra outage).


### PR DESCRIPTION
## Summary

- Adds Step 7 to the /pr skill: after the final push and body update, watch the PR's CI checks with `gh pr checks --watch --fail-fast` until every one completes.
- All green: report back that the PR is polished and CI passed.
- Any failure: list non-passing checks via `--json`/`jq`, pull the failing run's logs, diagnose the root cause (real defect vs. flaky test vs. unrelated breakage), alert the user with the diagnosis, and ask before pushing a fix or continuing work.
- Updates the skill frontmatter description and intro to match.
- Addresses Gemini review: fail-fast watch, foreground timeout instead of backgrounding, JSON-based failure triage commands.

## Impact

- Closes the gap where /pr reported "done" while CI could still fail minutes later; the skill now only finishes on a verified green check suite.

## Test plan

- [x] Next /pr run watches checks and reports the final CI state (verified by this PR's own /pr run: watched 7 checks on #4914 to completion, exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
