### PR TITLE
docs: warn against heredoc bodies for commit/PR/issue messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,14 @@ See `README.md` for full fork setup steps including how to add your fork as a re
 
 **PR title convention:** Never put an issue number in the PR title (no `(#1234)` suffix). It is visually indistinguishable from a PR number at a glance. Use `Closes #NNNN` in the PR body instead.
 
+**Multi-line commit/PR/issue bodies:** don't embed a `$(cat <<'EOF' ... EOF)` heredoc directly in a shell command for these. A heredoc body with backtick-quoted inline code (e.g. `` `location.hash` ``) can fail with `bad substitution` or `unexpected EOF` even though the delimiter is quoted. Write the body to a file first, then reference it:
+
+```bash
+git commit -F /tmp/commit-msg.md
+gh pr create --body-file /tmp/pr-body.md
+gh issue create --body-file /tmp/issue-body.md
+```
+
 ## Work Tracking
 
 Ideas progress through GitHub tools in stages — don't skip them:


### PR DESCRIPTION
## Summary

- Hit `bad substitution: no closing` and `unexpected EOF while looking for matching` twice in one session using `$(cat <<'EOF' ... EOF)` for a commit message and a `gh issue create` body, both times with backtick-heavy markdown. Writing the body to a file first and passing it via `-F`/`--body-file` avoided the failure both times; root cause not further investigated.
- Adds a short note to the Git Workflow section of `CLAUDE.md` so future commit/PR/issue bodies go through a file instead of an inline heredoc.

## Impact

- No user-facing impact; docs only.

## Test plan

- [x] N/A (documentation-only change)
