### PR TITLE
Right-size AI insight prompt budgets per context

### DIFF
--- a/frontend/src/cards/CardWrapper.tsx
+++ b/frontend/src/cards/CardWrapper.tsx
@@ -155,9 +155,11 @@ function CardWrapper(props: {
                 insightProps.dataTypeConfig,
                 insightProps.demographicType,
                 queryResponses,
-                insightProps.selectedGroups,
-                Boolean(regionRate),
-                insightProps.activeDemographicGroup,
+                {
+                  selectedGroups: insightProps.selectedGroups,
+                  activeDemographicGroup: insightProps.activeDemographicGroup,
+                  regionHasAllRate: Boolean(regionRate),
+                },
               )
             : 'empty'
         const showInsight =

--- a/frontend/src/utils/generateContrastInsight.ts
+++ b/frontend/src/utils/generateContrastInsight.ts
@@ -83,15 +83,9 @@ export async function generateContrastInsight(
     if (!metricConfig) return ''
     const rows = responses[0].getValidRowsForField(metricConfig.metricId)
     // Both sides land in one prompt, so each gets the tightest tier.
-    return formatDataRows(
-      rows,
-      hashId,
-      demographicType,
-      metricConfig,
-      undefined,
-      undefined,
-      INSIGHT_DATA_BUDGETS.contrast,
-    )
+    return formatDataRows(rows, hashId, demographicType, metricConfig, {
+      budgetBytes: INSIGHT_DATA_BUDGETS.contrast,
+    })
   }
 
   const data1 = buildDataSection(dataTypeConfig1, queryResponses1)

--- a/frontend/src/utils/generateContrastInsight.ts
+++ b/frontend/src/utils/generateContrastInsight.ts
@@ -12,8 +12,9 @@ import {
 } from './generateVisualizationInsight'
 import type { ScrollableHashId } from './hooks/useStepObserver'
 import { buildInsightCacheKey } from './insightCacheKey'
+import { INSIGHT_DATA_BUDGETS } from './insightPromptBudget'
 
-function buildContrastPrompt(
+export function buildContrastPrompt(
   topic1: string,
   topic2: string,
   location1: string,
@@ -81,7 +82,16 @@ export async function generateContrastInsight(
     const metricConfig = getPrimaryMetricConfig(hashId, config.metrics)
     if (!metricConfig) return ''
     const rows = responses[0].getValidRowsForField(metricConfig.metricId)
-    return formatDataRows(rows, hashId, demographicType, metricConfig)
+    // Both sides land in one prompt, so each gets the tightest tier.
+    return formatDataRows(
+      rows,
+      hashId,
+      demographicType,
+      metricConfig,
+      undefined,
+      undefined,
+      INSIGHT_DATA_BUDGETS.contrast,
+    )
   }
 
   const data1 = buildDataSection(dataTypeConfig1, queryResponses1)

--- a/frontend/src/utils/generateReportInsight.ts
+++ b/frontend/src/utils/generateReportInsight.ts
@@ -38,6 +38,10 @@ import {
 } from './generateVisualizationInsight'
 import { getDataManager } from './globals'
 import { buildInsightCacheKey } from './insightCacheKey'
+import {
+  INSIGHT_DATA_BUDGETS,
+  trimSectionToBudget,
+} from './insightPromptBudget'
 
 // The report-wide insight is a synthesis, not a walkthrough of the cards below
 // it. Trend and data-completeness findings fold into these four sections rather
@@ -270,7 +274,7 @@ export function formatUnknownShare(
     .join('\n')
 }
 
-type ReportDataSections = {
+export type ReportDataSections = {
   demographicSection: string
   geographicSection: string
   temporalSection: string
@@ -278,19 +282,23 @@ type ReportDataSections = {
   unknownSection: string
 }
 
-function buildReportInsightPrompt(
+export function buildReportInsightPrompt(
   topic: string,
   location: string,
   demographicLabel: string,
   data: ReportDataSections,
 ): string {
-  const {
-    demographicSection,
-    geographicSection,
-    temporalSection,
-    ageAdjustedSection,
-    unknownSection,
-  } = data
+  // Five sections share one prompt, so each is capped individually. Each is
+  // already reduced to a summary upstream; this is the backstop for a place
+  // whose group or period count outruns that reduction.
+  const trim = (section: string) =>
+    trimSectionToBudget(section, INSIGHT_DATA_BUDGETS.report)
+
+  const demographicSection = trim(data.demographicSection)
+  const geographicSection = trim(data.geographicSection)
+  const temporalSection = trim(data.temporalSection)
+  const ageAdjustedSection = trim(data.ageAdjustedSection)
+  const unknownSection = trim(data.unknownSection)
 
   const dataBlocks = [
     demographicSection &&

--- a/frontend/src/utils/generateVisualizationInsight.test.ts
+++ b/frontend/src/utils/generateVisualizationInsight.test.ts
@@ -69,14 +69,9 @@ describe('formatDataRows', () => {
       { fips_name: 'Alaska', race_and_ethnicity: 'Black (NH)', rate: 7 },
       { fips_name: 'Alaska', race_and_ethnicity: 'White (NH)', rate: 4 },
     ]
-    const result = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      'Black (NH)',
-    )
+    const result = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      activeDemographicGroup: 'Black (NH)',
+    })
     expect(result).toEqual(
       '- Alabama (All): 9 per 100k\n' +
         '- Alabama (Black (NH)): 12 per 100k\n' +
@@ -91,14 +86,9 @@ describe('formatDataRows', () => {
       { fips_name: 'Alabama', race_and_ethnicity: 'Black (NH)', rate: 12 },
       { fips_name: 'Alaska', race_and_ethnicity: 'All', rate: 5 },
     ]
-    const result = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      'All',
-    )
+    const result = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      activeDemographicGroup: 'All',
+    })
     expect(result.split('\n')).toHaveLength(3)
   })
 
@@ -116,14 +106,9 @@ describe('formatDataRows', () => {
         rate: 6.6,
       },
     ]
-    const result = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      'Black (NH)',
-    )
+    const result = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      activeDemographicGroup: 'Black (NH)',
+    })
     expect(result.split('\n')).toHaveLength(3)
     expect(result).toContain('- Gwinnett County (All): 7.3 per 100k')
   })
