### PR TITLE
Show two trend lines for intersectional topics in rate-over-time card

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -61,6 +61,8 @@ URL params (mls, dt1, demo, etc.)
 
 Each `VariableProvider` computes `usedAllsFallback` via `resolveDatasetId()` when the requested demographic dataset is not registered but its `alls_` fallback is (see `MetricQuery.ts`). The flag flows through `DataManager` into `MetricQueryResponse` and informs whether cards render `AllsFallbackAlert` (bar, trend, and table cards show it; the map card does not, since showing the overall rate is its default behavior) and which card-level features are available (e.g., compare mode fallback behavior).
 
+For intersectional topics (e.g. HIV prevalence for Black women), `MetricConfig.metrics.per100k.rateComparisonMetricForAlls` names a second metric from a reference dataset. `RateBarChartCard` and `RateTrendsChartCard` both detect this field, issue a second `MetricQuery` for the reference "All" population, and merge the result into the chart data so a comparison series renders alongside the intersectional group.
+
 Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
 
 **Unified URL param system** — all params written through a single path:

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -61,7 +61,7 @@ URL params (mls, dt1, demo, etc.)
 
 Each `VariableProvider` computes `usedAllsFallback` via `resolveDatasetId()` when the requested demographic dataset is not registered but its `alls_` fallback is (see `MetricQuery.ts`). The flag flows through `DataManager` into `MetricQueryResponse` and informs whether cards render `AllsFallbackAlert` (bar, trend, and table cards show it; the map card does not, since showing the overall rate is its default behavior) and which card-level features are available (e.g., compare mode fallback behavior).
 
-For intersectional topics (e.g. HIV prevalence for Black women), `MetricConfig.metrics.per100k.rateComparisonMetricForAlls` names a second metric from a reference dataset. `RateBarChartCard` and `RateTrendsChartCard` both detect this field, issue a second `MetricQuery` for the reference "All" population, and merge the result into the chart data so a comparison series renders alongside the intersectional group.
+For intersectional topics (e.g. HIV prevalence for Black women), `MetricConfig.metrics.per100k.rateComparisonMetricForAlls` names a second metric from a reference dataset. `RateBarChartCard` and `RateTrendsChartCard` both detect this field, issue a second `MetricQuery` for the reference "All" population, and merge the result into the chart data so a comparison series renders alongside the intersectional group. The `shortLabel` on `rateComparisonMetricForAlls` is typed as `DemographicGroup` (via `ComparisonMetricConfig`) — add the label as a named constant in `Constants.ts` and include it in `INTERSECTIONAL_COMPARISON_LABELS` so `GROUP_COLOR_MAP` can key on it with the correct color.
 
 Global UI state is managed with Jotai atoms, URL-synced via `jotai-location` (`src/utils/sharedSettingsState.ts`).
 

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -112,7 +112,7 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
   // second historical series for the reference "All" population so the trend
   // chart can show both lines, mirroring what the rate bar card already does.
   const allsQueryIndex = queries.length
