### PR TITLE
Ground the report-wide AI insight in the report's own data

### DIFF
--- a/frontend/src/pages/ExploreData/InsightReportCard.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportCard.tsx
@@ -1,10 +1,8 @@
 import AutoAwesome from '@mui/icons-material/AutoAwesome'
 import CloseIcon from '@mui/icons-material/Close'
-import DataUsage from '@mui/icons-material/DataUsage'
 import Info from '@mui/icons-material/Info'
 import LocationOn from '@mui/icons-material/LocationOn'
 import People from '@mui/icons-material/People'
-import TrendingUp from '@mui/icons-material/TrendingUp'
 import {
   Button,
   CircularProgress,
@@ -57,16 +55,6 @@ const SECTIONS: SectionConfig[] = [
     key: 'demographicInsights',
     label: 'Demographic Insights',
     icon: <People fontSize='small' />,
-  },
-  {
-    key: 'changeOverTime',
-    label: 'Change Over Time',
-    icon: <TrendingUp fontSize='small' />,
-  },
-  {
-    key: 'dataCompleteness',
-    label: 'Data Completeness',
-    icon: <DataUsage fontSize='small' />,
   },
   {
     key: 'whatThisMeans',
@@ -137,16 +125,9 @@ export default function InsightReportCard(props: InsightReportCardProps) {
     void handleGenerate()
   }
 
-  // Change Over Time and Data Completeness are only requested when the report
-  // has the data behind them, so a topic without a historical series or a
-  // reported unknown share simply renders fewer sections.
-  const presentSections = sections
-    ? SECTIONS.filter(({ key }) => sections[key])
-    : []
-
-  const insightText = presentSections
-    .map(({ key }) => sections?.[key])
-    .join(' ')
+  const insightText = sections
+    ? SECTIONS.map(({ key }) => sections[key]).join(' ')
+    : ''
 
   const handleClose = () => {
     setIsOpen(false)
@@ -208,7 +189,7 @@ export default function InsightReportCard(props: InsightReportCardProps) {
         {sections && !isGenerating && (
           <>
             <div className='flex flex-col gap-5'>
-              {presentSections.map(({ key, label, icon }) => (
+              {SECTIONS.map(({ key, label, icon }) => (
                 <div
                   key={key}
                   className={`flex flex-col gap-1 px-4 ${key === 'keyFindings' ? 'rounded-md bg-footer-color py-4 text-alt-black' : 'py-2'}`}

--- a/frontend/src/pages/ExploreData/InsightReportCard.tsx
+++ b/frontend/src/pages/ExploreData/InsightReportCard.tsx
@@ -1,8 +1,10 @@
 import AutoAwesome from '@mui/icons-material/AutoAwesome'
 import CloseIcon from '@mui/icons-material/Close'
+import DataUsage from '@mui/icons-material/DataUsage'
 import Info from '@mui/icons-material/Info'
 import LocationOn from '@mui/icons-material/LocationOn'
 import People from '@mui/icons-material/People'
+import TrendingUp from '@mui/icons-material/TrendingUp'
 import {
   Button,
   CircularProgress,
@@ -55,6 +57,16 @@ const SECTIONS: SectionConfig[] = [
     key: 'demographicInsights',
     label: 'Demographic Insights',
     icon: <People fontSize='small' />,
+  },
+  {
+    key: 'changeOverTime',
+    label: 'Change Over Time',
+    icon: <TrendingUp fontSize='small' />,
+  },
+  {
+    key: 'dataCompleteness',
+    label: 'Data Completeness',
+    icon: <DataUsage fontSize='small' />,
   },
   {
     key: 'whatThisMeans',
@@ -125,9 +137,16 @@ export default function InsightReportCard(props: InsightReportCardProps) {
     void handleGenerate()
   }
 
-  const insightText = sections
-    ? SECTIONS.map(({ key }) => sections[key]).join(' ')
-    : ''
+  // Change Over Time and Data Completeness are only requested when the report
+  // has the data behind them, so a topic without a historical series or a
+  // reported unknown share simply renders fewer sections.
+  const presentSections = sections
+    ? SECTIONS.filter(({ key }) => sections[key])
+    : []
+
+  const insightText = presentSections
+    .map(({ key }) => sections?.[key])
+    .join(' ')
 
   const handleClose = () => {
     setIsOpen(false)
@@ -189,7 +208,7 @@ export default function InsightReportCard(props: InsightReportCardProps) {
         {sections && !isGenerating && (
           <>
             <div className='flex flex-col gap-5'>
-              {SECTIONS.map(({ key, label, icon }) => (
+              {presentSections.map(({ key, label, icon }) => (
                 <div
                   key={key}
                   className={`flex flex-col gap-1 px-4 ${key === 'keyFindings' ? 'rounded-md bg-footer-color py-4 text-alt-black' : 'py-2'}`}

--- a/frontend/src/utils/generateReportInsight.test.ts
+++ b/frontend/src/utils/generateReportInsight.test.ts
@@ -85,7 +85,7 @@ describe('formatGeographicSpread', () => {
     expect(formatGeographicSpread(rows, metricConfig, 'counties')).toBe(
       [
         '- Highest: A 10, B 9, C 8 per 100k',
-        '- Lowest: G 4, F 5, E 6 per 100k',
+        '- Lowest reported: G 4, F 5, E 6 per 100k',
         '- Median across 7 counties: 7 per 100k',
       ].join('\n'),
     )
@@ -120,6 +120,20 @@ describe('formatTemporalChange', () => {
 
     expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
       '- All: 5 in 2020, 8 in 2022 per 100k',
+    )
+  })
+
+  // A monthly series like COVID-19 opens and closes at zero, so endpoints alone
+  // would describe a condition that never happened.
+  test('names the peak when it falls between the endpoints', () => {
+    const rows = [
+      point('All', '2020-01', 0),
+      point('All', '2020-12', 29),
+      point('All', '2024-05', 0),
+    ]
+
+    expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
+      '- All: 0 in 2020-01, peaking at 29 in 2020-12, 0 in 2024-05 per 100k',
     )
   })
 
@@ -198,9 +212,11 @@ describe('formatAgeAdjustedRatios', () => {
 })
 
 describe('formatUnknownShare', () => {
+  // The real pct_share shortLabel already names the unit and the topic, so a
+  // stand-in like '%' would hide a duplicated-unit bug in the output.
   const shareConfig = {
     metricId: 'share_unknown',
-    shortLabel: '%',
+    shortLabel: '% of COVID-19 deaths',
   } as unknown as MetricConfig
 
   test('keeps only the unknown rows, so known groups are not double-counted', () => {
@@ -210,7 +226,7 @@ describe('formatUnknownShare', () => {
     ]
 
     expect(formatUnknownShare(rows, DEMO, shareConfig)).toBe(
-      '- Unknown: 14.2% of cases',
+      '- Unknown: 14.2% of COVID-19 deaths',
     )
   })
 
@@ -221,9 +237,10 @@ describe('formatUnknownShare', () => {
     ]
 
     expect(formatUnknownShare(rows, DEMO, shareConfig)).toBe(
-      ['- Unknown race: 9% of cases', '- Unknown ethnicity: 21% of cases'].join(
-        '\n',
-      ),
+      [
+        '- Unknown race: 9% of COVID-19 deaths',
+        '- Unknown ethnicity: 21% of COVID-19 deaths',
+      ].join('\n'),
     )
   })
 

--- a/frontend/src/utils/generateReportInsight.test.ts
+++ b/frontend/src/utils/generateReportInsight.test.ts
@@ -1,0 +1,238 @@
+import type { MetricConfig } from '../data/config/MetricConfigTypes'
+import type { HetRow } from '../data/utils/DatasetTypes'
+import {
+  formatAgeAdjustedRatios,
+  formatDemographicRates,
+  formatGeographicSpread,
+  formatTemporalChange,
+  formatUnknownShare,
+} from './generateReportInsight'
+
+const DEMO = 'race_and_ethnicity'
+
+const metricConfig = {
+  metricId: 'rate',
+  shortLabel: 'per 100k',
+} as unknown as MetricConfig
+
+describe('formatDemographicRates', () => {
+  test('puts the overall row first, then groups from highest to lowest', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'White (NH)', rate: 4.1 },
+      { race_and_ethnicity: 'Black (NH)', rate: 9.2 },
+      { race_and_ethnicity: 'All', rate: 6.5 },
+    ]
+
+    expect(formatDemographicRates(rows, DEMO, metricConfig)).toBe(
+      [
+        '- All: 6.5 per 100k',
+        '- Black (NH): 9.2 per 100k',
+        '- White (NH): 4.1 per 100k',
+      ].join('\n'),
+    )
+  })
+
+  test('drops rows with no group or no numeric rate so no null reaches the model', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'All', rate: 6.5 },
+      { race_and_ethnicity: 'Asian (NH)', rate: null },
+      { race_and_ethnicity: null, rate: 3.3 },
+    ]
+
+    expect(formatDemographicRates(rows, DEMO, metricConfig)).toBe(
+      '- All: 6.5 per 100k',
+    )
+  })
+
+  test('renders identically regardless of row order, so the prompt hash is stable', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'All', rate: 6.5 },
+      { race_and_ethnicity: 'Black (NH)', rate: 9.2 },
+      { race_and_ethnicity: 'White (NH)', rate: 4.1 },
+    ]
+
+    expect(
+      formatDemographicRates([...rows].reverse(), DEMO, metricConfig),
+    ).toBe(formatDemographicRates(rows, DEMO, metricConfig))
+  })
+})
+
+describe('formatGeographicSpread', () => {
+  const place = (name: string, rate: number): HetRow => ({
+    fips_name: name,
+    rate,
+  })
+
+  test('names every place when the list is short enough to fit', () => {
+    const rows = [place('Fulton', 8), place('Cobb', 5), place('Clarke', 2)]
+
+    expect(formatGeographicSpread(rows, metricConfig, 'counties')).toBe(
+      '- All 3 counties: Fulton 8, Cobb 5, Clarke 2 per 100k',
+    )
+  })
+
+  test('summarizes as highest, lowest, and median once the list is long', () => {
+    const rows = [
+      place('A', 10),
+      place('B', 9),
+      place('C', 8),
+      place('D', 7),
+      place('E', 6),
+      place('F', 5),
+      place('G', 4),
+    ]
+
+    expect(formatGeographicSpread(rows, metricConfig, 'counties')).toBe(
+      [
+        '- Highest: A 10, B 9, C 8 per 100k',
+        '- Lowest: G 4, F 5, E 6 per 100k',
+        '- Median across 7 counties: 7 per 100k',
+      ].join('\n'),
+    )
+  })
+
+  test('says nothing for a single place, since one value is not a spread', () => {
+    expect(
+      formatGeographicSpread([place('Fulton', 8)], metricConfig, 'counties'),
+    ).toBe('')
+  })
+
+  test('ignores places with no numeric rate', () => {
+    const rows = [place('Fulton', 8), { fips_name: 'Cobb', rate: null }]
+
+    expect(formatGeographicSpread(rows, metricConfig, 'counties')).toBe('')
+  })
+})
+
+describe('formatTemporalChange', () => {
+  const point = (
+    group: string,
+    time_period: string,
+    rate: number | null,
+  ): HetRow => ({ race_and_ethnicity: group, time_period, rate })
+
+  test('reduces each series to its first and latest reported points', () => {
+    const rows = [
+      point('All', '2020', 5),
+      point('All', '2022', 8),
+      point('All', '2021', 6),
+    ]
+
+    expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
+      '- All: 5 in 2020, 8 in 2022 per 100k',
+    )
+  })
+
+  test('puts the overall series first, then groups by latest rate', () => {
+    const rows = [
+      point('White (NH)', '2020', 3),
+      point('White (NH)', '2022', 4),
+      point('Black (NH)', '2020', 7),
+      point('Black (NH)', '2022', 9),
+      point('All', '2020', 5),
+      point('All', '2022', 6),
+    ]
+
+    expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
+      [
+        '- All: 5 in 2020, 6 in 2022 per 100k',
+        '- Black (NH): 7 in 2020, 9 in 2022 per 100k',
+        '- White (NH): 3 in 2020, 4 in 2022 per 100k',
+      ].join('\n'),
+    )
+  })
+
+  test('drops a series with only one period, since one point is not a change', () => {
+    const rows = [
+      point('All', '2022', 5),
+      point('Black (NH)', '2020', 7),
+      point('Black (NH)', '2022', 9),
+    ]
+
+    expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
+      '- Black (NH): 7 in 2020, 9 in 2022 per 100k',
+    )
+  })
+
+  test('picks endpoints from the periods that actually report a rate', () => {
+    const rows = [
+      point('All', '2019', null),
+      point('All', '2020', 5),
+      point('All', '2022', 8),
+      point('All', '2023', null),
+    ]
+
+    expect(formatTemporalChange(rows, DEMO, metricConfig)).toBe(
+      '- All: 5 in 2020, 8 in 2022 per 100k',
+    )
+  })
+})
+
+describe('formatAgeAdjustedRatios', () => {
+  const ratioConfig = {
+    metricId: 'death_ratio_age_adjusted',
+    shortLabel: 'Ratio compared to White (NH)',
+  } as unknown as MetricConfig
+
+  test('ranks groups by how far their burden exceeds the baseline', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'Asian (NH)', death_ratio_age_adjusted: 1.1 },
+      { race_and_ethnicity: 'Black (NH)', death_ratio_age_adjusted: 2.4 },
+    ]
+
+    expect(formatAgeAdjustedRatios(rows, DEMO, ratioConfig)).toBe(
+      [
+        '- Black (NH): 2.4x the White (NH) rate',
+        '- Asian (NH): 1.1x the White (NH) rate',
+      ].join('\n'),
+    )
+  })
+
+  test('says nothing when no group has a computable ratio', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'Black (NH)', death_ratio_age_adjusted: null },
+    ]
+
+    expect(formatAgeAdjustedRatios(rows, DEMO, ratioConfig)).toBe('')
+  })
+})
+
+describe('formatUnknownShare', () => {
+  const shareConfig = {
+    metricId: 'share_unknown',
+    shortLabel: '%',
+  } as unknown as MetricConfig
+
+  test('keeps only the unknown rows, so known groups are not double-counted', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'Black (NH)', share_unknown: 0 },
+      { race_and_ethnicity: 'Unknown', share_unknown: 14.2 },
+    ]
+
+    expect(formatUnknownShare(rows, DEMO, shareConfig)).toBe(
+      '- Unknown: 14.2% of cases',
+    )
+  })
+
+  test('names both rows when race and ethnicity are reported separately', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'Unknown race', share_unknown: 9 },
+      { race_and_ethnicity: 'Unknown ethnicity', share_unknown: 21 },
+    ]
+
+    expect(formatUnknownShare(rows, DEMO, shareConfig)).toBe(
+      ['- Unknown race: 9% of cases', '- Unknown ethnicity: 21% of cases'].join(
+        '\n',
+      ),
+    )
+  })
+
+  test('says nothing when no unknown row reports a number', () => {
+    const rows: HetRow[] = [
+      { race_and_ethnicity: 'All', share_unknown: 100 },
+      { race_and_ethnicity: 'Unknown', share_unknown: null },
+    ]
+
+    expect(formatUnknownShare(rows, DEMO, shareConfig)).toBe('')
+  })
+})

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -303,7 +303,9 @@ function buildReportInsightPrompt(
   // the age-adjusted block already supplies ratios, so the model is describing a
   // figure it was given rather than deriving one.
   const keyFindingsSpec = demographicSection
-    ? '1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as "nearly twice as likely". Do not open with a rate per 100k, and use a figure only if it is a ratio shown above.'
+    ? // Single quotes inside: this string is interpolated into the JSON skeleton
+      // below, so a double quote here would show the model a malformed template.
+      "1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k, and use a figure only if it is a ratio shown above."
     : '1 sentence (max 25 words): the most important equity question this report helps answer. Do not state any rate or number.'
 
   const locationSpec = geographicSection

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -39,29 +39,22 @@ import {
 import { getDataManager } from './globals'
 import { buildInsightCacheKey } from './insightCacheKey'
 
-// The four base sections are always present. The other two are only requested
-// when the report actually has the data behind them (a historical series, a
-// reported unknown share), so a topic with only a current-year snapshot renders
-// four sections rather than two empty ones.
+// The report-wide insight is a synthesis, not a walkthrough of the cards below
+// it. Trend and data-completeness findings fold into these four sections rather
+// than each getting a section of their own, which would turn the card into a
+// table of contents for the report.
 export type ReportInsightSections = {
   keyFindings: string
   locationComparison: string
   demographicInsights: string
-  changeOverTime?: string
-  dataCompleteness?: string
   whatThisMeans: string
 }
 
-const REQUIRED_SECTION_KEYS = [
+const SECTION_KEYS = [
   'keyFindings',
   'locationComparison',
   'demographicInsights',
   'whatThisMeans',
-] as const satisfies readonly (keyof ReportInsightSections)[]
-
-const OPTIONAL_SECTION_KEYS = [
-  'changeOverTime',
-  'dataCompleteness',
 ] as const satisfies readonly (keyof ReportInsightSections)[]
 
 type ReportInsightResult = {
@@ -302,34 +295,47 @@ function buildReportInsightPrompt(
   // Every spec below has a no-data variant. Without it the model is told to lead
   // with a number it was never given, which is exactly how a fabricated rate
   // gets into a summary.
+
+  // This is the one line a reader who skips the charts will actually read, so it
+  // has to be the most accessible thing on the page rather than a restatement of
+  // the rate map. A per-100k rate means little without the denominator in your
+  // head; "twice as likely" lands immediately. Comparisons stay grounded because
+  // the age-adjusted block already supplies ratios, so the model is describing a
+  // figure it was given rather than deriving one.
   const keyFindingsSpec = demographicSection
-    ? '1 sentence (max 25 words): the single most striking disparity, leading with a specific number or rate from the data above.'
+    ? '1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as "nearly twice as likely". Do not open with a rate per 100k, and use a figure only if it is a ratio shown above.'
     : '1 sentence (max 25 words): the most important equity question this report helps answer. Do not state any rate or number.'
 
   const locationSpec = geographicSection
     ? '1-2 sentences (max 35 words): what the geographic spread shows about where the burden is heaviest.'
     : '1-2 sentences (max 35 words): what to look for when comparing places on this map. Do not state any rate or number.'
 
-  // Age adjustment is folded in here rather than given its own section: it is a
-  // correction to how the demographic gap should be read, not a separate finding.
+  // Age adjustment and the trend both fold in here rather than getting sections
+  // of their own: one corrects how the demographic gap should be read, the other
+  // says whether it is closing. Both are qualifiers on the gap, not new findings.
   const ageAdjustedClause = ageAdjustedSection
     ? ' Then use the age-adjusted ratios to say whether the gap holds once differences in age between groups are accounted for.'
     : ''
 
+  const temporalClause = temporalSection
+    ? ' Then say whether the gap between groups has widened or narrowed across the reported periods, naming the highest point if one is given.'
+    : ''
+
+  const demographicWordBudget =
+    35 + (ageAdjustedSection ? 20 : 0) + (temporalSection ? 20 : 0)
+
   const demographicSpec = demographicSection
-    ? `1-2 sentences (max ${ageAdjustedSection ? 55 : 35} words): which group is most affected and how large the gap is compared to others, using the rates above.${ageAdjustedClause}`
+    ? `2-3 sentences (max ${demographicWordBudget} words): which group is most affected and how large the gap is compared to others, using the rates above.${ageAdjustedClause}${temporalClause}`
     : '1-2 sentences (max 35 words): what to look for when comparing groups. Do not state any rate or number.'
 
-  const optionalSpecs = [
-    temporalSection &&
-      `  "changeOverTime": "1-2 sentences (max 35 words): how rates moved across the reported periods, naming the highest point when one is given, and whether the gap between groups widened or narrowed.",`,
-    unknownSection &&
-      `  "dataCompleteness": "1 sentence (max 30 words): what share of cases is missing ${demographicLabel} data, and that the rates above describe only the cases where it was recorded.",`,
-  ].filter(Boolean)
-
-  const optionalSpecBlock = optionalSpecs.length
-    ? `${optionalSpecs.join('\n')}\n`
+  // Missing demographic data is an equity finding, not a footnote: the groups
+  // absent from the record are usually the ones already least well served, so it
+  // belongs with what the report means rather than in a section of its own.
+  const completenessClause = unknownSection
+    ? ` Then note in one sentence what share of cases is missing ${demographicLabel} data, and that the rates above describe only the cases where it was recorded.`
     : ''
+
+  const whatThisMeansSpec = `${unknownSection ? '2-3' : '1-2'} sentences (max ${unknownSection ? 60 : 35} words): what this means for real people in these communities, in plain everyday language.${completenessClause}`
 
   return `You are a public health analyst reviewing a report about "${topic}" in ${location}, broken down by ${demographicLabel}. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
 
@@ -338,7 +344,9 @@ ${dataBlock}
 WRITING RULES, follow these strictly:
 - Use only numbers that appear in the data above. Never estimate, infer, round differently, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
 - Do not add causal explanations or place-specific facts that are not in the data.
-- A rate of 0 means the source reported no rate for that place or period. Never describe it as a place or time with no cases, no deaths, or no burden.
+- A rate of 0 means the source reported no rate for that place or period. Never cite a 0 as a rate, and never describe it as a place or time with no cases, no deaths, or no burden.
+- Call a figure a peak, a high point, or a low point only where the data above labels it as one. A first or latest reported value is neither.
+- Write every demographic group name exactly as it appears in the data above. Never expand, abbreviate, or reword it; the names shown are the ones used throughout the rest of the report.
 - Write at an 8th-grade reading level. Use short words and simple sentences.
 - Avoid jargon. If you must use a technical term, explain it immediately.
 - Do not repeat the same number in more than one section.
@@ -349,7 +357,7 @@ Respond ONLY with a valid JSON object, no markdown, no backticks, no explanation
   "keyFindings": "${keyFindingsSpec}",
   "locationComparison": "${locationSpec}",
   "demographicInsights": "${demographicSpec}",
-${optionalSpecBlock}  "whatThisMeans": "1-2 sentences (max 35 words): what this means for real people in these communities, in plain everyday language."
+  "whatThisMeans": "${whatThisMeansSpec}"
 }`
 }
 
@@ -358,22 +366,13 @@ function parseSections(raw: string): ReportInsightSections | null {
     const clean = raw.replace(/```json|```/g, '').trim()
     const parsed = JSON.parse(clean)
 
-    for (const key of REQUIRED_SECTION_KEYS) {
+    for (const key of SECTION_KEYS) {
       if (typeof parsed[key] !== 'string') return null
     }
 
-    const sections = Object.fromEntries(
-      REQUIRED_SECTION_KEYS.map((key) => [key, parsed[key]]),
+    return Object.fromEntries(
+      SECTION_KEYS.map((key) => [key, parsed[key]]),
     ) as ReportInsightSections
-
-    // Optional sections are dropped rather than rejected when the model omits
-    // one, so a single missing key never costs the user the whole summary.
-    for (const key of OPTIONAL_SECTION_KEYS) {
-      if (typeof parsed[key] === 'string' && parsed[key].trim())
-        sections[key] = parsed[key]
-    }
-
-    return sections
   } catch (error) {
     console.error('Failed to parse report insight JSON:', error)
     return null

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -71,6 +71,12 @@ type ReportInsightResult = {
 // counties still produces a bounded prompt.
 const SPREAD_SAMPLE_SIZE = 3
 
+// Word budgets for the two sections that absorb optional clauses. The base
+// covers the section's own finding; each clause folded in buys roughly one more
+// sentence, so a section never has to say more in the same breath.
+const SECTION_WORD_BUDGET = 35
+const CLAUSE_WORD_BUDGET = 20
+
 // Rates for every demographic group in the selected place, overall row first so
 // the model has a baseline to measure each group against. Sorted rather than
 // left in row order so the same data always renders the same text, which the
@@ -264,6 +270,14 @@ export function formatUnknownShare(
     .join('\n')
 }
 
+type ReportDataSections = {
+  demographicSection: string
+  geographicSection: string
+  temporalSection: string
+  ageAdjustedSection: string
+  unknownSection: string
+}
+
 function buildReportInsightPrompt(
   topic: string,
   location: string,
@@ -302,10 +316,17 @@ function buildReportInsightPrompt(
   // head; "twice as likely" lands immediately. Comparisons stay grounded because
   // the age-adjusted block already supplies ratios, so the model is describing a
   // figure it was given rather than deriving one.
+  // Inviting a comparison without supplying a ratio is how "ten times higher
+  // than average" gets computed from two rates and presented as a finding, so
+  // the headline may only cite a ratio when one was actually sent.
+  const ratioClause = ageAdjustedSection
+    ? ' You may cite one of the ratios shown above, but do not work out any other figure.'
+    : ' State no figure at all; make the comparison in words only.'
+
+  // Single quotes inside: this string is interpolated into the JSON skeleton
+  // below, so a double quote here would show the model a malformed template.
   const keyFindingsSpec = demographicSection
-    ? // Single quotes inside: this string is interpolated into the JSON skeleton
-      // below, so a double quote here would show the model a malformed template.
-      "1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k, and use a figure only if it is a ratio shown above."
+    ? `1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k.${ratioClause}`
     : '1 sentence (max 25 words): the most important equity question this report helps answer. Do not state any rate or number.'
 
   const locationSpec = geographicSection
@@ -324,7 +345,9 @@ function buildReportInsightPrompt(
     : ''
 
   const demographicWordBudget =
-    35 + (ageAdjustedSection ? 20 : 0) + (temporalSection ? 20 : 0)
+    SECTION_WORD_BUDGET +
+    (ageAdjustedSection ? CLAUSE_WORD_BUDGET : 0) +
+    (temporalSection ? CLAUSE_WORD_BUDGET : 0)
 
   const demographicSpec = demographicSection
     ? `2-3 sentences (max ${demographicWordBudget} words): which group is most affected and how large the gap is compared to others, using the rates above.${ageAdjustedClause}${temporalClause}`
@@ -337,18 +360,23 @@ function buildReportInsightPrompt(
     ? ` Then note in one sentence what share of cases is missing ${demographicLabel} data, and that the rates above describe only the cases where it was recorded.`
     : ''
 
-  const whatThisMeansSpec = `${unknownSection ? '2-3' : '1-2'} sentences (max ${unknownSection ? 60 : 35} words): what this means for real people in these communities, in plain everyday language.${completenessClause}`
+  const whatThisMeansWordBudget =
+    SECTION_WORD_BUDGET + (unknownSection ? CLAUSE_WORD_BUDGET : 0)
+
+  const whatThisMeansSpec = `${unknownSection ? '2-3' : '1-2'} sentences (max ${whatThisMeansWordBudget} words): what this means for real people in these communities, in plain everyday language.${completenessClause}`
 
   return `You are a public health analyst reviewing a report about "${topic}" in ${location}, broken down by ${demographicLabel}. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
 
 The page contains multiple charts: a rate map, rates over time, a rate bar chart, an unknowns map, inequities over time, and a population vs distribution chart.
 ${dataBlock}
 WRITING RULES, follow these strictly:
-- Use only numbers that appear in the data above. Never estimate, infer, round differently, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
+- Use only numbers that appear in the data above. Never estimate, infer, round differently, derive a new figure by combining two that are shown, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
 - Do not add causal explanations or place-specific facts that are not in the data.
 - A rate of 0 means the source reported no rate for that place or period. Never cite a 0 as a rate, and never describe it as a place or time with no cases, no deaths, or no burden.
 - Call a figure a peak, a high point, or a low point only where the data above labels it as one. A first or latest reported value is neither.
 - Write every demographic group name exactly as it appears in the data above. Never expand, abbreviate, or reword it; the names shown are the ones used throughout the rest of the report.
+- Never label a group vulnerable, at-risk, high-risk, underserved, or a minority. Those words describe people by a deficit rather than by what they face. Name the group and name the burden instead.
+- Use person-first wording: "people with diabetes", not "diabetics"; "people experiencing homelessness", not "the homeless".
 - Write at an 8th-grade reading level. Use short words and simple sentences.
 - Avoid jargon. If you must use a technical term, explain it immediately.
 - Do not repeat the same number in more than one section.
@@ -379,22 +407,6 @@ function parseSections(raw: string): ReportInsightSections | null {
     console.error('Failed to parse report insight JSON:', error)
     return null
   }
-}
-
-type ReportDataSections = {
-  demographicSection: string
-  geographicSection: string
-  temporalSection: string
-  ageAdjustedSection: string
-  unknownSection: string
-}
-
-const EMPTY_SECTIONS: ReportDataSections = {
-  demographicSection: '',
-  geographicSection: '',
-  temporalSection: '',
-  ageAdjustedSection: '',
-  unknownSection: '',
 }
 
 // A county has no child places, so Breakdowns.forChildrenFips would return the
@@ -444,7 +456,14 @@ async function loadReportData(
     'rate-map',
     dataTypeConfig.metrics,
   )
-  if (!metricConfig) return EMPTY_SECTIONS
+  if (!metricConfig)
+    return {
+      demographicSection: '',
+      geographicSection: '',
+      temporalSection: '',
+      ageAdjustedSection: '',
+      unknownSection: '',
+    }
 
   const breakdownFilter =
     demographicType === RACE
@@ -470,9 +489,14 @@ async function loadReportData(
     dataTypeConfig.metrics?.pct_share_unknown ??
     dataTypeConfig.metrics?.pct_share
 
-  // Age adjustment is published against a White (NH) baseline, so it is a race
-  // breakdown regardless of which demographic the report is set to.
-  const ageAdjustedConfig = dataTypeConfig.metrics?.age_adjusted_ratio
+  // Age adjustment is published only against a White (NH) baseline, so the
+  // ratios describe a race gap and nothing else. On a report broken down by age
+  // or sex they would qualify a gap the reader is not looking at, so they are
+  // left out entirely rather than sent alongside a mismatched breakdown.
+  const ageAdjustedConfig =
+    demographicType === RACE
+      ? dataTypeConfig.metrics?.age_adjusted_ratio
+      : undefined
 
   const [
     placeResponse,
@@ -509,6 +533,8 @@ async function loadReportData(
       ? getDataManager().loadMetrics(
           new MetricQuery(
             [unknownConfig.metricId],
+            // No exclude filter here, unlike the rate queries above: the unknown
+            // groups are the entire point of this one.
             Breakdowns.forFips(fips).addBreakdown(demographicType),
             dataTypeConfig.dataTypeId,
           ),

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -147,16 +147,20 @@ export function formatGeographicSpread(
 
   return [
     `- Highest: ${places.slice(0, SPREAD_SAMPLE_SIZE).map(render).join(', ')} ${unit}`,
-    `- Lowest: ${places.slice(-SPREAD_SAMPLE_SIZE).reverse().map(render).join(', ')} ${unit}`,
+    `- Lowest reported: ${places.slice(-SPREAD_SAMPLE_SIZE).reverse().map(render).join(', ')} ${unit}`,
     `- Median across ${places.length} ${placeNoun}: ${Math.round(median * 10) / 10} ${unit}`,
   ].join('\n')
 }
 
-// Each group's first and last reported rate, which is what the rates-over-time
-// chart is for. Endpoints rather than the full series: two points per group let
-// the model say both whether overall rates moved and whether the gap between
-// groups widened or narrowed, which is the same thing the inequities-over-time
-// chart plots, at a fraction of the prompt size.
+// Each group's first, highest, and latest reported rate, which is what the
+// rates-over-time chart is for. Three points per group rather than the full
+// series let the model say both whether overall rates moved and whether the gap
+// between groups widened or narrowed, which is the same thing the
+// inequities-over-time chart plots, at a fraction of the prompt size.
+//
+// The peak is not decoration. On a monthly series like COVID-19 the first and
+// last months both sit at zero, so endpoints alone would describe a condition
+// that never happened.
 export function formatTemporalChange(
   rows: HetRow[],
   demographicType: DemographicType,
@@ -178,9 +182,16 @@ export function formatTemporalChange(
       const sorted = [...groupRows].sort((a, b) =>
         String(a.time_period).localeCompare(String(b.time_period)),
       )
+      const peak = sorted.reduce((highest, row) =>
+        (row[metricConfig.metricId] as number) >
+        (highest[metricConfig.metricId] as number)
+          ? row
+          : highest,
+      )
       return {
         group,
         first: sorted[0],
+        peak,
         last: sorted[sorted.length - 1],
       }
     })
@@ -197,10 +208,18 @@ export function formatTemporalChange(
     })
 
   return spans
-    .map(
-      ({ group, first, last }) =>
-        `- ${group}: ${first[metricConfig.metricId]} in ${first.time_period}, ${last[metricConfig.metricId]} in ${last.time_period} ${metricConfig.shortLabel}`,
-    )
+    .map(({ group, first, peak, last }) => {
+      const points = [
+        `${first[metricConfig.metricId]} in ${first.time_period}`,
+        // A peak at either endpoint is already named, so repeating it would
+        // just invite the model to treat one number as two findings.
+        peak.time_period !== first.time_period &&
+          peak.time_period !== last.time_period &&
+          `peaking at ${peak[metricConfig.metricId]} in ${peak.time_period}`,
+        `${last[metricConfig.metricId]} in ${last.time_period}`,
+      ].filter(Boolean)
+      return `- ${group}: ${points.join(', ')} ${metricConfig.shortLabel}`
+    })
     .join('\n')
 }
 
@@ -245,7 +264,9 @@ export function formatUnknownShare(
     .filter((row) => Number.isFinite(row[metricConfig.metricId]))
     .map(
       (row) =>
-        `- ${row[demographicType]}: ${row[metricConfig.metricId]}${metricConfig.shortLabel} of cases`,
+        // shortLabel already carries the unit and the topic, e.g.
+        // "% of COVID-19 deaths", so nothing is appended to it here.
+        `- ${row[demographicType]}: ${row[metricConfig.metricId]}${metricConfig.shortLabel}`,
     )
     .join('\n')
 }
@@ -269,7 +290,7 @@ function buildReportInsightPrompt(
       `Current rates by ${demographicLabel} in ${location}:\n${demographicSection}`,
     geographicSection && `Geographic spread:\n${geographicSection}`,
     temporalSection &&
-      `Rates over time by ${demographicLabel} in ${location}, first and latest reported periods:\n${temporalSection}`,
+      `Rates over time by ${demographicLabel} in ${location}, first, highest, and latest reported periods:\n${temporalSection}`,
     ageAdjustedSection &&
       `Age-adjusted burden relative to the White (NH) baseline in ${location}:\n${ageAdjustedSection}`,
     unknownSection &&
@@ -301,7 +322,7 @@ function buildReportInsightPrompt(
 
   const optionalSpecs = [
     temporalSection &&
-      `  "changeOverTime": "1-2 sentences (max 35 words): whether overall rates rose or fell between the first and latest periods, and whether the gap between groups widened or narrowed.",`,
+      `  "changeOverTime": "1-2 sentences (max 35 words): how rates moved across the reported periods, naming the highest point when one is given, and whether the gap between groups widened or narrowed.",`,
     unknownSection &&
       `  "dataCompleteness": "1 sentence (max 30 words): what share of cases is missing ${demographicLabel} data, and that the rates above describe only the cases where it was recorded.",`,
   ].filter(Boolean)
@@ -317,6 +338,7 @@ ${dataBlock}
 WRITING RULES, follow these strictly:
 - Use only numbers that appear in the data above. Never estimate, infer, round differently, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
 - Do not add causal explanations or place-specific facts that are not in the data.
+- A rate of 0 means the source reported no rate for that place or period. Never describe it as a place or time with no cases, no deaths, or no burden.
 - Write at an 8th-grade reading level. Use short words and simple sentences.
 - Avoid jargon. If you must use a technical term, explain it immediately.
 - Do not repeat the same number in more than one section.

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -1,18 +1,68 @@
-import type { DataTypeConfig } from '../data/config/MetricConfigTypes'
+import type {
+  DataTypeConfig,
+  MetricConfig,
+} from '../data/config/MetricConfigTypes'
+import { exclude } from '../data/query/BreakdownFilter'
 import {
+  Breakdowns,
   DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE,
   type DemographicType,
 } from '../data/query/Breakdowns'
+import {
+  MetricQuery,
+  type MetricQueryResponse,
+} from '../data/query/MetricQuery'
+import {
+  ALL,
+  MULTI_OR_OTHER_STANDARD_NH,
+  NON_HISPANIC,
+  RACE,
+  UNKNOWN,
+  UNKNOWN_ETHNICITY,
+  UNKNOWN_RACE,
+  WHITE_NH,
+} from '../data/utils/Constants'
+import type { HetRow } from '../data/utils/DatasetTypes'
+import {
+  groupIsAll,
+  splitIntoKnownsAndUnknowns,
+} from '../data/utils/datasetutils'
 import type { Fips } from '../data/utils/Fips'
 import { ERROR_GENERATING_INSIGHT, fetchAIInsight } from './fetchAIInsight'
+import {
+  formatPeerComparison,
+  getPeerValues,
+  getPrimaryMetricConfig,
+  getRegionAllRate,
+  summarizePeerComparison,
+} from './generateVisualizationInsight'
+import { getDataManager } from './globals'
 import { buildInsightCacheKey } from './insightCacheKey'
 
+// The four base sections are always present. The other two are only requested
+// when the report actually has the data behind them (a historical series, a
+// reported unknown share), so a topic with only a current-year snapshot renders
+// four sections rather than two empty ones.
 export type ReportInsightSections = {
   keyFindings: string
   locationComparison: string
   demographicInsights: string
+  changeOverTime?: string
+  dataCompleteness?: string
   whatThisMeans: string
 }
+
+const REQUIRED_SECTION_KEYS = [
+  'keyFindings',
+  'locationComparison',
+  'demographicInsights',
+  'whatThisMeans',
+] as const satisfies readonly (keyof ReportInsightSections)[]
+
+const OPTIONAL_SECTION_KEYS = [
+  'changeOverTime',
+  'dataCompleteness',
+] as const satisfies readonly (keyof ReportInsightSections)[]
 
 type ReportInsightResult = {
   sections: ReportInsightSections | null
@@ -23,28 +73,261 @@ type ReportInsightResult = {
   cacheKey?: string
 }
 
+// How many places to name at each end of the geographic spread. Enough to show
+// a pattern rather than a lone outlier, few enough that a state with hundreds of
+// counties still produces a bounded prompt.
+const SPREAD_SAMPLE_SIZE = 3
+
+// Rates for every demographic group in the selected place, overall row first so
+// the model has a baseline to measure each group against. Sorted rather than
+// left in row order so the same data always renders the same text, which the
+// prompt-hash cache key depends on.
+export function formatDemographicRates(
+  rows: HetRow[],
+  demographicType: DemographicType,
+  metricConfig: MetricConfig,
+): string {
+  return rows
+    .filter(
+      (row) =>
+        row[demographicType] != null &&
+        Number.isFinite(row[metricConfig.metricId]),
+    )
+    .map((row) => ({
+      group: String(row[demographicType]),
+      value: row[metricConfig.metricId] as number,
+    }))
+    .sort((a, b) => {
+      if (groupIsAll(a.group) !== groupIsAll(b.group))
+        return groupIsAll(a.group) ? -1 : 1
+      return b.value - a.value
+    })
+    .map(
+      ({ group, value }) => `- ${group}: ${value} ${metricConfig.shortLabel}`,
+    )
+    .join('\n')
+}
+
+// The spread of overall rates across the child places shown on the report's map,
+// reduced to both extremes plus a median. Sending every county would dominate
+// the prompt without telling the model more than its shape does.
+export function formatGeographicSpread(
+  rows: HetRow[],
+  metricConfig: MetricConfig,
+  placeNoun: string,
+): string {
+  const places = rows
+    .filter(
+      (row) =>
+        row.fips_name != null && Number.isFinite(row[metricConfig.metricId]),
+    )
+    .map((row) => ({
+      name: String(row.fips_name),
+      value: row[metricConfig.metricId] as number,
+    }))
+    .sort((a, b) => b.value - a.value)
+
+  // One place is not a geographic comparison, so say nothing rather than
+  // present a lone value as if it were a spread.
+  if (places.length < 2) return ''
+
+  const unit = metricConfig.shortLabel
+  const render = (place: { name: string; value: number }) =>
+    `${place.name} ${place.value}`
+
+  // Naming every place beats a top/bottom split that would repeat most of them.
+  if (places.length <= SPREAD_SAMPLE_SIZE * 2) {
+    return `- All ${places.length} ${placeNoun}: ${places.map(render).join(', ')} ${unit}`
+  }
+
+  const values = places.map((place) => place.value)
+  const mid = Math.floor(values.length / 2)
+  const median =
+    values.length % 2 === 0 ? (values[mid - 1] + values[mid]) / 2 : values[mid]
+
+  return [
+    `- Highest: ${places.slice(0, SPREAD_SAMPLE_SIZE).map(render).join(', ')} ${unit}`,
+    `- Lowest: ${places.slice(-SPREAD_SAMPLE_SIZE).reverse().map(render).join(', ')} ${unit}`,
+    `- Median across ${places.length} ${placeNoun}: ${Math.round(median * 10) / 10} ${unit}`,
+  ].join('\n')
+}
+
+// Each group's first and last reported rate, which is what the rates-over-time
+// chart is for. Endpoints rather than the full series: two points per group let
+// the model say both whether overall rates moved and whether the gap between
+// groups widened or narrowed, which is the same thing the inequities-over-time
+// chart plots, at a fraction of the prompt size.
+export function formatTemporalChange(
+  rows: HetRow[],
+  demographicType: DemographicType,
+  metricConfig: MetricConfig,
+): string {
+  const byGroup = new Map<string, HetRow[]>()
+  for (const row of rows) {
+    const group = row[demographicType]
+    if (group == null) continue
+    if (!Number.isFinite(row[metricConfig.metricId])) continue
+    if (row.time_period == null) continue
+    const existing = byGroup.get(String(group))
+    if (existing) existing.push(row)
+    else byGroup.set(String(group), [row])
+  }
+
+  const spans = [...byGroup.entries()]
+    .map(([group, groupRows]) => {
+      const sorted = [...groupRows].sort((a, b) =>
+        String(a.time_period).localeCompare(String(b.time_period)),
+      )
+      return {
+        group,
+        first: sorted[0],
+        last: sorted[sorted.length - 1],
+      }
+    })
+    // A single time point is a rate, not a change, so it belongs in the
+    // demographic section rather than being restated here as a trend.
+    .filter(({ first, last }) => first.time_period !== last.time_period)
+    .sort((a, b) => {
+      if (groupIsAll(a.group) !== groupIsAll(b.group))
+        return groupIsAll(a.group) ? -1 : 1
+      return (
+        (b.last[metricConfig.metricId] as number) -
+        (a.last[metricConfig.metricId] as number)
+      )
+    })
+
+  return spans
+    .map(
+      ({ group, first, last }) =>
+        `- ${group}: ${first[metricConfig.metricId]} in ${first.time_period}, ${last[metricConfig.metricId]} in ${last.time_period} ${metricConfig.shortLabel}`,
+    )
+    .join('\n')
+}
+
+// Each group's age-adjusted burden relative to the White (non-Hispanic) baseline.
+// Only meaningful for conditions that skew heavily by age: without adjustment, a
+// group with an older age profile looks worse on the raw rate for reasons that
+// are demographic rather than inequitable, so this is the section that keeps the
+// insight from over-reading the crude rates above.
+export function formatAgeAdjustedRatios(
+  rows: HetRow[],
+  demographicType: DemographicType,
+  metricConfig: MetricConfig,
+): string {
+  return rows
+    .filter(
+      (row) =>
+        row[demographicType] != null &&
+        Number.isFinite(row[metricConfig.metricId]),
+    )
+    .map((row) => ({
+      group: String(row[demographicType]),
+      value: row[metricConfig.metricId] as number,
+    }))
+    .sort((a, b) => b.value - a.value)
+    .map(({ group, value }) => `- ${group}: ${value}x the White (NH) rate`)
+    .join('\n')
+}
+
+// The share of cases whose demographic was never recorded, which the report's
+// unknowns map shows. A high unknown share is itself an equity finding: it means
+// the disparities in every other chart are measured on incomplete data, so the
+// model needs the number to say so rather than treat the rates as the whole
+// picture. When race and ethnicity are reported separately a place can have two
+// unknown rows, so all of them are named.
+export function formatUnknownShare(
+  rows: HetRow[],
+  demographicType: DemographicType,
+  metricConfig: MetricConfig,
+): string {
+  const [, unknowns] = splitIntoKnownsAndUnknowns(rows, demographicType)
+  return unknowns
+    .filter((row) => Number.isFinite(row[metricConfig.metricId]))
+    .map(
+      (row) =>
+        `- ${row[demographicType]}: ${row[metricConfig.metricId]}${metricConfig.shortLabel} of cases`,
+    )
+    .join('\n')
+}
+
 function buildReportInsightPrompt(
   topic: string,
   location: string,
   demographicLabel: string,
+  data: ReportDataSections,
 ): string {
+  const {
+    demographicSection,
+    geographicSection,
+    temporalSection,
+    ageAdjustedSection,
+    unknownSection,
+  } = data
+
+  const dataBlocks = [
+    demographicSection &&
+      `Current rates by ${demographicLabel} in ${location}:\n${demographicSection}`,
+    geographicSection && `Geographic spread:\n${geographicSection}`,
+    temporalSection &&
+      `Rates over time by ${demographicLabel} in ${location}, first and latest reported periods:\n${temporalSection}`,
+    ageAdjustedSection &&
+      `Age-adjusted burden relative to the White (NH) baseline in ${location}:\n${ageAdjustedSection}`,
+    unknownSection &&
+      `Cases missing ${demographicLabel} data in ${location}:\n${unknownSection}`,
+  ].filter(Boolean)
+
+  const dataBlock = dataBlocks.length ? `\n\n${dataBlocks.join('\n\n')}\n` : ''
+
+  // Every spec below has a no-data variant. Without it the model is told to lead
+  // with a number it was never given, which is exactly how a fabricated rate
+  // gets into a summary.
+  const keyFindingsSpec = demographicSection
+    ? '1 sentence (max 25 words): the single most striking disparity, leading with a specific number or rate from the data above.'
+    : '1 sentence (max 25 words): the most important equity question this report helps answer. Do not state any rate or number.'
+
+  const locationSpec = geographicSection
+    ? '1-2 sentences (max 35 words): what the geographic spread shows about where the burden is heaviest.'
+    : '1-2 sentences (max 35 words): what to look for when comparing places on this map. Do not state any rate or number.'
+
+  // Age adjustment is folded in here rather than given its own section: it is a
+  // correction to how the demographic gap should be read, not a separate finding.
+  const ageAdjustedClause = ageAdjustedSection
+    ? ' Then use the age-adjusted ratios to say whether the gap holds once differences in age between groups are accounted for.'
+    : ''
+
+  const demographicSpec = demographicSection
+    ? `1-2 sentences (max ${ageAdjustedSection ? 55 : 35} words): which group is most affected and how large the gap is compared to others, using the rates above.${ageAdjustedClause}`
+    : '1-2 sentences (max 35 words): what to look for when comparing groups. Do not state any rate or number.'
+
+  const optionalSpecs = [
+    temporalSection &&
+      `  "changeOverTime": "1-2 sentences (max 35 words): whether overall rates rose or fell between the first and latest periods, and whether the gap between groups widened or narrowed.",`,
+    unknownSection &&
+      `  "dataCompleteness": "1 sentence (max 30 words): what share of cases is missing ${demographicLabel} data, and that the rates above describe only the cases where it was recorded.",`,
+  ].filter(Boolean)
+
+  const optionalSpecBlock = optionalSpecs.length
+    ? `${optionalSpecs.join('\n')}\n`
+    : ''
+
   return `You are a public health analyst reviewing a report about "${topic}" in ${location}, broken down by ${demographicLabel}. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
 
 The page contains multiple charts: a rate map, rates over time, a rate bar chart, an unknowns map, inequities over time, and a population vs distribution chart.
-
-WRITING RULES — follow these strictly:
+${dataBlock}
+WRITING RULES, follow these strictly:
+- Use only numbers that appear in the data above. Never estimate, infer, round differently, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
+- Do not add causal explanations or place-specific facts that are not in the data.
 - Write at an 8th-grade reading level. Use short words and simple sentences.
 - Avoid jargon. If you must use a technical term, explain it immediately.
-- Each section: 1-2 sentences maximum, 35 words or fewer.
-- keyFindings: 1 sentence, 25 words or fewer. Lead with the single most striking disparity or equity gap.
+- Do not repeat the same number in more than one section.
 
-Respond ONLY with a valid JSON object — no markdown, no backticks, no explanation outside the JSON. Use this exact structure:
+Respond ONLY with a valid JSON object, no markdown, no backticks, no explanation outside the JSON. Include every key below and no others. Use this exact structure:
 
 {
-  "keyFindings": "1 sentence (max 25 words): the single most striking disparity, leading with a specific number or rate.",
-  "locationComparison": "1-2 sentences (max 35 words): which places have the biggest gaps and why that might be.",
-  "demographicInsights": "1-2 sentences (max 35 words): which group is most affected and how large the gap is compared to others.",
-  "whatThisMeans": "1-2 sentences (max 35 words): what this means for real people in these communities, in plain everyday language."
+  "keyFindings": "${keyFindingsSpec}",
+  "locationComparison": "${locationSpec}",
+  "demographicInsights": "${demographicSpec}",
+${optionalSpecBlock}  "whatThisMeans": "1-2 sentences (max 35 words): what this means for real people in these communities, in plain everyday language."
 }`
 }
 
@@ -53,21 +336,214 @@ function parseSections(raw: string): ReportInsightSections | null {
     const clean = raw.replace(/```json|```/g, '').trim()
     const parsed = JSON.parse(clean)
 
-    const required: (keyof ReportInsightSections)[] = [
-      'keyFindings',
-      'locationComparison',
-      'demographicInsights',
-      'whatThisMeans',
-    ]
-
-    for (const key of required) {
+    for (const key of REQUIRED_SECTION_KEYS) {
       if (typeof parsed[key] !== 'string') return null
     }
 
-    return parsed as ReportInsightSections
+    const sections = Object.fromEntries(
+      REQUIRED_SECTION_KEYS.map((key) => [key, parsed[key]]),
+    ) as ReportInsightSections
+
+    // Optional sections are dropped rather than rejected when the model omits
+    // one, so a single missing key never costs the user the whole summary.
+    for (const key of OPTIONAL_SECTION_KEYS) {
+      if (typeof parsed[key] === 'string' && parsed[key].trim())
+        sections[key] = parsed[key]
+    }
+
+    return sections
   } catch (error) {
     console.error('Failed to parse report insight JSON:', error)
     return null
+  }
+}
+
+type ReportDataSections = {
+  demographicSection: string
+  geographicSection: string
+  temporalSection: string
+  ageAdjustedSection: string
+  unknownSection: string
+}
+
+const EMPTY_SECTIONS: ReportDataSections = {
+  demographicSection: '',
+  geographicSection: '',
+  temporalSection: '',
+  ageAdjustedSection: '',
+  unknownSection: '',
+}
+
+// A county has no child places, so Breakdowns.forChildrenFips would return the
+// county itself. Rank it against its same-level peers instead, the same
+// apples-to-apples comparison the map card's single-region insight makes.
+function formatCountyPeerRanking(
+  placeResponse: MetricQueryResponse,
+  peerResponse: MetricQueryResponse,
+  metricConfig: MetricConfig,
+  demographicType: DemographicType,
+  fips: Fips,
+  parentFips: Fips,
+): string {
+  const regionRate = getRegionAllRate(
+    placeResponse,
+    metricConfig,
+    demographicType,
+    fips.getDisplayName(),
+  )
+  if (!regionRate) return ''
+
+  const summary = summarizePeerComparison({
+    regionLabel: regionRate.label,
+    regionValue: regionRate.value,
+    peerNoun: `${parentFips.getDisplayName()} ${parentFips.getPluralChildFipsTypeDisplayName()}`,
+    peerValues: getPeerValues(
+      peerResponse,
+      metricConfig,
+      demographicType,
+      fips.code,
+    ),
+    shortLabel: metricConfig.shortLabel,
+  })
+
+  return summary ? formatPeerComparison(summary) : ''
+}
+
+// The rates the report's own cards already display, re-read through DataManager
+// so the insight describes the same numbers the user sees. Every query here is
+// one a card on the page has already issued, so this is usually cache-only.
+async function loadReportData(
+  dataTypeConfig: DataTypeConfig,
+  demographicType: DemographicType,
+  fips: Fips,
+): Promise<ReportDataSections> {
+  const metricConfig = getPrimaryMetricConfig(
+    'rate-map',
+    dataTypeConfig.metrics,
+  )
+  if (!metricConfig) return EMPTY_SECTIONS
+
+  const breakdownFilter =
+    demographicType === RACE
+      ? exclude(NON_HISPANIC, UNKNOWN, UNKNOWN_RACE, UNKNOWN_ETHNICITY)
+      : exclude(UNKNOWN)
+
+  const query = (breakdowns: Breakdowns) =>
+    new MetricQuery(
+      [metricConfig.metricId],
+      breakdowns.addBreakdown(demographicType, breakdownFilter),
+      dataTypeConfig.dataTypeId,
+    )
+
+  // A county has no child places, so Breakdowns.forChildrenFips would return the
+  // county itself. Rank it against its same-level peers instead, the same
+  // apples-to-apples comparison the map card's single-region insight makes.
+  const isCounty = fips.isCounty()
+  const parentFips = fips.getParentFips()
+
+  // Mirrors UnknownsMapCard: the unknown share lives on its own metric, and its
+  // query must NOT exclude the unknown groups the way the rate queries do.
+  const unknownConfig =
+    dataTypeConfig.metrics?.pct_share_unknown ??
+    dataTypeConfig.metrics?.pct_share
+
+  // Age adjustment is published against a White (NH) baseline, so it is a race
+  // breakdown regardless of which demographic the report is set to.
+  const ageAdjustedConfig = dataTypeConfig.metrics?.age_adjusted_ratio
+
+  const [
+    placeResponse,
+    geoResponse,
+    temporalResponse,
+    ageAdjustedResponse,
+    unknownResponse,
+  ] = await Promise.all([
+    getDataManager().loadMetrics(query(Breakdowns.forFips(fips))),
+    getDataManager().loadMetrics(
+      query(Breakdowns.forChildrenFips(isCounty ? parentFips : fips)),
+    ),
+    getDataManager().loadMetrics(
+      new MetricQuery(
+        [metricConfig.metricId],
+        Breakdowns.forFips(fips).addBreakdown(demographicType, breakdownFilter),
+        dataTypeConfig.dataTypeId,
+        'historical',
+      ),
+    ),
+    ageAdjustedConfig
+      ? getDataManager().loadMetrics(
+          new MetricQuery(
+            [ageAdjustedConfig.metricId],
+            Breakdowns.forFips(fips).addBreakdown(
+              RACE,
+              exclude(ALL, NON_HISPANIC, WHITE_NH, MULTI_OR_OTHER_STANDARD_NH),
+            ),
+            dataTypeConfig.dataTypeId,
+          ),
+        )
+      : undefined,
+    unknownConfig
+      ? getDataManager().loadMetrics(
+          new MetricQuery(
+            [unknownConfig.metricId],
+            Breakdowns.forFips(fips).addBreakdown(demographicType),
+            dataTypeConfig.dataTypeId,
+          ),
+        )
+      : undefined,
+  ])
+
+  const demographicSection = formatDemographicRates(
+    placeResponse.getValidRowsForField(metricConfig.metricId),
+    demographicType,
+    metricConfig,
+  )
+
+  const temporalSection = formatTemporalChange(
+    temporalResponse.getValidRowsForField(metricConfig.metricId),
+    demographicType,
+    metricConfig,
+  )
+
+  const ageAdjustedSection =
+    ageAdjustedConfig && ageAdjustedResponse
+      ? formatAgeAdjustedRatios(
+          ageAdjustedResponse.getValidRowsForField(ageAdjustedConfig.metricId),
+          RACE,
+          ageAdjustedConfig,
+        )
+      : ''
+
+  const unknownSection =
+    unknownConfig && unknownResponse
+      ? formatUnknownShare(
+          unknownResponse.getValidRowsForField(unknownConfig.metricId),
+          demographicType,
+          unknownConfig,
+        )
+      : ''
+
+  return {
+    demographicSection,
+    geographicSection: isCounty
+      ? formatCountyPeerRanking(
+          placeResponse,
+          geoResponse,
+          metricConfig,
+          demographicType,
+          fips,
+          parentFips,
+        )
+      : formatGeographicSpread(
+          geoResponse
+            .getValidRowsForField(metricConfig.metricId)
+            .filter((row) => groupIsAll(String(row[demographicType]))),
+          metricConfig,
+          fips.getPluralChildFipsTypeDisplayName(),
+        ),
+    temporalSection,
+    ageAdjustedSection,
+    unknownSection,
   }
 }
 
@@ -79,10 +555,12 @@ export async function generateReportInsight(
   try {
     const topic = dataTypeConfig.fullDisplayName
     const location = fips.getSentenceDisplayName()
+    const data = await loadReportData(dataTypeConfig, demographicType, fips)
     const prompt = buildReportInsightPrompt(
       topic,
       location,
       DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType],
+      data,
     )
     const cacheKey = buildInsightCacheKey('', prompt)
     const result = await fetchAIInsight(prompt, {


### PR DESCRIPTION
**Preview:** [COVID-19 deaths insight example](https://deploy-preview-5055--health-equity-tracker.netlify.app/exploredata?mls=1.covid-3.00&mlp=disparity&dt1=covid_deaths&demo=race_and_ethnicity&report-insight=true)

## Summary

The report-wide insight prompt asked the model to lead with "a specific number or rate" while sending it no data at all, so every figure in the summary was invented. This sends the numbers the report's own cards already display.

Closes #5047

No UI change. The card keeps its four sections and its existing icons; only the prompt and the parser changed.

## What the prompt now carries

Five data sections, each read through `DataManager` against queries the page has already issued, so this is usually cache-only:

- current rates by demographic group in the selected place
- geographic spread across child places, or, for a county, a same-level peer ranking reusing the map card's helpers
- first, peak, and latest reported rate per group
- age-adjusted ratios against the White (NH) baseline, when published
- share of cases missing demographic data

Every prompt spec has a no-data variant, so a topic without a given section is never told to lead with a number it was not given.

## Where the new data lands

Trend and completeness are qualifiers on findings the card already makes, not findings of their own, so they fold into the existing sections rather than each getting a section and an icon:

- **Demographic Insights** picks up whether the gap holds once age is accounted for, and whether it widened or narrowed over time. Both describe the same gap the section already reports.
- **What This Means** picks up the share of cases missing demographic data. The groups absent from the record are usually the ones already least well served, so it belongs with what the report means rather than in a footnote.

Each clause is appended only when its data exists, and the section's word budget grows with it.

**Key Findings is now plain language.** It is the one line a reader who skips every chart will actually read, so a per-100k rate is the wrong thing to lead with; a rate means little without the denominator in your head, while "nearly twice as likely" lands immediately. It asks for a comparison in words, grounded in the age-adjusted ratios the prompt already sends, so the model describes a figure it was given rather than deriving one.

## Defects caught by checking live reports

Verifying against the real COVID-19 deaths and HIV deaths reports surfaced problems that unit tests alone would not have:

- **Endpoints are the wrong pair for a monthly series.** COVID-19 deaths opens at 0 in 2020-01 and closes at 0 in 2024-05, so every group read "0 ... 0" and the model was being asked to describe a condition that never happened. Each series now also names its peak, which is where the equity signal lives: Indigenous (NH) peaked at 53 per 100k against 26 for White (NH). The peak is dropped when it coincides with an endpoint, so annual series like HIV stay two points wide.
- **Duplicated unit text.** The unknowns block appended `" of cases"` to `shortLabel`, which already carries both unit and topic, producing "14.9% of COVID-19 deaths of cases". The unit test used a fabricated `shortLabel` of `'%'` and so matched the bug rather than catching it; it now uses the real value.
- **Zeros that mean "not reported".** Hawaii and West Virginia both report 0 cumulative COVID-19 deaths per 100k, and the COVID monthly series ends at 0. Sent unqualified, that invites the model to write that a state was spared or that deaths stopped in May 2024, which it did. A writing rule now forbids citing a 0 as a rate at all, and the geographic label reads "Lowest reported".
- **Unsupported peaks.** HIV output called White (NH)'s latest reported value a "peak" when the data never labeled it one. A rule now restricts peak/high/low to figures the data marks as such.
- **Reworded group labels.** COVID output expanded "Indigenous (NH)" to "American Indian and Alaska Native", so the summary disagreed with every chart below it. A rule now requires group names verbatim.

The last three were each found by reading rendered output, fixing the rule, and re-running until the output was clean.

## Scoping and grounding rules

Age-adjusted ratios are published only against a White (NH) baseline, so they describe a race gap and nothing else. They were being loaded and sent on every report, which meant a report broken down by sex or age had its demographic gap qualified with ratios computed on a different axis. They are now loaded only for a race breakdown.

That exposed a second issue: Key Findings invited a comparison figure whether or not a ratio had been sent, so on an age report the model worked out "over ten times higher than the national average" from two rates it had been given. The headline may now cite a ratio only when one was supplied, and a writing rule forbids deriving a figure by combining two shown ones.

Two language rules were added after "our most vulnerable community members" appeared in generated output: no deficit labels (vulnerable, at-risk, underserved, minority), and person-first wording. The prose instruction to use person-first language was not sufficient on its own.

## Test plan

- [x] Verified the age-adjustment gate across three breakdowns of the same COVID-19 deaths report: `demo=race_and_ethnicity` cites the 1.8x age-adjusted ratio, while `demo=sex` and `demo=age` no longer receive or mention a White (NH) baseline
- [x] Confirmed no derived figures remain in any of the three: no computed ratio in the headline, and no complement percentage in the completeness sentence
- [x] Grepped all three rendered outputs for deficit language (vulnerable, at-risk, high-risk, underserved, minority); none present
- [x] 17 unit tests over the five formatters (`generateReportInsight.test.ts`)
- [x] Verified end to end on the live COVID-19 deaths and HIV deaths reports at `localhost:3000`: all `/fetch-ai-insight` calls return 200, both render the original four sections, and Key Findings leads with a plain-language comparison rather than a rate
- [x] Checked every figure in the generated output against the prompt data; no fabricated numbers, no 0 cited as a rate, no unlabeled value called a peak, and group names match the report's own labels
- [x] Confirmed HIV correctly carries no completeness clause: the CDC HIV race dataset publishes no unknown row, so the clause is omitted rather than invented

### Generated output, COVID-19 deaths

> **Key Findings** — Indigenous (NH) people have faced the highest death rate, and when adjusting for age, some groups remain nearly twice as likely to die than others.
>
> **Location Comparison** — The burden of COVID-19 deaths varies across the country, with the highest rates reported in Nevada, Arizona, and Arkansas.
>
> **Demographic Insights** — Indigenous (NH) people experienced the highest death rate at 446 per 100k, compared to 144 per 100k for Asian (NH) people. Even after accounting for age differences, Indigenous (NH) and Hispanic or Latino people were 1.8x as likely to die as the White (NH) population. During the peak in 2020-12, Indigenous (NH) people reached a high point of 53 deaths per 100k.
>
> **What This Means** — These differences show that COVID-19 has affected some communities much harder than others. It is important to address these gaps to ensure everyone has a fair chance at health. Data for 14.9% of COVID-19 deaths is missing race or ethnicity information, so these rates describe only the cases where this was recorded.

### Generated output, HIV deaths

> **Key Findings** — People identified as Two or more races (NH) face the heaviest burden, with a death rate more than 13 times higher than White (NH) residents.
>
> **Location Comparison** — The burden of HIV deaths is highest in the District of Columbia, Puerto Rico, and Louisiana, which all see higher rates than the national median of 4.6 deaths per 100k.
>
> **Demographic Insights** — The death rate for Black or African American (NH) individuals is 23.7 per 100k, which is 7.8 times higher than the rate for White (NH) residents after adjusting for age. While the rate for Black or African American (NH) individuals has decreased since 2008, the rate for Two or more races (NH) reached a peak of 30.7 in 2009.
>
> **What This Means** — These gaps show that some communities are still being hit much harder by HIV than others, highlighting a clear need to focus our support where it is needed most.

