### PR TITLE
fix(insights): close buttons, tooltips, title, and mobile viewports

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -195,6 +195,7 @@
 		"dfs",
 		"dict",
 		"divs",
+		"dvh",
 		"DOAC",
 		"doav",
 		"doesnt",

--- a/frontend/src/cards/ui/InsightVisualizationButton.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationButton.tsx
@@ -27,11 +27,15 @@ export default function InsightVisualizationButton({
 
   if (!SHOW_INSIGHT_GENERATION) return null
 
+  // disableTouchListener: on touch devices a tap opens the tooltip and leaves it
+  // covering the insight text it sits above. The aria-label carries the same
+  // wording, so hover and screen reader users lose nothing.
   if (inCompareMode) {
     const isOpen = contrastInsightOpen[scrollToHash] ?? false
     return (
       <Tooltip
         title={isOpen ? 'Clear comparison insights' : 'Comparison insights'}
+        disableTouchListener
       >
         <IconButton
           className='hide-on-screenshot remove-height-on-screenshot'
@@ -55,7 +59,10 @@ export default function InsightVisualizationButton({
   const openKey = `${scrollToHash}${isCompareCard ? '-2' : ''}`
   const isOpen = cardInsightOpen[openKey] ?? false
   return (
-    <Tooltip title={isOpen ? 'Clear insight' : 'Generate AI insight'}>
+    <Tooltip
+      title={isOpen ? 'Clear insight' : 'Generate AI insight'}
+      disableTouchListener
+    >
       <IconButton
         className='hide-on-screenshot remove-height-on-screenshot'
         onClick={() =>

--- a/frontend/src/pages/ExploreData/InsightReportCard.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportCard.tsx
@@ -134,14 +134,14 @@ export default function InsightReportCard(props: InsightReportCardProps) {
   return (
     <div className='md:sticky' style={{ top: props.headerScrollMargin ?? 0 }}>
       <div
-        className={`flex flex-col gap-3 bg-alt-white p-4 text-left ${props.isFlat ? '' : 'rounded-sm shadow-raised md:m-card-gutter'}`}
+        className={`flex flex-col gap-3 bg-alt-white text-left ${props.isFlat ? '' : 'rounded-sm p-4 shadow-raised md:m-card-gutter'}`}
       >
         {/* Header. isFlat means a parent dialog already supplies the frame and
             its own close button, so rendering ours would stack two. */}
         <div className='flex items-center justify-between gap-2'>
           <span className='flex items-center gap-2 font-semibold text-alt-dark'>
             <AutoAwesome fontSize='small' className='text-alt-green' />
-            AI Report Summary
+            Report Insights
           </span>
           {!props.isFlat && (
             <Tooltip title='Close' disableTouchListener>

--- a/frontend/src/pages/ExploreData/InsightReportCard.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportCard.tsx
@@ -139,10 +139,7 @@ export default function InsightReportCard(props: InsightReportCardProps) {
         {/* Header. isFlat means a parent dialog already supplies the frame and
             its own close button, so rendering ours would stack two. */}
         <div className='flex items-center justify-between gap-2'>
-          <span className='flex items-center gap-2 font-semibold text-alt-dark'>
-            <AutoAwesome fontSize='small' className='text-alt-green' />
-            Report Insights
-          </span>
+          <span className='font-semibold text-alt-dark'>Report Insights</span>
           {!props.isFlat && (
             <Tooltip title='Close' disableTouchListener>
               <IconButton onClick={handleClose} aria-label='close report'>
@@ -183,7 +180,9 @@ export default function InsightReportCard(props: InsightReportCardProps) {
                   key={key}
                   className={`flex flex-col gap-1 px-4 ${key === 'keyFindings' ? 'rounded-md bg-footer-color py-4 text-alt-black' : 'py-2'}`}
                 >
-                  <span className='flex items-center gap-1 font-semibold text-alt-green text-smallest uppercase tracking-wide'>
+                  {/* All-caps text has no descenders, so its visual center sits
+                      above the line box center that flex aligns the icon to. */}
+                  <span className='flex items-center gap-1 font-semibold text-alt-green text-smallest uppercase tracking-wide [&>svg]:-translate-y-0.5'>
                     {icon}
                     {label}
                   </span>

--- a/frontend/src/pages/ExploreData/InsightReportCard.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportCard.tsx
@@ -136,18 +136,20 @@ export default function InsightReportCard(props: InsightReportCardProps) {
       <div
         className={`flex flex-col gap-3 bg-alt-white p-4 text-left ${props.isFlat ? '' : 'rounded-sm shadow-raised md:m-card-gutter'}`}
       >
-        {/* Header */}
+        {/* Header. isFlat means a parent dialog already supplies the frame and
+            its own close button, so rendering ours would stack two. */}
         <div className='flex items-center justify-between gap-2'>
           <span className='flex items-center gap-2 font-semibold text-alt-dark'>
             <AutoAwesome fontSize='small' className='text-alt-green' />
             AI Report Summary
           </span>
-          {/* Close button */}
-          <Tooltip title='Close' disableTouchListener>
-            <IconButton onClick={handleClose} aria-label='close report'>
-              <CloseIcon fontSize='small' />
-            </IconButton>
-          </Tooltip>
+          {!props.isFlat && (
+            <Tooltip title='Close' disableTouchListener>
+              <IconButton onClick={handleClose} aria-label='close report'>
+                <CloseIcon fontSize='small' />
+              </IconButton>
+            </Tooltip>
+          )}
         </div>
 
         <Divider />

--- a/frontend/src/pages/ExploreData/InsightReportModal.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportModal.tsx
@@ -12,7 +12,7 @@ export default function InsightReportModal() {
     <HetResponsiveDialog
       open={Boolean(insightIsOpen)}
       onClose={() => setInsightIsOpen(false)}
-      ariaLabel='AI Report Summary'
+      ariaLabel='Report Insights'
       maxWidth='sm'
     >
       <InsightReportCard isFlat />

--- a/frontend/src/reports/ContrastInsightSection.tsx
+++ b/frontend/src/reports/ContrastInsightSection.tsx
@@ -160,7 +160,7 @@ export default function ContrastInsightSection({
           <AutoAwesome sx={{ fontSize: 12 }} />
           {sectionLabel} comparison
         </p>
-        <Tooltip title='Close'>
+        <Tooltip title='Close' disableTouchListener>
           <IconButton
             size='small'
             onClick={handleClose}

--- a/frontend/src/styles/HetComponents/HetResponsiveDialog.tsx
+++ b/frontend/src/styles/HetComponents/HetResponsiveDialog.tsx
@@ -53,7 +53,9 @@ export default function HetResponsiveDialog({
           paper: {
             style: {
               borderRadius: '16px 16px 0 0',
-              maxHeight: '90vh',
+              // dvh, not vh: in-app browser sheets (Slack, Claude iOS) report a vh
+              // larger than the visible area, which clips the header and its close button.
+              maxHeight: '90dvh',
               display: 'flex',
               flexDirection: 'column',
               overflow: 'hidden',
@@ -81,8 +83,8 @@ export default function HetResponsiveDialog({
         paper: {
           style:
             dialogHeight === 'full'
-              ? { height: '95vh' }
-              : { maxHeight: '90vh' },
+              ? { height: '95dvh' }
+              : { maxHeight: '90dvh' },
         },
       }}
     >


### PR DESCRIPTION
**Preview:** [Report Insights drawer, open](https://deploy-preview-5051--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.00&mlp=disparity&demo=race_and_ethnicity&report-insight=true)

## Summary

- **Duplicate close button (#5043).** `InsightReportCard` renders a close button in its own header. On mobile it is also wrapped in `HetResponsiveDialog`, which supplies one, so the drawer showed two stacked. The card's own is now suppressed when `isFlat` is set, which is exactly the "a parent dialog frames this" signal. Desktop, where the card renders standalone in the sidebar, keeps its button.
- **Sticky tooltips on touch devices (#5041).** The generate/clear insight tooltips open on tap on iOS and then linger over the insight text they sit above, making it hard to read. `disableTouchListener` on those tooltips, matching what the report card's Close tooltip already did. Each button's `aria-label` carries the same wording, so hover, keyboard, and screen reader users are unaffected.
- **Panel title and spacing.** The panel was the only surface calling this a "summary" while the trigger button and every other surface say "insights", so it is now titled **Report Insights** (dialog `aria-label` too). It also applied its own `p-4` inside the dialog's already-padded content wrapper, leaving 44px between the close button and the title; that padding now applies only to the standalone sidebar rendering, closing the gap to 28px and widening the drawer content. The sparkle icon next to the title was competing with the one on **Key Findings**, where it carries meaning, so it is dropped from the title. The four section icons also sat 2px below the visual center of their all-caps labels, since flex centers an icon against the line box while all-caps text reserves descender space it never uses; measured residual is now 0.33px.
- **Dialogs sized to `vh` overflowed in-app browsers.** In an in-app browser sheet (Claude iOS, Slack, and similar), `vh` reports the full screen rather than the visible area, so a `90vh` dialog overflowed and clipped its own header, putting the close button out of reach. Now `dvh`, which tracks the visible area. This one surfaced because the first fix above removed the second, redundant close button that had been masking it.

## Impact

- Restores a reachable close control in in-app browser sheets, where the dialog was previously unclosable without a page reload
- Fix lands in `HetResponsiveDialog`, so all five consumers benefit (insight report, multi-map, CHLP maps, topic info, vote.org), not just the modal where it was spotted
- Removes the duplicate close control in the mobile insight drawer
- Aligns panel title and section icons with visual hierarchy and consistent language

## Test plan

- [x] Insight drawer shows exactly one close control (was two) at 390×844, 844×390, and 768×1024, on both Chromium and WebKit
- [x] Close control stays fully in-viewport and dismisses the drawer at short in-app-sheet viewports (390×360, 390×500, 700×380), Chromium and WebKit
- [x] Close control stays pinned with a full-length insight scrolled to the bottom
- [x] Desktop sidebar report insight card still renders its own close button and keeps its padding
- [x] Drawer close-to-title gap measured 44px → 28px; no stale "AI Report Summary" strings remain
- [x] Section icon centers measured against their label glyph centers: 2.33px off → 0.33px, on all four sections
- [ ] Confirm on a real iOS device that the insight tooltips no longer linger after tap (not reproducible in Playwright, which cannot emulate iOS tooltip dismissal)
- [ ] Confirm the dialog is closable when opened from an in-app browser sheet (Playwright viewports cannot reproduce the `vh`/`dvh` divergence itself)

Closes #5043
Closes #5041

🤖 Generated with [Claude Code](https://claude.com/claude-code)