@@ -146,9 +131,9 @@ describe('formatDataRows', () => {
       { race_and_ethnicity: 'White (NH)', time_period: '2020', rate: 4 },
     ]
     expect(
-      formatDataRows(rows, 'rates-over-time', DEMO, metricConfig, [
-        'Black (NH)',
-      ]),
+      formatDataRows(rows, 'rates-over-time', DEMO, metricConfig, {
+        selectedGroups: ['Black (NH)'],
+      }),
     ).toEqual(
       '- Black (NH) (2010): 5 per 100k\n- Black (NH) (2020): 8 per 100k',
     )
@@ -218,14 +203,9 @@ describe('formatDataRows', () => {
       { fips_name: 'Alabama', race_and_ethnicity: 'Black women', rate: 11 },
       { fips_name: 'Alabama', race_and_ethnicity: 'White women', rate: 3 },
     ]
-    const result = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      'Black women',
-    )
+    const result = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      activeDemographicGroup: 'Black women',
+    })
     expect(result.split('\n')).toHaveLength(4)
     expect(result).toContain('- Georgia (All women): 5 per 100k')
     expect(result).toContain('- Alabama (All women): 6 per 100k')
@@ -239,14 +219,9 @@ describe('formatDataRows', () => {
       { fips_name: 'Alabama', race_and_ethnicity: 'All women', rate: 6 },
       { fips_name: 'Alabama', race_and_ethnicity: 'Black women', rate: 11 },
     ]
-    const result = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      'All women',
-    )
+    const result = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      activeDemographicGroup: 'All women',
+    })
     expect(result.split('\n')).toHaveLength(4)
   })
 })
