### PR TITLE
infra: rename Terraform resource frontend_service to server_service

### DIFF
--- a/config/run.tf
+++ b/config/run.tf
@@ -95,10 +95,14 @@ resource "google_cloud_run_service" "gcs_to_bq_service" {
 
 # Serves healthequitytracker.org. The Cloud Run service name is pinned to
 # "frontend-service" by the manually-managed domain mapping (see the domain
-# mapping note below). Terraform resource label stays frontend_service to avoid
-# a state conflict during this cleanup; rename to server_service follows in #4945
-# once "server-service" is gone from state.
-resource "google_cloud_run_service" "frontend_service" {
+# mapping note below). Terraform resource label is server_service; the Cloud
+# Run name must stay "frontend-service" or the domain mapping breaks.
+moved {
+  from = google_cloud_run_service.frontend_service
+  to   = google_cloud_run_service.server_service
+}
+
+resource "google_cloud_run_service" "server_service" {
   name     = var.frontend_service_name
   location = var.compute_region
   project  = var.project_id
@@ -227,7 +231,7 @@ resource "google_cloud_run_service" "exporter_service" {
 
 # Output the URL of the server for use in e2e tests and the buildAllAndDeploy action.
 output "frontend_url" {
-  value = google_cloud_run_service.frontend_service.status.0.url
+  value = google_cloud_run_service.server_service.status.0.url
 }
 
 # Output the URLs of the pipeline services (previously used for DAGs)

--- a/config/serviceaccounts.tf
+++ b/config/serviceaccounts.tf
@@ -126,9 +126,9 @@ resource "google_storage_bucket_iam_member" "data_server_flagged_insights_bindin
 
 # Make the server service public (Cloud Run name is "frontend-service"; see run.tf)
 resource "google_cloud_run_service_iam_member" "frontend_invoker_binding" {
-  location = google_cloud_run_service.frontend_service.location
-  project  = google_cloud_run_service.frontend_service.project
-  service  = google_cloud_run_service.frontend_service.name
+  location = google_cloud_run_service.server_service.location
+  project  = google_cloud_run_service.server_service.project
+  service  = google_cloud_run_service.server_service.name
   role     = "roles/run.invoker"
   member   = "allUsers"
 }


### PR DESCRIPTION
## Summary

- Adds `moved { from = frontend_service, to = server_service }` now that the old Cloud Run "server-service" is destroyed (#4943) and its state entry is gone
- Updates the `frontend_url` output and `frontend_invoker_binding` IAM member to reference `server_service`
- Cloud Run service name stays `"frontend-service"` — pinned by the manually-managed domain mapping

## Test plan

- [ ] `terraform plan` on infra-test shows only the rename (no destroy/create) — the `moved {}` block should produce a no-op plan for the underlying Cloud Run service

Closes #4945

🤖 Generated with [Claude Code](https://claude.com/claude-code)