### PR TITLE
Surface ALLs fallback with in-card notice on map and trends cards

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -55,8 +55,11 @@ URL params (mls, dt1, demo, etc.)
       → DataManager (src/data/loading/DataManager.ts) — LRU cache
         → VariableProvider (per-topic, src/data/providers/)
           → JSON fetch from server (Go server GCS proxy)
-            → MetricQueryResponse → Cards render charts
+            → MetricQueryResponse {data, consumedDatasetIds, usedAllsFallback}
+              → Cards render charts, surface fallback alert when needed
 ```
+
+Each `VariableProvider` computes `usedAllsFallback` via `resolveDatasetId()` when the requested demographic dataset is not registered but its `alls_` fallback is (see `MetricQuery.ts`). The flag flows through `DataManager` into `MetricQueryResponse` and informs whether cards render `AllsFallbackAlert` and which card-level features are available (e.g., compare mode fallback behavior).
 
 Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
 

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -75,6 +75,7 @@ import {
 } from '../utils/urlutils'
 import CardWrapper from './CardWrapper'
 import ChartTitle, { getChartTitleId } from './ChartTitle'
+import AllsFallbackAlert from './ui/AllsFallbackAlert'
 import CAWPCountyMultiDistrictAlert from './ui/CAWPCountyMultiDistrictAlert'
 import DemographicGroupMenu from './ui/DemographicGroupMenu'
 import { ExtremesListBox } from './ui/ExtremesListBox'
@@ -648,6 +649,12 @@ function MapCardWithKey(props: MapCardProps) {
                       ) : null
                     }
                   />
+                  {mapQueryResponse.usedAllsFallback && (
+                    <AllsFallbackAlert
+                      dataName={props.dataTypeConfig.fullDisplayName}
+                      demographicType={demographicType}
+                    />
+                  )}
                   {isGeorgiaWithCountyData && !isExtremesMode && (
                     <div className='flex justify-center'>
                       <HetLinkButton

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -32,6 +32,7 @@ import type { ScrollableHashId } from '../utils/hooks/useStepObserver'
 import CardWrapper from './CardWrapper'
 import ChartTitle, { getChartTitleId } from './ChartTitle'
 import UnknownPctRateGradient from './UnknownPctRateGradient'
+import AllsFallbackAlert from './ui/AllsFallbackAlert'
 import AltTableView from './ui/AltTableView'
 import Hiv2020Alert from './ui/Hiv2020Alert'
 import MissingDataAlert from './ui/MissingDataAlert'
@@ -260,6 +261,12 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
               <>
                 {/* ensure we don't render two of these in compare mode */}
                 {!props.isCompareCard && <UnknownPctRateGradient />}
+                {queryResponseRates.usedAllsFallback && (
+                  <AllsFallbackAlert
+                    dataName={props.dataTypeConfig.fullDisplayName}
+                    demographicType={props.demographicType}
+                  />
+                )}
                 <TrendsChart
                   chartTitleId={getChartTitleId(HASH_ID, props.isCompareCard)}
                   data={nestedRatesData}

--- a/frontend/src/cards/ui/AllsFallbackAlert.tsx
+++ b/frontend/src/cards/ui/AllsFallbackAlert.tsx
@@ -13,14 +13,11 @@ interface AllsFallbackAlertProps {
 export default function AllsFallbackAlert(props: AllsFallbackAlertProps) {
   const demographicName =
     DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]
-  // cSpell:ignore aeiou
-  const article = /^[aeiou]/i.test(demographicName) ? 'An' : 'A'
 
   return (
     <HetNotice kind='helpful-info'>
-      {article} <HetTerm>{demographicName}</HetTerm> breakdown isn't available
-      for <HetTerm>{props.dataName}</HetTerm>, so this card shows the overall
-      rate.
+      Breakdown by <HetTerm>{demographicName}</HetTerm> isn't available for{' '}
+      <HetTerm>{props.dataName}</HetTerm>, so this card shows the overall rate.
     </HetNotice>
   )
 }

--- a/frontend/src/cards/ui/AllsFallbackAlert.tsx
+++ b/frontend/src/cards/ui/AllsFallbackAlert.tsx
@@ -1,0 +1,23 @@
+import {
+  DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE,
+  type DemographicType,
+} from '../../data/query/Breakdowns'
+import HetNotice from '../../styles/HetComponents/HetNotice'
+import HetTerm from '../../styles/HetComponents/HetTerm'
+
+interface AllsFallbackAlertProps {
+  dataName: string
+  demographicType: DemographicType
+}
+
+export default function AllsFallbackAlert(props: AllsFallbackAlertProps) {
+  return (
+    <HetNotice kind='helpful-info'>
+      Our data sources do not report <HetTerm>{props.dataName}</HetTerm> by{' '}
+      <HetTerm>
+        {DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]}
+      </HetTerm>
+      , so this card shows combined rates for all people.
+    </HetNotice>
+  )
+}

--- a/frontend/src/cards/ui/AllsFallbackAlert.tsx
+++ b/frontend/src/cards/ui/AllsFallbackAlert.tsx
@@ -11,13 +11,16 @@ interface AllsFallbackAlertProps {
 }
 
 export default function AllsFallbackAlert(props: AllsFallbackAlertProps) {
+  const demographicName =
+    DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]
+  // cSpell:ignore aeiou
+  const article = /^[aeiou]/i.test(demographicName) ? 'An' : 'A'
+
   return (
     <HetNotice kind='helpful-info'>
-      Our data sources do not report <HetTerm>{props.dataName}</HetTerm> by{' '}
-      <HetTerm>
-        {DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[props.demographicType]}
-      </HetTerm>
-      , so this card shows combined rates for all people.
+      {article} <HetTerm>{demographicName}</HetTerm> breakdown isn't available
+      for <HetTerm>{props.dataName}</HetTerm>, so this card shows the overall
+      rate.
     </HetNotice>
   )
 }

--- a/frontend/src/charts/trendsChart/Index.tsx
+++ b/frontend/src/charts/trendsChart/Index.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import ChartTitle from '../../cards/ChartTitle'
 import type { DemographicType } from '../../data/query/Breakdowns'
-import type { DemographicGroup } from '../../data/utils/Constants'
+import { ALL, type DemographicGroup } from '../../data/utils/Constants'
 import { getMinMaxGroups } from '../../data/utils/DatasetTimeUtils'
 import useEscape from '../../utils/hooks/useEscape'
 import { useIsBreakpointAndUp } from '../../utils/hooks/useIsBreakpointAndUp'
@@ -213,7 +213,7 @@ export function TrendsChart({
             subtitle={chartSubTitle}
           />
         )}
-        {data && (
+        {data && !(data.length === 1 && data[0][0] === ALL) && (
           <FilterLegend
             data={data}
             selectedGroups={selectedTrendGroups}

--- a/frontend/src/data/loading/DataManager.ts
+++ b/frontend/src/data/loading/DataManager.ts
@@ -231,6 +231,8 @@ class MetricQueryCache extends ResourceCache<MetricQuery, MetricQueryResponse> {
     const resp = new MetricQueryResponse(
       queryResponses[0].data,
       uniqueConsumedDatasetIds,
+      undefined,
+      queryResponses[0].usedAllsFallback,
     )
 
     new DatasetOrganizer(resp.data, query.breakdowns).organize()

--- a/frontend/src/data/providers/AcsConditionProvider.ts
+++ b/frontend/src/data/providers/AcsConditionProvider.ts
@@ -59,7 +59,7 @@ class AcsConditionProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df, [datasetId])
+    return new MetricQueryResponse(df, [datasetId], undefined, !!isFallbackId)
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/AcsConditionProvider.ts
+++ b/frontend/src/data/providers/AcsConditionProvider.ts
@@ -57,8 +57,8 @@ class AcsConditionProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
     return new MetricQueryResponse(df, [datasetId], undefined, !!isFallbackId)
   }
 

--- a/frontend/src/data/providers/AhrProvider.test.ts
+++ b/frontend/src/data/providers/AhrProvider.test.ts
@@ -47,7 +47,7 @@ async function ensureCorrectDatasetsDownloaded(
     ahrDatasetId,
   ]
   expect(responseIncludingAll).toEqual(
-    new MetricQueryResponse([], consumedDatasetIds),
+    new MetricQueryResponse([], consumedDatasetIds, undefined, isFallback),
   )
 }
 

--- a/frontend/src/data/providers/AhrProvider.ts
+++ b/frontend/src/data/providers/AhrProvider.ts
@@ -170,7 +170,12 @@ class AhrProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds?: MetricId[]): boolean {

--- a/frontend/src/data/providers/AhrProvider.ts
+++ b/frontend/src/data/providers/AhrProvider.ts
@@ -167,8 +167,8 @@ class AhrProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
 
     return new MetricQueryResponse(
       df,

--- a/frontend/src/data/providers/CawpProvider.ts
+++ b/frontend/src/data/providers/CawpProvider.ts
@@ -151,7 +151,12 @@ class CawpProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds?: MetricId[]): boolean {

--- a/frontend/src/data/providers/CawpProvider.ts
+++ b/frontend/src/data/providers/CawpProvider.ts
@@ -149,8 +149,8 @@ class CawpProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
     return new MetricQueryResponse(
       df,
       consumedDatasetIds,

--- a/frontend/src/data/providers/CdcCancerProvider.ts
+++ b/frontend/src/data/providers/CdcCancerProvider.ts
@@ -93,8 +93,8 @@ class CdcCancerProvider extends VariableProvider {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
       } else {
         df = this.applyDemographicBreakdownFilters(df, breakdowns)
-        df = this.removeUnrequestedColumns(df, metricQuery)
       }
+      df = this.removeUnrequestedColumns(df, metricQuery)
 
       const consumedDatasetIds = [datasetId]
       return new MetricQueryResponse(

--- a/frontend/src/data/providers/CdcCancerProvider.ts
+++ b/frontend/src/data/providers/CdcCancerProvider.ts
@@ -97,7 +97,12 @@ class CdcCancerProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df, consumedDatasetIds)
+      return new MetricQueryResponse(
+        df,
+        consumedDatasetIds,
+        undefined,
+        !!isFallbackId,
+      )
     } catch (error) {
       console.error('Error fetching cancer data:', error)
       throw error

--- a/frontend/src/data/providers/CdcCovidProvider.ts
+++ b/frontend/src/data/providers/CdcCovidProvider.ts
@@ -130,8 +130,8 @@ class CdcCovidProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
 
     return new MetricQueryResponse(
       df,

--- a/frontend/src/data/providers/CdcCovidProvider.ts
+++ b/frontend/src/data/providers/CdcCovidProvider.ts
@@ -133,7 +133,12 @@ class CdcCovidProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
+++ b/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
@@ -60,7 +60,12 @@ class GunViolenceBlackMenProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df, consumedDatasetIds)
+      return new MetricQueryResponse(
+        df,
+        consumedDatasetIds,
+        undefined,
+        !!isFallbackId,
+      )
     } catch (error) {
       console.error('Error fetching gun homicides of Black men data:', error)
       throw error

--- a/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
+++ b/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
@@ -56,8 +56,8 @@ class GunViolenceBlackMenProvider extends VariableProvider {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
       } else {
         df = this.applyDemographicBreakdownFilters(df, breakdowns)
-        df = this.removeUnrequestedColumns(df, metricQuery)
       }
+      df = this.removeUnrequestedColumns(df, metricQuery)
 
       const consumedDatasetIds = [datasetId]
       return new MetricQueryResponse(

--- a/frontend/src/data/providers/GunViolenceProvider.test.ts
+++ b/frontend/src/data/providers/GunViolenceProvider.test.ts
@@ -26,6 +26,7 @@ async function ensureCorrectDatasetsDownloaded(
   timeView?: TimeView,
   metricIds?: MetricId[],
   scrollToHashId?: ScrollableHashId,
+  isFallback?: boolean,
 ) {
   // If these aren't sent as args, default to []
   metricIds = metricIds || []
@@ -53,7 +54,7 @@ async function ensureCorrectDatasetsDownloaded(
   const consumedDatasetIds = [gunViolenceDatasetId]
 
   expect(responseIncludingAll).toEqual(
-    new MetricQueryResponse([], consumedDatasetIds),
+    new MetricQueryResponse([], consumedDatasetIds, undefined, isFallback),
   )
 }
 
@@ -116,6 +117,7 @@ describe('GunViolenceProvider', () => {
       'current',
       ['gun_violence_homicide_per_100k'],
       'rate-map', // these metricQuery tests need a scrollToHashId to enable the fallbackId logic
+      true, // falls back to ALLS, so usedAllsFallback is true
     )
   })
 })

--- a/frontend/src/data/providers/GunViolenceProvider.ts
+++ b/frontend/src/data/providers/GunViolenceProvider.ts
@@ -115,8 +115,8 @@ class GunViolenceProvider extends VariableProvider {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
       } else {
         df = this.applyDemographicBreakdownFilters(df, breakdowns)
-        df = this.removeUnrequestedColumns(df, metricQuery)
       }
+      df = this.removeUnrequestedColumns(df, metricQuery)
 
       const consumedDatasetIds = [datasetId]
       return new MetricQueryResponse(

--- a/frontend/src/data/providers/GunViolenceProvider.ts
+++ b/frontend/src/data/providers/GunViolenceProvider.ts
@@ -119,7 +119,12 @@ class GunViolenceProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df, consumedDatasetIds)
+      return new MetricQueryResponse(
+        df,
+        consumedDatasetIds,
+        undefined,
+        !!isFallbackId,
+      )
     } catch (error) {
       console.error('Error fetching gun deaths data:', error)
       throw error

--- a/frontend/src/data/providers/GunViolenceYouthProvider.ts
+++ b/frontend/src/data/providers/GunViolenceYouthProvider.ts
@@ -71,8 +71,8 @@ class GunViolenceYouthProvider extends VariableProvider {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
       } else {
         df = this.applyDemographicBreakdownFilters(df, breakdowns)
-        df = this.removeUnrequestedColumns(df, metricQuery)
       }
+      df = this.removeUnrequestedColumns(df, metricQuery)
 
       const consumedDatasetIds = [datasetId]
       return new MetricQueryResponse(

--- a/frontend/src/data/providers/GunViolenceYouthProvider.ts
+++ b/frontend/src/data/providers/GunViolenceYouthProvider.ts
@@ -75,7 +75,12 @@ class GunViolenceYouthProvider extends VariableProvider {
       }
 
       const consumedDatasetIds = [datasetId]
-      return new MetricQueryResponse(df, consumedDatasetIds)
+      return new MetricQueryResponse(
+        df,
+        consumedDatasetIds,
+        undefined,
+        !!isFallbackId,
+      )
     } catch (error) {
       console.error('Error fetching gun deaths of youth data:', error)
       throw error

--- a/frontend/src/data/providers/HivBlackWomenProvider.ts
+++ b/frontend/src/data/providers/HivBlackWomenProvider.ts
@@ -72,8 +72,8 @@ class HivBlackWomenProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
 
     return new MetricQueryResponse(
       df,

--- a/frontend/src/data/providers/HivBlackWomenProvider.ts
+++ b/frontend/src/data/providers/HivBlackWomenProvider.ts
@@ -75,7 +75,12 @@ class HivBlackWomenProvider extends VariableProvider {
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
 
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, _metricIds: MetricId[]): boolean {

--- a/frontend/src/data/providers/HivProvider.ts
+++ b/frontend/src/data/providers/HivProvider.ts
@@ -118,7 +118,12 @@ class HivProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns, metricIds: MetricId[]): boolean {

--- a/frontend/src/data/providers/HivProvider.ts
+++ b/frontend/src/data/providers/HivProvider.ts
@@ -116,8 +116,8 @@ class HivProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
     return new MetricQueryResponse(
       df,
       consumedDatasetIds,

--- a/frontend/src/data/providers/IncarcerationProvider.tsx
+++ b/frontend/src/data/providers/IncarcerationProvider.tsx
@@ -114,7 +114,12 @@ class IncarcerationProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/MaternalMortalityProvider.ts
+++ b/frontend/src/data/providers/MaternalMortalityProvider.ts
@@ -58,7 +58,12 @@ class MaternalMortalityProvider extends VariableProvider {
         df = this.removeUnrequestedColumns(df, metricQuery)
       }
 
-      return new MetricQueryResponse(df, consumedDatasetIds)
+      return new MetricQueryResponse(
+        df,
+        consumedDatasetIds,
+        undefined,
+        !!isFallbackId,
+      )
     } catch (error) {
       console.error('Error fetching maternal mortality data:', error)
       throw error

--- a/frontend/src/data/providers/MaternalMortalityProvider.ts
+++ b/frontend/src/data/providers/MaternalMortalityProvider.ts
@@ -55,8 +55,8 @@ class MaternalMortalityProvider extends VariableProvider {
         df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
       } else {
         df = this.applyDemographicBreakdownFilters(df, breakdowns)
-        df = this.removeUnrequestedColumns(df, metricQuery)
       }
+      df = this.removeUnrequestedColumns(df, metricQuery)
 
       return new MetricQueryResponse(
         df,

--- a/frontend/src/data/providers/PhrmaBrfssProvider.ts
+++ b/frontend/src/data/providers/PhrmaBrfssProvider.ts
@@ -102,8 +102,8 @@ class PhrmaBrfssProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
 
     const consumedDatasetIds = [datasetId]
     return new MetricQueryResponse(

--- a/frontend/src/data/providers/PhrmaBrfssProvider.ts
+++ b/frontend/src/data/providers/PhrmaBrfssProvider.ts
@@ -106,7 +106,12 @@ class PhrmaBrfssProvider extends VariableProvider {
     }
 
     const consumedDatasetIds = [datasetId]
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/PhrmaProvider.ts
+++ b/frontend/src/data/providers/PhrmaProvider.ts
@@ -131,8 +131,8 @@ class PhrmaProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
 
     const consumedDatasetIds = [datasetId]
     return new MetricQueryResponse(

--- a/frontend/src/data/providers/PhrmaProvider.ts
+++ b/frontend/src/data/providers/PhrmaProvider.ts
@@ -135,7 +135,12 @@ class PhrmaProvider extends VariableProvider {
     }
 
     const consumedDatasetIds = [datasetId]
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/providers/VaccineProvider.ts
+++ b/frontend/src/data/providers/VaccineProvider.ts
@@ -79,8 +79,8 @@ class VaccineProvider extends VariableProvider {
       df = this.castAllsAsRequestedDemographicBreakdown(df, breakdowns)
     } else {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
-      df = this.removeUnrequestedColumns(df, metricQuery)
     }
+    df = this.removeUnrequestedColumns(df, metricQuery)
     return new MetricQueryResponse(
       df,
       consumedDatasetIds,

--- a/frontend/src/data/providers/VaccineProvider.ts
+++ b/frontend/src/data/providers/VaccineProvider.ts
@@ -81,7 +81,12 @@ class VaccineProvider extends VariableProvider {
       df = this.applyDemographicBreakdownFilters(df, breakdowns)
       df = this.removeUnrequestedColumns(df, metricQuery)
     }
-    return new MetricQueryResponse(df, consumedDatasetIds)
+    return new MetricQueryResponse(
+      df,
+      consumedDatasetIds,
+      undefined,
+      !!isFallbackId,
+    )
   }
 
   allowsBreakdowns(breakdowns: Breakdowns): boolean {

--- a/frontend/src/data/query/MetricQuery.ts
+++ b/frontend/src/data/query/MetricQuery.ts
@@ -79,15 +79,18 @@ export class MetricQueryResponse {
   readonly missingDataMessage: string | undefined
   readonly invalidValues: Record<string, number>
   readonly consumedDatasetIds: Array<DatasetId | DatasetIdWithStateFIPSCode>
+  readonly usedAllsFallback: boolean
 
   constructor(
     data: readonly HetRow[],
     consumedDatasetIds: Array<DatasetId | DatasetIdWithStateFIPSCode> = [],
     missingDataMessage: string | undefined = undefined,
+    usedAllsFallback = false,
   ) {
     this.data = Array.from(data)
     this.consumedDatasetIds = consumedDatasetIds
     this.invalidValues = getInvalidValues(this.data)
+    this.usedAllsFallback = usedAllsFallback
     this.missingDataMessage = missingDataMessage // possibly undefined
     if (this.missingDataMessage === undefined && this.data.length <= 0) {
       this.missingDataMessage = 'No rows returned'


### PR DESCRIPTION
**Preview:** [ALLs fallback alert](https://deploy-preview-4955--health-equity-tracker.netlify.app/exploredata)

## Summary

- Carries a `usedAllsFallback` flag through `MetricQueryResponse`: set by each provider from `resolveDatasetId()`'s `isFallbackId`, and preserved through the `DataManager` re-wrap that previously dropped it
- Adds a new `AllsFallbackAlert` (helpful-info `HetNotice`) rendered on the rate map and rates-over-time cards whenever the ALLs fallback fires, e.g. "Breakdown by **age** isn't available for **Maternal mortality**, so this card shows the overall rate."
- Hides the trend-chart group-selection chips ("Select groups" / "Showing all groups") when the only demographic group present is All, since filtering a single combined line is meaningless

## Impact

- UX clarity: users now see a neutral in-card notice when a requested demographic breakdown is unavailable. The wording avoids implying the data source is at fault (some subpopulations, e.g. Black women by race, are not logically stratifiable) and avoids the inaccurate "all people" phrasing for subpopulation cards

## Test plan

- [x] Compare Black women HIV prevalence vs maternal mortality by age: maternal mortality map and trends cards show the notice, HIV side stays stratified by age, trend chips hidden on all-only chart

Closes #4952

🤖 Generated with [Claude Code](https://claude.com/claude-code)
