### PR TITLE
fix(infra): remove applied moved{} block from run.tf

### DIFF
--- a/config/run.tf
+++ b/config/run.tf
@@ -97,11 +97,6 @@ resource "google_cloud_run_service" "gcs_to_bq_service" {
 # "frontend-service" by the manually-managed domain mapping (see the domain
 # mapping note below). Terraform resource label is server_service; the Cloud
 # Run name must stay "frontend-service" or the domain mapping breaks.
-moved {
-  from = google_cloud_run_service.frontend_service
-  to   = google_cloud_run_service.server_service
-}
-
 resource "google_cloud_run_service" "server_service" {
   name     = var.frontend_service_name
   location = var.compute_region


### PR DESCRIPTION
## Summary

- Removes the `moved {}` block from `config/run.tf` that caused the ReleaseV4.036 production outage
- This block was introduced in PR #4945 to rename `frontend_service` → `server_service` in Terraform state; it ran successfully during that deploy but was never removed
- On the ReleaseV4.036 prod deploy, the block conflicted with the existing `server_service` already in state, causing Terraform to destroy and recreate the Cloud Run service — which dropped the `allUsers / roles/run.invoker` IAM binding (HTTP 403)

## Root Cause

A Terraform `moved {}` block should be removed after it has been applied. Leaving it in causes Terraform to reprocess the state migration on every subsequent apply. In this case, `server_service` already existed in the prod state, so the block triggered a destroy/recreate cycle.

## Test plan

- [x] `config/run.tf` no longer contains a `moved {}` block
- [ ] Next `terraform plan` against prod shows no destroy operations on Cloud Run resources

Closes #4995