### PR TITLE
Add ALLs fallback regression coverage

### DIFF
--- a/frontend/playwright-tests/alls_fallback_contract.spec.ts
+++ b/frontend/playwright-tests/alls_fallback_contract.spec.ts
@@ -1,0 +1,44 @@
+import { DatasetMetadataMap } from '../src/data/config/DatasetMetadata'
+import { expect, test } from './utils/fixtures'
+
+// Contract guard for the ALLs fallback (issue #4962).
+//
+// Every registered `alls_` DatasetId is a promise that the exporter actually
+// writes that file to GCS. When a demographic dataset is missing, the frontend
+// silently resolves to its `alls_` sibling (see resolveDatasetId in
+// MetricQuery.ts), so a registered-but-never-exported id is invisible until a
+// user hits it and the server 500s. That is exactly how the NCI (#4960) and AHR
+// non-behavioral (#4961) files slipped through.
+//
+// This nightly probe fetches each registered `alls_` id from the API and fails
+// if any does not serve 200, turning a silent prod 500 into a red nightly run.
+
+const API_BASE =
+  process.env.HET_ALLS_API_URL ?? 'https://dev.healthequitytracker.org'
+
+const allsDatasetIds = Object.keys(DatasetMetadataMap).filter((id) =>
+  /[-_]alls_/.test(id),
+)
+
+test('every registered alls_ DatasetId is exported', async ({ request }) => {
+  expect(
+    allsDatasetIds.length,
+    'expected at least one registered alls_ DatasetId',
+  ).toBeGreaterThan(0)
+
+  const missing: string[] = []
+
+  await Promise.all(
+    allsDatasetIds.map(async (id) => {
+      const resp = await request.get(`${API_BASE}/api/dataset?name=${id}.json`)
+      if (resp.status() !== 200) {
+        missing.push(`${id} → ${resp.status()}`)
+      }
+    }),
+  )
+
+  expect(
+    missing,
+    `Registered alls_ ids that do not serve 200 (registered but not exported):\n${missing.join('\n')}`,
+  ).toEqual([])
+})

--- a/frontend/src/data/query/MetricQuery.test.ts
+++ b/frontend/src/data/query/MetricQuery.test.ts
@@ -1,7 +1,12 @@
 import type { DatasetId } from '../config/DatasetMetadata'
 import type { MetricId } from '../config/MetricConfigTypes'
-import { MetricQueryResponse } from '../query/MetricQuery'
 import { RACE } from '../utils/Constants'
+import { Breakdowns } from './Breakdowns'
+import {
+  MetricQuery,
+  MetricQueryResponse,
+  resolveDatasetId,
+} from './MetricQuery'
 
 let metricQueryResponse: MetricQueryResponse
 
@@ -94,5 +99,62 @@ describe('MetricQueryResponse', () => {
       invalid: 7,
     })
     expect(metricQueryResponse.isFieldMissing('covid_cases')).toEqual(false)
+  })
+})
+
+describe('resolveDatasetId ALLs fallback', () => {
+  const BQ = 'graphql_ahr_data'
+  const PREFIX = 'non-behavioral_health_'
+
+  const query = (
+    breakdowns: Breakdowns,
+    scrollToHashId?: 'rate-map' | 'unknown-demographic-map',
+  ) => new MetricQuery([], breakdowns, 'diabetes', 'current', scrollToHashId)
+
+  test('returns the requested demographic id when registered', () => {
+    const result = resolveDatasetId(
+      BQ,
+      PREFIX,
+      query(Breakdowns.national().andSex()),
+    )
+    expect(result.datasetId).toBe(
+      'graphql_ahr_data-non-behavioral_health_sex_national_current',
+    )
+    expect(result.isFallbackId).toBeUndefined()
+  })
+
+  test('falls back to the alls id for a fallback-eligible card', () => {
+    const result = resolveDatasetId(
+      BQ,
+      PREFIX,
+      query(Breakdowns.national().addBreakdown('urbanicity'), 'rate-map'),
+    )
+    expect(result.datasetId).toBe(
+      'graphql_ahr_data-non-behavioral_health_alls_national_current',
+    )
+    expect(result.isFallbackId).toBe(true)
+  })
+
+  test('does not fall back for a card not in CARDS_THAT_SHOULD_FALLBACK_TO_ALLS', () => {
+    const result = resolveDatasetId(
+      BQ,
+      PREFIX,
+      query(
+        Breakdowns.national().addBreakdown('urbanicity'),
+        'unknown-demographic-map',
+      ),
+    )
+    expect(result.datasetId).toBeUndefined()
+    expect(result.isFallbackId).toBe(false)
+  })
+
+  test('returns no datasetId when neither the demographic nor an alls id is registered', () => {
+    const result = resolveDatasetId(
+      BQ,
+      PREFIX,
+      query(Breakdowns.byCounty().addBreakdown('urbanicity'), 'rate-map'),
+    )
+    expect(result.datasetId).toBeUndefined()
+    expect(result.isFallbackId).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Adds unit coverage for `resolveDatasetId`'s ALLs fallback branches: the requested demographic id when registered, the `alls_` fallback (with `isFallbackId: true`) for a card in `CARDS_THAT_SHOULD_FALLBACK_TO_ALLS`, no fallback for an ineligible card, and no id at all when neither the demographic nor an `alls_` sibling is registered.
- Adds a nightly Playwright contract guard (`alls_fallback_contract.spec.ts`) that enumerates every registered `alls_` DatasetId from `DatasetMetadataMap` and asserts each serves 200 on the API.

## Impact

- Closes the gap that let the NCI (#4960) and AHR non-behavioral (#4961) `alls_` files ship registered-but-never-exported. A registered id whose export path is broken now fails a nightly run instead of surfacing as a prod 500 caught only by manual API probing.
- Covers 75 registered `alls_` ids today; the guard scales automatically as new fallback datasets are registered.

## Test plan

- [x] `resolveDatasetId` unit tests pass (`vitest run src/data/query/MetricQuery.test.ts`, 7 passed)
- [x] Contract guard passes against the dev API today (all 75 registered `alls_` ids serve 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
