### PR TITLE
Fix mobile share icon layout and over-dark select text

### DIFF
--- a/frontend/src/cards/ui/CardShareIconButtons.tsx
+++ b/frontend/src/cards/ui/CardShareIconButtons.tsx
@@ -85,7 +85,7 @@ export default function CardShareIconButtons(props: CardShareIconButtonsProps) {
             aria-label={ariaLabel}
             target={openInWindow ? '_blank' : undefined}
             rel={openInWindow ? 'noopener noreferrer' : undefined}
-            className='text-alt-black no-underline'
+            className='font-normal text-alt-black no-underline'
             onClick={
               openInWindow
                 ? (e) => {

--- a/frontend/src/pages/ui/JumpToSelect.tsx
+++ b/frontend/src/pages/ui/JumpToSelect.tsx
@@ -24,7 +24,7 @@ export default function JumpToSelect(props: JumpToSelectProps) {
         label={props.label ?? 'Jump to'}
       >
         <MenuItem value={' '}>
-          <a className='text-alt-black no-underline' href='#top'>
+          <a className='font-normal text-alt-black no-underline' href='#top'>
             Choose
           </a>
         </MenuItem>
@@ -37,7 +37,10 @@ export default function JumpToSelect(props: JumpToSelectProps) {
 
           return (
             <MenuItem key={stepId} value={stepId}>
-              <a className='text-alt-black no-underline' href={`#${stepId}`}>
+              <a
+                className='font-normal text-alt-black no-underline'
+                href={`#${stepId}`}
+              >
                 {stepInfo.label}
               </a>
             </MenuItem>

--- a/frontend/src/reports/ui/ShareButtons.tsx
+++ b/frontend/src/reports/ui/ShareButtons.tsx
@@ -24,7 +24,7 @@ export default function ShareButtons(props: ShareButtonProps) {
     title += ': ' + props.reportTitle
   }
 
-  const iconSize = props.isMobile ? 64 : 32
+  const iconSize = props.isMobile ? 40 : 32
   const iconFillColor = colors.altDark
 
   const fbHref = facebookShareUrl(sharedUrl)
@@ -41,7 +41,7 @@ export default function ShareButtons(props: ShareButtonProps) {
         props.reportTitle ? 'justify-center' : 'justify-start'
       }`}
     >
-      <div>
+      <div className='flex items-center gap-4'>
         <Tooltip title='Post this page to Facebook'>
           <a
             href={fbHref}

--- a/frontend/src/styles/theme/muiTheme.tsx
+++ b/frontend/src/styles/theme/muiTheme.tsx
@@ -153,6 +153,7 @@ const muiTheme = extendTheme({
         sizeSmall: {
           '& .MuiInputBase-input': {
             fontSize: typography.textSmallest,
+            color: colors.altBlack,
           },
         },
       },


### PR DESCRIPTION
**Preview:** [HIV prevalence report](https://deploy-preview-4972--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity)

## Summary

- **Report share icons** (`ShareButtons.tsx`): three social icons stacked vertically and oversized (64px) on mobile. Tailwind Preflight renders `<svg>` as `display:block`, so anchors wrapping them stacked. Made the container a horizontal `flex` row with gap, shrunk mobile icon to 40px.
- **Bold anchor-wrapped labels** (`CardShareIconButtons.tsx`, `JumpToSelect.tsx`): `index.css` applies `font-weight:500` to every `<a>`. Share-menu items and jump-to "Choose" value are wrapped in `<a>`, rendering bolder than adjacent plain-text items. Added `font-normal` to match.
- **Compare-mode select value** (`muiTheme.tsx`): palette never sets `text.primary`, so MUI small-input text used default `rgba(0,0,0,0.87)`. Scoped small-input override to `color: colors.altBlack` so select values match the app's standard text.

## Impact

No user-facing features changed; pure styling refinement for mobile readability. Improves visual consistency across mobile report UI.

## Test plan

- [ ] Verify on a mobile viewport: share icons sit horizontally at 40px, not vertically stacked at 64px; share menu, jump-to, and compare-mode select text no longer look overly bold/dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit
* **Style**  * Standardized link typography across sharing and navigation controls.  * Improved spacing and alignment for share buttons.  * Reduced mobile share icon sizes for a more compact layout.
  * Updated small input fields to use the correct text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
