### PR TITLE
fix: aria nav roles, dead hoverStyle prop, and duplicate choropleth legend labels

### DIFF
--- a/frontend/src/charts/choroplethMap/mapLegendUtils.test.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { createQuantileLegend } from './mapLegendUtils'
+import type { ColorScale } from './types'
+
+function makeScale(
+  quantiles: number[],
+  colorFn: (v: number) => string,
+): ColorScale & { quantiles(): number[] } {
+  return Object.assign(colorFn, {
+    quantiles: () => quantiles,
+  }) as unknown as ColorScale & { quantiles(): number[] }
+}
+
+describe('createQuantileLegend', () => {
+  it('deduplicates repeated quantile thresholds', () => {
+    const scale = makeScale([11, 11, 31, 31], (v) =>
+      v <= 11 ? '#low' : v <= 31 ? '#mid' : '#high',
+    )
+    const labels = createQuantileLegend(scale, String).map((i) => i.label)
+    expect(labels).toEqual(['< 11', '11 – 31', '≥ 31'])
+  })
+
+  it('returns empty array when all thresholds collapse to a single value', () => {
+    const scale = makeScale([11, 11, 11, 11], () => '#same')
+    expect(createQuantileLegend(scale, String)).toHaveLength(0)
+  })
+
+  it('passes through clean (no-duplicate) thresholds unchanged', () => {
+    const scale = makeScale([10, 20, 30], (v) =>
+      v <= 10 ? '#a' : v <= 20 ? '#b' : v <= 30 ? '#c' : '#d',
+    )
+    const labels = createQuantileLegend(scale, String).map((i) => i.label)
+    expect(labels).toEqual(['< 10', '10 – 20', '20 – 30', '≥ 30'])
+  })
+})

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.ts
@@ -210,7 +210,9 @@ export function createQuantileLegend(
   colorScale: ColorScale & { quantiles(): number[] },
   labelFormat: (value: number) => string,
 ): LegendItemData[] {
-  const thresholds = colorScale.quantiles()
+  // Deduplicate: when many data points share the same value, quantile boundaries
+  // can repeat (e.g. [11, 11, 31, 31]), producing labels like "31 – 31".
+  const thresholds = [...new Set(colorScale.quantiles())]
 
   if (thresholds.length <= 1) {
     return []

--- a/frontend/src/styles/HetComponents/HetCardMenu.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenu.tsx
@@ -37,9 +37,9 @@ function HetDesktopMenuItem(props: HetDesktopMenuItemProps) {
   return (
     <>
       {props.routeConfig.isTopLevel && (
-        <li className='m-0 list-none p-0' aria-hidden>
+        <div className='m-0 p-0' aria-hidden>
           <HetDivider />
-        </li>
+        </div>
       )}
 
       <HetListItemButton

--- a/frontend/src/styles/HetComponents/HetCardMenu.tsx
+++ b/frontend/src/styles/HetComponents/HetCardMenu.tsx
@@ -14,7 +14,6 @@ export default function HetCardMenu(props: HetCardMenuProps) {
 
   return (
     <nav
-      role='menu'
       aria-label={props.ariaLabel}
       className={`ml-0 flex flex-col rounded-sm py-0 pl-0 tracking-normal shadow-raised-tighter ${props.className ?? ''} `}
     >

--- a/frontend/src/styles/HetComponents/HetListItemButton.tsx
+++ b/frontend/src/styles/HetComponents/HetListItemButton.tsx
@@ -14,7 +14,6 @@ interface HetListItemButtonProps {
   selected?: boolean
   option?: HetListItemButtonOptionType
   style?: React.CSSProperties
-  hoverStyle?: React.CSSProperties
 }
 
 const optionsToClasses: Record<HetListItemButtonOptionType, string> = {
@@ -50,7 +49,6 @@ export default function HetListItemButton(props: HetListItemButtonProps) {
         onClick={props.onClick}
         aria-label={props.ariaLabel}
         selected={props.selected}
-        role='menuitem'
       >
         {inner}
       </ListItemButton>
@@ -66,7 +64,6 @@ export default function HetListItemButton(props: HetListItemButtonProps) {
       onClick={props.onClick}
       aria-label={props.ariaLabel}
       selected={props.selected}
-      role='menuitem'
     >
       {inner}
     </ListItemButton>


### PR DESCRIPTION
**Preview:** [Community Safety: Gun Homicides](https://deploy-preview-4994--health-equity-tracker.netlify.app/exploredata?mls=1.gun_deaths-2.00&mlp=disparity)

## Summary

- Drop `role="menu"` from `HetCardMenu` `<nav>` and `role="menuitem"` from `HetListItemButton` — WAI-ARIA menu/menuitem implies arrow-key navigation and focus-trap behavior that is not implemented here; `<nav aria-label="...">` is the correct and sufficient pattern for a static sidebar
- Remove unused `hoverStyle` prop from `HetListItemButton` interface (declared but never read)
- Deduplicate quantile thresholds in `createQuantileLegend` to prevent duplicate labels like "31 – 31" when many data points share the same integer value
- Replace orphaned `<li>` with `<div>` in `HetDesktopMenuItem` divider (invalid HTML; the element is `aria-hidden` and purely visual)
- Add unit tests for `createQuantileLegend` covering: duplicate-threshold dedup, all-same collapse, and clean passthrough

## Impact

- Assistive technologies (NVDA, JAWS) will no longer enter menu interaction mode on the sidebar, removing unexpected keyboard behavior for screen reader users (WCAG 4.1.2 Name, Role, Value)
- Choropleth maps with tied data values (gun homicides by urbanicity, gun homicides in Mississippi by race) no longer show repeated legend entries
- Fixed invalid HTML (bare `<li>` outside of list context)
- Added regression guard: 3 Vitest cases for `createQuantileLegend` deduplication logic

## Test plan

- [x] Sidebar nav `role="menu"` and `role="menuitem"` removed; `<nav aria-label="...">` present (Playwright)
- [x] Gun homicides by urbanicity legend shows no duplicate labels at county level (Playwright)
- [x] Gun homicides in Mississippi by race legend shows no duplicate labels (Playwright)
- [x] `mapLegendUtils.test.ts` passes all 3 unit test cases (Vitest)

Closes #4888
Closes #4894
Closes #4895

🤖 Generated with [Claude Code](https://claude.com/claude-code)
