### PR TITLE
fix(pr-skill): check out the PR branch before running any steps

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -22,15 +22,13 @@ gh pr view <number> --json number,title,body,headRefName,baseRefName
 
 If no open PR is found: print an error and stop.
 
-**Check out the PR's branch before doing anything else.** When a PR number is passed, the working tree is often still on `main` (or another branch). Every later step — Biome, tsc, the behind-main merge check, review fixes — must run against the PR's own branch, so switch to `headRefName` now if you are not already on it:
+**Check out the PR's branch before doing anything else.** When a PR number is passed, the working tree is often still on `main` (or another branch). Every later step — Biome, tsc, the behind-main merge check, review fixes — must run against the PR's own branch, so switch to it now:
 
 ```bash
-HEAD_REF=$(gh pr view <number> --json headRefName -q .headRefName)
-CURRENT=$(git rev-parse --abbrev-ref HEAD)
-if [ "$CURRENT" != "$HEAD_REF" ]; then
-  git checkout "$HEAD_REF"
-fi
+gh pr checkout <number>
 ```
+
+`gh pr checkout` fetches the head branch from a fork if it isn't local yet, sets up tracking, and checks it out — a raw `git checkout <headRefName>` would fail for a not-yet-fetched fork branch, which is the norm in this repo's fork-based workflow. Skip this when no PR number was given (you are already on the branch).
 
 If the working tree is dirty and the checkout fails, stop and ask the user to commit or stash first — do not discard changes.
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -12,13 +12,27 @@ The user may pass a PR number as an argument (e.g. `/pr 4764`). If none is given
 
 ---
 
-## Step 1 — Identify the PR and derive context
+## Step 1 — Identify the PR, check out its branch, and derive context
+
+Pass the PR number through when one was given (`gh pr view <number> ...`); omit it to detect the PR from the current branch.
 
 ```bash
-gh pr view --json number,title,body,headRefName,baseRefName
+gh pr view <number> --json number,title,body,headRefName,baseRefName
 ```
 
 If no open PR is found: print an error and stop.
+
+**Check out the PR's branch before doing anything else.** When a PR number is passed, the working tree is often still on `main` (or another branch). Every later step — Biome, tsc, the behind-main merge check, review fixes — must run against the PR's own branch, so switch to `headRefName` now if you are not already on it:
+
+```bash
+HEAD_REF=$(gh pr view <number> --json headRefName -q .headRefName)
+CURRENT=$(git rev-parse --abbrev-ref HEAD)
+if [ "$CURRENT" != "$HEAD_REF" ]; then
+  git checkout "$HEAD_REF"
+fi
+```
+
+If the working tree is dirty and the checkout fails, stop and ask the user to commit or stash first — do not discard changes.
 
 Then derive two variables used throughout the remaining steps:
 


### PR DESCRIPTION
## Summary

- When `/pr` is invoked with a PR number, the working tree is often still on `main`. The skill's Step 1 read `headRefName` but never checked it out, so Biome, tsc, and the behind-main merge check all ran against `main`.
- The behind-main check compared `origin/main...HEAD` with `HEAD` on local `main` (already up to date), found no divergence, and skipped the merge, leaving a recently-merged fix out of the PR branch.
- Step 1 now checks out `headRefName` up front (guarding against a dirty tree), so every later step runs against the PR's own branch.

## Impact

- Fixes a silent gap where `/pr <number>` could report "up to date with main" while the PR branch was actually behind, skipping the auto-merge of newly-landed fixes.

## Test plan

- [x] Manually reproduced: `/pr 4927` ran on `main` and missed the merged margin fix (#4928); the branch was behind by that commit until merged by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)