### PR TITLE
fix: scope legend to extremes-filtered map rows

### DIFF
--- a/frontend/playwright-tests/map_legend_extremes.ci.spec.ts
+++ b/frontend/playwright-tests/map_legend_extremes.ci.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from './utils/fixtures'
+
+// Extremes mode narrows the map to the highest and lowest geographies. The legend
+// has to describe that subset, not the full dataset, or it enumerates a bucket per
+// geography and stops matching what is drawn.
+const SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST = 5
+const MAX_ABSENCE_SWATCHES = 2
+
+const CASES = [
+  { name: 'Utah counties', mls: '1.hiv-3.49' },
+  { name: 'national states', mls: '1.hiv-3.00' },
+]
+
+for (const { name, mls } of CASES) {
+  test(`extremes legend stays scoped to the mapped geographies: ${name}`, async ({
+    page,
+  }) => {
+    const url = `/exploredata?mls=${mls}&mlp=disparity&demo=race_and_ethnicity`
+    const legend = page.locator('.legend-items-box').first()
+
+    await page.goto(url, { waitUntil: 'domcontentloaded' })
+    await expect(legend).toBeVisible()
+    const normalRows = (await legend.innerText()).split('\n').length
+
+    await page.goto(`${url}&extremes=true`, { waitUntil: 'domcontentloaded' })
+    await expect(legend).toBeVisible()
+    await expect
+      .poll(async () => (await legend.innerText()).split('\n').length)
+      .toBeLessThanOrEqual(
+        SIZE_OF_HIGHEST_LOWEST_GEOS_RATES_LIST * 2 + MAX_ABSENCE_SWATCHES,
+      )
+
+    const extremeRows = (await legend.innerText()).split('\n')
+    expect(extremeRows.length).toBeGreaterThan(0)
+
+    // A bucket whose ends carry the same label describes nothing; two-significant-
+    // figure rate labels make distinct values collide unless they are collapsed.
+    for (const row of extremeRows) {
+      const ends = row.split('–').map((end) => end.trim())
+      if (ends.length === 2) expect(ends[0]).not.toEqual(ends[1])
+    }
+
+    // Guards the regression itself: extremes previously produced a longer legend
+    // than the unfiltered map because it enumerated every value in the dataset.
+    expect(extremeRows.length).toBeLessThanOrEqual(normalRows + 1)
+  })
+}

--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -754,11 +754,12 @@ function MapCardWithKey(props: MapCardProps) {
                     dataTypeConfig={props.dataTypeConfig}
                     metricConfig={metricConfig}
                     legendTitle={metricConfig.shortLabel}
-                    data={dataForActiveDemographicGroup}
+                    data={displayData}
                     description={'Legend for rate map'}
                     fipsTypeDisplayName={fipsTypeDisplayName}
                     mapConfig={mapConfig}
                     isSummaryLegend={isSummaryLegend}
+                    isExtremesMode={isExtremesMode}
                     isPhrmaAdherence={isPhrmaAdherence}
                     fips={props.fips}
                     isCompareMode={isCompareMode}

--- a/frontend/src/charts/choroplethMap/RateMapLegend.tsx
+++ b/frontend/src/charts/choroplethMap/RateMapLegend.tsx
@@ -26,6 +26,7 @@ interface RateMapLegendProps {
   mapConfig: MapConfig
   isPhrmaAdherence: boolean
   isSummaryLegend?: boolean
+  isExtremesMode?: boolean
   fips: Fips
   isMulti?: boolean
   legendTitle: string
@@ -43,6 +44,7 @@ export default function RateMapLegend(props: RateMapLegendProps) {
     fipsTypeDisplayName,
     isPhrmaAdherence,
     isSummaryLegend,
+    isExtremesMode,
     colorScale,
   } = props
 
@@ -67,6 +69,7 @@ export default function RateMapLegend(props: RateMapLegendProps) {
     fipsTypeDisplayName,
     isPhrmaAdherence,
     isSummaryLegend,
+    isExtremesMode,
     colorScale,
   ])
 

--- a/frontend/src/charts/choroplethMap/legendDataProcessor.test.ts
+++ b/frontend/src/charts/choroplethMap/legendDataProcessor.test.ts
@@ -145,4 +145,17 @@ describe('processLegendData territory coverage', () => {
       }).specialItems,
     ).toEqual([])
   })
+
+  it('adds no absence swatch in extremes mode, where white means filtered out', () => {
+    expect(
+      processLegendData({
+        data: everyTerritory.slice(1),
+        metricConfig,
+        mapConfig,
+        colorScale,
+        fips: new Fips('00'),
+        isExtremesMode: true,
+      }).specialItems,
+    ).toEqual([])
+  })
 })

--- a/frontend/src/charts/choroplethMap/legendDataProcessor.ts
+++ b/frontend/src/charts/choroplethMap/legendDataProcessor.ts
@@ -23,6 +23,7 @@ export interface ProcessLegendDataParams {
   colorScale: ColorScale
   isPhrmaAdherence?: boolean
   isSummaryLegend?: boolean
+  isExtremesMode?: boolean
   fipsTypeDisplayName?: GeographicBreakdown
   fips?: Fips
 }