@@ -301,7 +276,7 @@ describe('prepareInsightData', () => {
       dataTypeConfig,
       DEMO,
       [response],
-      ['Black (NH)'],
+      { selectedGroups: ['Black (NH)'] },
     )
     // first + last year for the one selected group
     expect(result.entryCount).toBe(2)
@@ -326,14 +301,9 @@ describe('getInsightDataStatus', () => {
 
   test("'single-region' when a map has under two values but the region has an overall rate", () => {
     expect(
-      getInsightDataStatus(
-        'rate-map',
-        dataTypeConfig,
-        DEMO,
-        [oneRow],
-        undefined,
-        true,
-      ),
+      getInsightDataStatus('rate-map', dataTypeConfig, DEMO, [oneRow], {
+        regionHasAllRate: true,
+      }),
     ).toBe('single-region')
   })
 
@@ -341,28 +311,18 @@ describe('getInsightDataStatus', () => {
     // A lone subgroup row leaves no overall rate, so the region can't be ranked
     // as an overall value against its peers — it stays hidden.
     expect(
-      getInsightDataStatus(
-        'rate-map',
-        dataTypeConfig,
-        DEMO,
-        [oneRow],
-        undefined,
-        false,
-      ),
+      getInsightDataStatus('rate-map', dataTypeConfig, DEMO, [oneRow], {
+        regionHasAllRate: false,
+      }),
     ).toBe('empty')
   })
 
   test("a non-map chart is 'empty' even with an overall region rate", () => {
     // Peer ranking only makes sense for maps.
     expect(
-      getInsightDataStatus(
-        'data-table',
-        dataTypeConfig,
-        DEMO,
-        [oneRow],
-        undefined,
-        true,
-      ),
+      getInsightDataStatus('data-table', dataTypeConfig, DEMO, [oneRow], {
+        regionHasAllRate: true,
+      }),
     ).toBe('empty')
   })
 
@@ -370,14 +330,9 @@ describe('getInsightDataStatus', () => {
     // A state map whose county children have no data: entryCount 0, but the
     // state's own rate lets it rank against peer states.
     expect(
-      getInsightDataStatus(
-        'rate-map',
-        dataTypeConfig,
-        DEMO,
-        [empty],
-        undefined,
-        true,
-      ),
+      getInsightDataStatus('rate-map', dataTypeConfig, DEMO, [empty], {
+        regionHasAllRate: true,
+      }),
     ).toBe('single-region')
   })
 

--- a/frontend/src/utils/generateVisualizationInsight.test.ts
+++ b/frontend/src/utils/generateVisualizationInsight.test.ts
@@ -15,6 +15,7 @@ import {
   prepareInsightData,
   summarizePeerComparison,
 } from './generateVisualizationInsight'
+import { byteLength, INSIGHT_DATA_BUDGETS } from './insightPromptBudget'
 
 const DEMO = 'race_and_ethnicity'
 
@@ -190,9 +191,7 @@ describe('formatDataRows', () => {
     expect(tailYears).toEqual(
       tailYears.map((_, i) => 2016 - (tail.length - 1) + i),
     )
-    expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(
-      12 * 1024,
-    )
+    expect(byteLength(result)).toBeLessThanOrEqual(INSIGHT_DATA_BUDGETS.card)
   })
 
   test('more groups than fit the budget yields whole lines only, never a truncated one', () => {
@@ -207,9 +206,7 @@ describe('formatDataRows', () => {
     for (const line of lines) {
       expect(line).toMatch(/^- Group \d+ \(2020\): \d+ per 100k$/)
     }
-    expect(new TextEncoder().encode(result).length).toBeLessThanOrEqual(
-      12 * 1024,
-    )
+    expect(byteLength(result)).toBeLessThanOrEqual(INSIGHT_DATA_BUDGETS.card)
   })
 
   test('a multi-place map keeps the "All women" baseline for women-only topics', () => {

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -17,6 +17,11 @@ import type { Fips } from '../data/utils/Fips'
 import { fetchAIInsight, type InsightResult } from './fetchAIInsight'
 import type { ScrollableHashId } from './hooks/useStepObserver'
 import { buildInsightCacheKey } from './insightCacheKey'
+import {
+  byteLength,
+  INSIGHT_DATA_BUDGETS,
+  trimLinesToBudget,
+} from './insightPromptBudget'
 
 const MAP_CHART_IDS: ScrollableHashId[] = [
   'rate-map',
@@ -28,11 +33,6 @@ const TIME_SERIES_CHART_IDS: ScrollableHashId[] = [
   'rates-over-time',
   'inequities-over-time',
 ]
-
-// Per-side data-section budget for time series. Compare mode sends two of
-// these in one prompt, so this is set well under half the server's prompt
-// cap (server/insight_budget.go) to leave room for scaffold text on both sides.
-const TIME_SERIES_TARGET_BYTES = 12 * 1024
 
 // Select the most relevant metric config for the given chart type
 export function getPrimaryMetricConfig(
@@ -64,6 +64,9 @@ export function formatDataRows(
   // geographic comparison to make, so send every group for that one place
   // instead (the ALL-groups-within-place fallback).
   activeDemographicGroup?: DemographicGroup,
+  // Bytes this data section may occupy. Defaults to the single-card tier; a
+  // prompt that carries more than one section passes a tighter budget.
+  budgetBytes: number = INSIGHT_DATA_BUDGETS.card,
 ): string {
   const isMap = MAP_CHART_IDS.includes(hashId)
   const isTimeSeries = TIME_SERIES_CHART_IDS.includes(hashId)
@@ -106,9 +109,6 @@ export function formatDataRows(
       return [sorted[0], ...sorted.slice(-recentCount)]
     }
 
-    const encoder = new TextEncoder()
-    const byteLength = (text: string) => encoder.encode(text).length
-
     const render = (recentCount: number) =>
       sortedByGroup
         .flatMap(([group, sorted]) =>
@@ -123,7 +123,7 @@ export function formatDataRows(
       ...sortedByGroup.map(([, sorted]) => sorted.length),
     )
     const full = render(longest)
-    if (byteLength(full) <= TIME_SERIES_TARGET_BYTES) return full
+    if (byteLength(full) <= budgetBytes) return full
 
     // Largest recent window that still fits. Binary search rather than stepping
     // down one point at a time, since a monthly series over decades can be
@@ -134,7 +134,7 @@ export function formatDataRows(
     while (low <= high) {
       const mid = Math.floor((low + high) / 2)
       const candidate = render(mid)
-      if (byteLength(candidate) <= TIME_SERIES_TARGET_BYTES) {
+      if (byteLength(candidate) <= budgetBytes) {
         best = candidate
         low = mid + 1
       } else {
@@ -143,19 +143,8 @@ export function formatDataRows(
     }
     if (best) return best
 
-    // Enough groups that even one recent point each overflows the budget. Keep
-    // whole lines from the start until the budget is spent, so the result is
-    // always a well-formed, in-budget list rather than a truncated final line.
-    const lines = render(1).split('\n')
-    const kept: string[] = []
-    let used = 0
-    for (const line of lines) {
-      const cost = byteLength(line) + (kept.length ? 1 : 0)
-      if (used + cost > TIME_SERIES_TARGET_BYTES) break
-      kept.push(line)
-      used += cost
-    }
-    return kept.join('\n')
+    // Enough groups that even one recent point each overflows the budget.
+    return trimLinesToBudget(render(1).split('\n'), budgetBytes)
   }
 
   // For population-vs-distribution, include both the outcome share and
@@ -195,22 +184,25 @@ export function formatDataRows(
         )
       : filteredRows
 
-  return activeRows
-    .map((row) => {
-      // On a map, label each row with BOTH its place and demographic group so
-      // the model can read either a geographic gap (across places) or a
-      // within-place gap (across groups, with "All" as the baseline). Other
-      // charts already vary only by demographic group, so the group alone suffices.
-      const label = isMap
-        ? `${row.fips_name} (${row[demographicType]})`
-        : `${row[demographicType]}`
-      const val = `${row[metricConfig.metricId]} ${metricConfig.shortLabel}`
-      if (popMetric && row[popMetric.metricId] != null) {
-        return `- ${label}: outcome share ${val}, population share ${row[popMetric.metricId]} ${popMetric.shortLabel}`
-      }
-      return `- ${label}: ${val}`
-    })
-    .join('\n')
+  const lines = activeRows.map((row) => {
+    // On a map, label each row with BOTH its place and demographic group so
+    // the model can read either a geographic gap (across places) or a
+    // within-place gap (across groups, with "All" as the baseline). Other
+    // charts already vary only by demographic group, so the group alone suffices.
+    const label = isMap
+      ? `${row.fips_name} (${row[demographicType]})`
+      : `${row[demographicType]}`
+    const val = `${row[metricConfig.metricId]} ${metricConfig.shortLabel}`
+    if (popMetric && row[popMetric.metricId] != null) {
+      return `- ${label}: outcome share ${val}, population share ${row[popMetric.metricId]} ${popMetric.shortLabel}`
+    }
+    return `- ${label}: ${val}`
+  })
+
+  // Group filtering bounds a map section in the common case, but a wide
+  // breakdown over hundreds of places can still outgrow the budget, and the
+  // data table has no geographic filter at all.
+  return trimLinesToBudget(lines, budgetBytes)
 }
 
 export function buildPrompt(

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -47,27 +47,39 @@ export function getPrimaryMetricConfig(
   return metrics.per100k ?? metrics.pct_rate ?? metrics.index ?? null
 }
 
-// Format HetRows as a text list to embed in the prompt
-export function formatDataRows(
-  rows: HetRow[],
-  hashId: ScrollableHashId,
-  demographicType: DemographicType,
-  metricConfig: MetricConfig,
+// Which rows a data section covers and how many bytes it may occupy. Grouped
+// into one object so a caller that needs only the budget isn't forced to pass
+// placeholders for the filters it doesn't use.
+export interface InsightDataOptions {
   // When the user has focused a chart (e.g. the trend legend) on a subset of
   // groups, restrict the rows to those groups so the insight describes only
   // what is on screen. Empty/undefined means "all groups".
-  selectedGroups?: DemographicGroup[],
+  selectedGroups?: DemographicGroup[]
   // The demographic group currently highlighted on a map. When the map is
   // showing multiple places (a real geographic comparison), default to only
   // this group's rows across places, since that's what's on screen and it
   // keeps the prompt small. When only one place is in view, there's no
   // geographic comparison to make, so send every group for that one place
   // instead (the ALL-groups-within-place fallback).
-  activeDemographicGroup?: DemographicGroup,
+  activeDemographicGroup?: DemographicGroup
   // Bytes this data section may occupy. Defaults to the single-card tier; a
   // prompt that carries more than one section passes a tighter budget.
-  budgetBytes: number = INSIGHT_DATA_BUDGETS.card,
+  budgetBytes?: number
+}
+
+// Format HetRows as a text list to embed in the prompt
+export function formatDataRows(
+  rows: HetRow[],
+  hashId: ScrollableHashId,
+  demographicType: DemographicType,
+  metricConfig: MetricConfig,
+  options: InsightDataOptions = {},
 ): string {
+  const {
+    selectedGroups,
+    activeDemographicGroup,
+    budgetBytes = INSIGHT_DATA_BUDGETS.card,
+  } = options
   const isMap = MAP_CHART_IDS.includes(hashId)
   const isTimeSeries = TIME_SERIES_CHART_IDS.includes(hashId)
   const groupFilter =
@@ -453,8 +465,7 @@ export function prepareInsightData(
   dataTypeConfig: DataTypeConfig,
   demographicType: DemographicType,
   queryResponses?: MetricQueryResponse[],
-  selectedGroups?: DemographicGroup[],
-  activeDemographicGroup?: DemographicGroup,
+  options: InsightDataOptions = {},
 ): InsightData {
   let dataSection = ''
   if (queryResponses?.[0]) {
@@ -466,8 +477,7 @@ export function prepareInsightData(
         hashId,
         demographicType,
         metricConfig,
-        selectedGroups,
-        activeDemographicGroup,
+        options,
       )
     }
   }
@@ -492,23 +502,24 @@ export function getInsightDataStatus(
   dataTypeConfig: DataTypeConfig,
   demographicType: DemographicType,
   queryResponses?: MetricQueryResponse[],
-  selectedGroups?: DemographicGroup[],
-  // Whether the selected region has its own overall "All" rate (from the
-  // region-self query). Gates the peer fallback so a lone subgroup row — with no
-  // overall rate — stays hidden rather than being ranked as the region's overall.
-  regionHasAllRate = false,
-  activeDemographicGroup?: DemographicGroup,
+  options: InsightDataOptions & {
+    // Whether the selected region has its own overall "All" rate (from the
+    // region-self query). Gates the peer fallback so a lone subgroup row, with
+    // no overall rate, stays hidden rather than being ranked as the region's
+    // overall.
+    regionHasAllRate?: boolean
+  } = {},
 ): InsightDataStatus {
   const { entryCount } = prepareInsightData(
     hashId,
     dataTypeConfig,
     demographicType,
     queryResponses,
-    selectedGroups,
-    activeDemographicGroup,
+    options,
   )
   if (entryCount >= 2) return 'multi'
-  if (MAP_CHART_IDS.includes(hashId) && regionHasAllRate) return 'single-region'
+  if (MAP_CHART_IDS.includes(hashId) && options.regionHasAllRate)
+    return 'single-region'
   return 'empty'
 }
 
@@ -530,8 +541,10 @@ export async function generateCardInsight(
     dataTypeConfig,
     demographicType,
     queryResponses,
-    context?.selectedGroups,
-    context?.activeDemographicGroup,
+    {
+      selectedGroups: context?.selectedGroups,
+      activeDemographicGroup: context?.activeDemographicGroup,
+    },
   )
 
   // Single-region map: rank the region against its same-level peers instead of

--- a/frontend/src/utils/insightPromptBudget.test.ts
+++ b/frontend/src/utils/insightPromptBudget.test.ts
@@ -114,9 +114,9 @@ describe('formatDataRows budget tiers', () => {
       'rates-over-time',
       DEMO,
       metricConfig,
-      undefined,
-      undefined,
-      INSIGHT_DATA_BUDGETS.contrast,
+      {
+        budgetBytes: INSIGHT_DATA_BUDGETS.contrast,
+      },
     )
     expect(byteLength(section)).toBeLessThanOrEqual(
       INSIGHT_DATA_BUDGETS.contrast,
@@ -126,15 +126,9 @@ describe('formatDataRows budget tiers', () => {
   test('the contrast tier is tighter than the single-card tier', () => {
     const rows = oversizedMapRows()
     const card = formatDataRows(rows, 'rate-map', DEMO, metricConfig)
-    const contrast = formatDataRows(
-      rows,
-      'rate-map',
-      DEMO,
-      metricConfig,
-      undefined,
-      undefined,
-      INSIGHT_DATA_BUDGETS.contrast,
-    )
+    const contrast = formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+      budgetBytes: INSIGHT_DATA_BUDGETS.contrast,
+    })
     expect(byteLength(contrast)).toBeLessThan(byteLength(card))
   })
 })
@@ -161,15 +155,9 @@ describe('assembled prompts stay under the server ceiling', () => {
   test('compare-mode contrast prompt, both sides oversized', () => {
     const rows = oversizedMapRows()
     const side = () =>
-      formatDataRows(
-        rows,
-        'rate-map',
-        DEMO,
-        metricConfig,
-        undefined,
-        undefined,
-        INSIGHT_DATA_BUDGETS.contrast,
-      )
+      formatDataRows(rows, 'rate-map', DEMO, metricConfig, {
+        budgetBytes: INSIGHT_DATA_BUDGETS.contrast,
+      })
     const prompt = buildContrastPrompt(
       'HIV diagnoses',
       'Diabetes',

--- a/frontend/src/utils/insightPromptBudget.test.ts
+++ b/frontend/src/utils/insightPromptBudget.test.ts
@@ -1,0 +1,217 @@
+import type { MetricConfig } from '../data/config/MetricConfigTypes'
+import type { HetRow } from '../data/utils/DatasetTypes'
+import { buildContrastPrompt } from './generateContrastInsight'
+import { buildReportInsightPrompt } from './generateReportInsight'
+import { buildPrompt, formatDataRows } from './generateVisualizationInsight'
+import {
+  byteLength,
+  INSIGHT_DATA_BUDGETS,
+  INSIGHT_PROMPT_MAX_BYTES,
+  trimLinesToBudget,
+  trimSectionToBudget,
+} from './insightPromptBudget'
+
+const DEMO = 'race_and_ethnicity'
+
+const metricConfig = {
+  metricId: 'rate',
+  shortLabel: 'per 100k',
+} as unknown as MetricConfig
+
+// A breakdown wide enough to outgrow every budget tier: 400 places x 6 groups.
+function oversizedMapRows(): HetRow[] {
+  const groups = [
+    'All',
+    'Black (NH)',
+    'White (NH)',
+    'Hispanic',
+    'Asian (NH)',
+    'AI/AN (NH)',
+  ]
+  return Array.from({ length: 400 }, (_, place) =>
+    groups.map((group) => ({
+      fips_name: `Some Very Long County Name Number ${place}`,
+      [DEMO]: group,
+      rate: 100 + place,
+    })),
+  ).flat()
+}
+
+function oversizedSection(): string {
+  return Array.from(
+    { length: 2000 },
+    (_, i) => `- Group number ${i} with a long label: ${i} per 100k`,
+  ).join('\n')
+}
+
+describe('trimLinesToBudget', () => {
+  test('returns every line when the whole list fits', () => {
+    expect(trimLinesToBudget(['- a: 1', '- b: 2'], 1024)).toEqual(
+      '- a: 1\n- b: 2',
+    )
+  })
+
+  test('drops whole lines rather than cutting one mid-value', () => {
+    const lines = ['- aaaa: 1', '- bbbb: 2', '- cccc: 3']
+    // Room for the first two lines and their separator, not the third.
+    const result = trimLinesToBudget(lines, 19)
+    expect(result).toEqual('- aaaa: 1\n- bbbb: 2')
+    expect(byteLength(result)).toBeLessThanOrEqual(19)
+  })
+
+  test('counts bytes rather than characters for multi-byte labels', () => {
+    // Each "ñ" is two bytes, so this line costs more than its length suggests.
+    // cSpell:ignore ñññññ
+    const line = '- ñññññ: 1'
+    expect(byteLength(line)).toBeGreaterThan(line.length)
+    expect(trimLinesToBudget([line], line.length)).toEqual('')
+  })
+})
+
+describe('trimSectionToBudget', () => {
+  test('leaves an in-budget section byte-identical', () => {
+    const section = '- Alabama (All): 9 per 100k\n- Alaska (All): 5 per 100k'
+    expect(trimSectionToBudget(section, 1024)).toEqual(section)
+  })
+
+  test('caps an over-budget section', () => {
+    const result = trimSectionToBudget(oversizedSection(), 2048)
+    expect(byteLength(result)).toBeLessThanOrEqual(2048)
+    expect(result.split('\n').at(-1)).toMatch(/per 100k$/)
+  })
+})
+
+describe('formatDataRows budget tiers', () => {
+  test('a map section is capped at the single-card tier by default', () => {
+    const section = formatDataRows(
+      oversizedMapRows(),
+      'rate-map',
+      DEMO,
+      metricConfig,
+    )
+    expect(byteLength(section)).toBeLessThanOrEqual(INSIGHT_DATA_BUDGETS.card)
+    expect(section.split('\n').at(-1)).toMatch(/per 100k$/)
+  })
+
+  test('a data-table section is capped too', () => {
+    const section = formatDataRows(
+      oversizedMapRows(),
+      'data-table',
+      DEMO,
+      metricConfig,
+    )
+    expect(byteLength(section)).toBeLessThanOrEqual(INSIGHT_DATA_BUDGETS.card)
+  })
+
+  test('a time-series section honors the budget it is given', () => {
+    const rows: HetRow[] = Array.from({ length: 4000 }, (_, i) => ({
+      [DEMO]: `Group ${i % 8}`,
+      time_period: String(1980 + Math.floor(i / 8)),
+      rate: i,
+    }))
+    const section = formatDataRows(
+      rows,
+      'rates-over-time',
+      DEMO,
+      metricConfig,
+      undefined,
+      undefined,
+      INSIGHT_DATA_BUDGETS.contrast,
+    )
+    expect(byteLength(section)).toBeLessThanOrEqual(
+      INSIGHT_DATA_BUDGETS.contrast,
+    )
+  })
+
+  test('the contrast tier is tighter than the single-card tier', () => {
+    const rows = oversizedMapRows()
+    const card = formatDataRows(rows, 'rate-map', DEMO, metricConfig)
+    const contrast = formatDataRows(
+      rows,
+      'rate-map',
+      DEMO,
+      metricConfig,
+      undefined,
+      undefined,
+      INSIGHT_DATA_BUDGETS.contrast,
+    )
+    expect(byteLength(contrast)).toBeLessThan(byteLength(card))
+  })
+})
+
+describe('assembled prompts stay under the server ceiling', () => {
+  test('single-card prompt', () => {
+    const section = formatDataRows(
+      oversizedMapRows(),
+      'rate-map',
+      DEMO,
+      metricConfig,
+    )
+    const prompt = buildPrompt(
+      'rate-map',
+      'HIV diagnoses',
+      'Georgia',
+      'race and ethnicity',
+      section,
+      'Black (NH)',
+    )
+    expect(byteLength(prompt)).toBeLessThanOrEqual(INSIGHT_PROMPT_MAX_BYTES)
+  })
+
+  test('compare-mode contrast prompt, both sides oversized', () => {
+    const rows = oversizedMapRows()
+    const side = () =>
+      formatDataRows(
+        rows,
+        'rate-map',
+        DEMO,
+        metricConfig,
+        undefined,
+        undefined,
+        INSIGHT_DATA_BUDGETS.contrast,
+      )
+    const prompt = buildContrastPrompt(
+      'HIV diagnoses',
+      'Diabetes',
+      'Georgia',
+      'Alabama',
+      'race and ethnicity',
+      side(),
+      side(),
+    )
+    expect(byteLength(prompt)).toBeLessThanOrEqual(INSIGHT_PROMPT_MAX_BYTES)
+  })
+
+  test('report-wide prompt with all five sections oversized', () => {
+    const section = oversizedSection()
+    const prompt = buildReportInsightPrompt(
+      'HIV diagnoses',
+      'Georgia',
+      'race and ethnicity',
+      {
+        demographicSection: section,
+        geographicSection: section,
+        temporalSection: section,
+        ageAdjustedSection: section,
+        unknownSection: section,
+      },
+    )
+    expect(byteLength(prompt)).toBeLessThanOrEqual(INSIGHT_PROMPT_MAX_BYTES)
+  })
+
+  test('report-wide prompt with no sections at all', () => {
+    const prompt = buildReportInsightPrompt(
+      'HIV diagnoses',
+      'Georgia',
+      'race and ethnicity',
+      {
+        demographicSection: '',
+        geographicSection: '',
+        temporalSection: '',
+        ageAdjustedSection: '',
+        unknownSection: '',
+      },
+    )
+    expect(byteLength(prompt)).toBeLessThanOrEqual(INSIGHT_PROMPT_MAX_BYTES)
+  })
+})

--- a/frontend/src/utils/insightPromptBudget.ts
+++ b/frontend/src/utils/insightPromptBudget.ts
@@ -1,0 +1,52 @@
+// The server rejects any prompt larger than this (server/insight_budget.go).
+// Every budget below is sized so the assembled prompt, data plus scaffold text,
+// lands under it no matter which sections are present.
+export const INSIGHT_PROMPT_MAX_BYTES = 30 * 1024
+
+// Bytes of data rows a prompt may carry, tiered by how many data sections that
+// prompt holds. A prompt with one section can afford to send far more of it than
+// a prompt that always carries two.
+export const INSIGHT_DATA_BUDGETS = {
+  // Single card insight: one data section, so it gets the most room. Sized so
+  // the largest real view measured, a national map of every state across every
+  // race group (~21KB), is sent whole rather than losing the tail of the list.
+  card: 24 * 1024,
+  // Report-wide insight: up to five sections, each capped at this.
+  report: 4 * 1024,
+  // Compare-mode contrast insight: always two sections, one per side.
+  contrast: 12 * 1024,
+} as const
+
+const encoder = new TextEncoder()
+
+export function byteLength(text: string): number {
+  return encoder.encode(text).length
+}
+
+// Keeps whole lines from the start until the budget is spent, so an over-budget
+// section degrades to a shorter well-formed list rather than a list whose last
+// entry is cut mid-number. Order is preserved rather than re-ranked, since the
+// prompt hash that keys the insight cache depends on the same rows rendering the
+// same way every time.
+export function trimLinesToBudget(
+  lines: string[],
+  budgetBytes: number,
+): string {
+  const kept: string[] = []
+  let used = 0
+  for (const line of lines) {
+    const cost = byteLength(line) + (kept.length ? 1 : 0)
+    if (used + cost > budgetBytes) break
+    kept.push(line)
+    used += cost
+  }
+  return kept.join('\n')
+}
+
+export function trimSectionToBudget(
+  section: string,
+  budgetBytes: number,
+): string {
+  if (byteLength(section) <= budgetBytes) return section
+  return trimLinesToBudget(section.split('\n'), budgetBytes)
+}

--- a/server/insight_budget.go
+++ b/server/insight_budget.go
@@ -18,10 +18,10 @@ import (
 )
 
 const (
-	// Client-side group-filtering and time-series thinning keep even the
-	// largest map or compare-mode prompt well under this; measured
-	// compare-mode contrast prompts (two data sections in one request) run
-	// ~11-17KB.
+	// Clients trim every data section to a per-context budget before assembling
+	// a prompt (frontend/src/utils/insightPromptBudget.ts), sized so the worst
+	// case in each context lands under this. Raising a client budget without
+	// re-checking it against this value is what would push a prompt over.
 	insightPromptMaxBytes = 30 * 1024
 	killSwitchObject      = "insights-generation-disabled"
 	killSwitchTTL         = 60 * time.Second


### PR DESCRIPTION
## Summary

- Extract byte accounting into `insightPromptBudget.ts` with three tiers per context
- Single card 24KB (one data section), report-wide 4KB per section (five sections), compare-mode 12KB per side (two sections)
- All sections now trim to whole lines so over-budget lists degrade gracefully rather than cutting mid-number
- Measured against live backend: card 21.8KB, contrast 25.2KB, report 3.7KB

## Impact

- Closes a gap where map and data-table sections had no byte ceiling. Real-world case (national prison map across every race group) was 21.8KB with nothing bounding it.
- Card tier now guarantees the largest measured view is sent whole rather than losing tail rows.
- All three tiers land safely under the server's 30KB prompt cap.

## Test plan

- [x] Unit tests for all three budget tiers, including worst-case synthetic data
- [x] 13 new tests in insightPromptBudget.test.ts, all passing
- [x] Measured real prompts against live backend (card 21.8KB, contrast 25.2KB, report 3.7KB)
- [x] Go server tests pass (insight_budget.go comment updated)
- [x] 532/532 frontend unit tests pass

Closes #5046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
