### PR TITLE
fix(insights): use qualitative peer rank labels and round min/max

### DIFF
--- a/frontend/src/utils/generateVisualizationInsight.test.ts
+++ b/frontend/src/utils/generateVisualizationInsight.test.ts
@@ -277,7 +277,7 @@ describe('summarizePeerComparison', () => {
 })
 
 describe('formatPeerComparison', () => {
-  test('renders the region rate, its rank, and the peer spread', () => {
+  test('renders the region rate, its qualitative standing, and the peer spread', () => {
     const text = formatPeerComparison({
       regionLabel: 'Bartow County',
       regionValue: 13,
@@ -290,10 +290,35 @@ describe('formatPeerComparison', () => {
       shortLabel: 'per 100k',
     })
     expect(text).toContain('- Bartow County: 13 per 100k')
-    expect(text).toContain(
-      'Ranked against 52 Georgia counties that report this measure: higher than 41 of them',
-    )
+    // 41/52 = 0.788 -> "higher than most"; raw fraction must not appear
+    expect(text).toContain('Among 52 Georgia counties: higher than most')
+    expect(text).not.toContain('41 of')
     expect(text).toContain('Peer median 8.1 per 100k; range 2.3–21 per 100k')
+  })
+
+  test('uses correct label at each tier boundary', () => {
+    const base = {
+      regionLabel: 'X',
+      regionValue: 10,
+      peerNoun: 'places',
+      median: 8,
+      min: 2,
+      max: 20,
+      shortLabel: 'per 100k',
+    }
+    const label = (higher: number, total: number) =>
+      formatPeerComparison({
+        ...base,
+        reportingCount: total,
+        higherThanCount: higher,
+      })
+    expect(label(9, 10)).toContain('among the highest') // 0.90
+    expect(label(8, 10)).toContain('higher than most') // 0.80
+    expect(label(6, 10)).toContain('above the typical') // 0.60
+    expect(label(5, 10)).toContain('near the typical') // 0.50
+    expect(label(3, 10)).toContain('below the typical') // 0.30
+    expect(label(2, 10)).toContain('lower than most') // 0.20
+    expect(label(0, 10)).toContain('among the lowest') // 0.00
   })
 })
 

--- a/frontend/src/utils/generateVisualizationInsight.test.ts
+++ b/frontend/src/utils/generateVisualizationInsight.test.ts
@@ -312,12 +312,12 @@ describe('formatPeerComparison', () => {
         reportingCount: total,
         higherThanCount: higher,
       })
-    expect(label(9, 10)).toContain('among the highest') // 0.90
-    expect(label(8, 10)).toContain('higher than most') // 0.80
-    expect(label(6, 10)).toContain('above the typical') // 0.60
-    expect(label(5, 10)).toContain('near the typical') // 0.50
-    expect(label(3, 10)).toContain('below the typical') // 0.30
-    expect(label(2, 10)).toContain('lower than most') // 0.20
+    expect(label(9, 10)).toContain('among the highest') // 0.90 (>=0.9 boundary)
+    expect(label(3, 4)).toContain('higher than most') // 0.75 (>=0.75 boundary)
+    expect(label(6, 10)).toContain('above the typical') // 0.60 (>=0.6 boundary)
+    expect(label(2, 5)).toContain('near the typical') // 0.40 (>=0.4 boundary)
+    expect(label(1, 4)).toContain('below the typical') // 0.25 (>=0.25 boundary)
+    expect(label(1, 10)).toContain('lower than most') // 0.10 (>=0.1 boundary)
     expect(label(0, 10)).toContain('among the lowest') // 0.00
   })
 })

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -233,18 +233,38 @@ export function summarizePeerComparison(
     reportingCount: values.length,
     higherThanCount: values.filter((v) => v < peer.regionValue).length,
     median: Math.round(median * 10) / 10,
-    min: sorted[0],
-    max: sorted[sorted.length - 1],
+    min: Math.round(sorted[0] * 10) / 10,
+    max: Math.round(sorted[sorted.length - 1] * 10) / 10,
     shortLabel: peer.shortLabel,
   }
 }
 
+// Maps a rank ratio to a plain-English standing label so the model never sees
+// raw fractions like "higher than 23 of 28" and restates them verbatim.
+function peerRankLabel(
+  higherThanCount: number,
+  reportingCount: number,
+): string {
+  const ratio = higherThanCount / reportingCount
+  if (ratio >= 0.9) return 'among the highest'
+  if (ratio >= 0.75) return 'higher than most'
+  if (ratio >= 0.6) return 'above the typical'
+  if (ratio >= 0.4) return 'near the typical'
+  if (ratio >= 0.25) return 'below the typical'
+  if (ratio >= 0.1) return 'lower than most'
+  return 'among the lowest'
+}
+
 // Renders a peer rank summary as prompt bullet lines. Leads with the region's
-// own rate, then its standing among peers and the peer distribution.
+// own rate, then its qualitative standing and the peer distribution.
 export function formatPeerComparison(summary: PeerRankSummary): string {
+  const rankLabel = peerRankLabel(
+    summary.higherThanCount,
+    summary.reportingCount,
+  )
   return [
     `- ${summary.regionLabel}: ${summary.regionValue} ${summary.shortLabel}`,
-    `- Ranked against ${summary.reportingCount} ${summary.peerNoun} that report this measure: higher than ${summary.higherThanCount} of them`,
+    `- Among ${summary.reportingCount} ${summary.peerNoun}: ${rankLabel}`,
     `- Peer median ${summary.median} ${summary.shortLabel}; range ${summary.min}–${summary.max} ${summary.shortLabel}`,
   ].join('\n')
 }


### PR DESCRIPTION
**Preview:** [Single-region map with peer comparison](https://deploy-preview-5018--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.13&mlp=disparity&demo=race_and_ethnicity) — open an insight card to see the peer rank line

## Summary

Follow-up polish to #4988 (peer comparison in single-region map insights), closing items 1 and 2 of #5003.

- **Qualitative rank labels:** `formatPeerComparison` now converts the raw rank fraction to a plain-English tier label before passing it to the model. The model was replicating the literal number (e.g. "higher than 41 of 52 counties") in generated text instead of synthesizing it. Now it receives "higher than most" and is free to paraphrase naturally.
- **Min/max rounding:** `summarizePeerComparison` now rounds `min` and `max` to one decimal place, consistent with the existing rounding on `median`. Prevents peer range lines like "range 2.34567–19.8765 per 100k".

Seven tier labels: among the highest (>=0.9), higher than most (>=0.75), above the typical (>=0.6), near the typical (>=0.4), below the typical (>=0.25), lower than most (>=0.1), among the lowest (<0.1).

## Impact

- Removes raw-fraction prompt artifacts that caused the model to restate "41 of 52" verbatim rather than paraphrasing — follows the prompt-engineering best practice of feeding pre-summarized, model-friendly tokens over raw statistics.
- Min/max rounding eliminates floating-point noise in peer range lines (e.g. "2.34567" → "2.3").

## Test plan

- [x] `formatPeerComparison` test: asserts "Among 52 Georgia counties: higher than most" and that raw fraction "41 of" does not appear
- [x] Tier-boundary test: 7 cases each at the exact `>=` cutoff value (0.9, 0.75, 0.6, 0.4, 0.25, 0.1, 0.0)

Closes #5003 (items 1 and 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
