### PR TITLE
refactor: collapse InsightVisualizationCard state to a reducer

### DIFF
--- a/frontend/src/cards/ui/InsightVisualizationCard.test.ts
+++ b/frontend/src/cards/ui/InsightVisualizationCard.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+import type { PeerComparison } from '../../utils/generateVisualizationInsight'
+import {
+  type InsightState,
+  initialInsightState,
+  insightReducer,
+} from './InsightVisualizationCard'
+
+const fakePeers: PeerComparison = {
+  regionLabel: 'Bartow County',
+  regionValue: 12,
+  peerNoun: 'Georgia counties',
+  peerValues: [8, 10, 14],
+  shortLabel: 'per 100k',
+}
+
+describe('insightReducer reset', () => {
+  it('clears the server cache key so the flag button cannot submit the previous insight', () => {
+    const state: InsightState = {
+      ...initialInsightState,
+      serverCacheKey: 'previous-key',
+    }
+    expect(insightReducer(state, { type: 'reset' }).serverCacheKey).toBeNull()
+  })
+
+  it('keeps peerComparison, which is scoped to the region rather than the cache key', () => {
+    const state: InsightState = {
+      ...initialInsightState,
+      peerComparison: fakePeers,
+    }
+    expect(insightReducer(state, { type: 'reset' }).peerComparison).toBe(
+      fakePeers,
+    )
+  })
+
+  it('returns terminal statuses to idle so generation can run for the new cache key', () => {
+    for (const status of ['errored', 'unavailable'] as const) {
+      const state: InsightState = {
+        ...initialInsightState,
+        status,
+        error: 'boom',
+      }
+      const next = insightReducer(state, { type: 'reset' })
+      expect(next.status).toBe('idle')
+      expect(next.error).toBeNull()
+    }
+  })
+
+  it('leaves in-flight statuses alone', () => {
+    for (const status of ['generating', 'loadingPeers'] as const) {
+      const state: InsightState = { ...initialInsightState, status }
+      expect(insightReducer(state, { type: 'reset' }).status).toBe(status)
+    }
+  })
+})
+
+describe('insightReducer peer transitions', () => {
+  it('drops any stale ranking when a new peer fetch starts', () => {
+    const state: InsightState = {
+      ...initialInsightState,
+      peerComparison: fakePeers,
+    }
+    const next = insightReducer(state, { type: 'peersRequested' })
+    expect(next.status).toBe('loadingPeers')
+    expect(next.peerComparison).toBeNull()
+  })
+
+  it('returns to idle with the ranking attached once peers load', () => {
+    const next = insightReducer(
+      { ...initialInsightState, status: 'loadingPeers' },
+      { type: 'peersLoaded', peerComparison: fakePeers },
+    )
+    expect(next.status).toBe('idle')
+    expect(next.peerComparison).toBe(fakePeers)
+  })
+})
+
+describe('insightReducer generation transitions', () => {
+  it('clears a prior error when generation starts', () => {
+    const state: InsightState = {
+      ...initialInsightState,
+      status: 'errored',
+      error: 'boom',
+    }
+    const next = insightReducer(state, { type: 'generationStarted' })
+    expect(next.status).toBe('generating')
+    expect(next.error).toBeNull()
+  })
+
+  it('captures the server cache key on both success and failure', () => {
+    expect(
+      insightReducer(initialInsightState, {
+        type: 'generationSucceeded',
+        serverCacheKey: 'abc',
+      }),
+    ).toMatchObject({ status: 'idle', serverCacheKey: 'abc' })
+
+    expect(
+      insightReducer(initialInsightState, {
+        type: 'generationFailed',
+        serverCacheKey: 'abc',
+        error: 'boom',
+      }),
+    ).toMatchObject({ status: 'errored', serverCacheKey: 'abc', error: 'boom' })
+  })
+})

