### PR TITLE
Export NCI cancer ALLs file and enforce demographic on ALLs export

### DIFF
--- a/.github/workflows/dagNciCancer.yml
+++ b/.github/workflows/dagNciCancer.yml
@@ -29,4 +29,5 @@ jobs:
           service_url: ${{ env.EXPORTER_SERVICE_URL }}
           gcp_sa_key: ${{ secrets.DEPLOYER_SA_KEY }}
           dataset_name: ${{ env.DATASET_NAME }}
+          demographic: ${{ env.RACE_AND_ETHNICITY }}
           should_export_as_alls: "true"

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -25,6 +25,17 @@ def export_dataset_tables():
     if data.get("category") is not None:
         category = data.get("category")
     should_export_as_alls = data.get("should_export_as_alls", False)
+
+    # The ALLs export filters on and renames the demographic column, so it
+    # cannot run without one. Fail loudly on a misconfigured DAG rather than
+    # silently skipping the alls file (which the frontend fallback relies on).
+    if should_export_as_alls and not demographic:
+        return (
+            'Request set "should_export_as_alls" but did not include a "demographic". '
+            "Add the demographic input to the DAG's export step.",
+            400,
+        )
+
     dataset_name = data["dataset_name"]
     project_id = os.environ.get("PROJECT_ID")
     export_bucket = os.environ.get("EXPORT_BUCKET")

--- a/exporter/test_exporter.py
+++ b/exporter/test_exporter.py
@@ -77,6 +77,23 @@ def testExportDatasetTables_InvalidInput(
 
 @mock.patch("main.export_split_county_tables")
 @mock.patch("google.cloud.bigquery.Client")
+def testExportDatasetTables_AllsWithoutDemographic(
+    mock_bq_client: mock.MagicMock, mock_split_county: mock.MagicMock, client: FlaskClient
+):
+    # should_export_as_alls requires a demographic; a missing one (or the
+    # action's empty-string default) must fail loudly before any BQ work.
+    for demographic in ({}, {"demographic": ""}):
+        payload = {"dataset_name": "my-dataset", "should_export_as_alls": True, **demographic}
+        response = client.post("/", json=payload)
+
+        assert response.status_code == 400
+        assert b"should_export_as_alls" in response.data
+    assert mock_bq_client.call_count == 0
+    assert mock_split_county.call_count == 0
+
+
+@mock.patch("main.export_split_county_tables")
+@mock.patch("google.cloud.bigquery.Client")
 def testExportDatasetTables_NoTables(
     mock_bq_client: mock.MagicMock, mock_split_county: mock.MagicMock, client: FlaskClient
 ):


### PR DESCRIPTION
## Summary
- The NCI cancer DAG's export step set `should_export_as_alls: "true"` but omitted the `demographic:` input, so the exporter ran `export_alls` with an empty demographic and never produced `nci_cancer-alls_county_current`. That id is registered in `DatasetMetadataNciCancer.ts`, so the frontend ALLs fallback (rate map / trends, and now rate chart / data table) resolves to that file and gets a 500.
- Add the missing `demographic` input to `dagNciCancer.yml`, matching the CHR and Maternal Mortality DAGs (the other county/race single-demographic sources that export ALLs correctly).
- Enforce the contract in `exporter/main.py`: a request with `should_export_as_alls` but no `demographic` now returns 400 before any BigQuery work. The export action already fails the step on HTTP >= 400, so a future misconfiguration surfaces as a red GitHub Actions step with the message printed, not just a Cloud Run log line.
- Add an exporter unit test covering both the missing-key and empty-string (the action's default) cases.

## Test plan
- [x] `pytest exporter/test_exporter.py` (6 passed)
- [ ] Run the NCI cancer DAG against the test project and confirm `nci_cancer-alls_county_current.json` serves 200


Closes #4960
