### PR TITLE
docs: reflect Go server as the live serving path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,27 +4,36 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-The [Health Equity Tracker](https://healthequitytracker.org/) aggregates demographic health data by race, ethnicity, sex, and socioeconomic status across the US. It consists of a React frontend, lightweight Node server, Python data server, and a GCP-hosted data pipeline.
+The [Health Equity Tracker](https://healthequitytracker.org/) aggregates demographic health data by race, ethnicity, sex, and socioeconomic status across the US. It consists of a React frontend, a combined Go server that serves the app and its data APIs, and a GCP-hosted data pipeline.
 
 > **Service-specific guidance:** See each service's own `CLAUDE.md` for details.
-> `frontend/` · `frontend_server/` · `data_server/` · `server/` · `exporter/` · `python/`
+> `frontend/` · `server/` · `exporter/` · `python/`
+> (Legacy `frontend_server/` and `data_server/` are deprecated and slated for removal; see #4902.)
 
 ## Architecture
 
-### Three-Tier Frontend
+### Serving Architecture
+
+Since the 2026-07 production cutover (#4901), a single combined Go server is the live serving path for both dev and prod, handling the frontend and all data APIs:
 
 ```plaintext
-frontend/         React app (TypeScript, Vite, MUI, Tailwind, D3, Jotai)
-frontend_server/  Lightweight Node server — serves React static files, proxies data requests
-data_server/      Python Flask server — responds with JSON/CSV files exported from BigQuery
-server/           Combined Go server (experimental) — replaces both frontend_server and data_server
-                  with a single ~15 MB binary: static files + GCS data + Anthropic + Webflow
+frontend/  React app (TypeScript, Vite, MUI, Tailwind, D3, Jotai)
+server/    Combined Go server: the live serving path for dev and prod. One
+           ~15 MB binary (static files + GCS data + Anthropic + Webflow) that
+           replaces frontend_server and data_server.
+```
+
+The two original services are deprecated and pending removal (#4902); do not build new functionality on them:
+
+```plaintext
+frontend_server/  (legacy) Node server that served React static files and proxied data requests
+data_server/      (legacy) Python Flask server that served JSON/CSV files exported from BigQuery
 ```
 
 ### Backend Data Pipeline
 
 ```plaintext
-run_ingestion/  →  GCS bucket  →  run_gcs_to_bq/  →  BigQuery  →  exporter/  →  GCS JSON  →  data_server/
+run_ingestion/  →  GCS bucket  →  run_gcs_to_bq/  →  BigQuery  →  exporter/  →  GCS JSON  →  server/
 (fetch raw data)                  (runs DataSource                  (splits county
                                    modules in /python)               files by state)
 ```

--- a/README.md
+++ b/README.md
@@ -267,8 +267,12 @@ Everything below is more detailed, advanced info that you probably won't need ri
 The frontend consists of
 
 1. `health-equity-tracker/frontend/`: A React app that contains all code and static resources needed in the browser (html, TS, CSS, images). Built with [Vite 8](https://vite.dev/) (Rolldown-powered) and tested with [Vitest 4](https://vitest.dev/).
-2. `health-equity-tracker/frontend_server/`: A lightweight server that serves the React app as static files and forwards data requests to the data server.
-3. `health-equity-tracker/data_server/`: A data server that responds to data requests by serving data files that have been exported from the data pipeline.
+2. `health-equity-tracker/server/`: A combined Go server that is the live serving path for both dev and prod. It serves the React app's static files and responds to data requests with files exported from the data pipeline, in a single binary.
+
+Two original services are now deprecated and pending removal (see #4902); do not build new functionality on them:
+
+- `health-equity-tracker/frontend_server/`: (legacy) A lightweight Node server that served the React app as static files and forwarded data requests to the data server.
+- `health-equity-tracker/data_server/`: (legacy) A server that responded to data requests by serving data files exported from the data pipeline.
 
 ### Frontend Design System & Theme Architecture
 
@@ -376,7 +380,7 @@ The backend consists of:
 - `health-equity-tracker/.github/workflows/`: Workflow code that controls the DAGs which orchestrate the execution of these various microservices via GitHub Actions
 - `health-equity-tracker/config/`: Terraform configuration for setting permissions and provisioning needed resources for cloud computing
 - `health-equity-tracker/data/`: In code-base "bucket" used to store manually downloaded data from outside sources where it isn't possible to fetch new data directly via and API endpoint or linkable file URL
-- `health-equity-tracker/server_smoke_tests/`: Post-deploy smoke tests that hit the live `data_server` and `frontend_server` GCP services to verify they are responding correctly
+- `health-equity-tracker/server_smoke_tests/`: Post-deploy smoke tests that hit the live combined Go `server` GCP service to verify it is responding correctly
 - `health-equity-tracker/exporter/`: Code for the microservice responsible for taking HET-style data from HET BigQuery tables and storing them in buckets as .json files. NOTE: County-level files are broken up by state when exporting.
 - `health-equity-tracker/python/`: Code for the Python modules responsible for fetching data from outside sources and wrangling into a HET-style table with rows for every combination of demographic group, geographic area, and optionally time period, and columns for each measured metric
 - `health-equity-tracker/requirements/`: Packages required for the HET


### PR DESCRIPTION
## Summary

- The 2026-07 prod cutover (#4901) made the combined Go `server/` the live serving path for both dev and prod. Update the root `CLAUDE.md` and `README.md` architecture sections to say so, and drop the stale "experimental" / "three-tier" framing.
- Mark `frontend_server/` and `data_server/` as deprecated and pending removal, pointing at the tracking issue (#4902) so no one builds new work on them.
- Repoint the pipeline diagram's serving endpoint and the `server_smoke_tests` description from the legacy servers to `server/`.

## Impact

- Docs-only. Removes a stale mental model (Go server labeled "experimental" when it has served prod since 2026-07-08) that could misdirect where new serving/caching work lands. Full legacy-dir deletion and the deeper README local-dev rewrite are owned by #4902.

## Test plan

- [x] No code changed; cspell pre-commit hook passed on both `.md` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
