### PR TITLE
fix(e2e): scope poverty alt-table-view locator to fix strict-mode violation

### DIFF
--- a/frontend/playwright-tests/poverty.spec.ts
+++ b/frontend/playwright-tests/poverty.spec.ts
@@ -24,7 +24,12 @@ test('Poverty', async ({ page }) => {
   await page
     .getByRole('button', { name: 'Expand rates over time table' })
     .click()
-  await page.getByText('Add or remove columns by').click()
+  await page
+    .locator(
+      '[id="Rates-of-poverty-over-time-in-the-United-States-by-race/ethnicity-alt-table-view1"]',
+    )
+    .getByText('Add or remove columns by')
+    .click()
   await page.getByText('View and download full .csv').click()
   await page
     .locator('#rate-chart')


### PR DESCRIPTION
## Summary

- The dev-site E2E for Poverty failed with a Playwright strict-mode violation: `getByText('Add or remove columns by')` resolved to two elements, the rates-over-time table and the relative-inequity table, since both render an `alt-table-view` column toggle.
- Scoped the line-27 locator to the rates-over-time table's `alt-table-view` container so it can never match the relative-inequity table.

## Root cause

Latent ambiguity, not a behavioral regression. Both over-time tables share the same "Add or remove columns by" toggle text; the click's auto-wait retry window intermittently caught both in the DOM. Matches the earlier `vaccination.ci.spec.ts` fix pattern of targeting the table by id.

## Impact

- Restores green dev-site E2E on `main`. No product code changed; test-only.

## Test plan

- [x] `poverty.spec.ts` passes locally against the dev backend (E2E_NIGHTLY, 9.2s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)