@@ -52,6 +53,7 @@ export function processLegendData(
     colorScale,
     isPhrmaAdherence,
     isSummaryLegend,
+    isExtremesMode,
     fipsTypeDisplayName,
     fips,
   } = params
@@ -75,7 +77,11 @@ export function processLegendData(
   // dataset carries a row for it, so a territory the source omits entirely
   // renders white while never appearing in `data`. Without this the map shows
   // a swatch the legend has no key for.
+  // Extremes mode is a filter, so every shape outside the selection is drawn
+  // white as background context. Absence swatches would relabel that white as
+  // missing data and describe geographies the map is deliberately not showing.
   const hasAbsentTerritory =
+    !isExtremesMode &&
     fips?.isUsa() === true &&
     Object.keys(TERRITORY_CODES).some(
       (code) => !data.some((row) => row.fips === code),

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.test.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { createQuantileLegend } from './mapLegendUtils'
+import {
+  createLegendForSmallDataset,
+  createQuantileLegend,
+} from './mapLegendUtils'
 import type { ColorScale } from './types'
 
 function makeScale(
@@ -31,5 +34,34 @@ describe('createQuantileLegend', () => {
     )
     const labels = createQuantileLegend(scale, String).map((i) => i.label)
     expect(labels).toEqual(['< 10', '10 – 20', '20 – 30', '≥ 30'])
+  })
+})
+
+describe('createLegendForSmallDataset', () => {
+  const scale = (() => '#fill') as unknown as ColorScale
+  // Rates render to two significant figures, so 119.6 and 123 both read "120".
+  const twoSigFigs = (v: number) => String(Math.round(v / 10) * 10)
+
+  it('collapses values that share a rounded label', () => {
+    const labels = createLegendForSmallDataset(
+      [92, 119.6, 123, 240],
+      scale,
+      twoSigFigs,
+    ).map((i) => i.label)
+    expect(labels).not.toContain('120 – 120')
+    expect(labels).toEqual(['90 – 120', '120 – 240', '≥ 240'])
+  })
+
+  it('keeps values whose labels differ', () => {
+    const labels = createLegendForSmallDataset([10, 20, 30], scale, String).map(
+      (i) => i.label,
+    )
+    expect(labels).toEqual(['10 – 19.99', '20 – 29.99', '≥ 30'])
+  })
+
+  it('renders a single item when every value shares one label', () => {
+    expect(
+      createLegendForSmallDataset([119, 120, 121], scale, twoSigFigs),
+    ).toHaveLength(1)
   })
 })

--- a/frontend/src/charts/choroplethMap/mapLegendUtils.ts
+++ b/frontend/src/charts/choroplethMap/mapLegendUtils.ts
@@ -133,10 +133,21 @@ export function createLabelFormatter(metricConfig: MetricConfig) {
  * Creates legend items for datasets with 1-4 unique values
  */
 export function createLegendForSmallDataset(
-  uniqueValues: number[],
+  values: number[],
   colorScale: ColorScale,
   labelFormat: (value: number) => string,
 ): LegendItemData[] {
+  // Rates are labeled to two significant figures, so distinct values can share a
+  // label (119.6 and 123 both read "120") and produce a bucket like "120 – 120".
+  // Collapse them to the first value carrying each label.
+  const seenLabels = new Set<string>()
+  const uniqueValues = values.filter((value) => {
+    const label = labelFormat(value)
+    if (seenLabels.has(label)) return false
+    seenLabels.add(label)
+    return true
+  })
+
   if (uniqueValues.length === 1) {
     // Single value - just show that value
     return [


### PR DESCRIPTION
**Preview:** [Utah counties extremes legend](https://deploy-preview-5052--health-equity-tracker.netlify.app/exploredata?mls=1.hiv-3.49&mlp=disparity&demo=race_and_ethnicity&extremes=true)

## Summary

- The rate map legend is now built from the same rows the map draws. In extremes mode the color scale was already derived from the highest/lowest subset while the legend still read the full dataset, so the legend enumerated a bucket per geography and no longer described what was painted.
- Buckets whose two ends round to the same label are collapsed. Rates are formatted to two significant figures, so distinct values like 119.6 and 123 both read "120" and produced an empty `120 – 120` bucket.
- The "No data" / "Suppressed" swatches are skipped in extremes mode, where a white shape means "outside the selection" rather than "missing", matching the meaning `getFillColor` already assigns to white there.

## Impact

Utah counties, HIV prevalence per 100k, extremes mode legend reduced from 20 rows (including degenerate `52 – 52`, `120 – 120`) to 5. Normal mode unchanged.

## Test plan

- [x] New CI spec `map_legend_extremes.ci.spec.ts` (Utah counties, USA states) asserts legend size stays within extremes-filter bounds and contains no collapsed buckets
- [x] Verified spec fails against pre-fix code (Utah case reports 18 rows against ceiling of 12), confirming regression guard
- [x] Compared four map configurations in both modes; normal mode byte-identical before/after
- [x] Confirmed extremes map still shows only selected geographies (22 of 29 Utah counties white vs. 21 colored in normal mode)
- [x] 4 new unit tests; 36 pass in `src/charts/choroplethMap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
