### PR TITLE
refactor(insights): derive insight cache keys from a prompt hash

### DIFF
--- a/frontend/src/cards/ui/InsightVisualizationCard.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationCard.tsx
@@ -15,7 +15,6 @@ import type {
 import {
   buildInsightFocusSuffix,
   generateCardInsight,
-  INSIGHT_CACHE_VERSION,
   summarizePeerComparison,
 } from '../../utils/generateVisualizationInsight'
 import { getDataManager } from '../../utils/globals'
@@ -194,13 +193,14 @@ export default function InsightVisualizationCard({
 
   // A stable suffix so the insight regenerates when the user changes which
   // group(s) the chart is focused on (highlighted map group / selected trend
-  // legend lines) — those change the data the model sees. Shared with the server
-  // cache key in generateCardInsight so both caches key on focus identically.
+  // legend lines) — those change the data the model sees. This in-session memo
+  // key is read before a prompt exists, so it describes the view rather than
+  // hashing the prompt the way the server key does.
   const focusSuffix = buildInsightFocusSuffix({
     activeDemographicGroup,
     selectedGroups,
   })
-  const cacheKey = `${scrollToHash}-${dataTypeConfig.dataTypeId}-${fips.code}-${demographicType}${isCompareCard ? '-2' : ''}${focusSuffix ? `-${focusSuffix}` : ''}-${INSIGHT_CACHE_VERSION}`
+  const cacheKey = `${scrollToHash}-${dataTypeConfig.dataTypeId}-${fips.code}-${demographicType}${isCompareCard ? '-2' : ''}${focusSuffix ? `-${focusSuffix}` : ''}`
   const insight = cardInsights[cacheKey]
 
   const handleGenerate = useCallback(async () => {

--- a/frontend/src/utils/generateContrastInsight.ts
+++ b/frontend/src/utils/generateContrastInsight.ts
@@ -11,7 +11,7 @@ import {
   getPrimaryMetricConfig,
 } from './generateVisualizationInsight'
 import type { ScrollableHashId } from './hooks/useStepObserver'
-import { REPORT_INSIGHT_PARAM_KEY } from './urlutils'
+import { buildInsightCacheKey } from './insightCacheKey'
 
 function buildContrastPrompt(
   topic1: string,
@@ -97,9 +97,7 @@ export async function generateContrastInsight(
     data2,
   )
 
-  const params = new URLSearchParams(window.location.search)
-  params.delete(REPORT_INSIGHT_PARAM_KEY)
-  const cacheKey = `${window.location.pathname}?${params.toString()}#${hashId}-contrast`
+  const cacheKey = buildInsightCacheKey(`#${hashId}-contrast`, prompt)
 
   const result = await fetchAIInsight(prompt, {
     cacheKey,

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -5,7 +5,7 @@ import {
 } from '../data/query/Breakdowns'
 import type { Fips } from '../data/utils/Fips'
 import { ERROR_GENERATING_INSIGHT, fetchAIInsight } from './fetchAIInsight'
-import { REPORT_INSIGHT_PARAM_KEY } from './urlutils'
+import { buildInsightCacheKey } from './insightCacheKey'
 
 export type ReportInsightSections = {
   keyFindings: string
@@ -84,9 +84,7 @@ export async function generateReportInsight(
       location,
       DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType],
     )
-    const params = new URLSearchParams(window.location.search)
-    params.delete(REPORT_INSIGHT_PARAM_KEY)
-    const cacheKey = `${window.location.pathname}?${params.toString()}`
+    const cacheKey = buildInsightCacheKey('', prompt)
     const result = await fetchAIInsight(prompt, {
       cacheKey,
       topic: dataTypeConfig.dataTypeId,

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -16,13 +16,7 @@ import { groupIsAll } from '../data/utils/datasetutils'
 import type { Fips } from '../data/utils/Fips'
 import { fetchAIInsight, type InsightResult } from './fetchAIInsight'
 import type { ScrollableHashId } from './hooks/useStepObserver'
-import { REPORT_INSIGHT_PARAM_KEY } from './urlutils'
-
-// Bump when the prompt wording changes materially, so already-cached insights
-// (keyed by view, not by prompt text) are invalidated instead of served stale.
-// v2: parent/national reference rates → same-level peer ranking + no-preamble rule.
-// v3: fixed a lazy-fetch race that cached peer insights generated before peers loaded.
-export const INSIGHT_CACHE_VERSION = 'v3'
+import { buildInsightCacheKey } from './insightCacheKey'
 
 const MAP_CHART_IDS: ScrollableHashId[] = [
   'rate-map',
@@ -442,10 +436,10 @@ export interface InsightContext {
 
 // A stable suffix that changes when the user focuses the chart on a different
 // group (highlighted map group / selected trend-legend lines). Those are local
-// React state, not URL params, so without this the cache key would not change
-// and a re-focused chart would serve the stale insight from the prior focus.
-// Both the client-side insight cache and the server cache key derive from this
-// single source so they can never disagree about what "the same view" means.
+// React state, not URL params, so without this the client-side memo key would
+// not change and a re-focused chart would show the insight from the prior focus.
+// Only that in-session memo key needs this; the server key hashes the prompt,
+// which already reflects the focused rows.
 export function buildInsightFocusSuffix(context?: InsightContext): string {
   return [
     context?.activeDemographicGroup && context.activeDemographicGroup !== ALL
@@ -577,14 +571,11 @@ export async function generateCardInsight(
       Boolean(peerSummary),
     ) + outputRule
 
-  const params = new URLSearchParams(window.location.search)
-  params.delete(REPORT_INSIGHT_PARAM_KEY)
   const cardSuffix = isCompareCard ? '-2' : ''
-  // Focus (highlighted map group / selected trend lines) lives in React state,
-  // not the URL, so it must be folded into the key or the server returns the
-  // insight cached for the previous focus even though the prompt has changed.
-  const focusSuffix = buildInsightFocusSuffix(context)
-  const cacheKey = `${window.location.pathname}?${params.toString()}#${hashId}${cardSuffix}${focusSuffix ? `-${focusSuffix}` : ''}-${INSIGHT_CACHE_VERSION}`
+  // Focus (highlighted map group / selected trend lines) needs no suffix here:
+  // it changes which rows formatDataRows emits, so the prompt hash already
+  // separates one focus from another.
+  const cacheKey = buildInsightCacheKey(`#${hashId}${cardSuffix}`, prompt)
 
   const result = await fetchAIInsight(prompt, {
     cacheKey,

--- a/frontend/src/utils/insightCacheKey.test.ts
+++ b/frontend/src/utils/insightCacheKey.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { buildInsightCacheKey } from './insightCacheKey'
+
+const PROMPT = 'Rate map of HIV in Georgia\n- Fulton (All): 41.2 per 100k'
+
+describe('buildInsightCacheKey', () => {
+  it('returns the same key for the same prompt, so an unchanged pipeline run keeps the cache warm', () => {
+    expect(buildInsightCacheKey('#rate-map', PROMPT)).toBe(
+      buildInsightCacheKey('#rate-map', PROMPT),
+    )
+  })
+
+  it('changes the key when the data rows change, invalidating without a version bump', () => {
+    const refreshed = PROMPT.replace('41.2', '43.8')
+    expect(buildInsightCacheKey('#rate-map', refreshed)).not.toBe(
+      buildInsightCacheKey('#rate-map', PROMPT),
+    )
+  })
+
+  it('changes the key when only the template wording changes', () => {
+    expect(
+      buildInsightCacheKey('#rate-map', `Write one sentence.\n${PROMPT}`),
+    ).not.toBe(buildInsightCacheKey('#rate-map', PROMPT))
+  })
+
+  it('separates insights that share a URL but not a view scope', () => {
+    const card = buildInsightCacheKey('#rate-map', PROMPT)
+    const compareCard = buildInsightCacheKey('#rate-map-2', PROMPT)
+    const contrast = buildInsightCacheKey('#rate-map-contrast', PROMPT)
+    const report = buildInsightCacheKey('', PROMPT)
+    expect(new Set([card, compareCard, contrast, report]).size).toBe(4)
+  })
+
+  it('keeps the URL readable so a flagged key identifies its report', () => {
+    expect(buildInsightCacheKey('#rate-map', PROMPT)).toContain(
+      `${window.location.pathname}?`,
+    )
+  })
+
+  it('ends in an 8-char hex hash', () => {
+    expect(buildInsightCacheKey('#rate-map', PROMPT)).toMatch(/-[0-9a-f]{8}$/)
+  })
+
+  it('hashes non-ASCII prompt text without collapsing distinct prompts', () => {
+    const enDash = 'range 3.1–61.0 per 100k'
+    const hyphen = 'range 3.1-61.0 per 100k'
+    expect(buildInsightCacheKey('', enDash)).not.toBe(
+      buildInsightCacheKey('', hyphen),
+    )
+  })
+})

--- a/frontend/src/utils/insightCacheKey.ts
+++ b/frontend/src/utils/insightCacheKey.ts
@@ -1,0 +1,40 @@
+/* cSpell:ignore fnv */
+import { REPORT_INSIGHT_PARAM_KEY } from './urlutils'
+
+// FNV-1a, 32 bits, as 8 hex chars. Synchronous and dependency-free so a key can
+// be built inline at call time. This is a cache key, not a security digest, and
+// a collision would have to land within one view scope to matter at all.
+function fnv1a32(text: string): string {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < text.length; i++) {
+    hash ^= text.charCodeAt(i)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0')
+}
+
+// The single source of server cache keys for every generated insight: per-card,
+// report-wide, and compare-mode contrast.
+//
+// The rendered prompt carries both the template wording and the data rows, so
+// hashing it invalidates an entry exactly when either one changes. A pipeline
+// run that ships new numbers yields a new key on its own, and one that
+// reproduces identical numbers keeps the cache warm — neither outcome needs a
+// version constant bumped by hand.
+//
+// Invalidation is therefore scoped per view rather than per topic or per
+// pipeline: refreshed HIV data leaves every diabetes insight cached, and leaves
+// the HIV insights whose rendered rows did not move cached too.
+//
+// `viewScope` distinguishes the insights that share a URL and must not share an
+// entry, and arrives already prefixed (e.g. `#rate-map`, `#rate-map-contrast`,
+// or '' for the report-wide insight). The URL stays readable in the key because
+// scripts/review_flagged_insights.sh prints these to whoever triages a flag.
+export function buildInsightCacheKey(
+  viewScope: string,
+  prompt: string,
+): string {
+  const params = new URLSearchParams(window.location.search)
+  params.delete(REPORT_INSIGHT_PARAM_KEY)
+  return `${window.location.pathname}?${params.toString()}${viewScope}-${fnv1a32(prompt)}`
+}


### PR DESCRIPTION
## Summary

All three insight paths built their server cache key independently, and two of them never invalidated at all.

| path | key before | invalidated on |
|---|---|---|
| per-card | `pathname?params#hashId[-2][-focus]-v3` | manual `INSIGHT_CACHE_VERSION` bump |
| report-wide | `pathname?params` | **never** |
| compare contrast | `pathname?params#hashId-contrast` | **never** |

With a 180-day server TTL (`server/insights.go:21`), an insight generated under old prompt wording or superseded data kept serving for six months.

This routes all three through a new `buildInsightCacheKey(viewScope, prompt)` that hashes the rendered prompt. The prompt carries both the template text and the data rows, so an entry invalidates exactly when either changes, and `INSIGHT_CACHE_VERSION` retires with no hand-maintained bump to forget.

## Why hash the prompt rather than scope to pipeline runs

Hashing the prompt is *finer*-grained than per-DAG invalidation, not coarser:

- A run that ships new numbers only displaces the views whose rendered rows actually moved. Refreshed HIV data leaves every diabetes insight cached, and leaves the HIV insights whose rows did not move cached too. Scoping by DAG would drop every HIV insight across all 50 states even if three counties moved.
- A run that reproduces identical numbers keeps the cache warm entirely, which neither a version constant nor a run-ID scheme can do.
- Insights generate lazily on user request, so a displaced key for a view nobody opens costs nothing. Real spend is `views opened` × `data changed since last open`.

The one case that invalidates everything is editing the prompt template itself, since that text is in every prompt. That is the same blast radius as today's manual bump, just automatic instead of forgettable.

## Notes

- The focus suffix drops out of the server key: focusing a chart changes which rows `formatDataRows` emits, so the hash already separates one focus from another. It stays in the client-side memo key in `InsightVisualizationCard.tsx`, which is read before a prompt exists and so cannot key on one.
- The URL stays readable ahead of the hash because `scripts/review_flagged_insights.sh` prints these keys to whoever triages a flagged insight.
- No server change needed. `validateInsightKey` (`server/insights.go:42`) checks only length and path traversal, and the new keys are shorter than the old ones.
- No JSX or props changed, only a memo key string and comments, so there is no visual diff to screenshot.

Closes #5029

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run cleanup` (Biome) clean
- [x] 57 tests pass across `insightCacheKey.test.ts`, `generateVisualizationInsight.test.ts`, `InsightVisualizationCard.test.ts`
- [x] New tests cover: identical prompt → identical key, changed data rows → new key, changed template → new key, four view scopes sharing a URL stay distinct, non-ASCII prompt text (en-dash in peer ranges) hashes distinctly
- [ ] Verify on deploy preview that opening a card, report, and compare insight each still generate and flag correctly
