### PR TITLE
fix: regression specs and CAWP trend line regression (#4996 #4997 #4999)

### DIFF
--- a/frontend/playwright-tests/alls_fallback_ui.ci.spec.ts
+++ b/frontend/playwright-tests/alls_fallback_ui.ci.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from './utils/fixtures'
+
+// Regression for #4997.
+//
+// AllsFallbackAlert renders when a topic has no dataset for the active
+// demographic but does have an alls_ fallback. This only surfaces reliably in
+// comparevars mode: when hiv_black_women (age-only) is compared with
+// women_in_gov (race-only), both panels share demo=age from the URL. The
+// women_in_gov panel has no age dataset so resolveDatasetId falls back to alls_
+// and cards render AllsFallbackAlert.
+
+test('ALLs fallback alert visible in comparevars when demographic unavailable', async ({
+  page,
+}) => {
+  await page.goto(
+    '/exploredata?mls=1.hiv_black_women-3.women_in_gov-5.00&mlp=comparevars&dt1=hiv_prevalence_black_women&dt2=women_in_us_congress',
+    { waitUntil: 'domcontentloaded' },
+  )
+
+  await expect(
+    page.getByText(/isn't available for/i).first(),
+  ).toBeVisible({ timeout: 40000 })
+})

--- a/frontend/playwright-tests/alls_fallback_ui.ci.spec.ts
+++ b/frontend/playwright-tests/alls_fallback_ui.ci.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from './utils/fixtures'
 
-// Regression for #4997.
+// Regression for #4997 and #4999.
 //
 // AllsFallbackAlert renders when a topic has no dataset for the active
 // demographic but does have an alls_ fallback. This only surfaces reliably in
@@ -8,6 +8,9 @@ import { expect, test } from './utils/fixtures'
 // women_in_gov (race-only), both panels share demo=age from the URL. The
 // women_in_gov panel has no age dataset so resolveDatasetId falls back to alls_
 // and cards render AllsFallbackAlert.
+//
+// #4999: a label-transform bug caused the alls_ trend line to render blank even
+// though the data was present. The second assertion guards against regression.
 
 test('ALLs fallback alert visible in comparevars when demographic unavailable', async ({
   page,
@@ -20,4 +23,13 @@ test('ALLs fallback alert visible in comparevars when demographic unavailable', 
   await expect(
     page.getByText(/isn't available for/i).first(),
   ).toBeVisible({ timeout: 40000 })
+
+  // The alls_ trend line must actually render (not just the alert with an empty
+  // chart). Use .last() to target the women_in_gov rates-over-time panel.
+  const womenGovTrend = page.locator('#rates-over-time').last()
+  await womenGovTrend.scrollIntoViewIfNeeded()
+  await expect(womenGovTrend.locator('svg').first()).toBeVisible({
+    timeout: 20000,
+  })
+  await expect(womenGovTrend.getByText(/Graph unavailable/i)).toHaveCount(0)
 })

--- a/frontend/playwright-tests/hiv_black_women.ci.spec.ts
+++ b/frontend/playwright-tests/hiv_black_women.ci.spec.ts
@@ -39,6 +39,11 @@ test('HIV Black Women: Prevalance Top Cards', async ({ page }) => {
         )
         .toBeVisible(),
       expect.soft(page.getByLabel('Include 65+')).toBeVisible(),
+      // Regression for #4996: PR #4978 added a second comparison series for
+      // all Black women ages 13+; verify the label renders in the chart.
+      expect
+        .soft(ratesOverTime.getByText('All Black Women Ages 13+').first())
+        .toBeVisible({ timeout: 15000 }),
     ])
   })
 

--- a/frontend/src/cards/RateTrendsChartCard.tsx
+++ b/frontend/src/cards/RateTrendsChartCard.tsx
@@ -243,9 +243,10 @@ export default function RateTrendsChartCard(props: RateTrendsChartCardProps) {
           ? allDemographicGroups
           : allDemographicGroups.filter((group) => group !== 'Unknown race')
 
-        const demographicGroupsLabelled = isCawp
-          ? demographicGroups.map((race) => getWomenRaceLabel(race))
-          : demographicGroups
+        const demographicGroupsLabelled =
+          isCawp && props.demographicType === 'race_and_ethnicity'
+            ? demographicGroups.map((race) => getWomenRaceLabel(race))
+            : demographicGroups
 
         // we want to send Unknowns as Knowns for CAWP so we can plot as a line as well
         const [knownRatesData] = isCawp

--- a/frontend/src/cards/ui/AllsFallbackAlert.test.tsx
+++ b/frontend/src/cards/ui/AllsFallbackAlert.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { expect, test } from 'vitest'
+import AllsFallbackAlert from './AllsFallbackAlert'
+
+// Regression for #4997: the AllsFallbackAlert cannot be triggered reliably via
+// URL params (MadLib normalizes invalid demo values before data fetching), so
+// this unit test verifies the component renders the correct message text.
+
+test('renders fallback notice for age demographic', () => {
+  render(
+    <AllsFallbackAlert
+      dataName='Preventable Hospitalizations'
+      demographicType='age'
+    />,
+  )
+  const notice = screen.getByRole('note')
+  expect(notice.textContent).toMatch(/isn't available for/i)
+  expect(notice.textContent).toContain('age')
+  expect(notice.textContent).toContain('Preventable Hospitalizations')
+})
+
+test('renders fallback notice for sex demographic', () => {
+  render(
+    <AllsFallbackAlert dataName='Non-Medical Drug Use' demographicType='sex' />,
+  )
+  const notice = screen.getByRole('note')
+  expect(notice.textContent).toMatch(/isn't available for/i)
+  expect(notice.textContent).toContain('sex')
+  expect(notice.textContent).toContain('Non-Medical Drug Use')
+})


### PR DESCRIPTION
**Preview:** [Regression specs](https://deploy-preview-4998--health-equity-tracker.netlify.app/exploredata?mls=1.hiv_black_women-3.women_in_gov-5.00&mlp=comparevars&dt1=hiv_prevalence_black_women&dt2=women_in_us_congress)

## Summary

- **#4996**: Add `'All Black Women Ages 13+'` comparison series label assertion to `hiv_black_women.ci.spec.ts` rates-over-time step. Original smoke test used wrong selector (`#rate-over-time-chart`) and wrong URL (`hiv` instead of `hiv_black_women`).
- **#4997**: Add `alls_fallback_ui.ci.spec.ts` regression test using comparevars URL where `women_in_gov` lacks age data (triggers alls_ fallback and `AllsFallbackAlert`). Also add `AllsFallbackAlert.test.tsx` Vitest unit test confirming the component text.
- **#4999**: Fix CAWP rates-over-time trend line rendering when alls_ fallback is active with non-race demographic. Gate `getWomenRaceLabel` transform in `demographicGroupsLabelled` on `demographicType === 'race_and_ethnicity'` so the age alls_ fallback doesn't produce mismatched group labels.

## Impact

Regression test coverage prevents future smoke test failures from silent label/selector changes. CAWP trend line now renders correctly when alls_ fallback is active (previously blank despite valid data).

## Test plan

- [x] `hiv_black_women.ci.spec.ts` - all 4 tests pass with new comparison label check
- [x] `alls_fallback_ui.ci.spec.ts` - passes with AllsFallbackAlert text and trend SVG assertions
- [x] `AllsFallbackAlert.test.tsx` - 2 Vitest tests pass (age and sex demographics)
- [x] `cawp.ci.spec.ts` - all 3 tests pass (race breakdown unaffected by fix)

Closes #4996
Closes #4997
Closes #4999
