### PR TITLE
Label missing map tooltip values as unavailable unless truly suppressed

### DIFF
--- a/frontend/src/cards/ui/geoContextHelpers.ts
+++ b/frontend/src/cards/ui/geoContextHelpers.ts
@@ -1,12 +1,11 @@
+import { DATA_UNAVAILABLE } from '../../charts/mapGlobals'
 import type { DataTypeConfig } from '../../data/config/MetricConfigTypes'
 import type { DemographicType } from '../../data/query/Breakdowns'
 import type { HetRow } from '../../data/utils/DatasetTypes'
 
-const POP_MISSING_VALUE = 'unavailable'
-
 export function getTotalACSPopulationPhrase(populationData: HetRow[]): string {
   const popAllCount: string = populationData?.[0]?.population?.toLocaleString()
-  return `Total population: ${popAllCount ?? POP_MISSING_VALUE} (from ACS 2022)`
+  return `Total population: ${popAllCount ?? DATA_UNAVAILABLE} (from ACS 2022)`
 }
 
 export function getSubPopulationPhrase(
@@ -24,7 +23,7 @@ export function getSubPopulationPhrase(
   const popAllCount: string =
     rawPop != null && !isNaN(rawPop)
       ? rawPop.toLocaleString('en-US', { maximumFractionDigits: 0 })
-      : POP_MISSING_VALUE
+      : DATA_UNAVAILABLE
 
   const combinedSubPop = [
     dataTypeConfig.otherSubPopulationLabel,

--- a/frontend/src/cards/ui/geoContextHelpers.ts
+++ b/frontend/src/cards/ui/geoContextHelpers.ts
@@ -4,8 +4,12 @@ import type { DemographicType } from '../../data/query/Breakdowns'
 import type { HetRow } from '../../data/utils/DatasetTypes'
 
 export function getTotalACSPopulationPhrase(populationData: HetRow[]): string {
-  const popAllCount: string = populationData?.[0]?.population?.toLocaleString()
-  return `Total population: ${popAllCount ?? DATA_UNAVAILABLE} (from ACS 2022)`
+  const rawPop = populationData?.[0]?.population
+  const popAllCount: string =
+    rawPop != null && !isNaN(rawPop)
+      ? rawPop.toLocaleString()
+      : DATA_UNAVAILABLE
+  return `Total population: ${popAllCount} (from ACS 2022)`
 }
 
 export function getSubPopulationPhrase(

--- a/frontend/src/charts/choroplethMap/mapHelpers.test.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import type { MetricConfig } from '../../data/config/MetricConfigTypes'
+import { DATA_SUPPRESSED, DATA_UNAVAILABLE } from '../mapGlobals'
+import { createDataMap } from './mapHelpers'
+
+const metric = {
+  metricId: 'gun_violence_homicide_per_100k',
+  shortLabel: 'per 100k',
+  type: 'per100k',
+} as MetricConfig
+
+const countColsMap = {
+  numeratorConfig: { metricId: 'gun_homicides_estimated_total' },
+  denominatorConfig: { metricId: 'fatal_population' },
+}
+
+const build = (row: Record<string, any>) =>
+  createDataMap([row], 'homicides per 100k', metric, 'homicides', 'people', {
+    ...countColsMap,
+  }).get(row.fips) as Record<string, any>
+
+describe('createDataMap suppressed vs unavailable labels', () => {
+  it('labels a missing numerator as suppressed when the rate is flagged suppressed', () => {
+    const entry = build({
+      fips: '01001',
+      gun_violence_homicide_per_100k: null,
+      gun_violence_homicide_per_100k_is_suppressed: true,
+      gun_homicides_estimated_total: null,
+      fatal_population: 55000,
+    })
+    expect(entry['# homicides']).toEqual(DATA_SUPPRESSED)
+  })
+
+  it('labels a missing numerator as unavailable when the rate is not flagged suppressed', () => {
+    const entry = build({
+      fips: '01001',
+      gun_violence_homicide_per_100k: null,
+      gun_violence_homicide_per_100k_is_suppressed: false,
+      gun_homicides_estimated_total: null,
+      fatal_population: 55000,
+    })
+    expect(entry['# homicides']).toEqual(DATA_UNAVAILABLE)
+  })
+
+  it('never labels a missing denominator as suppressed, even on a suppressed row', () => {
+    const entry = build({
+      fips: '01001',
+      gun_violence_homicide_per_100k: null,
+      gun_violence_homicide_per_100k_is_suppressed: true,
+      gun_homicides_estimated_total: null,
+      fatal_population: undefined,
+    })
+    expect(entry['# people']).toEqual(DATA_UNAVAILABLE)
+  })
+
+  it('passes real counts through untouched', () => {
+    const entry = build({
+      fips: '01001',
+      gun_violence_homicide_per_100k: 12.3,
+      gun_homicides_estimated_total: 7,
+      fatal_population: 55000,
+    })
+    expect(entry['# homicides']).toEqual(7)
+    expect(entry['# people']).toEqual(55000)
+  })
+
+  it('keeps a zero count rather than treating it as missing', () => {
+    const entry = build({
+      fips: '01001',
+      gun_violence_homicide_per_100k: 0,
+      gun_homicides_estimated_total: 0,
+      fatal_population: 0,
+    })
+    expect(entry['# homicides']).toEqual(0)
+    expect(entry['# people']).toEqual(0)
+  })
+})

--- a/frontend/src/charts/choroplethMap/mapHelpers.test.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.test.ts
@@ -48,7 +48,7 @@ describe('createDataMap suppressed vs unavailable labels', () => {
       gun_violence_homicide_per_100k: null,
       gun_violence_homicide_per_100k_is_suppressed: true,
       gun_homicides_estimated_total: null,
-      fatal_population: undefined,
+      fatal_population: null,
     })
     expect(entry['# people']).toEqual(DATA_UNAVAILABLE)
   })

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -13,7 +13,7 @@ import {
   ATLANTA_METRO_COUNTY_FIPS,
   type CountColsMap,
   DATA_SUPPRESSED,
-  NO_DATA_MESSAGE,
+  DATA_UNAVAILABLE,
 } from '../mapGlobals'
 import {
   getCawpMapGroupDenominatorLabel,
@@ -167,6 +167,8 @@ export const createDataMap = (
   denominatorPhrase: string,
   countColsMap: any,
 ): Map<string, MetricData> => {
+  const rateIsSuppressedColumn = `${metric.metricId}_is_suppressed`
+
   return new Map(
     dataWithHighestLowest.map((d) => [
       d.fips,
@@ -178,11 +180,14 @@ export const createDataMap = (
         value: d[metric.metricId],
         ...(countColsMap?.numeratorConfig && {
           [`# ${numeratorPhrase}`]:
-            d?.[countColsMap.numeratorConfig.metricId] ?? NO_DATA_MESSAGE,
+            d?.[countColsMap.numeratorConfig.metricId] ??
+            (d?.[rateIsSuppressedColumn] === true
+              ? DATA_SUPPRESSED
+              : DATA_UNAVAILABLE),
         }),
         ...(countColsMap?.denominatorConfig && {
           [`# ${denominatorPhrase}`]:
-            d[countColsMap.denominatorConfig.metricId],
+            d[countColsMap.denominatorConfig.metricId] ?? DATA_UNAVAILABLE,
         }),
         ...(d.highestGroup && { ['Highest rate group']: d.highestGroup }),
         ...(d.lowestGroup && { ['Lowest rate group']: d.lowestGroup }),

--- a/frontend/src/charts/choroplethMap/mapHelpers.ts
+++ b/frontend/src/charts/choroplethMap/mapHelpers.ts
@@ -167,6 +167,8 @@ export const createDataMap = (
   denominatorPhrase: string,
   countColsMap: any,
 ): Map<string, MetricData> => {
+  // sources that carry no suppression semantics never emit this column, so the
+  // lookup is undefined and every missing numerator falls through to unavailable
   const rateIsSuppressedColumn = `${metric.metricId}_is_suppressed`
 
   return new Map(

--- a/frontend/src/charts/mapGlobals.ts
+++ b/frontend/src/charts/mapGlobals.ts
@@ -7,6 +7,9 @@ import { colors } from '../styles/tokens/colors'
 import type { ColorScheme } from './choroplethMap/types'
 
 export const DATA_SUPPRESSED = 'Data suppressed'
+// only ever provable for a numerator, and only from its rate's own _is_suppressed
+// flag; denominators come from a separate source so suppression never applies
+export const DATA_UNAVAILABLE = 'unavailable'
 export const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
 
 type PopulationSubset =

--- a/frontend/src/data/utils/datasetutils.ts
+++ b/frontend/src/data/utils/datasetutils.ts
@@ -395,6 +395,9 @@ export function allMissingValuesAreSuppressed(
 ) {
   const rateIsSuppressedColumn = metricId + '_is_suppressed'
   const rowsWithMissingRates = data.filter((row) => row[metricId] == null)
+  // an empty array would vacuously satisfy .every(), reporting suppression on a
+  // map that is missing nothing at all
+  if (rowsWithMissingRates.length === 0) return false
   return rowsWithMissingRates.every(
     (row) => row[rateIsSuppressedColumn] === true,
   )


### PR DESCRIPTION
**Preview:** [Gun violence youth map](https://deploy-preview-5022--health-equity-tracker.netlify.app?mls=1.gun_violence_youth-3.00&group1=All&demo=race_and_ethnicity&dt1=gun_deaths_young_adults#rate-map)

## Summary

- Map tooltips labeled missing values "Data suppressed" when nothing was suppressed. The numerator and denominator were handled asymmetrically in `createDataMap`, and the denominator inherited a map-wide suppression verdict computed solely from the rate column.
- Decided per row and per field instead: numerator consults the rate's own `_is_suppressed` flag, denominator is always `unavailable` (population denominators come from ACS, so the topic source's suppression rules cannot apply to them).
- Fixed a latent `.every()`-on-empty-array false positive in `allMissingValuesAreSuppressed`. A fully-populated map reported map-wide suppression, which is what surfaced the mislabel.
- Promoted `POP_MISSING_VALUE` to a shared `DATA_UNAVAILABLE` constant so the tooltip agrees with the "Total population: ..." breadcrumb from #4646.

## Scope

This PR stops the **mislabeling**. It does not make the `Data suppressed` label appear, because that label is currently unreachable for reasons upstream of this diff:

1. `removeUnrequestedColumns` (`VariableProvider.ts:62-81`) strips every `*_is_suppressed` column, since no card requests one in its `metricIds`.
2. `MapCard.tsx:423-424` filters null-rate rows out via `getValidRowsForField` before `createDataMap` runs, and the backend flags suppression only on null-rate rows.

The suppressed branch added here is therefore correct but dormant. Making it reachable requires threading the flag through the query layer and rebuilding the map's `dataMap` from unfiltered rows, which touches the colorScale domain and extremes mode. That work, plus the broader cleanup of the three overlapping absence sentinels and the truthy filters that eat legitimate zeros, is tracked in #5023.

`processPhrmaData` has the same denominator mislabel but is gated behind `isPhrma` and never runs for the MIOVD maps that surfaced this. Tracked in #5021.

## Impact

Removes incorrect "Data suppressed" labels from population denominators sourced from ACS rather than the topic dataset. Wrongly telling a user that health data was withheld to protect privacy, when in fact it was simply never collected for that geography, misrepresents the data on a tracker whose purpose is to make gaps visible.

## Test plan

- [x] Vitest: 9 passed (`mapHelpers.test.ts` + `GeoContext.test.ts`). Covers all four label rules plus a zero-count guard (`??` not `||`, so a legitimate 0 is not relabeled).
- [x] Playwright: app loads and explore page renders without errors
- [x] Manual: county gun violence homicide map, suppressed county reads `unavailable` rather than `Data suppressed`
- [ ] Manual: unknowns map still shows `no data` (asserted by `vaccination.ci.spec.ts:57`)

Closes #5020

🤖 Generated with [Claude Code](https://claude.com/claude-code)