--- a/frontend/src/cards/ui/InsightVisualizationCard.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationCard.tsx
@@ -1,6 +1,6 @@
 import { Button, CircularProgress } from '@mui/material'
 import { useAtom, useAtomValue } from 'jotai'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useReducer } from 'react'
 import type { DataTypeConfig } from '../../data/config/MetricConfigTypes'
 import type { DemographicType } from '../../data/query/Breakdowns'
 import type { MetricQueryResponse } from '../../data/query/MetricQuery'
@@ -25,6 +25,85 @@ import {
   cardInsightsAtom,
 } from '../../utils/sharedSettingsState'
 import FlagInsightButton from './FlagInsightButton'
+
+// One status at a time, so the render is a switch rather than a chain of
+// independent booleans that can contradict each other.
+type InsightStatus =
+  | 'idle'
+  | 'loadingPeers'
+  | 'peersErrored'
+  | 'peersInsufficient'
+  | 'generating'
+  | 'errored'
+  | 'unavailable'
+
+interface InsightState {
+  status: InsightStatus
+  // Peer ranking for single-region maps. Null until it resolves, and always null
+  // in the modes that never fetch one.
+  peerComparison: PeerComparison | null
+  error: string | null
+  // The exact server cache key used, captured so the flag button targets this insight.
+  serverCacheKey: string | null
+}
+
+type InsightAction =
+  | { type: 'reset' }
+  | { type: 'peersRequested' }
+  | { type: 'peersLoaded'; peerComparison: PeerComparison }
+  | { type: 'peersInsufficient' }
+  | { type: 'peersFailed' }
+  | { type: 'generationStarted' }
+  | { type: 'generationSucceeded'; serverCacheKey: string | null }
+  | { type: 'generationFailed'; serverCacheKey: string | null; error: string }
+  | { type: 'generationUnavailable'; serverCacheKey: string | null }
+
+const initialInsightState: InsightState = {
+  status: 'idle',
+  peerComparison: null,
+  error: null,
+  serverCacheKey: null,
+}
+
+function insightReducer(
+  state: InsightState,
+  action: InsightAction,
+): InsightState {
+  switch (action.type) {
+    case 'reset':
+      // Clears only the terminal states that would block generation for the new
+      // cache key. An in-flight fetch or an already-loaded peer ranking is left
+      // alone, since neither is invalidated by the key change.
+      return state.status === 'errored' || state.status === 'unavailable'
+        ? { ...state, status: 'idle', error: null }
+        : state
+    case 'peersRequested':
+      return { ...state, status: 'loadingPeers', peerComparison: null }
+    case 'peersLoaded':
+      return { ...state, status: 'idle', peerComparison: action.peerComparison }
+    case 'peersInsufficient':
+      return { ...state, status: 'peersInsufficient', peerComparison: null }
+    case 'peersFailed':
+      return { ...state, status: 'peersErrored', peerComparison: null }
+    case 'generationStarted':
+      return { ...state, status: 'generating', error: null }
+    case 'generationSucceeded':
+      return { ...state, status: 'idle', serverCacheKey: action.serverCacheKey }
+    case 'generationFailed':
+      return {
+        ...state,
+        status: 'errored',
+        error: action.error,
+        serverCacheKey: action.serverCacheKey,
+      }
+    case 'generationUnavailable':
+      return {
+        ...state,
+        status: 'unavailable',
+        serverCacheKey: action.serverCacheKey,
+      }
+  }
+}
 
 interface InsightVisualizationCardProps {
   scrollToHash: ScrollableHashId
@@ -60,11 +139,8 @@ export default function InsightVisualizationCard({
   const [cardInsights, setCardInsights] = useAtom(cardInsightsAtom)
   const openKey = `${scrollToHash}${isCompareCard ? '-2' : ''}`
   const isOpen = useAtomValue(cardInsightOpenAtom)[openKey] ?? false
-  const [isGenerating, setIsGenerating] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [unavailable, setUnavailable] = useState(false)
-  // The exact server cache key used, captured so the flag button targets this insight.
-  const [serverCacheKey, setServerCacheKey] = useState<string | null>(null)
+  const [state, dispatch] = useReducer(insightReducer, initialInsightState)
+  const { status, peerComparison, serverCacheKey } = state
 
   // Single-region maps rank the region against its same-level peers. The peer
   // file is fetched here, lazily, and only once the insight is actually opened —
@@ -75,50 +151,37 @@ export default function InsightVisualizationCard({
   // across query-array changes, so toggling the query on open left it stuck on
   // the stale empty result. Loading the peer query directly through the
   // DataManager (LRU-cached) gives an explicit, reliable loading→ready state.
-  const [peerResult, setPeerResult] = useState<
-    MetricQueryResponse | 'loading' | 'error' | null
-  >(null)
   const peerQueryKey = peerConfig?.peerQuery.getUniqueKey()
   useEffect(() => {
-    if (!(peerMode && isOpen && peerConfig)) return
+    if (!(peerMode && isOpen && peerConfig && regionRate)) return
     let cancelled = false
-    setPeerResult('loading')
+    dispatch({ type: 'peersRequested' })
     getDataManager()
       .loadMetrics(peerConfig.peerQuery)
-      .then((response) => {
-        if (!cancelled) setPeerResult(response)
+      .then((response: MetricQueryResponse) => {
+        if (cancelled) return
+        const comparison: PeerComparison = {
+          regionLabel: regionRate.label,
+          regionValue: regionRate.value,
+          peerNoun: peerConfig.peerNoun,
+          peerValues: peerConfig.getPeerValues([response]),
+          shortLabel: regionRate.shortLabel,
+        }
+        // Peers loaded, but too few report the measure to rank against honestly.
+        if (summarizePeerComparison(comparison) === null) {
+          dispatch({ type: 'peersInsufficient' })
+        } else {
+          dispatch({ type: 'peersLoaded', peerComparison: comparison })
+        }
       })
       .catch(() => {
-        if (!cancelled) setPeerResult('error')
+        if (!cancelled) dispatch({ type: 'peersFailed' })
       })
     return () => {
       cancelled = true
     }
     // peerConfig.peerQuery is a fresh object each render; peerQueryKey identifies it.
-    // biome-ignore lint/correctness/useExhaustiveDependencies: fetch is keyed by peerQueryKey
   }, [peerMode, isOpen, peerQueryKey])
-
-  const peersReady =
-    peerResult != null && peerResult !== 'loading' && peerResult !== 'error'
-  const peersErrored = peerMode && isOpen && peerResult === 'error'
-  // Covers both the initial null and the explicit 'loading' state so the spinner
-  // shows continuously until peers arrive (never an empty box).
-  const peersLoading = peerMode && isOpen && !peersReady && !peersErrored
-  const peerComparison: PeerComparison | undefined =
-    peerMode && peerConfig && regionRate && peersReady
-      ? {
-          regionLabel: regionRate.label,
-          regionValue: regionRate.value,
-          peerNoun: peerConfig.peerNoun,
-          peerValues: peerConfig.getPeerValues([peerResult]),
-          shortLabel: regionRate.shortLabel,
-        }
-      : undefined
-  // Peers loaded, but too few report the measure to rank against honestly.
-  const peerInsufficient =
-    peerMode &&
-    peersReady &&
-    (!peerComparison || summarizePeerComparison(peerComparison) === null)
 
   // A stable suffix so the insight regenerates when the user changes which
   // group(s) the chart is focused on (highlighted map group / selected trend
@@ -132,8 +195,7 @@ export default function InsightVisualizationCard({
   const insight = cardInsights[cacheKey]
 
   const handleGenerate = useCallback(async () => {
-    setIsGenerating(true)
-    setError(null)
+    dispatch({ type: 'generationStarted' })
     try {
       const result = await generateCardInsight(
         scrollToHash,
@@ -142,20 +204,45 @@ export default function InsightVisualizationCard({
         fips,
         queryResponses,
         isCompareCard,
-        { activeDemographicGroup, selectedGroups, peerComparison },
+        {
+          activeDemographicGroup,
+          selectedGroups,
+          peerComparison: peerComparison ?? undefined,
+        },
       )
-      setServerCacheKey(result.cacheKey ?? null)
+      const resultCacheKey = result.cacheKey ?? null
       if (result.rateLimited) {
-        setError('Too many requests. Please wait a moment and try again.')
+        dispatch({
+          type: 'generationFailed',
+          serverCacheKey: resultCacheKey,
+          error: 'Too many requests. Please wait a moment and try again.',
+        })
       } else if (result.unavailable) {
-        setUnavailable(true)
+        dispatch({
+          type: 'generationUnavailable',
+          serverCacheKey: resultCacheKey,
+        })
       } else if (result.error) {
-        setError('Unable to generate insight. Please try again.')
+        dispatch({
+          type: 'generationFailed',
+          serverCacheKey: resultCacheKey,
+          error: 'Unable to generate insight. Please try again.',
+        })
       } else {
         setCardInsights((prev) => ({ ...prev, [cacheKey]: result.content }))
+        dispatch({
+          type: 'generationSucceeded',
+          serverCacheKey: resultCacheKey,
+        })
       }
-    } finally {
-      setIsGenerating(false)
+    } catch {
+      // Without this the status would stay 'generating' forever and the card
+      // would spin with no way back.
+      dispatch({
+        type: 'generationFailed',
+        serverCacheKey: null,
+        error: 'Unable to generate insight. Please try again.',
+      })
     }
   }, [
     cacheKey,
@@ -182,88 +269,115 @@ export default function InsightVisualizationCard({
     })
   }
 
-  // Reset error and flag state when the cacheKey changes (user switched
-  // demographic, fips, etc.) — otherwise stale state from old params would
-  // block generation for the new ones.
+  // Reset error state when the cacheKey changes (user switched demographic,
+  // fips, etc.) — otherwise stale state from old params would block generation
+  // for the new ones.
   useEffect(() => {
-    setError(null)
-    setUnavailable(false)
+    dispatch({ type: 'reset' })
   }, [cacheKey])
 
-  // `error` is in the guard so a failed call doesn't get auto-retried on the
-  // next render — the user must click Try again. Clearing the insight (e.g. after
-  // flagging) re-fires this effect and regenerates. In peer mode we also wait for
-  // the peer fetch to resolve and skip generation when too few peers report.
+  // Only 'idle' generates: every other status is either already in flight or a
+  // terminal state the user must act on, so a failed call is never auto-retried.
+  // Clearing the insight (e.g. after flagging) re-fires this effect. In peer mode
+  // a null comparison means peers are still loading, failed, or too sparse to
+  // rank against, all of which must block generation.
   useEffect(() => {
-    if (!isOpen || insight || error || unavailable || isGenerating) return
-    if (peerMode && (!peersReady || peerInsufficient)) return
+    if (!isOpen || insight || status !== 'idle') return
+    if (peerMode && !peerComparison) return
     void handleGenerate()
   }, [
     isOpen,
     insight,
-    error,
-    unavailable,
-    isGenerating,
+    status,
     cacheKey,
     handleGenerate,
     peerMode,
-    peersReady,
-    peerInsufficient,
+    peerComparison,
   ])
+
+  const renderBody = () => {
+    switch (status) {
+      case 'loadingPeers':
+        return (
+          <div className='flex items-center gap-2 py-1'>
+            <CircularProgress size={14} className='shrink-0' />
+            <p className='m-0 text-alt-dark text-small'>
+              Gathering peer comparison data...
+            </p>
+          </div>
+        )
+      case 'generating':
+        return (
+          <div className='flex items-center gap-2 py-1'>
+            <CircularProgress size={14} className='shrink-0' />
+            <p className='m-0 text-alt-dark text-small'>
+              Analyzing health equity data with AI...
+            </p>
+          </div>
+        )
+      case 'peersErrored':
+        return (
+          <p className='m-0 text-red-orange text-small'>
+            Unable to load comparison data. Please try again later.
+          </p>
+        )
+      case 'peersInsufficient':
+        return (
+          <p className='m-0 text-alt-dark text-small'>
+            Not enough comparable places report this measure to generate an
+            insight.
+          </p>
+        )
+      case 'errored':
+        return (
+          <div className='flex flex-col gap-1'>
+            <p className='m-0 text-red-orange text-small'>{state.error}</p>
+            <Button size='small' onClick={handleGenerate}>
+              Try again
+            </Button>
+          </div>
+        )
+      // Also the resting state after a successful generation, where the text is
+      // read back out of the shared cache rather than held here.
+      case 'idle':
+        return insight ? (
+          <>
+            <p className='m-0 font-bold text-alt-dark leading-snug'>
+              {insight}
+            </p>
+            <p className='m-0 mt-2 text-alt-dark text-smallest'>
+              AI-generated. Verify with chart data.{' '}
+              <FlagInsightButton
+                cacheKey={serverCacheKey ?? undefined}
+                content={insight}
+                topic={dataTypeConfig.dataTypeId}
+                onFlagged={handleFlagged}
+              />
+            </p>
+          </>
+        ) : null
+      case 'unavailable':
+        return null
+      default: {
+        // Forces a compile error if a status is added without a case here.
+        const unhandled: never = status
+        return unhandled
+      }
+    }
+  }
 
   // When generation is unavailable the section renders nothing at all, rather
   // than an empty container or an error the reader can do nothing about.
-  if (!SHOW_INSIGHT_GENERATION || !isOpen || unavailable) return null
+  if (!SHOW_INSIGHT_GENERATION || !isOpen || status === 'unavailable') {
+    return null
+  }
 
   return (
     <div
       role='status'
       className='mb-3 animate-expand-down rounded-md bg-footer-color p-3'
     >
-      {peersLoading ? (
-        <div className='flex items-center gap-2 py-1'>
-          <CircularProgress size={14} className='shrink-0' />
-          <p className='m-0 text-alt-dark text-small'>
-            Gathering peer comparison data...
-          </p>
-        </div>
-      ) : isGenerating ? (
-        <div className='flex items-center gap-2 py-1'>
-          <CircularProgress size={14} className='shrink-0' />
-          <p className='m-0 text-alt-dark text-small'>
-            Analyzing health equity data with AI...
-          </p>
-        </div>
-      ) : peersErrored ? (
-        <p className='m-0 text-red-orange text-small'>
-          Unable to load comparison data. Please try again later.
-        </p>
-      ) : peerInsufficient ? (
-        <p className='m-0 text-alt-dark text-small'>
-          Not enough comparable places report this measure to generate an
-          insight.
-        </p>
-      ) : error ? (
-        <div className='flex flex-col gap-1'>
-          <p className='m-0 text-red-orange text-small'>{error}</p>
-          <Button size='small' onClick={handleGenerate}>
-            Try again
-          </Button>
-        </div>
-      ) : insight ? (
-        <>
-          <p className='m-0 font-bold text-alt-dark leading-snug'>{insight}</p>
-          <p className='m-0 mt-2 text-alt-dark text-smallest'>
-            AI-generated. Verify with chart data.{' '}
-            <FlagInsightButton
-              cacheKey={serverCacheKey ?? undefined}
-              content={insight}
-              topic={dataTypeConfig.dataTypeId}
-              onFlagged={handleFlagged}
-            />
-          </p>
-        </>
-      ) : null}
+      {renderBody()}
     </div>
   )
 }

--- a/frontend/src/cards/ui/InsightVisualizationCard.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationCard.tsx
@@ -72,11 +72,18 @@ function insightReducer(
   switch (action.type) {
     case 'reset':
       // Clears only the terminal states that would block generation for the new
-      // cache key. An in-flight fetch or an already-loaded peer ranking is left
-      // alone, since neither is invalidated by the key change.
-      return state.status === 'errored' || state.status === 'unavailable'
-        ? { ...state, status: 'idle', error: null }
-        : state
+      // cache key. Unconditionally clear the stale cache key and peer comparison
+      // so FlagInsightButton cannot submit data from the previous insight.
+      return {
+        ...state,
+        status:
+          state.status === 'errored' || state.status === 'unavailable'
+            ? 'idle'
+            : state.status,
+        error: null,
+        serverCacheKey: null,
+        peerComparison: null,
+      }
     case 'peersRequested':
       return { ...state, status: 'loadingPeers', peerComparison: null }
     case 'peersLoaded':

--- a/frontend/src/cards/ui/InsightVisualizationCard.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationCard.tsx
@@ -28,7 +28,7 @@ import FlagInsightButton from './FlagInsightButton'
 
 // One status at a time, so the render is a switch rather than a chain of
 // independent booleans that can contradict each other.
-type InsightStatus =
+export type InsightStatus =
   | 'idle'
   | 'loadingPeers'
   | 'peersErrored'
@@ -37,7 +37,7 @@ type InsightStatus =
   | 'errored'
   | 'unavailable'
 
-interface InsightState {
+export interface InsightState {
   status: InsightStatus
   // Peer ranking for single-region maps. Null until it resolves, and always null
   // in the modes that never fetch one.
@@ -58,22 +58,25 @@ type InsightAction =
   | { type: 'generationFailed'; serverCacheKey: string | null; error: string }
   | { type: 'generationUnavailable'; serverCacheKey: string | null }
 
-const initialInsightState: InsightState = {
+export const initialInsightState: InsightState = {
   status: 'idle',
   peerComparison: null,
   error: null,
   serverCacheKey: null,
 }
 
-function insightReducer(
+export function insightReducer(
   state: InsightState,
   action: InsightAction,
 ): InsightState {
   switch (action.type) {
     case 'reset':
-      // Clears only the terminal states that would block generation for the new
-      // cache key. Unconditionally clear the stale cache key and peer comparison
-      // so FlagInsightButton cannot submit data from the previous insight.
+      // Clears the terminal states that would block generation for the new cache
+      // key, plus the cache key itself so FlagInsightButton cannot submit the
+      // previous insight's key. peerComparison is deliberately kept: it is scoped
+      // to the region, not the cache key, and the peer effect only refetches when
+      // peerQueryKey changes, so clearing it here would strand peer-mode cards
+      // with no way to reload.
       return {
         ...state,
         status:
@@ -82,7 +85,6 @@ function insightReducer(
             : state.status,
         error: null,
         serverCacheKey: null,
-        peerComparison: null,
       }
     case 'peersRequested':
       return { ...state, status: 'loadingPeers', peerComparison: null }


### PR DESCRIPTION
**Preview:** [collapse state machine](https://deploy-preview-5050--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity)

## Summary

- `InsightVisualizationCard` had seven interdependent flags (`peerResult`, `peersReady`, `peersErrored`, `peersLoading`, `peerInsufficient`, `isGenerating`, `error`, `unavailable`) driving a five-level nested ternary at render, with nothing preventing contradictory states (both true at once).
- Replaces flags with a single reducer over an explicit status union; render is now a `switch` whose `default` is a never-check, so new statuses can't be added without handling them.
- Peer ranking moves into the fetch callback and stores as a resolved `PeerComparison`, collapsing four boolean fields and three status branches into one nullable field.
- Fixes latent bug: old code cleared `isGenerating` without setting error on exception, so the auto-generate guard re-fired and looped. Status now moves to `errored` with Try again.
- Clears the stale `serverCacheKey` on cache key change, so the flag button can't target the previous insight. Peer rankings are deliberately preserved across that reset, since they are scoped to the region rather than the cache key.
- Adds unit tests for the reducer's reset, peer, and generation transitions.

## Impact

Reduces nesting depth from 5 levels to 1. Eliminates impossible states. Fixes infinite-retry loop on exception. Prevents flagging stale insights. No user-facing behavior change.

## Test plan

- [x] Card insight opens, generates, and renders real text plus flag link (verified against dev backend)
- [x] Clear insight collapses the section and button returns to Generate
- [x] Rate-limited response renders error state with working Try again button
- [x] Changing the focused demographic group on a single-region map keeps the peer-ranked insight rendering
- [x] No visual regression to insight card
- [x] `npx vitest run src/cards/ui/InsightVisualizationCard.test.ts`: 8 passed

Closes #5015

🤖 Generated with [Claude Code](https://claude.com/claude-code)
