### PR TITLE
Remove map card ALLs alert and rephrase shared alert text

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -59,7 +59,7 @@ URL params (mls, dt1, demo, etc.)
               → Cards render charts, surface fallback alert when needed
 ```
 
-Each `VariableProvider` computes `usedAllsFallback` via `resolveDatasetId()` when the requested demographic dataset is not registered but its `alls_` fallback is (see `MetricQuery.ts`). The flag flows through `DataManager` into `MetricQueryResponse` and informs whether cards render `AllsFallbackAlert` and which card-level features are available (e.g., compare mode fallback behavior).
+Each `VariableProvider` computes `usedAllsFallback` via `resolveDatasetId()` when the requested demographic dataset is not registered but its `alls_` fallback is (see `MetricQuery.ts`). The flag flows through `DataManager` into `MetricQueryResponse` and informs whether cards render `AllsFallbackAlert` (bar, trend, and table cards show it; the map card does not, since showing the overall rate is its default behavior) and which card-level features are available (e.g., compare mode fallback behavior).
 
 Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
 

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -75,7 +75,6 @@ import {
 } from '../utils/urlutils'
 import CardWrapper from './CardWrapper'
 import ChartTitle, { getChartTitleId } from './ChartTitle'
-import AllsFallbackAlert from './ui/AllsFallbackAlert'
 import CAWPCountyMultiDistrictAlert from './ui/CAWPCountyMultiDistrictAlert'
 import DemographicGroupMenu from './ui/DemographicGroupMenu'
 import { ExtremesListBox } from './ui/ExtremesListBox'
@@ -649,12 +648,7 @@ function MapCardWithKey(props: MapCardProps) {
                       ) : null
                     }
                   />
-                  {mapQueryResponse.usedAllsFallback && (
-                    <AllsFallbackAlert
-                      dataName={props.dataTypeConfig.fullDisplayName}
-                      demographicType={demographicType}
-                    />
-                  )}
+
                   {isGeorgiaWithCountyData && !isExtremesMode && (
                     <div className='flex justify-center'>
                       <HetLinkButton

--- a/frontend/src/cards/ui/AllsFallbackAlert.tsx
+++ b/frontend/src/cards/ui/AllsFallbackAlert.tsx
@@ -17,7 +17,7 @@ export default function AllsFallbackAlert(props: AllsFallbackAlertProps) {
   return (
     <HetNotice kind='helpful-info'>
       Breakdown by <HetTerm>{demographicName}</HetTerm> isn't available for{' '}
-      <HetTerm>{props.dataName}</HetTerm>, so this card shows the overall rate.
+      <HetTerm>{props.dataName}</HetTerm>, so overall rates are shown.
     </HetNotice>
   )
 }


### PR DESCRIPTION
**Preview:** [HIV Black Women vs Women in Gov (compare mode, race/ethnicity)](https://deploy-preview-4977--health-equity-tracker.netlify.app/exploredata?mls=1.hiv_black_women-3.women_in_gov-5.00&mlp=comparevars&demo=race_and_ethnicity)

## Summary

- Removes `AllsFallbackAlert` from `MapCard` entirely. The map always renders the overall rate for intersectional topics by design, so the alert described expected behavior rather than a meaningful fallback.
- Rephrases the shared alert text from "so this card shows the overall rate" to "so overall rates are shown" — the previous wording was singular and read oddly once the rate bar card began showing two groups side by side.
- Updates `frontend/CLAUDE.md` to document the map card exception.

## Impact

Removes a redundant notice that added visual noise without informing the user of anything unexpected. The bar and trend cards retain the alert where it is genuinely meaningful (when a demographic breakdown isn't available and rates fall back to ALLs).

## Test plan

Note: the `usedAllsFallback` path for HIV Black Women is only reachable in compare-variables mode with `demo=race_and_ethnicity` — that demographic option is not available in the standard disparity view.

- [x] Map card does not contain alert text in compare mode (Playwright)
- [x] Rate bar card shows new "overall rates are shown" wording in compare mode (Playwright)
- [x] Old singular phrasing ("so this card shows the overall rate") is absent everywhere (Playwright)
- [ ] Manually confirm: table card still shows the alert with updated wording in compare mode

Closes #4973
Closes #4974
Part of milestone: Intersectional card polish (#60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
