### PR TITLE
Fix: sidebar color consistency and remove verbose above on desktop

### DIFF
--- a/frontend/src/pages/ExploreData/DefaultHelperBox.tsx
+++ b/frontend/src/pages/ExploreData/DefaultHelperBox.tsx
@@ -17,7 +17,6 @@ export default function DefaultHelperBox() {
             className='m-0 text-center font-bold font-sans-title text-alt-green text-title leading-tight md:text-header md:leading-modal-heading'
           >
             Select a topic
-            <span className='hidden md:inline'> above</span>
           </h1>
           <p className='mt-1 mb-2 text-center text-text md:my-4'>
             <span className='md:hidden'>or explore these reports:</span>

--- a/frontend/src/pages/ui/InsightReportButton.tsx
+++ b/frontend/src/pages/ui/InsightReportButton.tsx
@@ -24,7 +24,7 @@ export default function InsightReportButton(props: InsightReportButtonProps) {
     <Button
       onClick={handleClick}
       variant={props.variant ?? 'text'}
-      className={`font-roboto text-alt-black text-smallest normal-case ${props.variant === 'outlined' ? 'rounded-sm border-light-outline px-3.5 py-[8.5px] font-medium hover:border-border-color hover:bg-transparent' : 'font-normal'}`}
+      className={`font-roboto text-alt-dark text-smallest normal-case ${props.variant === 'outlined' ? 'rounded-sm border-light-outline px-3.5 py-[8.5px] font-medium hover:border-border-color hover:bg-transparent' : 'font-normal'}`}
       aria-label='open the AI report insight'
     >
       <AutoAwesome className='mr-2 text-base text-hex-share-icon-gray' />

--- a/frontend/src/pages/ui/TableOfContents.tsx
+++ b/frontend/src/pages/ui/TableOfContents.tsx
@@ -55,7 +55,7 @@ export default function TableOfContents(props: TableOfContentsProps) {
             >
               <span
                 // hide labels visually but not from screen readers on small screens
-                className='sr-only text-smallest md:not-sr-only'
+                className='sr-only text-alt-dark text-smallest md:not-sr-only'
               >
                 {reportProviderSteps[stepId].label}
               </span>

--- a/frontend/src/pages/ui/TopicInfoModalButton.tsx
+++ b/frontend/src/pages/ui/TopicInfoModalButton.tsx
@@ -36,7 +36,7 @@ export default function TopicInfoModalButton() {
       onClick={() => {
         setTopicInfoModalIsOpen(true)
       }}
-      className='font-roboto text-alt-black text-smallest'
+      className='font-roboto text-alt-dark text-smallest'
       aria-label='open the topic info modal'
     >
       <InfoOutlinedIcon sx={{ mr: '4px', mb: '0px' }} fontSize='small' />


### PR DESCRIPTION
## Summary
- Removes the desktop-only ` above` text appended to "Select a topic" in the default helper box — it was in the heading font and added noise
- Unifies sidebar button text color: `TopicInfoModalButton`, `InsightReportButton`, and `TableOfContents` step labels all now use `text-alt-dark` (#5f6368) instead of the near-black `text-alt-black` (#383838)

Closes #4983