### PR TITLE
fix(e2e): serialize alls_ contract probe to avoid Cloud Run 503s

### DIFF
--- a/frontend/playwright-tests/alls_fallback_contract.spec.ts
+++ b/frontend/playwright-tests/alls_fallback_contract.spec.ts
@@ -28,14 +28,12 @@ test('every registered alls_ DatasetId is exported', async ({ request }) => {
 
   const missing: string[] = []
 
-  await Promise.all(
-    allsDatasetIds.map(async (id) => {
-      const resp = await request.get(`${API_BASE}/api/dataset?name=${id}.json`)
-      if (resp.status() !== 200) {
-        missing.push(`${id} → ${resp.status()}`)
-      }
-    }),
-  )
+  for (const id of allsDatasetIds) {
+    const resp = await request.get(`${API_BASE}/api/dataset?name=${id}.json`)
+    if (resp.status() !== 200) {
+      missing.push(`${id} → ${resp.status()}`)
+    }
+  }
 
   expect(
     missing,


### PR DESCRIPTION
## Summary

- Replaces `Promise.all` over 56 concurrent requests with a sequential `for...of` loop in the alls_ fallback contract spec
- The burst was overwhelming dev Cloud Run: the large `cdc_restricted_data-alls_county_historical` file (county x historical COVID data) timed out on cold GCS hits, causing Cloud Run to return 503 at the infrastructure layer before the Go server could write a response
- The test still catches any genuinely missing file; sequential execution adds no meaningful cost for a nightly-only spec

## Impact

- Eliminates the recurring false-positive CI failure that blocked `alls_fallback_contract` ~3-4 times per week on dev; CI signal is now reliable

## Test plan

- [ ] Nightly E2E run against dev passes (verified by the next CI run post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
