### PR TITLE
perf(ui): virtualize the location search listbox

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -38,6 +38,7 @@
         "react-router-hash-link": "^2.4.3",
         "react-scroll": "^1.9.3",
         "react-share": "^5.3.0",
+        "react-window": "^2.2.7",
         "seamless-scroll-polyfill": "^2.3.4",
         "topojson-client": "^3.1.0"
       },
@@ -6786,6 +6787,16 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-2.2.7.tgz",
+      "integrity": "sha512-SH5nvfUQwGHYyriDUAOt7wfPsfG9Qxd6OdzQxl5oQ4dsSsUicqQvjV7dR+NqZ4coY0fUn3w1jnC5PwzIUWEg5w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/redent": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,6 +41,7 @@
 		"react-router-hash-link": "^2.4.3",
 		"react-scroll": "^1.9.3",
 		"react-share": "^5.3.0",
+		"react-window": "^2.2.7",
 		"seamless-scroll-polyfill": "^2.3.4",
 		"topojson-client": "^3.1.0"
 	},

--- a/frontend/playwright-tests/location_search.ci.spec.ts
+++ b/frontend/playwright-tests/location_search.ci.spec.ts
@@ -72,6 +72,55 @@ test('typo tolerance: "sarsota" still finds Sarasota County', async ({
   ).toBeVisible()
 })
 
