### PR TITLE
fix(ci): drop removed terraform-var-file input from infra-test deploy

### DIFF
--- a/.github/workflows/testBackendChangesInfraTest.yml
+++ b/.github/workflows/testBackendChangesInfraTest.yml
@@ -21,7 +21,6 @@ jobs:
         with:
           ref: infra-test
           environment: dev
-          terraform-var-file: gcp.tfvars
           deployer-sa-key: ${{ secrets.DEPLOYER_SA_KEY }}
           project-id: ${{ secrets.TEST_PROJECT_ID }}
           tf-state-bucket: ${{ secrets.TEST_TF_STATE_BUCKET }}


### PR DESCRIPTION
## Summary

- `testBackendChangesInfraTest.yml` passed `terraform-var-file: gcp.tfvars` to the `buildAllAndDeploy` composite action, but that input was removed from the action in #4943. The action rejects unknown inputs, so every infra-test deploy failed with `Unexpected input(s) 'terraform-var-file'`.
- The prod-path `deployInfraTest.yml` was updated at the time; this test-path workflow was missed. It went unnoticed because infra-test had not been redeployed since (last run 2026-07-07).
- Removes the stale line to match the action's current input set (`ref, environment, deployer-sa-key, project-id, tf-state-bucket`).

## Impact

- Restores the ability to deploy backend changes to the test project via `git push origin HEAD:infra-test -f`. No behavior change to the prod deploy path.

## Test plan

- [x] Pushed to infra-test; the deploy workflow gets past the input-validation error (previously failed at the first step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
