### PR TITLE
feat(data): register AHR non-behavioral alls dataset ids

### DIFF
--- a/frontend/src/data/config/DatasetMetadataAhr.ts
+++ b/frontend/src/data/config/DatasetMetadataAhr.ts
@@ -29,6 +29,10 @@ export type DatasetIdAhr =
   | 'graphql_ahr_data-behavioral_health_alls_state_current'
   | 'graphql_ahr_data-behavioral_health_alls_national_historical'
   | 'graphql_ahr_data-behavioral_health_alls_state_historical'
+  | 'graphql_ahr_data-non-behavioral_health_alls_national_current'
+  | 'graphql_ahr_data-non-behavioral_health_alls_state_current'
+  | 'graphql_ahr_data-non-behavioral_health_alls_national_historical'
+  | 'graphql_ahr_data-non-behavioral_health_alls_state_historical'
 
 export const DatasetMetadataMapAhr: Record<DatasetIdAhr, DatasetMetadata> = {
   'graphql_ahr_data-behavioral_health_age_national_current': {
@@ -183,6 +187,26 @@ export const DatasetMetadataMapAhr: Record<DatasetIdAhr, DatasetMetadata> = {
     original_data_sourced: '1995-2022',
     source_id: 'ahr',
   },
+  'graphql_ahr_data-non-behavioral_health_alls_national_current': {
+    name: 'Prevalence of multiple behavioral and mental health conditions, nationally',
+    original_data_sourced: '2022',
+    source_id: 'ahr',
+  },
+  'graphql_ahr_data-non-behavioral_health_alls_state_current': {
+    name: 'Prevalence of multiple behavioral and mental health conditions by state',
+    original_data_sourced: '2022',
+    source_id: 'ahr',
+  },
+  'graphql_ahr_data-non-behavioral_health_alls_national_historical': {
+    name: 'Prevalence of multiple behavioral and mental health conditions by year, nationally',
+    original_data_sourced: '1995-2022',
+    source_id: 'ahr',
+  },
+  'graphql_ahr_data-non-behavioral_health_alls_state_historical': {
+    name: 'Prevalence of multiple behavioral and mental health conditions by year, by state',
+    original_data_sourced: '1995-2022',
+    source_id: 'ahr',
+  },
 }
 
 interface DataSourceMetadataAhr
@@ -231,6 +255,10 @@ export const datasourceMetadataAhr: DataSourceMetadataAhr = {
     'graphql_ahr_data-behavioral_health_alls_state_current',
     'graphql_ahr_data-behavioral_health_alls_national_historical',
     'graphql_ahr_data-behavioral_health_alls_state_historical',
+    'graphql_ahr_data-non-behavioral_health_alls_national_current',
+    'graphql_ahr_data-non-behavioral_health_alls_state_current',
+    'graphql_ahr_data-non-behavioral_health_alls_national_historical',
+    'graphql_ahr_data-non-behavioral_health_alls_state_historical',
   ],
   downloadable: true,
   data_source_release_years: null,


### PR DESCRIPTION
## Summary

- Registers the four AHR non-behavioral health `alls` dataset ids on the frontend (`DatasetIdAhr` union, `DatasetMetadataMapAhr` entries, and `datasourceMetadataAhr.dataset_ids`):
  - `graphql_ahr_data-non-behavioral_health_alls_national_current`
  - `graphql_ahr_data-non-behavioral_health_alls_state_current`
  - `graphql_ahr_data-non-behavioral_health_alls_national_historical`
  - `graphql_ahr_data-non-behavioral_health_alls_state_historical`
- Display names follow the file's existing convention for the `non-behavioral_health` category.

## Known-failing state (intentional)

The four backend files do **not** yet serve 200 — the `dagAhr` re-run fails at the gcs_to_bq source→BQ step because the test project's `ahr-api-key` Secret Manager secret is unset (`AHR_API_KEY` unset → `ValueError` → swallowed to `("", 400)` in `run_gcs_to_bq/main.py`). Landing this registration deliberately surfaces the gap as a visible 500 on dev until the secret is set and the DAG re-run produces the files. Tracked in #4961.

## Impact

- Completes the frontend half of full AHR `alls` coverage. Until the backend files return 200, the AHR non-behavioral `alls` fallback and catalog downloads will 500 by design, as a forcing signal.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] After `ahr-api-key` is set and `dagAhr` re-run: 4 files serve 200 on dev (blocked on secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
