### PR TITLE
Surface exporter ALLs and county-split failures so the DAG fails loudly

### DIFF
--- a/exporter/main.py
+++ b/exporter/main.py
@@ -58,13 +58,10 @@ def export_dataset_tables():
     if category is not None:
         tables = [table for table in tables if category in table.table_id]
 
-    if not tables:
-        return (f'Dataset has no tables with "{demographic}" and "{category}" in the table_id.', 500)
-
     # If there are no tables in the dataset, return an error so the pipeline will alert
     # and a human can look into any potential issues.
     if not tables:
-        return (f'Dataset has no tables with "{demographic}" in the table_id.', 500)
+        return (f'Dataset has no tables with "{demographic}" and "{category}" in the table_id.', 500)
 
     for table in tables:
         # split up county-level tables by state and export those individually.

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -67,9 +67,12 @@ def export_dataset_tables():
         return (f'Dataset has no tables with "{demographic}" in the table_id.', 500)
 
     for table in tables:
-        # split up county-level tables by state and export those individually
+        # split up county-level tables by state and export those individually.
+        # Propagate any error so the DAG step fails instead of reporting success.
         if not has_multi_demographics(table.table_id):
-            export_split_county_tables(bq_client, table, export_bucket)
+            error = export_split_county_tables(bq_client, table, export_bucket)
+            if error is not None:
+                return error
 
         # export the full table
         dest_uri = f"gs://{export_bucket}/{dataset_name}-{table.table_id}.json"
@@ -84,8 +87,12 @@ def export_dataset_tables():
                 500,
             )
 
+        # Propagate any ALLs export error; a swallowed failure here silently
+        # drops the file the frontend fallback depends on.
         if should_export_as_alls:
-            export_alls(bq_client, table, export_bucket, demographic)
+            error = export_alls(bq_client, table, export_bucket, demographic)
+            if error is not None:
+                return error
 
     return ("", 204)
 
