### PR TITLE
fix(e2e): update drinking test column header after per_100k to pct_rate switch

### DIFF
--- a/frontend/playwright-tests/drinking.spec.ts
+++ b/frontend/playwright-tests/drinking.spec.ts
@@ -45,7 +45,7 @@ test('Excessive Drinking Flow', async ({ page }) => {
   await page.getByRole('columnheader', { name: 'Race/Ethnicity' }).click()
   await page
     .getByRole('columnheader', {
-      name: 'Excessive drinking cases per 100k adults',
+      name: 'Excessive drinking rate',
     })
     .click()
   await page


### PR DESCRIPTION
The data table column header for excessive drinking changed from "Excessive drinking cases per 100k adults" to "Excessive drinking rate" when #4982 switched the metric from `per_100k` to `pct_rate`. The E2E spec was not updated alongside that change, causing the dev E2E suite to fail on every push to main since.

## Summary
- Updates `drinking.spec.ts` column header assertion to match the new `pct_rate` metric label

## Test plan
- [x] `drinking.spec.ts` column header assertion matches current dev site

🤖 Generated with [Claude Code](https://claude.com/claude-code)