### PR TITLE
test(e2e): cervical cancer county-level label overrides

### DIFF
--- a/frontend/playwright-tests/cervical_cancer.spec.ts
+++ b/frontend/playwright-tests/cervical_cancer.spec.ts
@@ -21,6 +21,9 @@ test('Cervical Cancer: state-level uses standard labels', async ({ page }) => {
     await expect
       .soft(definitionsList.getByText('CDC WONDER'))
       .toBeVisible()
+    await expect
+      .soft(definitionsList.getByText('crude rates'))
+      .toBeVisible()
   })
 
   await page.getByRole('button', { name: 'Data table' }).click()

--- a/frontend/playwright-tests/cervical_cancer.spec.ts
+++ b/frontend/playwright-tests/cervical_cancer.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from './utils/fixtures'
+
+test('Cervical Cancer: state-level uses standard labels', async ({ page }) => {
+  await page.goto(
+    '/exploredata?mls=1.cancer_incidence-3.12&dt1=cervical_cancer_incidence&demo=race_and_ethnicity&group1=All',
+    { waitUntil: 'domcontentloaded' },
+  )
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+
+  await test.step('Map heading uses standard chart title', async () => {
+    await expect
+      .soft(rateMap.getByRole('heading', { name: 'Cervical cancer rates' }))
+      .toBeVisible()
+  })
+
+  await test.step('Definition uses standard CDC WONDER text', async () => {
+    const definitionsList = page.locator('#definitionsList')
+    await definitionsList.scrollIntoViewIfNeeded()
+    await expect
+      .soft(definitionsList.getByText('CDC WONDER'))
+      .toBeVisible()
+  })
+
+  await page.getByRole('button', { name: 'Data table' }).click()
+  await page.getByText('Summary for cervical cancer cases').scrollIntoViewIfNeeded()
+
+  await test.step('Data table uses standard column header without age-adjusted', async () => {
+    await expect
+      .soft(
+        page.getByRole('columnheader', {
+          name: 'Cervical cancer cases per 100k',
+          exact: true,
+        }),
+      )
+      .toBeVisible()
+    await expect
+      .soft(
+        page.getByRole('columnheader', {
+          name: 'Cervical cancer cases per 100k (age-adjusted)',
+        }),
+      )
+      .not.toBeVisible()
+  })
+})
+
+test('Cervical Cancer: county-level uses age-adjusted label overrides', async ({
+  page,
+}) => {
+  await page.goto(
+    '/exploredata?mls=1.cancer_incidence-3.06037&dt1=cervical_cancer_incidence&demo=race_and_ethnicity&group1=All',
+    { waitUntil: 'domcontentloaded' },
+  )
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+
+  await test.step('Map heading uses age-adjusted chart title override', async () => {
+    await expect
+      .soft(
+        rateMap.getByRole('heading', {
+          name: 'Age-adjusted cervical cancer rates',
+        }),
+      )
+      .toBeVisible()
+  })
+
+  await test.step('Definition uses NCI county override text', async () => {
+    const definitionsList = page.locator('#definitionsList')
+    await definitionsList.scrollIntoViewIfNeeded()
+    await expect
+      .soft(definitionsList.getByText('NCI State Cancer Profiles'))
+      .toBeVisible()
+    await expect
+      .soft(definitionsList.getByText('age-adjusted rates'))
+      .toBeVisible()
+  })
+
+  await page.getByRole('button', { name: 'Data table' }).click()
+  await page.getByText('Summary for cervical cancer cases').scrollIntoViewIfNeeded()
+
+  await test.step('Data table uses age-adjusted column header override', async () => {
+    await expect
+      .soft(
+        page.getByRole('columnheader', {
+          name: 'Cervical cancer cases per 100k (age-adjusted)',
+        }),
+      )
+      .toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- Add E2E tests for cervical cancer with county-level label overrides
- State-level test verifies standard labels: "Cervical cancer rates", "crude rates" (CDC WONDER)
- County-level test verifies overridden labels: "Age-adjusted cervical cancer rates", "age-adjusted rates" (NCI State Cancer Profiles)
- Covers map headings, definitions, and data table column headers

## Impact

- Closes #4682: adds comprehensive E2E coverage for cervical cancer county-level `geoOverrides`
- Prevents regressions in definition text and metric labels at different geographic levels

## Test plan

- [x] Both E2E tests pass locally with enhanced definition assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
