### PR TITLE
Fix Netlify deploy previews by bumping build to Node 24

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,4 +4,4 @@ publish = "build"
 command = "npm run build:deploy_preview"
 
 [build.environment]
-  NODE_VERSION = "22"
+  NODE_VERSION = "24"


### PR DESCRIPTION
## Summary

- Deploy previews have failed **repo-wide since ~2026-07-14**, including on `main`. Every deploy errored at 0s before building.
- Root cause: the npm pin (#4951) raised `frontend/package.json` to `engines.node >= 24.0.0` / `npm >= 11.16.0` with `.npmrc` `engine-strict=true`, but `netlify.toml` still built on `NODE_VERSION = "22"`. npm aborts with `EBADENGINE` (Node v22.23.1 / npm 10.9.8) before installing.
- Fix: bump `netlify.toml` `NODE_VERSION` to `24`, matching the Node version CI already resolves from `frontend/package.json` via `node-version-file`.

## Impact

- Restores Netlify deploy previews for all PRs (currently 0% deploy across the repo). No app code change.

## Test plan

- [ ] Netlify deploy preview for this PR builds and publishes successfully (Node 24, npm >= 11.16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)