-  if (rateComparisonConfig) {
+  if (rateComparisonConfig && props.dataTypeConfig.rateComparisonDataTypeId) {
     const breakdownsForAlls = Breakdowns.forFips(props.fips).addBreakdown(
       'sex',
       exclude('Male', 'Female'),
@@ -190,7 +190,7 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
           const referenceRows: HetRow[] = allsRows.map((allsRow) => ({
             fips: allsRow.fips,
             fips_name: allsRow.fips_name,
-            time_period: allsRow[TIME_PERIOD],
+            [TIME_PERIOD]: allsRow[TIME_PERIOD],
             [props.demographicType]: ALL,
             [metricConfigRates.metricId]:
               allsRow[rateComparisonConfig.metricId],
@@ -229,9 +229,9 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
         const allDemographicGroups: DemographicGroup[] = rateComparisonConfig
           ? [
               ...new Set(
-                ratesData.map(
-                  (row) => row[props.demographicType] as DemographicGroup,
-                ),
+                ratesData
+                  .map((row) => row[props.demographicType] as DemographicGroup)
+                  .filter(Boolean),
               ),
             ]
           : queryResponseRates.getFieldValues(

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -102,9 +102,29 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
       /* timeView */ 'historical',
     )
 
+  const rateComparisonConfig = metricConfigRates?.rateComparisonMetricForAlls
+
   const queries = [ratesQuery]
 
   pctShareQuery && queries.push(pctShareQuery)
+
+  // For intersectional topics (e.g. HIV prevalence for Black women), fetch a
+  // second historical series for the reference "All" population so the trend
+  // chart can show both lines, mirroring what the rate bar card already does.
+  const allsQueryIndex = queries.length
+  if (rateComparisonConfig) {
+    const breakdownsForAlls = Breakdowns.forFips(props.fips).addBreakdown(
+      'sex',
+      exclude('Male', 'Female'),
+    )
+    const allsRateQuery = new MetricQuery(
+      [rateComparisonConfig.metricId],
+      breakdownsForAlls,
+      props.dataTypeConfig.rateComparisonDataTypeId,
+      'historical',
+    )
+    queries.push(allsRateQuery)
+  }
 
   function getTitleText() {
     return `${
@@ -142,15 +162,41 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
       demographicType={props.demographicType}
       selectedGroups={selectedTableGroups}
     >
-      {(
-        [queryResponseRates, queryResponsePctShares],
-        _metadata,
-        _geoData,
-        overrideCardHasData,
-      ) => {
+      {(queryResponses, _metadata, _geoData, overrideCardHasData) => {
+        const [queryResponseRates, queryResponsePctShares] = queryResponses
+        const queryResponseRatesAlls = rateComparisonConfig
+          ? queryResponses[allsQueryIndex]
+          : undefined
+
         let ratesData = queryResponseRates.getValidRowsForField(
           metricConfigRates.metricId,
         )
+
+        // For intersectional topics, rename the "All" group in the main data
+        // (e.g. "All" → "All Black Women Ages 13+") and prepend a reference
+        // "All" people series from the comparison dataset, giving two lines.
+        if (rateComparisonConfig && queryResponseRatesAlls) {
+          ratesData = ratesData.map((row) =>
+            row[props.demographicType] === ALL
+              ? {
+                  ...row,
+                  [props.demographicType]: rateComparisonConfig.shortLabel,
+                }
+              : row,
+          )
+          const allsRows = queryResponseRatesAlls.getValidRowsForField(
+            rateComparisonConfig.metricId,
+          )
+          const referenceRows: HetRow[] = allsRows.map((allsRow) => ({
+            fips: allsRow.fips,
+            fips_name: allsRow.fips_name,
+            time_period: allsRow[TIME_PERIOD],
+            [props.demographicType]: ALL,
+            [metricConfigRates.metricId]:
+              allsRow[rateComparisonConfig.metricId],
+          }))
+          ratesData = [...referenceRows, ...ratesData]
+        }
 
         // TODO: this is a stop-gap to deal with sketchy data. we should solve a different way
         if (
@@ -177,12 +223,21 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
             })
           : ratesData
 
-        // retrieve list of all present demographic groups
-        const allDemographicGroups: DemographicGroup[] =
-          queryResponseRates.getFieldValues(
-            props.demographicType,
-            metricConfigRates.metricId,
-          ).withData
+        // retrieve list of all present demographic groups; for intersectional
+        // topics the merged ratesData already contains both "All" and the
+        // renamed label, so derive groups from the data rather than the response.
+        const allDemographicGroups: DemographicGroup[] = rateComparisonConfig
+          ? [
+              ...new Set(
+                ratesData.map(
+                  (row) => row[props.demographicType] as DemographicGroup,
+                ),
+              ),
+            ]
+          : queryResponseRates.getFieldValues(
+              props.demographicType,
+              metricConfigRates.metricId,
+            ).withData
 
         const demographicGroups = isCawpStateLeg
           ? allDemographicGroups

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -67,13 +67,13 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   [WHITE]: colors.redOrange,
 
   // race and ethnicity for CAWP
-  [ALL_W]: colors.altBlack,
+  [ALL_W]: colors.altGreen,
   [AIANNH_W]: colors.timeCyanBlue,
   [AAPI_W]: colors.timePastelGreen,
   [AIAN_API_W]: colors.timePastelGreen,
   [BLACK_W]: colors.mapLight,
   [HISP_W]: colors.timePurple,
-  [MENA_W]: colors.altGreen,
+  [MENA_W]: colors.altBlack,
   [OTHER_W]: colors.timePink,
   [WHITE_W]: colors.redOrange,
   [UNKNOWN_W]: colors.darkBlue,

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -73,7 +73,7 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   [AIAN_API_W]: colors.timePastelGreen,
   [BLACK_W]: colors.mapLight,
   [HISP_W]: colors.timePurple,
-  [MENA_W]: colors.timeYellow,
+  [MENA_W]: colors.altBlack,
   [OTHER_W]: colors.timePink,
   [WHITE_W]: colors.redOrange,
   [UNKNOWN_W]: colors.darkBlue,
@@ -89,7 +89,7 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   // sex
   Female: colors.timeCyanBlue,
   Male: colors.timePurple,
-  Other: colors.timeYellow,
+  Other: colors.altBlack,
 
   // age
   '0-9': colors.timeCyanBlue,
@@ -99,7 +99,7 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   '40-49': colors.timePink,
   '50-59': colors.timeDarkRed,
   '60-69': colors.redOrange,
-  '70-79': colors.timeYellow,
+  '70-79': colors.altBlack,
   '80+': colors.mapLight,
 
   // age for HIV + ACS CONDITION
@@ -117,8 +117,8 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   '26-34': colors.timePink,
   '35-44': colors.timeDarkRed,
   '45-54': colors.redOrange,
-  '55+': colors.timeYellow,
-  '55-64': colors.timeYellow,
+  '55+': colors.altBlack,
+  '55-64': colors.altBlack,
   '65-74': colors.mapLight,
   '75+': colors.mapLighter,
 
@@ -134,12 +134,12 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   '18-44': colors.timeCyanBlue,
   '24-34': colors.timePink,
   '45-64': colors.mapLight,
-  '65+': colors.timeYellow,
+  '65+': colors.altBlack,
   '75-84': colors.mapLighter,
 
   // urbanicity / City Size
   Metro: colors.timePurple,
-  'Non-Metro': colors.timeYellow,
+  'Non-Metro': colors.altBlack,
 }
 
 const COLOR_DOMAIN = Object.keys(GROUP_COLOR_MAP)

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -7,6 +7,8 @@ import {
   AIAN_API_W,
   AIAN_NH,
   AIANNH_W,
+  ALL_BLACK_MEN_LABEL,
+  ALL_BLACK_WOMEN_13PLUS_LABEL,
   ALL_W,
   API_NH,
   ASIAN,
@@ -37,7 +39,12 @@ import {
 import { colors } from '../../styles/tokens/colors'
 
 export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
-  All: colors.altBlack,
+  // For intersectional topics the trend chart shows exactly two lines:
+  //   "All" = reference overall population (yellow, matching the rate bar chart)
+  //   shortLabel = subgroup overall rate (black)
+  All: colors.timeYellow,
+  [ALL_BLACK_WOMEN_13PLUS_LABEL]: colors.altBlack,
+  [ALL_BLACK_MEN_LABEL]: colors.altBlack,
   Unknown: colors.darkBlue,
 
   // race and ethnicity (NH)

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -73,7 +73,7 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   [AIAN_API_W]: colors.timePastelGreen,
   [BLACK_W]: colors.mapLight,
   [HISP_W]: colors.timePurple,
-  [MENA_W]: colors.altBlack,
+  [MENA_W]: colors.altGreen,
   [OTHER_W]: colors.timePink,
   [WHITE_W]: colors.redOrange,
   [UNKNOWN_W]: colors.darkBlue,

--- a/frontend/src/charts/trendsChart/constants.ts
+++ b/frontend/src/charts/trendsChart/constants.ts
@@ -43,8 +43,8 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   //   "All" = reference overall population (yellow, matching the rate bar chart)
   //   shortLabel = subgroup overall rate (black)
   All: colors.timeYellow,
-  [ALL_BLACK_WOMEN_13PLUS_LABEL]: colors.altBlack,
-  [ALL_BLACK_MEN_LABEL]: colors.altBlack,
+  [ALL_BLACK_WOMEN_13PLUS_LABEL]: colors.altGreen,
+  [ALL_BLACK_MEN_LABEL]: colors.altGreen,
   Unknown: colors.darkBlue,
 
   // race and ethnicity (NH)
@@ -73,7 +73,7 @@ export const GROUP_COLOR_MAP: Partial<Record<DemographicGroup, string>> = {
   [AIAN_API_W]: colors.timePastelGreen,
   [BLACK_W]: colors.mapLight,
   [HISP_W]: colors.timePurple,
-  [MENA_W]: colors.altGreen,
+  [MENA_W]: colors.altBlack,
   [OTHER_W]: colors.timePink,
   [WHITE_W]: colors.redOrange,
   [UNKNOWN_W]: colors.darkBlue,

--- a/frontend/src/data/config/MetricConfigCommunitySafety.ts
+++ b/frontend/src/data/config/MetricConfigCommunitySafety.ts
@@ -3,6 +3,7 @@ import {
   menHigherIsWorseMapConfig,
   youthHigherIsWorseMapConfig,
 } from '../../charts/mapGlobals'
+import { ALL_BLACK_MEN_LABEL } from '../../data/utils/Constants'
 import {
   populationPctShortLabel,
   populationPctTitle,
@@ -419,7 +420,7 @@ export const GUN_DEATHS_BLACK_MEN_METRICS: DataTypeConfig[] = [
         rateComparisonMetricForAlls: {
           chartTitle: '',
           metricId: 'gun_violence_homicide_per_100k',
-          shortLabel: 'All Black Men',
+          shortLabel: ALL_BLACK_MEN_LABEL,
           type: 'per100k',
         },
         rateNumeratorMetric: {

--- a/frontend/src/data/config/MetricConfigHivCategory.ts
+++ b/frontend/src/data/config/MetricConfigHivCategory.ts
@@ -3,6 +3,7 @@ import {
   defaultHigherIsWorseMapConfig,
   womenHigherIsWorseMapConfig,
 } from '../../charts/mapGlobals'
+import { ALL_BLACK_WOMEN_13PLUS_LABEL } from '../../data/utils/Constants'
 import { populationPctShortLabel } from './MetricConfigConstants'
 import type { DataTypeConfig } from './MetricConfigTypes'
 
@@ -435,7 +436,7 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
         rateComparisonMetricForAlls: {
           chartTitle: '',
           metricId: 'hiv_prevalence_per_100k',
-          shortLabel: 'All Black Women Ages 13+',
+          shortLabel: ALL_BLACK_WOMEN_13PLUS_LABEL,
           type: 'per100k',
         },
         rateNumeratorMetric: {
@@ -509,7 +510,7 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
         rateComparisonMetricForAlls: {
           chartTitle: '',
           metricId: 'hiv_diagnoses_per_100k',
-          shortLabel: 'All Black Women Ages 13+',
+          shortLabel: ALL_BLACK_WOMEN_13PLUS_LABEL,
           type: 'per100k',
         },
         rateNumeratorMetric: {
@@ -582,7 +583,7 @@ export const HIV_BW_DISEASE_METRICS: DataTypeConfig[] = [
         rateComparisonMetricForAlls: {
           chartTitle: '',
           metricId: 'hiv_deaths_per_100k',
-          shortLabel: 'All Black Women Ages 13+',
+          shortLabel: ALL_BLACK_WOMEN_13PLUS_LABEL,
           type: 'per100k',
         },
         rateNumeratorMetric: {

--- a/frontend/src/data/config/MetricConfigTypes.ts
+++ b/frontend/src/data/config/MetricConfigTypes.ts
@@ -1,6 +1,7 @@
 import type { ColorScheme } from '../../charts/choroplethMap/types'
 import type { CategoryTypeId } from '../../utils/MadLibs'
 import type { GeographicBreakdown } from '../query/Breakdowns'
+import type { DemographicGroup } from '../utils/Constants'
 import type { DropdownVarId } from './DropDownIds'
 import type {
   BehavioralHealthDataTypeId,
@@ -81,6 +82,13 @@ export type MetricType =
 
 export type TimeSeriesCadenceType = 'monthly' | 'yearly' | 'fourYearly'
 
+// Narrowed MetricConfig for rateComparisonMetricForAlls: shortLabel must be a
+// DemographicGroup so GROUP_COLOR_MAP can key on it without widening to string.
+export interface ComparisonMetricConfig
+  extends Omit<MetricConfig, 'shortLabel'> {
+  shortLabel: DemographicGroup
+}
+
 export interface MetricConfig {
   metricId: MetricId
   columnTitleHeader?: string
@@ -92,7 +100,7 @@ export interface MetricConfig {
   populationComparisonMetric?: MetricConfig
   rateNumeratorMetric?: MetricConfig
   rateDenominatorMetric?: MetricConfig
-  rateComparisonMetricForAlls?: MetricConfig
+  rateComparisonMetricForAlls?: ComparisonMetricConfig
   timeSeriesCadence?: TimeSeriesCadenceType
 
   // This metric is one where the denominator only includes records where

--- a/frontend/src/data/utils/Constants.ts
+++ b/frontend/src/data/utils/Constants.ts
@@ -326,8 +326,24 @@ const SEX_GROUPS = [MALE, FEMALE, OTHER, UNKNOWN, ALL] as const
 // CREATE SEX-GROUP TYPE
 type SexGroup = (typeof SEX_GROUPS)[number]
 
+// Labels used as the renamed "All" subgroup in intersectional comparison charts
+// (rateComparisonMetricForAlls.shortLabel). Defined here so GROUP_COLOR_MAP can
+// key on them without widening to Record<string, string>.
+export const ALL_BLACK_WOMEN_13PLUS_LABEL = 'All Black Women Ages 13+' as const
+export const ALL_BLACK_MEN_LABEL = 'All Black Men' as const
+const INTERSECTIONAL_COMPARISON_LABELS = [
+  ALL_BLACK_WOMEN_13PLUS_LABEL,
+  ALL_BLACK_MEN_LABEL,
+] as const
+type IntersectionalComparisonLabel =
+  (typeof INTERSECTIONAL_COMPARISON_LABELS)[number]
+
 // CREATE A DEMOGRAPHIC GROUP TYPE INCL ALL SEX/AGE/RACE OPTIONS
-export type DemographicGroup = AgeBucket | SexGroup | RaceAndEthnicityGroup
+export type DemographicGroup =
+  | AgeBucket
+  | SexGroup
+  | RaceAndEthnicityGroup
+  | IntersectionalComparisonLabel
 
 // TIME SERIES CONSTANTS
 


### PR DESCRIPTION
**Preview:** [HIV Black Women vs Women in Gov, compare mode](https://deploy-preview-4978--health-equity-tracker.netlify.app/exploredata?mls=1.hiv_black_women-3.women_in_gov-5.00&mlp=comparevars&demo=race_and_ethnicity)

## Summary

- Rate-over-time card now renders two lines for intersectional topics, matching the rate bar card: a yellow reference "All" line and a green in-group "All" line.
- Detects `rateComparisonMetricForAlls` on the per100k metric config, issues a second historical `MetricQuery`, and merges both series before `getNestedData` is called.
- Extracts `ALL_BLACK_WOMEN_13PLUS_LABEL` and `ALL_BLACK_MEN_LABEL` as named constants; expands `DemographicGroup` to include them. `ALL_W` (CAWP) follows the same in-group pattern.
- Introduces `ComparisonMetricConfig` (`shortLabel: DemographicGroup`) on `rateComparisonMetricForAlls` — wrong label strings are a compile error, not a silent color mismatch.
- Unified color vocabulary across bar and trend cards: `timeYellow` = true "All" reference; `altGreen` = any in-group "All" (`ALL_W`, `ALL_BLACK_WOMEN_13PLUS_LABEL`, `ALL_BLACK_MEN_LABEL`); groups previously using yellow shifted to `altBlack`.

## Impact

- Users see the same reference-vs-subgroup comparison in the trend card that the rate bar card already provides, with a consistent color vocabulary across both cards on the same page.
- Type-safety: new intersectional topics must register a `DemographicGroup` constant for their comparison label or the build fails.

## Test plan

- [x] Rate-over-time card renders two SVG line paths for intersectional topic in compare mode (Playwright)
- [x] Non-intersectional topic (HIV by race) trends card is unaffected (Playwright)
- [x] "All" line is yellow, "All Black Women Ages 13+" line is green in the rate-over-time card (verified via local screenshot)
- [x] "All" line sorts above the subgroup line (existing LineChart behavior, confirmed in screenshot)

Closes #4975
Part of milestone: Intersectional card polish (#60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
