### PR TITLE
fix(e2e): scope black men homicide All-button locator after #4978 adds trend legend

### DIFF
--- a/frontend/playwright-tests/black_men_gun_homicides.spec.ts
+++ b/frontend/playwright-tests/black_men_gun_homicides.spec.ts
@@ -17,7 +17,7 @@ test('Black Men Homicide Test: Top Half of Cards', async ({ page }) => {
       expect
         .soft(page.getByText('City Size:'))
         .toBeVisible(),
-      expect.soft(page.getByRole('button', { name: 'All' })).toBeVisible(),
+      expect.soft(page.getByRole('button', { name: 'Include All', exact: true })).toBeVisible(),
 
       // Check Map Headers
       expect


### PR DESCRIPTION
## Summary

PR #4978 added an "Include All Black Men" legend button to the rate-over-time card for intersectional topics. That introduced a Playwright strict-mode violation: `getByRole('button', { name: 'All' })` now resolves to two elements on the Black Men gun homicide page.

- Change the locator to `{ name: 'Include All', exact: true }` to target the urbanicity filter button specifically.

## Separate issue: `cdc_restricted_data-alls_county_historical → 503`

The nightly `alls_fallback_contract` test is also red. This file passed when the test was added (#4971, Jul 16) but is now returning 503 from dev. It is not a code regression - the CDC COVID DAG needs to be re-run on infra-test to regenerate the missing county alls file.

Closes none (data fix needed separately).