### PR TITLE
Backtick-quote table names in exporter ALLs and county-split queries

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -111,9 +111,10 @@ def export_split_county_tables(bq_client: bigquery.Client, table: bigquery.Table
 
     for fips in STATE_LEVEL_FIPS_LIST:
         state_file_name = f"{table.dataset_id}-{table.table_id}-{fips}.json"
+        # Backticks required so hyphens in the project id / table id don't break the query.
         query = f"""
             SELECT *
-            FROM {table_name}
+            FROM `{table_name}`
             WHERE county_fips LIKE '{fips}___'
             """
 
@@ -173,9 +174,12 @@ def export_alls(bq_client: bigquery.Client, table: bigquery.Table, export_bucket
         demo_cols.append("race_category_id")
 
     bucket = prepare_bucket(export_bucket)
+    # Backticks are required: fully-qualified names contain hyphens (the project id
+    # and hyphenated table ids like `non-behavioral_health_...`), which are a BigQuery
+    # syntax error when unquoted.
     query = f"""
         SELECT *
-        FROM {table_name}
+        FROM `{table_name}`
         WHERE {demo_col} = 'All'
     """
 

--- a/exporter/test_exporter.py
+++ b/exporter/test_exporter.py
@@ -8,7 +8,7 @@ from flask.testing import FlaskClient
 from google.cloud import bigquery  # type: ignore
 import pandas as pd
 
-from main import app, STATE_LEVEL_FIPS_LIST, get_table_name, has_multi_demographics
+from main import app, STATE_LEVEL_FIPS_LIST, export_alls, get_table_name, has_multi_demographics
 
 # UNIT TESTS
 
@@ -178,7 +178,7 @@ def testExportSplitCountyTables(
         table_names = [get_table_name(x) for x in TEST_TABLES]
         expected_query_string = f"""
             SELECT *
-            FROM {table_names[3]}
+            FROM `{table_names[3]}`
             WHERE county_fips LIKE '{fips}___'
             """
 
@@ -190,3 +190,25 @@ def testExportSplitCountyTables(
         table = TEST_TABLES[3]
         expected_file_name = f"{table.dataset_id}-{table.table_id}-{fips}.json"
         assert state_file_name == expected_file_name
+
+
+# TEST ALLS EXPORT
+
+
+@mock.patch("main.export_nd_json_to_blob")
+@mock.patch("main.prepare_blob")
+@mock.patch("main.prepare_bucket")
+@mock.patch("main.get_query_results_as_df", return_value=pd.DataFrame({"sex": ["All"], "value": [1]}))
+def testExportAllsBacktickQuotesHyphenatedTable(
+    mock_query_df: mock.MagicMock,
+    mock_prepare_bucket: mock.MagicMock,
+    mock_prepare_blob: mock.MagicMock,
+    mock_export: mock.MagicMock,
+):
+    # Hyphenated table ids (e.g. `non-behavioral_health_...`) must be backtick-quoted
+    # or BigQuery rejects the query as a syntax error.
+    table = bigquery.Table("my-project.my-dataset.non-behavioral_health_sex_national_current")
+    export_alls(mock.Mock(), table, "my-bucket", "sex")
+
+    generated_query_string = mock_query_df.call_args[0][1]
+    assert f"FROM `{get_table_name(table)}`" in generated_query_string


### PR DESCRIPTION
## Summary
- `export_alls` built raw BigQuery SQL with an **unquoted** fully-qualified table name. Hyphenated table ids (e.g. `non-behavioral_health_*`) and the hyphenated project id (`het-infra-test-05`) are a BigQuery syntax error unless backtick-quoted, so the four non-behavioral AHR ALLs files were never written.
- The failure was masked: the return value of `export_alls` is ignored by its caller, so the DAG reported success while writing nothing. Behavioral tables have no hyphen, which is why only they ever produced ALLs files.
- Applied the same backtick fix to the county-split query (same latent bug, not currently triggered) and added a regression test that asserts the ALLs query is backtick-quoted for a hyphenated table.

## Impact
- Restores generation of 4 previously-missing datasets (`non-behavioral_health_alls_{national,state}_{current,historical}`), unblocking the #4961 frontend ALLs fallback that would otherwise hard-500.
- Fixes a whole class of silent failures: any dataset whose table ids contain hyphens (all `non-behavioral_health_*` tables) was affected.

## Context
This unblocks #4961. That issue assumed the missing ALLs files were purely an operational gap (DAG not re-run); in fact there was also this exporter bug plus a separately-fixed AHR API key.

## Verification (real GCP infra-test)
- Deployed this branch to `infra-test`, re-ran `dagAhr.yml` (green).
- All four files now serve **200** on the dev API with real data:
  - `graphql_ahr_data-non-behavioral_health_alls_national_current`
  - `graphql_ahr_data-non-behavioral_health_alls_state_current`
  - `graphql_ahr_data-non-behavioral_health_alls_national_historical`
  - `graphql_ahr_data-non-behavioral_health_alls_state_historical`

## Ordering gate
The frontend registration of these four ids (#4961 step 2) must merge **after** this, or the fallback hard-500s.

## Test plan
- [x] `pytest exporter/test_exporter.py` (7 passed, includes new backtick regression test)
- [x] Four ALLs files serve 200 on dev API after infra-test DAG run

🤖 Generated with [Claude Code](https://claude.com/claude-code)