@@ -124,11 +131,9 @@ def export_split_county_tables(bq_client: bigquery.Client, table: bigquery.Table
             export_nd_json_to_blob(blob, nd_json)
 
         except Exception as err:
-            logging.error(err)
-            return (
-                f"Error splitting county-level table {table_name} into {state_file_name}:\n {err}",
-                500,
-            )
+            message = f"Error splitting county-level table {table_name} into {state_file_name}:\n {err}"
+            logging.error(message)
+            return (message, 500)
 
 
 def has_multi_demographics(table_id: str):
@@ -187,11 +192,9 @@ def export_alls(bq_client: bigquery.Client, table: bigquery.Table, export_bucket
         export_nd_json_to_blob(blob, nd_json)
 
     except Exception as err:
-        logging.error(err)
-        return (
-            f"Error extracting the ALLS rows from table {table_name} into {alls_file_name}:\n {err}",
-            500,
-        )
+        message = f"Error extracting the ALLS rows from table {table_name} into {alls_file_name}:\n {err}"
+        logging.error(message)
+        return (message, 500)
 
 
 def get_table_name(table):

--- a/exporter/main.py
+++ b/exporter/main.py
@@ -114,7 +114,12 @@ def export_split_county_tables(bq_client: bigquery.Client, table: bigquery.Table
         return
 
     logging.info(f"Exporting county-level data from {table_name} into additional files, split by state/territory.")
-    bucket = prepare_bucket(export_bucket)
+    try:
+        bucket = prepare_bucket(export_bucket)
+    except Exception as err:
+        message = f"Error preparing bucket for county-level table {table_name}:\n {err}"
+        logging.error(message)
+        return (message, 500)
 
     for fips in STATE_LEVEL_FIPS_LIST:
         state_file_name = f"{table.dataset_id}-{table.table_id}-{fips}.json"
@@ -178,7 +183,6 @@ def export_alls(bq_client: bigquery.Client, table: bigquery.Table, export_bucket
     if demographic == "race":
         demo_cols.append("race_category_id")
 
-    bucket = prepare_bucket(export_bucket)
     # Backticks are required: fully-qualified names contain hyphens (the project id
     # and hyphenated table ids like `non-behavioral_health_...`), which are a BigQuery
     # syntax error when unquoted.
@@ -189,6 +193,7 @@ def export_alls(bq_client: bigquery.Client, table: bigquery.Table, export_bucket
     """
 
     try:
+        bucket = prepare_bucket(export_bucket)
         blob = prepare_blob(bucket, alls_file_name)
         alls_df = get_query_results_as_df(bq_client, query)
         alls_df.drop(columns=demo_cols, inplace=True)

--- a/exporter/test_exporter.py
+++ b/exporter/test_exporter.py
@@ -54,6 +54,8 @@ def testExportDatasetTables(mock_bq_client: mock.MagicMock, mock_split_county: m
     # Set up mocks
     mock_bq_instance = mock_bq_client.return_value
     mock_bq_instance.list_tables.return_value = TEST_TABLES
+    # None signals a successful county split (no error to propagate)
+    mock_split_county.return_value = None
 
     payload = {"dataset_name": "my-dataset", "demographic": "age"}
     response = client.post("/", json=payload)
@@ -116,6 +118,7 @@ def testExportDatasetTables_ExtractJobFailure(
     # Set up mocks
     mock_bq_instance = mock_bq_client.return_value
     mock_bq_instance.list_tables.return_value = TEST_TABLES
+    mock_split_county.return_value = None
     mock_extract_job = Mock()
     mock_bq_instance.extract_table.return_value = mock_extract_job
     mock_extract_job.result.side_effect = google.cloud.exceptions.InternalServerError("Internal")
@@ -190,3 +193,57 @@ def testExportSplitCountyTables(
         table = TEST_TABLES[3]
         expected_file_name = f"{table.dataset_id}-{table.table_id}-{fips}.json"
         assert state_file_name == expected_file_name
+
+
+# TEST THAT SWALLOWED FAILURES NOW SURFACE AS 500
+
+
+@mock.patch("main.export_nd_json_to_blob")
+@mock.patch("main.prepare_blob")
+@mock.patch("main.prepare_bucket")
+@mock.patch("main.get_query_results_as_df", side_effect=Exception("boom"))
+@mock.patch("google.cloud.bigquery.Client")
+def testExportAllsFailureReturns500(
+    mock_bq_client: mock.MagicMock,
+    mock_query_df: mock.MagicMock,
+    mock_prepare_bucket: mock.MagicMock,
+    mock_prepare_blob: mock.MagicMock,
+    mock_export: mock.MagicMock,
+    client: FlaskClient,
+):
+    # An ALLs export failure must fail the request (and thus the DAG step),
+    # not be swallowed while the endpoint reports success.
+    mock_bq_instance = mock_bq_client.return_value
+    mock_bq_instance.list_tables.return_value = [
+        bigquery.Table("my-project.my-dataset.non-behavioral_health_sex_national_current")
+    ]
+
+    payload = {"dataset_name": "my-dataset", "demographic": "sex", "should_export_as_alls": True}
+    response = client.post("/", json=payload)
+
+    assert response.status_code == 500
+    assert b"ALLS rows" in response.data
+
+
+@mock.patch("main.export_nd_json_to_blob")
+@mock.patch("main.prepare_blob")
+@mock.patch("main.prepare_bucket")
+@mock.patch("main.get_query_results_as_df", side_effect=Exception("boom"))
+@mock.patch("google.cloud.bigquery.Client")
+def testExportSplitCountyFailureReturns500(
+    mock_bq_client: mock.MagicMock,
+    mock_query_df: mock.MagicMock,
+    mock_prepare_bucket: mock.MagicMock,
+    mock_prepare_blob: mock.MagicMock,
+    mock_export: mock.MagicMock,
+    client: FlaskClient,
+):
+    # A county-split failure must likewise fail the request.
+    mock_bq_instance = mock_bq_client.return_value
+    mock_bq_instance.list_tables.return_value = [bigquery.Table("my-project.my-county-dataset.t4-age")]
+
+    payload = {"dataset_name": "my-dataset", "demographic": "age"}
+    response = client.post("/", json=payload)
+
+    assert response.status_code == 500
+    assert b"county-level" in response.data


### PR DESCRIPTION
## Summary
- The exporter per-table loop discarded the return values of `export_split_county_tables` and `export_alls`. Both helpers `logging.error(...)` and `return (message, 500)` on failure, but the caller ignored the return and the endpoint still returned `204`, so the GitHub Actions DAG step reported success while writing nothing.
- Capture and propagate the error tuple from both helpers so the endpoint returns `500` and the DAG step fails (red) when an export actually fails.
- Wrap `prepare_bucket` calls in both helpers with try-except so GCS initialization errors are caught and returned cleanly instead of propagating uncaught.
- Log the offending table and destination file explicitly so failures are greppable in Cloud Run / GHA logs.
- Remove duplicate unreachable `if not tables:` check.

## Context
This is the follow-up hardening for the swallowed-error behavior that let the missing non-behavioral AHR ALLs files hide behind green DAG runs. The specific BigQuery syntax error was fixed in the backtick PR; this change ensures any *future* failure in these two export paths is alerted instead of masked.

Closes #4968.

## Verification
- `pytest exporter/test_exporter.py` (9 passed), including two new tests asserting the endpoint returns `500` when `export_alls` or `export_split_county_tables` raises.
- Gemini Code Assist flagged that `prepare_bucket` calls occurred outside try-except blocks, risking uncaught exceptions. Addressed by wrapping both calls.
- Removed duplicate unreachable `if not tables:` check (line 66 was unreachable).
- I did not force a red run on shared `infra-test`: a healthy run still returns `204`, and forcing a failure there would leave the shared branch red. The endpoint-level unit tests cover the `500` path that drives the DAG step result.

## Merge ordering
Independent of the backtick fix, but both touch `exporter/main.py`. Recommend merging the backtick PR first; this branch may need a trivial rebase afterward (different regions of the same functions).

## Test plan
- [x] `pytest exporter/test_exporter.py` (9 passed)
- [x] New tests assert `500` surfaces from ALLs and county-split failures
- [x] Bucket preparation errors caught and returned cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
