### PR TITLE
Require the frontend dev server to run on port 3000

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -20,10 +20,13 @@ npm run e2e statins.nightly.spec.ts
 npm run e2e hiv          # Matches any filename containing "hiv"
 ```
 
-**Always start servers through these npm scripts, never a bare `npx vite` or `vite preview`.** The scripts wrap Vite in `env-cmd -f .env.localhost`, which is where `VITE_BASE_API_URL` lives. Without it the app still builds and renders, but every data fetch 404s and cards come up empty, so the failure looks like a product bug rather than a missing env. If a scratch server on another port is needed, keep the wrapper:
+**Always start servers through these npm scripts, never a bare `npx vite` or `vite preview`.** The scripts wrap Vite in `env-cmd -f .env.localhost`, which is where `VITE_BASE_API_URL` lives. Without it the app still builds and renders, but every data fetch 404s and cards come up empty, so the failure looks like a product bug rather than a missing env.
+
+**Always serve on port 3000.** Vite silently increments to the next free port when 3000 is taken, and other tooling hardcodes 3000: the Go server's insight origin allowlist only accepts `http://localhost:3000`, so an app served from 3009 gets a 403 on every `/fetch-ai-insight` call and the AI insight card renders an error. Never work around a server that landed elsewhere, and never spin up a scratch server on another port. Free 3000 and restart, or reuse what is already there:
 
 ```bash
-npx env-cmd -f .env.localhost npx vite --port 3100
+lsof -ti :3000            # what holds it, if anything
+kill $(lsof -ti :3000)    # free it, then npm run localhost
 ```
 
 **Important: Package Dependency Workflow**


### PR DESCRIPTION
## Summary

- Documents that the frontend dev server must always run on port 3000, not whatever port Vite lands on.
- Removes the previous suggestion to spin up a scratch server on another port, which encouraged the workaround rather than the fix.

## Why

Vite silently increments to the next free port when 3000 is taken, so `npm run localhost` can quietly come up on 3009 and the app looks fine. Enough tooling assumes 3000 that the drift is not harmless: the insight origin allowlist accepts `http://localhost:3000`, so an app served from another port gets a 403 on every insight call and the AI insight card renders an error that reads like a product bug.

This cost real debugging time while verifying #5047 locally. Freeing the port takes one command; the doc now says so.

## Test plan

- [x] Docs-only change, no code paths touched
- [x] `lsof -ti :3000` / `kill $(lsof -ti :3000)` verified locally, then `npm run localhost` came up on 3000
