### PR TITLE
docs: require npm scripts for starting a dev server

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -309,7 +309,9 @@ git diff origin/main -- frontend/src/ | grep -E '^-.*"[A-Z][^"]{5,}"' | \
   done | sort -u
 ```
 
-**Start the dev server** (connects to the live dev GCP backend — no build step needed, data fetches work):
+**Start the dev server** (connects to the live dev GCP backend — no build step needed, data fetches work).
+
+Use `npm run dev` exactly as written; never substitute a bare `npx vite`, even for a scratch server on another port. The npm script wraps Vite in `env-cmd -f .env.localhost`, which supplies `VITE_BASE_API_URL`. Without it the app renders but every data fetch 404s, so specs fail with "element(s) not found" and the missing env looks like a product regression. A scratch server must keep the wrapper: `npx env-cmd -f .env.localhost npx vite --port 3100`.
 
 ```bash
 cd frontend

--- a/.claude/skills/screenshot-pr/SKILL.md
+++ b/.claude/skills/screenshot-pr/SKILL.md
@@ -105,7 +105,7 @@ grep -rn "useParamState" frontend/src/ --include="*.tsx" --include="*.ts"
 curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
 ```
 
-If not `200`:
+If not `200`, restart it. Use `npm run dev` as written; a bare `npx vite` skips `env-cmd -f .env.localhost` and leaves `VITE_BASE_API_URL` unset, which renders the shell but no data, producing empty screenshots.
 
 ```bash
 lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1

--- a/.claude/skills/screenshot-pr/SKILL.md
+++ b/.claude/skills/screenshot-pr/SKILL.md
@@ -99,13 +99,16 @@ grep -rn "useParamState" frontend/src/ --include="*.tsx" --include="*.ts"
 
 ---
 
-## Step 4 — Ensure dev server is running
+## Step 4 — Ensure dev server is running with the right env
+
+A server started as a bare `npx vite` still answers `200`, so a status check alone is not enough. It skips the `env-cmd -f .env.localhost` wrapper, leaving `VITE_BASE_API_URL` unset, and every screenshot comes back with an empty page. Require both a healthy response *and* evidence the process was launched through the npm script:
 
 ```bash
 curl -s -o /dev/null -w "%{http_code}" http://localhost:3000
+pgrep -f "env-cmd -f .env.localhost" > /dev/null && echo "env ok" || echo "env missing"
 ```
 
-If not `200`, restart it. Use `npm run dev` as written; a bare `npx vite` skips `env-cmd -f .env.localhost` and leaves `VITE_BASE_API_URL` unset, which renders the shell but no data, producing empty screenshots.
+Restart unless the status is `200` **and** the env check printed `env ok`:
 
 ```bash
 lsof -ti :3000 | xargs kill -9 2>/dev/null; sleep 1

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,6 +20,12 @@ npm run e2e statins.nightly.spec.ts
 npm run e2e hiv          # Matches any filename containing "hiv"
 ```
 
+**Always start servers through these npm scripts, never a bare `npx vite` or `vite preview`.** The scripts wrap Vite in `env-cmd -f .env.localhost`, which is where `VITE_BASE_API_URL` lives. Without it the app still builds and renders, but every data fetch 404s and cards come up empty, so the failure looks like a product bug rather than a missing env. If a scratch server on another port is needed, keep the wrapper:
+
+```bash
+npx env-cmd -f .env.localhost npx vite --port 3100
+```
+
 **Important: Package Dependency Workflow**
 
 Any time you modify `package.json` (add, remove, or update packages), you must run `npm install` afterward and **commit the resulting lock file changes**. The lock file must always be in sync with package.json, or CI's `npm ci` step will fail with "package-lock.json or npm-shrinkwrap.json are not in sync."


### PR DESCRIPTION
## Summary

- A bare `npx vite` skips the `env-cmd -f .env.localhost` wrapper the npm scripts apply, leaving `VITE_BASE_API_URL` unset. The app shell renders but every data fetch 404s, so cards come up empty and it reads as a product regression rather than a missing env.
- Documents the rule and the scratch-server escape hatch (`npx env-cmd -f .env.localhost npx vite --port 3100`) in `frontend/CLAUDE.md` and at both skill steps that spin up a server.
- `/screenshot-pr` reused whatever server was already on port 3000 if it answered `200`, which a badly-started one does. It now also requires `pgrep -f "env-cmd -f .env.localhost"` before trusting it.

## Impact

- Removes a silent failure mode that cost a full debugging cycle: five passing Playwright specs failed with "element(s) not found" and the missing env was mistaken for a product bug.
- No user-facing impact; docs and skill instructions only.

## Test plan

- [x] Server started via `npm run dev` reports `status=200 env ok`
- [x] Server started via a bare `npx vite --port 3000` reports `status=200 env missing`, so the new gate catches the case a status check alone would pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
