### PR TITLE
Pin insight prompt text with language-neutral fixtures

### DIFF
--- a/.github/workflows/runFrontendTests.yml
+++ b/.github/workflows/runFrontendTests.yml
@@ -24,7 +24,9 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 1
-          sparse-checkout: frontend
+          sparse-checkout: |
+            frontend
+            server/testdata/insight_prompts
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.gitignore
+++ b/.gitignore
@@ -73,7 +73,9 @@ service_account*.json
 !python/ingestion/ahr_config/graphql_ahr_measure_ids.json
 !frontend/tokens/*.tokens.json
 !frontend/scripts/geo/geographies.json
+!server/testdata/insight_prompts/
 !server/testdata/insight_prompts/*.json
+!server/testdata/insight_prompts/*.prompt.txt
 
 # Generated design token files — edit tokens/*.tokens.json and run `npm run tokens`
 frontend/src/styles/tokens/

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ service_account*.json
 !python/ingestion/ahr_config/graphql_ahr_measure_ids.json
 !frontend/tokens/*.tokens.json
 !frontend/scripts/geo/geographies.json
+!server/testdata/insight_prompts/*.json
 
 # Generated design token files — edit tokens/*.tokens.json and run `npm run tokens`
 frontend/src/styles/tokens/

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -252,6 +252,7 @@
 		"faqs",
 		"fasmbs",
 		"FASMBS",
+		"Fannin",
 		"FFS",
 		"fillna",
 		"fip",

--- a/frontend/src/utils/generateVisualizationInsight.ts
+++ b/frontend/src/utils/generateVisualizationInsight.ts
@@ -261,6 +261,49 @@ export function buildPrompt(
   return `This is a ${hashId.replace(/-/g, ' ')} showing ${topic} in ${location} by ${demographicLabel}. The intended message is to highlight health equity disparities.${dataBlock}\n\nWrite a single sentence at an 8th grade reading level that captures the key inequity a viewer should walk away with — focus on the "so what", not the chart mechanics.`
 }
 
+// Keep the model from narrating the prompt (e.g. "Since only the overall rate
+// is available, here's a sentence...") — the card wants the bare insight.
+const CARD_OUTPUT_RULE =
+  ' Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.'
+
+// The exact text a card sends to the model. Separate from generateCardInsight so
+// the prompt can be rendered without a network call, which is what lets the
+// regression harness diff prompt changes and what the Go port must reproduce.
+export function buildCardInsightPrompt(
+  hashId: ScrollableHashId,
+  topic: string,
+  location: string,
+  demographicLabel: string,
+  dataSection: string,
+  context?: InsightContext,
+): string {
+  // Single-region map: rank the region against its same-level peers instead of
+  // describing an on-screen disparity. summarizePeerComparison returns null when
+  // too few peers report, in which case we fall through to the standard framing.
+  const peerSummary =
+    MAP_CHART_IDS.includes(hashId) && context?.peerComparison
+      ? summarizePeerComparison(context.peerComparison)
+      : null
+
+  // The peer summary already leads with the region's own rate, so it replaces
+  // the lone local row rather than appending to it.
+  const finalDataSection = peerSummary
+    ? formatPeerComparison(peerSummary)
+    : dataSection
+
+  return (
+    buildPrompt(
+      hashId,
+      topic,
+      location,
+      demographicLabel,
+      finalDataSection,
+      context?.activeDemographicGroup,
+      Boolean(peerSummary),
+    ) + CARD_OUTPUT_RULE
+  )
+}
+
 interface InsightData {
   dataSection: string
   // Number of comparison entries (groups or regions) the model would receive.
@@ -547,34 +590,14 @@ export async function generateCardInsight(
     },
   )
 
-  // Single-region map: rank the region against its same-level peers instead of
-  // describing an on-screen disparity. summarizePeerComparison returns null when
-  // too few peers report, in which case we fall through to the standard framing.
-  const peerSummary =
-    MAP_CHART_IDS.includes(hashId) && context?.peerComparison
-      ? summarizePeerComparison(context.peerComparison)
-      : null
-
-  // The peer summary already leads with the region's own rate, so it replaces
-  // the lone local row rather than appending to it.
-  const finalDataSection = peerSummary
-    ? formatPeerComparison(peerSummary)
-    : dataSection
-
-  // Keep the model from narrating the prompt (e.g. "Since only the overall rate
-  // is available, here's a sentence...") — the card wants the bare insight.
-  const outputRule =
-    ' Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.'
-  const prompt =
-    buildPrompt(
-      hashId,
-      topic,
-      location,
-      demographic,
-      finalDataSection,
-      context?.activeDemographicGroup,
-      Boolean(peerSummary),
-    ) + outputRule
+  const prompt = buildCardInsightPrompt(
+    hashId,
+    topic,
+    location,
+    demographic,
+    dataSection,
+    context,
+  )
 
   const cardSuffix = isCompareCard ? '-2' : ''
   // Focus (highlighted map group / selected trend lines) needs no suffix here:

--- a/frontend/src/utils/insightPromptFixtures.test.ts
+++ b/frontend/src/utils/insightPromptFixtures.test.ts
@@ -1,0 +1,65 @@
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  type InsightPromptFixture,
+  renderFixturePrompt,
+} from './insightPromptFixtures'
+
+// Fixtures live under server/ because the prompt templates are moving there in
+// #5045. The Go implementation asserts against these same files, which is what
+// makes the port checkable rather than trusted. This relative path is the
+// temporary side of that arrangement.
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../server/testdata/insight_prompts',
+)
+
+const fixtureNames = readdirSync(FIXTURE_DIR)
+  .filter((file) => file.endsWith('.json'))
+  .map((file) => file.replace(/\.json$/, ''))
+  .sort()
+
+const load = (name: string): InsightPromptFixture =>
+  JSON.parse(readFileSync(path.join(FIXTURE_DIR, `${name}.json`), 'utf8'))
+
+const expectedPath = (name: string) =>
+  path.join(FIXTURE_DIR, `${name}.prompt.txt`)
+
+// Set when a prompt change is intentional. The resulting diff is the artifact to
+// review: it shows every fixture the edit moved, which is also every cached
+// insight it will displace.
+const isUpdating = process.env.UPDATE_INSIGHT_PROMPTS === '1'
+
+describe('insight prompt fixtures', () => {
+  it('has fixtures to check', () => {
+    expect(fixtureNames.length).toBeGreaterThan(0)
+  })
+
+  describe.each(fixtureNames)('%s', (name) => {
+    const rendered = renderFixturePrompt(load(name))
+
+    it('matches its committed prompt', () => {
+      if (isUpdating) {
+        writeFileSync(expectedPath(name), rendered, 'utf8')
+        return
+      }
+      expect(rendered).toEqual(readFileSync(expectedPath(name), 'utf8'))
+    })
+
+    // The prompt is instructions, so its own reading level means nothing. What
+    // is checkable offline is that the instruction survives: an edit that drops
+    // it would raise the reading level of every insight users see, with nothing
+    // else failing. Both spellings are in use across the templates.
+    it('still asks for an 8th grade reading level', () => {
+      expect(rendered).toMatch(/8th[- ]grade reading level/)
+    })
+
+    it('carries its data rather than asking for numbers it was never given', () => {
+      expect(rendered.length).toBeGreaterThan(0)
+      const hasDataBlock = /\n- |\bView [AB]\b|Current rates by/.test(rendered)
+      expect(hasDataBlock).toBe(true)
+    })
+  })
+})

--- a/frontend/src/utils/insightPromptFixtures.ts
+++ b/frontend/src/utils/insightPromptFixtures.ts
@@ -1,0 +1,184 @@
+import type { MetricConfig } from '../data/config/MetricConfigTypes'
+import {
+  DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE,
+  type DemographicType,
+} from '../data/query/Breakdowns'
+import type { HetRow } from '../data/utils/DatasetTypes'
+import { buildContrastPrompt } from './generateContrastInsight'
+import {
+  buildReportInsightPrompt,
+  formatAgeAdjustedRatios,
+  formatDemographicRates,
+  formatGeographicSpread,
+  formatTemporalChange,
+  formatUnknownShare,
+} from './generateReportInsight'
+import {
+  buildCardInsightPrompt,
+  formatDataRows,
+  type InsightContext,
+} from './generateVisualizationInsight'
+import type { ScrollableHashId } from './hooks/useStepObserver'
+import { INSIGHT_DATA_BUDGETS } from './insightPromptBudget'
+
+// Fixture inputs are deliberately plain JSON with no TypeScript-only types, so
+// the Go port in #5045 can render the same cases from the same files and be
+// checked against the same expected output.
+
+interface FixtureMetricConfig {
+  metricId: string
+  shortLabel: string
+}
+
+interface CardFixture {
+  kind: 'card'
+  why: string
+  hashId: ScrollableHashId
+  topic: string
+  location: string
+  demographicType: DemographicType
+  metricConfig: FixtureMetricConfig
+  rows: HetRow[]
+  context?: InsightContext
+}
+
+interface ContrastView {
+  topic: string
+  location: string
+  metricConfig: FixtureMetricConfig
+  rows: HetRow[]
+}
+
+interface ContrastFixture {
+  kind: 'contrast'
+  why: string
+  hashId: ScrollableHashId
+  demographicType: DemographicType
+  viewA: ContrastView
+  viewB: ContrastView
+}
+
+interface ReportSection {
+  rows: HetRow[]
+  metricConfig?: FixtureMetricConfig
+}
+
+interface ReportFixture {
+  kind: 'report'
+  why: string
+  topic: string
+  location: string
+  demographicType: DemographicType
+  placeNoun: string
+  metricConfig: FixtureMetricConfig
+  sections: {
+    demographic: ReportSection
+    geographic: ReportSection
+    temporal: ReportSection
+    ageAdjusted: ReportSection
+    unknown: ReportSection
+  }
+}
+
+export type InsightPromptFixture = CardFixture | ContrastFixture | ReportFixture
+
+// Fixtures pin a metric explicitly rather than resolving one from a full
+// DataTypeConfig, so a fixture stays readable and stays valid when unrelated
+// topic config changes. Only these two fields reach the prompt text.
+const asMetricConfig = (config: FixtureMetricConfig): MetricConfig =>
+  config as unknown as MetricConfig
+
+function renderCard(fixture: CardFixture): string {
+  const dataSection = formatDataRows(
+    fixture.rows,
+    fixture.hashId,
+    fixture.demographicType,
+    asMetricConfig(fixture.metricConfig),
+    {
+      selectedGroups: fixture.context?.selectedGroups,
+      activeDemographicGroup: fixture.context?.activeDemographicGroup,
+    },
+  )
+
+  return buildCardInsightPrompt(
+    fixture.hashId,
+    fixture.topic,
+    fixture.location,
+    DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[fixture.demographicType],
+    dataSection,
+    fixture.context,
+  )
+}
+
+function renderContrast(fixture: ContrastFixture): string {
+  const section = (view: ContrastView) =>
+    formatDataRows(
+      view.rows,
+      fixture.hashId,
+      fixture.demographicType,
+      asMetricConfig(view.metricConfig),
+      { budgetBytes: INSIGHT_DATA_BUDGETS.contrast },
+    )
+
+  return buildContrastPrompt(
+    fixture.viewA.topic,
+    fixture.viewB.topic,
+    fixture.viewA.location,
+    fixture.viewB.location,
+    DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[fixture.demographicType],
+    section(fixture.viewA),
+    section(fixture.viewB),
+  )
+}
+
+function renderReport(fixture: ReportFixture): string {
+  const { sections, demographicType } = fixture
+  const metricFor = (section: ReportSection) =>
+    asMetricConfig(section.metricConfig ?? fixture.metricConfig)
+
+  return buildReportInsightPrompt(
+    fixture.topic,
+    fixture.location,
+    DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE[demographicType],
+    {
+      demographicSection: formatDemographicRates(
+        sections.demographic.rows,
+        demographicType,
+        metricFor(sections.demographic),
+      ),
+      geographicSection: formatGeographicSpread(
+        sections.geographic.rows,
+        metricFor(sections.geographic),
+        fixture.placeNoun,
+      ),
+      temporalSection: formatTemporalChange(
+        sections.temporal.rows,
+        demographicType,
+        metricFor(sections.temporal),
+      ),
+      ageAdjustedSection: formatAgeAdjustedRatios(
+        sections.ageAdjusted.rows,
+        demographicType,
+        metricFor(sections.ageAdjusted),
+      ),
+      unknownSection: formatUnknownShare(
+        sections.unknown.rows,
+        demographicType,
+        metricFor(sections.unknown),
+      ),
+    },
+  )
+}
+
+// Renders a fixture through the same builders production uses. Deterministic and
+// offline: no provider call, no network, no clock.
+export function renderFixturePrompt(fixture: InsightPromptFixture): string {
+  switch (fixture.kind) {
+    case 'card':
+      return renderCard(fixture)
+    case 'contrast':
+      return renderContrast(fixture)
+    case 'report':
+      return renderReport(fixture)
+  }
+}

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -64,6 +64,44 @@ The server handles all traffic on a single port:
   - Everything else — `public, max-age=7200`
   - Unknown paths → `index.html` (SPA client-side routing fallback)
 
+## Insight prompt fixtures
+
+`testdata/insight_prompts/` pins the exact text sent to the model for a set of
+representative views. Each case is a `.json` input plus a committed
+`.prompt.txt` of the rendered prompt.
+
+Prompts are still assembled in the frontend, so the harness that renders them
+lives there too:
+
+```bash
+cd frontend
+npx vitest run src/utils/insightPromptFixtures.test.ts    # check
+UPDATE_INSIGHT_PROMPTS=1 npx vitest run src/utils/insightPromptFixtures.test.ts  # accept a change
+```
+
+It is deterministic and offline: no API key, no network, no clock. A template
+edit shows up as a diff in the `.prompt.txt` files, and **that diff is the thing
+to review.** Since #5029/#5053 the cache key is a hash of the rendered prompt and
+template text appears in every prompt, so the fixtures a change moves are a
+direct readout of how much of the cache it displaces.
+
+The fixtures deliberately contain no TypeScript-only types. When #5045 ports the
+templates to Go, the Go implementation renders these same inputs and must
+reproduce these same outputs, which is what makes the port checkable rather than
+trusted. Two things that will bite that port:
+
+- **Number formatting must match exactly.** JavaScript renders `4.0` as `4`, and
+  the committed prompts record that. Go's default float formatting has to be
+  made to agree.
+- **The reading-level instruction is spelled two ways.** Card and contrast
+  templates say "8th grade reading level"; the report template says
+  "8th-grade reading level". Both are load-bearing cached text, so normalizing
+  them would displace every cached insight for no user-visible gain.
+
+Reading level is asserted as *instruction presence*, not measured. The prompt is
+instructions, so its own reading level is meaningless; measuring the reading
+level of generated output belongs to the opt-in generate mode in #5064.
+
 ## Dockerfile
 
 Three-stage build (build context is the repo root, like all other services):

--- a/server/testdata/insight_prompts/card_map_single_region_peers.json
+++ b/server/testdata/insight_prompts/card_map_single_region_peers.json
@@ -1,0 +1,33 @@
+{
+  "kind": "card",
+  "why": "A county where every demographic subgroup is suppressed, leaving only an overall rate. There is no local disparity to describe, so the prompt must switch to ranking the county against its same-level peers. Guards the peer-comparison branch and the ordinal rank wording.",
+  "hashId": "rate-map",
+  "topic": "HIV diagnoses",
+  "location": "Bartow County, Georgia",
+  "demographicType": "race_and_ethnicity",
+  "metricConfig": {
+    "metricId": "hiv_diagnoses_per_100k",
+    "shortLabel": "cases per 100k"
+  },
+  "rows": [
+    {
+      "fips": "13015",
+      "fips_name": "Bartow County",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 12.4
+    }
+  ],
+  "context": {
+    "peerComparison": {
+      "regionLabel": "Bartow County",
+      "regionValue": 12.4,
+      "peerNoun": "Georgia counties",
+      "shortLabel": "cases per 100k",
+      "peerValues": [
+        2.1, 3.4, 4.0, 5.2, 5.8, 6.1, 6.6, 7.0, 7.3, 7.9, 8.4, 8.8, 9.1, 9.5,
+        10.2, 10.8, 11.1, 11.6, 13.9, 14.2, 15.8, 17.3, 19.4, 22.0, 26.5, 31.2,
+        37.5, 44.1
+      ]
+    }
+  }
+}

--- a/server/testdata/insight_prompts/card_map_single_region_peers.prompt.txt
+++ b/server/testdata/insight_prompts/card_map_single_region_peers.prompt.txt
@@ -1,0 +1,8 @@
+This is a choropleth map of HIV diagnoses in Bartow County, Georgia. Because only its overall rate is available locally, Bartow County, Georgia is ranked against its peer places at the same geographic level — which draw on the same data source and methodology, so the comparison is fair.
+
+Data:
+- Bartow County: 12.4 cases per 100k
+- Among 28 Georgia counties: above the typical
+- Peer median 9.9 cases per 100k; range 2.1–44.1 cases per 100k
+
+Write a single sentence at an 8th grade reading level that says where Bartow County, Georgia falls among its peers (for example, higher than most, near the middle, or among the lowest), using the specific numbers, and what that means for the people who live there. Focus on the "so what", not the chart mechanics. Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.

--- a/server/testdata/insight_prompts/card_map_strong_disparity.json
+++ b/server/testdata/insight_prompts/card_map_strong_disparity.json
@@ -1,0 +1,71 @@
+{
+  "kind": "card",
+  "why": "The common case: a multi-place county map with a wide gap between racial groups and an actively highlighted group. Exercises place-and-group row labeling and the highlighted-group focus clause.",
+  "hashId": "rate-map",
+  "topic": "HIV diagnoses",
+  "location": "Georgia",
+  "demographicType": "race_and_ethnicity",
+  "metricConfig": {
+    "metricId": "hiv_diagnoses_per_100k",
+    "shortLabel": "cases per 100k"
+  },
+  "context": {
+    "activeDemographicGroup": "Black or African American (NH)"
+  },
+  "rows": [
+    {
+      "fips": "13121",
+      "fips_name": "Fulton County",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 41.2
+    },
+    {
+      "fips": "13121",
+      "fips_name": "Fulton County",
+      "race_and_ethnicity": "Black or African American (NH)",
+      "hiv_diagnoses_per_100k": 68.9
+    },
+    {
+      "fips": "13121",
+      "fips_name": "Fulton County",
+      "race_and_ethnicity": "White (NH)",
+      "hiv_diagnoses_per_100k": 9.4
+    },
+    {
+      "fips": "13089",
+      "fips_name": "DeKalb County",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 37.5
+    },
+    {
+      "fips": "13089",
+      "fips_name": "DeKalb County",
+      "race_and_ethnicity": "Black or African American (NH)",
+      "hiv_diagnoses_per_100k": 55.1
+    },
+    {
+      "fips": "13089",
+      "fips_name": "DeKalb County",
+      "race_and_ethnicity": "White (NH)",
+      "hiv_diagnoses_per_100k": 7.2
+    },
+    {
+      "fips": "13051",
+      "fips_name": "Chatham County",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 22.8
+    },
+    {
+      "fips": "13051",
+      "fips_name": "Chatham County",
+      "race_and_ethnicity": "Black or African American (NH)",
+      "hiv_diagnoses_per_100k": 40.3
+    },
+    {
+      "fips": "13051",
+      "fips_name": "Chatham County",
+      "race_and_ethnicity": "White (NH)",
+      "hiv_diagnoses_per_100k": 5.9
+    }
+  ]
+}

--- a/server/testdata/insight_prompts/card_map_strong_disparity.prompt.txt
+++ b/server/testdata/insight_prompts/card_map_strong_disparity.prompt.txt
@@ -1,0 +1,11 @@
+This is a choropleth map showing HIV diagnoses in Georgia by race/ethnicity. Each data row is labeled with its place and race/ethnicity group; an "All" row gives the overall rate for that place. The map currently highlights the Black or African American (NH) group, so lead with that group and use the "All" baseline for comparison.
+
+Data:
+- Fulton County (All): 41.2 cases per 100k
+- Fulton County (Black or African American (NH)): 68.9 cases per 100k
+- DeKalb County (All): 37.5 cases per 100k
+- DeKalb County (Black or African American (NH)): 55.1 cases per 100k
+- Chatham County (All): 22.8 cases per 100k
+- Chatham County (Black or African American (NH)): 40.3 cases per 100k
+
+Write a single sentence at an 8th grade reading level that highlights the most important health equity disparity — either a geographic gap between places or a gap between race/ethnicity groups within a place — and captures why it matters for real people. Focus on the "so what", not the chart mechanics. Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.

--- a/server/testdata/insight_prompts/card_table_suppressed.json
+++ b/server/testdata/insight_prompts/card_table_suppressed.json
@@ -7,32 +7,48 @@
   "demographicType": "race_and_ethnicity",
   "metricConfig": {
     "metricId": "cervical_cancer_per_100k",
-    "shortLabel": "cases per 100k"
+    "shortLabel": "cases per 100k",
+    "populationComparisonMetric": {
+      "metricId": "cervical_cancer_population_pct",
+      "shortLabel": "% of population"
+    }
   },
   "rows": [
     {
       "race_and_ethnicity": "All",
-      "cervical_cancer_per_100k": 6.8
+      "cervical_cancer_per_100k": 6.8,
+      "cervical_cancer_pct_share": 100,
+      "cervical_cancer_population_pct": 100
     },
     {
       "race_and_ethnicity": "White (NH)",
-      "cervical_cancer_per_100k": 6.5
+      "cervical_cancer_per_100k": 6.5,
+      "cervical_cancer_pct_share": 78,
+      "cervical_cancer_population_pct": 92
     },
     {
       "race_and_ethnicity": "Black or African American (NH)",
-      "cervical_cancer_per_100k": null
+      "cervical_cancer_per_100k": null,
+      "cervical_cancer_pct_share": null,
+      "cervical_cancer_population_pct": 4
     },
     {
       "race_and_ethnicity": "Asian (NH)",
-      "cervical_cancer_per_100k": null
+      "cervical_cancer_per_100k": null,
+      "cervical_cancer_pct_share": null,
+      "cervical_cancer_population_pct": 2
     },
     {
       "race_and_ethnicity": "American Indian and Alaska Native (NH)",
-      "cervical_cancer_per_100k": null
+      "cervical_cancer_per_100k": null,
+      "cervical_cancer_pct_share": null,
+      "cervical_cancer_population_pct": 1
     },
     {
       "race_and_ethnicity": "Hispanic or Latino",
-      "cervical_cancer_per_100k": null
+      "cervical_cancer_per_100k": null,
+      "cervical_cancer_pct_share": null,
+      "cervical_cancer_population_pct": 1
     }
   ]
 }

--- a/server/testdata/insight_prompts/card_table_suppressed.json
+++ b/server/testdata/insight_prompts/card_table_suppressed.json
@@ -1,0 +1,38 @@
+{
+  "kind": "card",
+  "why": "A data table where most groups are suppressed and only two survive. The suppressed rows must be absent from the prompt entirely rather than appearing as zero or null, since a fabricated zero would read as 'no burden in this group' and invert the finding.",
+  "hashId": "data-table",
+  "topic": "Cervical cancer incidence",
+  "location": "Vermont",
+  "demographicType": "race_and_ethnicity",
+  "metricConfig": {
+    "metricId": "cervical_cancer_per_100k",
+    "shortLabel": "cases per 100k"
+  },
+  "rows": [
+    {
+      "race_and_ethnicity": "All",
+      "cervical_cancer_per_100k": 6.8
+    },
+    {
+      "race_and_ethnicity": "White (NH)",
+      "cervical_cancer_per_100k": 6.5
+    },
+    {
+      "race_and_ethnicity": "Black or African American (NH)",
+      "cervical_cancer_per_100k": null
+    },
+    {
+      "race_and_ethnicity": "Asian (NH)",
+      "cervical_cancer_per_100k": null
+    },
+    {
+      "race_and_ethnicity": "American Indian and Alaska Native (NH)",
+      "cervical_cancer_per_100k": null
+    },
+    {
+      "race_and_ethnicity": "Hispanic or Latino",
+      "cervical_cancer_per_100k": null
+    }
+  ]
+}

--- a/server/testdata/insight_prompts/card_table_suppressed.json
+++ b/server/testdata/insight_prompts/card_table_suppressed.json
@@ -1,54 +1,38 @@
 {
   "kind": "card",
-  "why": "A data table where most groups are suppressed and only two survive. The suppressed rows must be absent from the prompt entirely rather than appearing as zero or null, since a fabricated zero would read as 'no burden in this group' and invert the finding.",
+  "why": "A data table where most groups are suppressed and only two survive. The suppressed rows must be absent from the prompt entirely rather than appearing as zero or null, since a fabricated zero would read as 'no burden in this group' and invert the finding. This fixture also pins a known defect: the data-table template says it is 'showing rates, population shares, and outcome shares' but formatDataRows only emits shares for the population-vs-distribution chart, so the rendered prompt carries rates alone. Adding share fields to these rows would not change the output. #5066 fixes the template and the payload together, and the diff on this file is the readout of what that displaces.",
   "hashId": "data-table",
   "topic": "Cervical cancer incidence",
   "location": "Vermont",
   "demographicType": "race_and_ethnicity",
   "metricConfig": {
     "metricId": "cervical_cancer_per_100k",
-    "shortLabel": "cases per 100k",
-    "populationComparisonMetric": {
-      "metricId": "cervical_cancer_population_pct",
-      "shortLabel": "% of population"
-    }
+    "shortLabel": "cases per 100k"
   },
   "rows": [
     {
       "race_and_ethnicity": "All",
-      "cervical_cancer_per_100k": 6.8,
-      "cervical_cancer_pct_share": 100,
-      "cervical_cancer_population_pct": 100
+      "cervical_cancer_per_100k": 6.8
     },
     {
       "race_and_ethnicity": "White (NH)",
-      "cervical_cancer_per_100k": 6.5,
-      "cervical_cancer_pct_share": 78,
-      "cervical_cancer_population_pct": 92
+      "cervical_cancer_per_100k": 6.5
     },
     {
       "race_and_ethnicity": "Black or African American (NH)",
-      "cervical_cancer_per_100k": null,
-      "cervical_cancer_pct_share": null,
-      "cervical_cancer_population_pct": 4
+      "cervical_cancer_per_100k": null
     },
     {
       "race_and_ethnicity": "Asian (NH)",
-      "cervical_cancer_per_100k": null,
-      "cervical_cancer_pct_share": null,
-      "cervical_cancer_population_pct": 2
+      "cervical_cancer_per_100k": null
     },
     {
       "race_and_ethnicity": "American Indian and Alaska Native (NH)",
-      "cervical_cancer_per_100k": null,
-      "cervical_cancer_pct_share": null,
-      "cervical_cancer_population_pct": 1
+      "cervical_cancer_per_100k": null
     },
     {
       "race_and_ethnicity": "Hispanic or Latino",
-      "cervical_cancer_per_100k": null,
-      "cervical_cancer_pct_share": null,
-      "cervical_cancer_population_pct": 1
+      "cervical_cancer_per_100k": null
     }
   ]
 }

--- a/server/testdata/insight_prompts/card_table_suppressed.prompt.txt
+++ b/server/testdata/insight_prompts/card_table_suppressed.prompt.txt
@@ -1,0 +1,7 @@
+This is a data table summarizing Cervical cancer incidence in Vermont by race/ethnicity, showing rates, population shares, and outcome shares for each group.
+
+Data:
+- All: 6.8 cases per 100k
+- White (NH): 6.5 cases per 100k
+
+Write a single sentence at an 8th grade reading level that goes beyond the single biggest disparity — consider the pattern across multiple groups, or compare how different groups' burdens relate to their population shares. Focus on the "so what" for the community. Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.

--- a/server/testdata/insight_prompts/card_trends_sparse.json
+++ b/server/testdata/insight_prompts/card_trends_sparse.json
@@ -1,0 +1,54 @@
+{
+  "kind": "card",
+  "why": "A time series with few reported periods and uneven coverage across groups, including a group that reports only one year. Guards the historical-anchor-plus-recent-tail selection in formatDataRows, which behaves differently when a series is shorter than the recent window.",
+  "hashId": "rates-over-time",
+  "topic": "HIV diagnoses",
+  "location": "Wyoming",
+  "demographicType": "race_and_ethnicity",
+  "metricConfig": {
+    "metricId": "hiv_diagnoses_per_100k",
+    "shortLabel": "cases per 100k"
+  },
+  "rows": [
+    {
+      "time_period": "2019",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 3.1
+    },
+    {
+      "time_period": "2020",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 2.8
+    },
+    {
+      "time_period": "2021",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 3.6
+    },
+    {
+      "time_period": "2022",
+      "race_and_ethnicity": "All",
+      "hiv_diagnoses_per_100k": 4.0
+    },
+    {
+      "time_period": "2019",
+      "race_and_ethnicity": "American Indian and Alaska Native (NH)",
+      "hiv_diagnoses_per_100k": 8.7
+    },
+    {
+      "time_period": "2022",
+      "race_and_ethnicity": "American Indian and Alaska Native (NH)",
+      "hiv_diagnoses_per_100k": 14.2
+    },
+    {
+      "time_period": "2022",
+      "race_and_ethnicity": "White (NH)",
+      "hiv_diagnoses_per_100k": 2.2
+    },
+    {
+      "time_period": "2021",
+      "race_and_ethnicity": "Hispanic or Latino",
+      "hiv_diagnoses_per_100k": null
+    }
+  ]
+}

--- a/server/testdata/insight_prompts/card_trends_sparse.prompt.txt
+++ b/server/testdata/insight_prompts/card_trends_sparse.prompt.txt
@@ -1,0 +1,12 @@
+This is a line chart showing how HIV diagnoses rates have changed over time in Wyoming across race/ethnicity groups.
+
+Data:
+- All (2019): 3.1 cases per 100k
+- All (2020): 2.8 cases per 100k
+- All (2021): 3.6 cases per 100k
+- All (2022): 4 cases per 100k
+- American Indian and Alaska Native (NH) (2019): 8.7 cases per 100k
+- American Indian and Alaska Native (NH) (2022): 14.2 cases per 100k
+- White (NH) (2022): 2.2 cases per 100k
+
+Write a single sentence at an 8th grade reading level that names the specific years covered, describes whether the gap between groups is improving or worsening, and includes specific numbers — focus on what this trend means for real people. Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.

--- a/server/testdata/insight_prompts/contrast_compare_geos.json
+++ b/server/testdata/insight_prompts/contrast_compare_geos.json
@@ -1,0 +1,54 @@
+{
+  "kind": "contrast",
+  "why": "Compare mode with the same topic in two places, which selects the compare-geo framing and the tighter per-view byte budget. Both views land in one prompt, so this is the case where a budget regression would silently truncate one side.",
+  "hashId": "rate-chart",
+  "demographicType": "race_and_ethnicity",
+  "viewA": {
+    "topic": "HIV diagnoses",
+    "location": "Georgia",
+    "metricConfig": {
+      "metricId": "hiv_diagnoses_per_100k",
+      "shortLabel": "cases per 100k"
+    },
+    "rows": [
+      {
+        "race_and_ethnicity": "All",
+        "hiv_diagnoses_per_100k": 24.6
+      },
+      {
+        "race_and_ethnicity": "Black or African American (NH)",
+        "hiv_diagnoses_per_100k": 44.8
+      },
+      {
+        "race_and_ethnicity": "White (NH)",
+        "hiv_diagnoses_per_100k": 6.3
+      },
+      {
+        "race_and_ethnicity": "Hispanic or Latino",
+        "hiv_diagnoses_per_100k": 17.1
+      }
+    ]
+  },
+  "viewB": {
+    "topic": "HIV diagnoses",
+    "location": "Vermont",
+    "metricConfig": {
+      "metricId": "hiv_diagnoses_per_100k",
+      "shortLabel": "cases per 100k"
+    },
+    "rows": [
+      {
+        "race_and_ethnicity": "All",
+        "hiv_diagnoses_per_100k": 2.9
+      },
+      {
+        "race_and_ethnicity": "Black or African American (NH)",
+        "hiv_diagnoses_per_100k": 11.4
+      },
+      {
+        "race_and_ethnicity": "White (NH)",
+        "hiv_diagnoses_per_100k": 2.4
+      }
+    ]
+  }
+}

--- a/server/testdata/insight_prompts/contrast_compare_geos.prompt.txt
+++ b/server/testdata/insight_prompts/contrast_compare_geos.prompt.txt
@@ -1,0 +1,14 @@
+Two side-by-side charts show the same health metric — HIV diagnoses — across race/ethnicity groups, in two different places.
+
+View A (Georgia) data:
+- All: 24.6 cases per 100k
+- Black or African American (NH): 44.8 cases per 100k
+- White (NH): 6.3 cases per 100k
+- Hispanic or Latino: 17.1 cases per 100k
+
+View B (Vermont) data:
+- All: 2.9 cases per 100k
+- Black or African American (NH): 11.4 cases per 100k
+- White (NH): 2.4 cases per 100k
+
+Write one sentence at an 8th grade reading level that contrasts these two views. Focus on what comparing these two places reveals that either view alone does not — for example, whether disparities within one place exceed disparities between places, or whether the same patterns recur at different geographic scales. Be specific — name the places, groups, or numbers from the data above. Use only facts present in the data; do not introduce additional statistics, causal explanations, or place-specific facts that are not shown.

--- a/server/testdata/insight_prompts/report_full.json
+++ b/server/testdata/insight_prompts/report_full.json
@@ -1,0 +1,135 @@
+{
+  "kind": "report",
+  "why": "A report-wide insight with all five data sections populated. This is the prompt that produces the one line a reader who skips the charts will actually read, so it carries the most output structure and the most ways to regress.",
+  "topic": "HIV diagnoses",
+  "location": "Georgia",
+  "demographicType": "race_and_ethnicity",
+  "placeNoun": "counties",
+  "metricConfig": {
+    "metricId": "hiv_diagnoses_per_100k",
+    "shortLabel": "cases per 100k"
+  },
+  "sections": {
+    "demographic": {
+      "rows": [
+        {
+          "race_and_ethnicity": "All",
+          "hiv_diagnoses_per_100k": 24.6
+        },
+        {
+          "race_and_ethnicity": "Black or African American (NH)",
+          "hiv_diagnoses_per_100k": 44.8
+        },
+        {
+          "race_and_ethnicity": "Hispanic or Latino",
+          "hiv_diagnoses_per_100k": 17.1
+        },
+        {
+          "race_and_ethnicity": "White (NH)",
+          "hiv_diagnoses_per_100k": 6.3
+        }
+      ]
+    },
+    "geographic": {
+      "rows": [
+        { "fips_name": "Fulton County", "hiv_diagnoses_per_100k": 41.2 },
+        { "fips_name": "DeKalb County", "hiv_diagnoses_per_100k": 37.5 },
+        { "fips_name": "Clayton County", "hiv_diagnoses_per_100k": 33.8 },
+        { "fips_name": "Chatham County", "hiv_diagnoses_per_100k": 22.8 },
+        { "fips_name": "Richmond County", "hiv_diagnoses_per_100k": 21.4 },
+        { "fips_name": "Muscogee County", "hiv_diagnoses_per_100k": 18.9 },
+        { "fips_name": "Bibb County", "hiv_diagnoses_per_100k": 16.2 },
+        { "fips_name": "Cobb County", "hiv_diagnoses_per_100k": 12.7 },
+        { "fips_name": "Bartow County", "hiv_diagnoses_per_100k": 12.4 },
+        { "fips_name": "Hall County", "hiv_diagnoses_per_100k": 9.8 },
+        { "fips_name": "Forsyth County", "hiv_diagnoses_per_100k": 4.1 },
+        { "fips_name": "Fannin County", "hiv_diagnoses_per_100k": 2.6 }
+      ]
+    },
+    "temporal": {
+      "rows": [
+        {
+          "time_period": "2018",
+          "race_and_ethnicity": "All",
+          "hiv_diagnoses_per_100k": 27.9
+        },
+        {
+          "time_period": "2020",
+          "race_and_ethnicity": "All",
+          "hiv_diagnoses_per_100k": 21.3
+        },
+        {
+          "time_period": "2022",
+          "race_and_ethnicity": "All",
+          "hiv_diagnoses_per_100k": 24.6
+        },
+        {
+          "time_period": "2018",
+          "race_and_ethnicity": "Black or African American (NH)",
+          "hiv_diagnoses_per_100k": 52.4
+        },
+        {
+          "time_period": "2020",
+          "race_and_ethnicity": "Black or African American (NH)",
+          "hiv_diagnoses_per_100k": 39.8
+        },
+        {
+          "time_period": "2022",
+          "race_and_ethnicity": "Black or African American (NH)",
+          "hiv_diagnoses_per_100k": 44.8
+        },
+        {
+          "time_period": "2018",
+          "race_and_ethnicity": "White (NH)",
+          "hiv_diagnoses_per_100k": 7.1
+        },
+        {
+          "time_period": "2020",
+          "race_and_ethnicity": "White (NH)",
+          "hiv_diagnoses_per_100k": 5.4
+        },
+        {
+          "time_period": "2022",
+          "race_and_ethnicity": "White (NH)",
+          "hiv_diagnoses_per_100k": 6.3
+        }
+      ]
+    },
+    "ageAdjusted": {
+      "metricConfig": {
+        "metricId": "hiv_deaths_ratio_age_adjusted",
+        "shortLabel": "x"
+      },
+      "rows": [
+        {
+          "race_and_ethnicity": "Black or African American (NH)",
+          "hiv_deaths_ratio_age_adjusted": 7.1
+        },
+        {
+          "race_and_ethnicity": "Hispanic or Latino",
+          "hiv_deaths_ratio_age_adjusted": 2.4
+        },
+        {
+          "race_and_ethnicity": "Asian (NH)",
+          "hiv_deaths_ratio_age_adjusted": 0.6
+        }
+      ]
+    },
+    "unknown": {
+      "metricConfig": {
+        "metricId": "hiv_diagnoses_pct_share",
+        "shortLabel": "% of cases"
+      },
+      "rows": [
+        {
+          "race_and_ethnicity": "Unknown race",
+          "hiv_diagnoses_pct_share": 8.3
+        },
+        {
+          "race_and_ethnicity": "Unknown ethnicity",
+          "hiv_diagnoses_pct_share": 4.9
+        }
+      ]
+    }
+  }
+}

--- a/server/testdata/insight_prompts/report_full.prompt.txt
+++ b/server/testdata/insight_prompts/report_full.prompt.txt
@@ -1,0 +1,50 @@
+You are a public health analyst reviewing a report about "HIV diagnoses" in Georgia, broken down by race/ethnicity. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
+
+The page contains multiple charts: a rate map, rates over time, a rate bar chart, an unknowns map, inequities over time, and a population vs distribution chart.
+
+
+Current rates by race/ethnicity in Georgia:
+- All: 24.6 cases per 100k
+- Black or African American (NH): 44.8 cases per 100k
+- Hispanic or Latino: 17.1 cases per 100k
+- White (NH): 6.3 cases per 100k
+
+Geographic spread:
+- Highest: Fulton County 41.2, DeKalb County 37.5, Clayton County 33.8 cases per 100k
+- Lowest reported: Fannin County 2.6, Forsyth County 4.1, Hall County 9.8 cases per 100k
+- Median across 12 counties: 17.5 cases per 100k
+
+Rates over time by race/ethnicity in Georgia, first, highest, and latest reported periods:
+- All: 27.9 in 2018, 24.6 in 2022 cases per 100k
+- Black or African American (NH): 52.4 in 2018, 44.8 in 2022 cases per 100k
+- White (NH): 7.1 in 2018, 6.3 in 2022 cases per 100k
+
+Age-adjusted burden relative to the White (NH) baseline in Georgia:
+- Black or African American (NH): 7.1x the White (NH) rate
+- Hispanic or Latino: 2.4x the White (NH) rate
+- Asian (NH): 0.6x the White (NH) rate
+
+Cases missing race/ethnicity data in Georgia:
+- Unknown race: 8.3% of cases
+- Unknown ethnicity: 4.9% of cases
+
+WRITING RULES, follow these strictly:
+- Use only numbers that appear in the data above. Never estimate, infer, round differently, derive a new figure by combining two that are shown, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
+- Do not add causal explanations or place-specific facts that are not in the data.
+- A rate of 0 means the source reported no rate for that place or period. Never cite a 0 as a rate, and never describe it as a place or time with no cases, no deaths, or no burden.
+- Call a figure a peak, a high point, or a low point only where the data above labels it as one. A first or latest reported value is neither.
+- Write every demographic group name exactly as it appears in the data above. Never expand, abbreviate, or reword it; the names shown are the ones used throughout the rest of the report.
+- Never label a group vulnerable, at-risk, high-risk, underserved, or a minority. Those words describe people by a deficit rather than by what they face. Name the group and name the burden instead.
+- Use person-first wording: "people with diabetes", not "diabetics"; "people experiencing homelessness", not "the homeless".
+- Write at an 8th-grade reading level. Use short words and simple sentences.
+- Avoid jargon. If you must use a technical term, explain it immediately.
+- Do not repeat the same number in more than one section.
+
+Respond ONLY with a valid JSON object, no markdown, no backticks, no explanation outside the JSON. Include every key below and no others. Use this exact structure:
+
+{
+  "keyFindings": "1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k. You may cite one of the ratios shown above, but do not work out any other figure.",
+  "locationComparison": "1-2 sentences (max 35 words): what the geographic spread shows about where the burden is heaviest.",
+  "demographicInsights": "2-3 sentences (max 75 words): which group is most affected and how large the gap is compared to others, using the rates above. Then use the age-adjusted ratios to say whether the gap holds once differences in age between groups are accounted for. Then say whether the gap between groups has widened or narrowed across the reported periods, naming the highest point if one is given.",
+  "whatThisMeans": "2-3 sentences (max 55 words): what this means for real people in these communities, in plain everyday language. Then note in one sentence what share of cases is missing race/ethnicity data, and that the rates above describe only the cases where it was recorded."
+}

--- a/server/testdata/insight_prompts/report_no_age_adjusted.json
+++ b/server/testdata/insight_prompts/report_no_age_adjusted.json
@@ -1,0 +1,40 @@
+{
+  "kind": "report",
+  "why": "A report with no age-adjusted ratios, which is the majority of topics. This is the highest-stakes no-data variant: with no ratio supplied, the prompt must forbid citing any figure in the headline. Without that clause the model is invited to derive 'seven times higher' from two raw rates and present it as a finding, which is exactly how a fabricated statistic reaches a reader.",
+  "topic": "Preventable hospitalizations",
+  "location": "Mississippi",
+  "demographicType": "race_and_ethnicity",
+  "placeNoun": "counties",
+  "metricConfig": {
+    "metricId": "preventable_hospitalizations_per_100k",
+    "shortLabel": "per 100k"
+  },
+  "sections": {
+    "demographic": {
+      "rows": [
+        {
+          "race_and_ethnicity": "All",
+          "preventable_hospitalizations_per_100k": 4820
+        },
+        {
+          "race_and_ethnicity": "Black or African American (NH)",
+          "preventable_hospitalizations_per_100k": 6140
+        },
+        {
+          "race_and_ethnicity": "White (NH)",
+          "preventable_hospitalizations_per_100k": 3990
+        }
+      ]
+    },
+    "geographic": {
+      "rows": [
+        { "fips_name": "Hinds County", "preventable_hospitalizations_per_100k": 5610 },
+        { "fips_name": "Harrison County", "preventable_hospitalizations_per_100k": 4770 },
+        { "fips_name": "DeSoto County", "preventable_hospitalizations_per_100k": 3840 }
+      ]
+    },
+    "temporal": { "rows": [] },
+    "ageAdjusted": { "rows": [] },
+    "unknown": { "rows": [] }
+  }
+}

--- a/server/testdata/insight_prompts/report_no_age_adjusted.prompt.txt
+++ b/server/testdata/insight_prompts/report_no_age_adjusted.prompt.txt
@@ -1,0 +1,33 @@
+You are a public health analyst reviewing a report about "Preventable hospitalizations" in Mississippi, broken down by race/ethnicity. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
+
+The page contains multiple charts: a rate map, rates over time, a rate bar chart, an unknowns map, inequities over time, and a population vs distribution chart.
+
+
+Current rates by race/ethnicity in Mississippi:
+- All: 4820 per 100k
+- Black or African American (NH): 6140 per 100k
+- White (NH): 3990 per 100k
+
+Geographic spread:
+- All 3 counties: Hinds County 5610, Harrison County 4770, DeSoto County 3840 per 100k
+
+WRITING RULES, follow these strictly:
+- Use only numbers that appear in the data above. Never estimate, infer, round differently, derive a new figure by combining two that are shown, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
+- Do not add causal explanations or place-specific facts that are not in the data.
+- A rate of 0 means the source reported no rate for that place or period. Never cite a 0 as a rate, and never describe it as a place or time with no cases, no deaths, or no burden.
+- Call a figure a peak, a high point, or a low point only where the data above labels it as one. A first or latest reported value is neither.
+- Write every demographic group name exactly as it appears in the data above. Never expand, abbreviate, or reword it; the names shown are the ones used throughout the rest of the report.
+- Never label a group vulnerable, at-risk, high-risk, underserved, or a minority. Those words describe people by a deficit rather than by what they face. Name the group and name the burden instead.
+- Use person-first wording: "people with diabetes", not "diabetics"; "people experiencing homelessness", not "the homeless".
+- Write at an 8th-grade reading level. Use short words and simple sentences.
+- Avoid jargon. If you must use a technical term, explain it immediately.
+- Do not repeat the same number in more than one section.
+
+Respond ONLY with a valid JSON object, no markdown, no backticks, no explanation outside the JSON. Include every key below and no others. Use this exact structure:
+
+{
+  "keyFindings": "1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k. State no figure at all; make the comparison in words only.",
+  "locationComparison": "1-2 sentences (max 35 words): what the geographic spread shows about where the burden is heaviest.",
+  "demographicInsights": "2-3 sentences (max 35 words): which group is most affected and how large the gap is compared to others, using the rates above.",
+  "whatThisMeans": "1-2 sentences (max 35 words): what this means for real people in these communities, in plain everyday language."
+}


### PR DESCRIPTION
**Preview:** N/A (testing infrastructure only, no UI changes)

## Summary

Prompt edits are unusually expensive in this codebase: since #5029/#5053 the insight cache key is a hash of the rendered prompt, so any template change silently displaces every cached insight it touches. Nothing made that blast radius visible at review time.

This pins the exact text sent to the model for seven representative views. Each case is a plain JSON input plus a committed `.prompt.txt` of the rendered output, so a template edit shows up as a diff across exactly the fixtures it moves, which is also exactly the cache it displaces. **That diff is the artifact to review.**

- Deterministic and offline: no API key, no network, no clock.
- Fixtures carry no TypeScript-only types and live under `server/` so the Go port in #5045 can render the same inputs and be checked against the same expected output rather than trusted.
- Extracts `buildCardInsightPrompt` from `generateCardInsight` so a card prompt can be rendered without a network call. The seam takes the full `InsightContext`, which keeps the peer-comparison branch inside the tested function instead of forcing the harness to reimplement it. Output is byte-identical, so this PR displaces no cache.

Two Go-port hazards are documented in `server/CLAUDE.md`, both found while building this:

- **Number formatting must match exactly.** JavaScript renders `4.0` as `4`, and the committed prompts record that. Go's default float formatting has to be made to agree.
- **The reading-level instruction is spelled two ways.** Card and contrast templates say "8th grade reading level"; the report template says "8th-grade reading level". Both are load-bearing cached text, so normalizing them would displace every cached insight for no user-visible gain.

## A defect the fixtures pin rather than fix

`card_table_suppressed` records a real gap that review surfaced: the `data-table` template says it is "showing rates, population shares, and outcome shares" but `formatDataRows` only resolves `populationComparisonMetric` for the `population-vs-distribution` chart, so the prompt carries rates alone.

Adding share fields to the fixture rows does not change the output, because nothing reads them on that code path. Fixing it means changing the template and the payload together, which is #5066, and #5066 needs #5067's population column first. So the fixture pins current behavior and states the defect in its `why` field. When #5066 lands, the diff on this file is the readout of what that change displaces.

## Coverage

| Fixture | What it pins |
|---|---|
| `card_map_strong_disparity` | Multi-region map with a clear geographic gap |
| `card_map_single_region_peers` | Single region with no local comparison, ranked against peers |
| `card_trends_sparse` | Time series with few points per group |
| `card_table_suppressed` | Data table where two groups are visible and most are suppressed |
| `contrast_compare_geos` | Two-view compare mode under the tighter contrast byte budget |
| `report_full` | Report insight with all five sections populated |
| `report_no_age_adjusted` | Report with no ratio supplied, the case where the prompt must forbid citing a figure in the headline |

## Test plan

- [x] `npx vitest run src/utils/insightPromptFixtures.test.ts` passes (22 tests)
- [x] CI failures fixed: `server/testdata/insight_prompts` added to the `runFrontendTests.yml` sparse-checkout, `.gitignore` directory negation, `Fannin` added to cspell

Closes #5064
