### PR TITLE
fix(ui): restore MUI option styles in the virtualized location dropdown

### DIFF
--- a/frontend/playwright-tests/location_search.ci.spec.ts
+++ b/frontend/playwright-tests/location_search.ci.spec.ts
@@ -134,6 +134,30 @@ test('arrow keys plus Enter navigate to the highlighted option', async ({
   await expect(page).toHaveURL(/3\.04/, { timeout: 8000 })
 })
 
+test('virtualized options keep MUI option styling', async ({ page }) => {
+  const input = await openLocationSearch(page)
+  await input.press('ArrowDown')
+  await expect(page.getByRole('listbox')).toBeVisible()
+  // The custom listbox slot replaces MUI's default listbox, which is where
+  // MUI defines option styles; the muiTheme paper override must restore them.
+  const styles = await page
+    .getByRole('option')
+    .first()
+    .evaluate((el) => {
+      const cs = getComputedStyle(el)
+      return {
+        display: cs.display,
+        alignItems: cs.alignItems,
+        paddingLeft: cs.paddingLeft,
+      }
+    })
+  expect(styles).toEqual({
+    display: 'flex',
+    alignItems: 'center',
+    paddingLeft: '24px',
+  })
+})
+
 test('options list stays below the input in short viewports', async ({
   page,
 }) => {

--- a/frontend/src/styles/theme/muiTheme.tsx
+++ b/frontend/src/styles/theme/muiTheme.tsx
@@ -93,12 +93,13 @@ const muiTheme = extendTheme({
             '&[aria-selected="true"]': {
               backgroundColor: theme.alpha(
                 (theme.vars || theme).palette.primary.main,
-                (theme.vars || theme).palette.action.selectedOpacity,
+                theme.palette.action.selectedOpacity,
               ),
               '&.Mui-focused': {
                 backgroundColor: theme.alpha(
                   (theme.vars || theme).palette.primary.main,
-                  `${(theme.vars || theme).palette.action.selectedOpacity} + ${(theme.vars || theme).palette.action.hoverOpacity}`,
+                  theme.palette.action.selectedOpacity +
+                    theme.palette.action.hoverOpacity,
                 ),
                 '@media (hover: none)': {
                   backgroundColor: (theme.vars || theme).palette.action

--- a/frontend/src/styles/theme/muiTheme.tsx
+++ b/frontend/src/styles/theme/muiTheme.tsx
@@ -66,6 +66,48 @@ const muiTheme = extendTheme({
         endAdornment: {
           top: 'inherit',
         },
+        // MUI defines option styles on its default listbox slot, which the
+        // virtualized listbox in VirtualizedListbox.tsx replaces. Re-declare
+        // them (copied from MUI's AutocompleteListbox/GroupUl) on the paper
+        // slot, which still renders, so option rows keep MUI's look.
+        paper: ({ theme }) => ({
+          '& .MuiAutocomplete-option': {
+            display: 'flex',
+            overflow: 'hidden',
+            justifyContent: 'flex-start',
+            alignItems: 'center',
+            cursor: 'pointer',
+            boxSizing: 'border-box',
+            outline: '0',
+            WebkitTapHighlightColor: 'transparent',
+            padding: '6px 16px 6px 24px',
+            '&.Mui-focused': {
+              backgroundColor: (theme.vars || theme).palette.action.hover,
+              '@media (hover: none)': {
+                backgroundColor: 'transparent',
+              },
+            },
+            '&.Mui-focusVisible': {
+              backgroundColor: (theme.vars || theme).palette.action.focus,
+            },
+            '&[aria-selected="true"]': {
+              backgroundColor: theme.alpha(
+                (theme.vars || theme).palette.primary.main,
+                (theme.vars || theme).palette.action.selectedOpacity,
+              ),
+              '&.Mui-focused': {
+                backgroundColor: theme.alpha(
+                  (theme.vars || theme).palette.primary.main,
+                  `${(theme.vars || theme).palette.action.selectedOpacity} + ${(theme.vars || theme).palette.action.hoverOpacity}`,
+                ),
+                '@media (hover: none)': {
+                  backgroundColor: (theme.vars || theme).palette.action
+                    .selected,
+                },
+              },
+            },
+          },
+        }),
       },
     },
     MuiButton: {


### PR DESCRIPTION
**Preview:** [open the location dropdown](https://deploy-preview-4928--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity)

## Summary

- MUI defines all `.MuiAutocomplete-option` styles (flex centering, padding, focused/selected backgrounds) on its default listbox slot, so the custom virtualized listbox from #4924 silently dropped them: option text sat top-left in each row with zero padding, keyboard highlight had no background, and group headers were indented further than options (most visible on phones with 48px rows)
- Re-declares those styles, copied from MUI's own `AutocompleteListbox`/`AutocompleteGroupUl` source, under the Autocomplete `paper` slot in `muiTheme.tsx`, which still renders when the listbox slot is replaced
- Adds a Playwright test pinning the computed option styles (`display: flex`, `align-items: center`, 24px grouped indent) so a future MUI or slot change fails CI instead of silently regressing

## Impact

- Restores pre-#4924 dropdown appearance: options vertically centered with 24px indent under 16px group headers, and visible hover/keyboard-highlight backgrounds (the missing highlight was also an accessibility regression for keyboard users)

## Test plan

- [x] Playwright: computed option styles assert flex layout, centering, and 24px left padding
- [x] Full `location_search.ci.spec.ts` suite passes locally (11/11)
- [x] Verified at 390px phone viewport: rows centered, headers/options aligned as before virtualization, focused row shows highlight
- [x] On the deploy preview from a phone, confirm the dropdown rows look correct (matches the report screenshot scenario)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