+test('virtualization mounts only a small slice of the options', async ({
+  page,
+}) => {
+  const input = await openLocationSearch(page)
+  await input.press('ArrowDown')
+  await expect(page.getByRole('listbox')).toBeVisible()
+  const optionCount = await page.getByRole('option').count()
+  expect(optionCount).toBeGreaterThan(0)
+  expect(optionCount).toBeLessThan(40)
+  expect(
+    await page.locator('ul[role="listbox"] li[role="presentation"]').count(),
+  ).toBeGreaterThan(0)
+})
+
+test('aria-activedescendant resolves to a mounted option after scrolling', async ({
+  page,
+}) => {
+  const input = await openLocationSearch(page)
+  await input.press('ArrowDown')
+  await expect(page.getByRole('listbox')).toBeVisible()
+  // Cross the initially mounted window so rows must scroll and remount.
+  for (let i = 0; i < 20; i++) {
+    await input.press('ArrowDown')
+  }
+  const activeId = await input.getAttribute('aria-activedescendant')
+  expect(activeId).toBeTruthy()
+  const activeOption = page.locator(`[id="${activeId}"]`)
+  await expect(activeOption).toBeVisible()
+  expect(await activeOption.getAttribute('role')).toBe('option')
+})
+
+test('arrow keys plus Enter navigate to the highlighted option', async ({
+  page,
+}) => {
+  const input = await openLocationSearch(page)
+  await input.press('ArrowDown')
+  await expect(page.getByRole('listbox')).toBeVisible()
+  // Wait for autoHighlight to land on the first option and for the list to
+  // finish measuring and mounting its first window of rows.
+  await expect(input).toHaveAttribute('aria-activedescendant', /.+/)
+  await expect(page.getByRole('option').nth(5)).toBeAttached()
+  // Empty query keeps original order: United States, Alabama, Alaska, Arizona.
+  await input.press('ArrowDown')
+  await input.press('ArrowDown')
+  await input.press('ArrowDown')
+  await input.press('Enter')
+  await expect(page).toHaveURL(/3\.04/, { timeout: 8000 })
+})
+
 test('options list stays below the input in short viewports', async ({
   page,
 }) => {

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -1,5 +1,6 @@
 import CloseIcon from '@mui/icons-material/Close'
 import { Autocomplete, TextField } from '@mui/material'
+import type { ReactNode } from 'react'
 import { useMemo, useState } from 'react'
 import { USA_DISPLAY_NAME, USA_FIPS } from '../../data/utils/ConstantsGeography'
 import { Fips } from '../../data/utils/Fips'
@@ -9,6 +10,10 @@ import {
   buildFipsSearchIndex,
   filterAndRankFips,
 } from '../../utils/locationSearch'
+import VirtualizedListbox, {
+  createListboxSyncStore,
+  ListboxSyncContext,
+} from './VirtualizedListbox'
 
 interface HetLocationSearchProps {
   clearRecentLocations: () => void
@@ -36,65 +41,83 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
     [props.options],
   )
 
+  // The virtualized listbox needs the highlighted option and current query to
+  // keep the highlighted row mounted and reset scroll when results change.
+  const listboxSync = useMemo(createListboxSyncStore, [])
+
   return (
     <div className='min-w-72 p-5'>
       <h3 className='my-1 font-semibold text-small md:text-title'>
         Search for location
       </h3>
-      <Autocomplete
-        disableClearable={true}
-        autoHighlight={true}
-        options={props.options}
-        filterOptions={(options, { inputValue }) =>
-          filterAndRankFips(options, searchIndex, inputValue)
-        }
-        groupBy={(option) => option.getFipsCategory()}
-        clearOnEscape={true}
-        getOptionLabel={(fips) => fips.getFullDisplayName()}
-        renderOption={(optionProps, fips: Fips) => (
-          <li {...optionProps} key={optionProps.key}>
-            {fips.getFullDisplayName()}
-          </li>
-        )}
-        open={autoCompleteOpen}
-        onOpen={() => setAutoCompleteOpen(true)}
-        onClose={() => setAutoCompleteOpen(false)}
-        slotProps={{
-          // With the on-screen keyboard open, Popper's flip renders the list
-          // above the input and covers it. Always drop down, and on phones
-          // keep the list short enough to scroll in the remaining space.
-          popper: { modifiers: [{ name: 'flip', enabled: false }] },
-          listbox: isSmAndUp ? undefined : { style: { maxHeight: '30vh' } },
-        }}
-        renderInput={(params) => (
-          <TextField
-            placeholder='County, state, or territory...'
-            /* eslint-disable-next-line */
-            autoFocus
-            margin='dense'
-            variant='outlined'
-            {...params}
-            slotProps={{
-              ...params.slotProps,
-              input: {
-                ...params.slotProps?.input,
-                sx: {
-                  '& .MuiAutocomplete-endAdornment': {
-                    top: '50%',
-                    transform: 'translateY(-50%)',
-                    position: 'absolute',
-                    right: '9px',
+      <ListboxSyncContext.Provider value={listboxSync}>
+        <Autocomplete
+          disableClearable={true}
+          autoHighlight={true}
+          options={props.options}
+          filterOptions={(options, { inputValue }) =>
+            filterAndRankFips(options, searchIndex, inputValue)
+          }
+          groupBy={(option) => option.getFipsCategory()}
+          clearOnEscape={true}
+          getOptionLabel={(fips) => fips.getFullDisplayName()}
+          // The listbox slot receives these raw [props, option] tuples and
+          // group params and renders only the visible rows itself.
+          renderOption={(optionProps, fips: Fips) =>
+            [optionProps, fips] as unknown as ReactNode
+          }
+          renderGroup={(params) => params as unknown as ReactNode}
+          onInputChange={(_e, value) => {
+            listboxSync.update({ inputValue: value, highlighted: null })
+          }}
+          onHighlightChange={(_e, fips, reason) =>
+            listboxSync.update({
+              highlighted: fips
+                ? { code: fips.code, keyboard: reason === 'keyboard' }
+                : null,
+            })
+          }
+          open={autoCompleteOpen}
+          onOpen={() => setAutoCompleteOpen(true)}
+          onClose={() => setAutoCompleteOpen(false)}
+          slots={{ listbox: VirtualizedListbox }}
+          slotProps={{
+            // With the on-screen keyboard open, Popper's flip renders the list
+            // above the input and covers it. Always drop down, and on phones
+            // keep the list short enough to scroll in the remaining space.
+            popper: { modifiers: [{ name: 'flip', enabled: false }] },
+            listbox: isSmAndUp ? undefined : { style: { maxHeight: '30vh' } },
+          }}
+          renderInput={(params) => (
+            <TextField
+              placeholder='County, state, or territory...'
+              /* eslint-disable-next-line */
+              autoFocus
+              margin='dense'
+              variant='outlined'
+              {...params}
+              slotProps={{
+                ...params.slotProps,
+                input: {
+                  ...params.slotProps?.input,
+                  sx: {
+                    '& .MuiAutocomplete-endAdornment': {
+                      top: '50%',
+                      transform: 'translateY(-50%)',
+                      position: 'absolute',
+                      right: '9px',
+                    },
                   },
                 },
-              },
-            }}
-          />
-        )}
-        onChange={(_e, fips) => {
-          props.onOptionUpdate(fips.code)
-          props.popover.close()
-        }}
-      />
+              }}
+            />
+          )}
+          onChange={(_e, fips) => {
+            props.onOptionUpdate(fips.code)
+            props.popover.close()
+          }}
+        />
+      </ListboxSyncContext.Provider>
       {visibleRecent.length > 0 && (
         <div className='mt-3 border-divider-gray border-t pt-3'>
           <div className='mb-1 flex items-center justify-between'>

--- a/frontend/src/styles/HetComponents/HetLocationSearch.tsx
+++ b/frontend/src/styles/HetComponents/HetLocationSearch.tsx
@@ -43,7 +43,7 @@ export default function HetLocationSearch(props: HetLocationSearchProps) {
 
   // The virtualized listbox needs the highlighted option and current query to
   // keep the highlighted row mounted and reset scroll when results change.
-  const listboxSync = useMemo(createListboxSyncStore, [])
+  const [listboxSync] = useState(createListboxSyncStore)
 
   return (
     <div className='min-w-72 p-5'>

--- a/frontend/src/styles/HetComponents/VirtualizedListbox.tsx
+++ b/frontend/src/styles/HetComponents/VirtualizedListbox.tsx
@@ -156,7 +156,12 @@ const VirtualizedListbox = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
 
     const { rows, offsets, totalHeight } = useMemo(() => {
       const flattened: RowData[] = []
-      for (const group of (children as VirtualizedGroupParams[]) ?? []) {
+      const childrenArray = Array.isArray(children)
+        ? children
+        : children
+          ? [children]
+          : []
+      for (const group of childrenArray as VirtualizedGroupParams[]) {
         flattened.push({ variant: 'header', label: group.group })
         for (const [optionProps, fips] of (group.children ??
           []) as VirtualizedOptionTuple[]) {
@@ -188,12 +193,13 @@ const VirtualizedListbox = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
       if (rows.length > 0) {
         listApi?.scrollToRow({ index: 0, behavior: 'instant' })
       }
-    }, [inputValue, listApi])
+    }, [inputValue, listApi, rows.length])
 
     // Keyboard highlight moves (including wrap-around) must keep the
     // highlighted row mounted so aria-activedescendant resolves.
+    // Guard on keyboard flag to avoid scrolling on mouse hover.
     useEffect(() => {
-      if (!highlighted) return
+      if (!highlighted?.keyboard) return
       const index = rows.findIndex(
         (row) => row.variant === 'option' && row.fips.code === highlighted.code,
       )

--- a/frontend/src/styles/HetComponents/VirtualizedListbox.tsx
+++ b/frontend/src/styles/HetComponents/VirtualizedListbox.tsx
@@ -1,0 +1,234 @@
+import { ListSubheader } from '@mui/material'
+import type { CSSProperties, HTMLAttributes, ReactNode } from 'react'
+import {
+  createContext,
+  forwardRef,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useSyncExternalStore,
+} from 'react'
+import { List, type RowComponentProps, useListCallbackRef } from 'react-window'
+import type { Fips } from '../../data/utils/Fips'
+import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
+
+// renderOption returns [liProps, fips] and renderGroup returns its params
+// untouched; this component receives them via children and renders the rows
+// itself so only the visible slice of ~3,000 options is mounted.
+export type VirtualizedOptionTuple = [
+  HTMLAttributes<HTMLLIElement> & { key: string },
+  Fips,
+]
+
+interface VirtualizedGroupParams {
+  key: string
+  group: string
+  children?: ReactNode
+}
+
+export interface ListboxHighlight {
+  code: string
+  keyboard: boolean
+}
+
+interface ListboxSyncValue {
+  highlighted: ListboxHighlight | null
+  inputValue: string
+}
+
+// Plain external store instead of React state: setting state in the
+// Autocomplete's parent on every onHighlightChange re-renders useAutocomplete,
+// whose filteredOptionsChanged effect then re-runs syncHighlightedIndex and,
+// with no selected value, resets the highlight to the top. Only this listbox
+// subscribes, so highlight moves never re-render the Autocomplete itself.
+export interface ListboxSyncStore {
+  getSnapshot: () => ListboxSyncValue
+  subscribe: (onChange: () => void) => () => void
+  update: (next: Partial<ListboxSyncValue>) => void
+}
+
+export function createListboxSyncStore(): ListboxSyncStore {
+  let value: ListboxSyncValue = { highlighted: null, inputValue: '' }
+  const listeners = new Set<() => void>()
+  return {
+    getSnapshot: () => value,
+    subscribe: (onChange) => {
+      listeners.add(onChange)
+      return () => listeners.delete(onChange)
+    },
+    update: (next) => {
+      value = { ...value, ...next }
+      for (const onChange of listeners) {
+        onChange()
+      }
+    },
+  }
+}
+
+export const ListboxSyncContext = createContext<ListboxSyncStore>(
+  createListboxSyncStore(),
+)
+
+const HEADER_HEIGHT = 48
+const OPTION_HEIGHT_SM_AND_UP = 36
+const OPTION_HEIGHT_PHONE = 48
+const VISIBLE_OPTION_ROWS = 8
+const OVERSCAN_ROWS = 5
+
+type RowData =
+  | { variant: 'header'; label: string }
+  | {
+      variant: 'option'
+      optionProps: HTMLAttributes<HTMLLIElement> & { key: string }
+      fips: Fips
+    }
+
+interface RowExtraProps {
+  rows: RowData[]
+  offsets: number[]
+  highlighted: ListboxHighlight | null
+}
+
+function Row({
+  index,
+  style,
+  rows,
+  offsets,
+  highlighted,
+}: RowComponentProps<RowExtraProps>) {
+  const row = rows[index]
+  // react-window positions rows with translateY, which leaves offsetTop at 0
+  // and breaks the offsetTop-based scroll sync inside MUI useAutocomplete.
+  // Explicit top offsets keep both scroll systems accurate.
+  const positioned: CSSProperties = {
+    ...style,
+    transform: 'none',
+    top: offsets[index],
+  }
+  if (row.variant === 'header') {
+    return (
+      <ListSubheader
+        component='li'
+        role='presentation'
+        disableSticky
+        style={positioned}
+      >
+        {row.label}
+      </ListSubheader>
+    )
+  }
+  const { key, className, ...optionProps } = row.optionProps
+  // MUI applies Mui-focused imperatively, but virtualized rows can remount
+  // while highlighted (scroll away and back), losing the class. Deriving it
+  // from state keeps the visual highlight consistent with aria-activedescendant.
+  const isHighlighted = row.fips.code === highlighted?.code
+  const rowClassName = [
+    className,
+    isHighlighted ? 'Mui-focused' : '',
+    isHighlighted && highlighted?.keyboard ? 'Mui-focusVisible' : '',
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return (
+    <li key={key} {...optionProps} className={rowClassName} style={positioned}>
+      <span className='min-w-0 overflow-hidden text-ellipsis whitespace-nowrap'>
+        {row.fips.getFullDisplayName()}
+      </span>
+    </li>
+  )
+}
+
+const VirtualizedListbox = forwardRef<HTMLElement, HTMLAttributes<HTMLElement>>(
+  function VirtualizedListbox(props, ref) {
+    const { children, className, style, ...other } = props
+    const store = useContext(ListboxSyncContext)
+    const { highlighted, inputValue } = useSyncExternalStore(
+      store.subscribe,
+      store.getSnapshot,
+    )
+    const isSmAndUp = useIsBreakpointAndUp('sm')
+    // Matches the MuiAutocomplete-option min-height breakpoint so touch
+    // targets stay 48px on phones.
+    const optionHeight = isSmAndUp
+      ? OPTION_HEIGHT_SM_AND_UP
+      : OPTION_HEIGHT_PHONE
+
+    const { rows, offsets, totalHeight } = useMemo(() => {
+      const flattened: RowData[] = []
+      for (const group of (children as VirtualizedGroupParams[]) ?? []) {
+        flattened.push({ variant: 'header', label: group.group })
+        for (const [optionProps, fips] of (group.children ??
+          []) as VirtualizedOptionTuple[]) {
+          flattened.push({ variant: 'option', optionProps, fips })
+        }
+      }
+      const rowOffsets: number[] = []
+      let y = 0
+      for (const row of flattened) {
+        rowOffsets.push(y)
+        y += row.variant === 'header' ? HEADER_HEIGHT : optionHeight
+      }
+      return { rows: flattened, offsets: rowOffsets, totalHeight: y }
+    }, [children, optionHeight])
+
+    // Callback-ref state so the forwarded ref re-fires once the list element
+    // actually exists; MUI useAutocomplete queries options through this DOM
+    // ref and re-syncs its highlight when the ref attaches. Key the handle on
+    // the element, not the api object: react-window recreates the api after
+    // measuring, and a ref re-fire makes MUI reset the highlight to the top.
+    const [listApi, setListApi] = useListCallbackRef(null)
+    const listElement = listApi?.element ?? null
+    useImperativeHandle(ref, () => listElement as HTMLElement, [listElement])
+
+    // Typing changes the result set and autoHighlight moves back to the
+    // first option, so snap the scroll window back to the top. Keys off the
+    // query text only; rows identity changes every render.
+    useEffect(() => {
+      if (rows.length > 0) {
+        listApi?.scrollToRow({ index: 0, behavior: 'instant' })
+      }
+    }, [inputValue, listApi])
+
+    // Keyboard highlight moves (including wrap-around) must keep the
+    // highlighted row mounted so aria-activedescendant resolves.
+    useEffect(() => {
+      if (!highlighted) return
+      const index = rows.findIndex(
+        (row) => row.variant === 'option' && row.fips.code === highlighted.code,
+      )
+      if (index >= 0) {
+        listApi?.scrollToRow({
+          index,
+          align: 'smart',
+          behavior: 'instant',
+        })
+      }
+    }, [highlighted, rows, listApi])
+
+    const height = Math.min(
+      totalHeight,
+      HEADER_HEIGHT + VISIBLE_OPTION_ROWS * optionHeight,
+    )
+
+    return (
+      <List
+        listRef={setListApi}
+        rowComponent={Row}
+        rowCount={rows.length}
+        rowHeight={(index: number) =>
+          rows[index].variant === 'header' ? HEADER_HEIGHT : optionHeight
+        }
+        rowProps={{ rows, offsets, highlighted }}
+        overscanCount={OVERSCAN_ROWS}
+        tagName='ul'
+        defaultHeight={height}
+        className={className}
+        style={{ height, paddingTop: 0, paddingBottom: 0, ...style }}
+        {...other}
+      />
+    )
+  },
+)
+
+export default VirtualizedListbox


### PR DESCRIPTION
**Preview:** [Location search]( https://deploy-preview-4924--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity)

Closes #4917

## Summary

- Virtualizes the location search listbox with react-window v2 (new dep, ~7 KB gz): only the visible window of rows plus overscan is mounted instead of all ~2,900 options
- New `VirtualizedListbox` flattens MUI group/option render params into header and option rows, self-computes row offsets so MUI useAutocomplete's offsetTop-based scroll sync keeps working, and derives the `Mui-focused` highlight declaratively so it survives row remounts
- Highlight and query state flow through a small external store (`useSyncExternalStore`) instead of parent React state: a parent re-render trips MUI's `syncHighlightedIndex` effect, which resets the keyboard highlight to the top when no value is selected
- Keyboard navigation scrolls the highlighted row into view so `aria-activedescendant` always resolves to a mounted option
- Addressed four review comments: normalize children to array (single group crash-safety), skip scroll-to-item on mouse hover (preserve standard scroll behavior), use useState for store instantiation (semantic persistence guarantee), add missing dependency to scroll-reset effect

## Impact

- Options mounted in the DOM on open: ~2,912 li elements before, under 40 after (asserted by a Playwright test), a >98% reduction in mounted nodes for the popover
- Removes the main open/typing lag on mobile, where mounting thousands of rows blocked the main thread

## Test plan

- [x] Playwright: open with empty query mounts fewer than 40 options and renders group headers
- [x] Playwright: after 20 ArrowDowns, `aria-activedescendant` resolves to a mounted, visible `role="option"` element
- [x] Playwright: ArrowDown x3 plus Enter navigates to the highlighted option (Arizona)
- [x] Playwright: all PR 1 fuzzy search tests pass unchanged (Sarasota FL, DC, Saint John, anasco, sarsota)
- [x] Playwright: full E2E_CI suite (74 tests) passes, including geo_selector_recents
- [ ] Manual VoiceOver pass: open search, arrow through options across group headers, hear each option announced, Enter selects

🤖 Generated with [Claude Code](https://claude.com/claude-code)
