### PR TITLE
Emit structured insight request logs for volume and cache hit rate

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -94,6 +94,7 @@ object and hits are the hot path.
 | `suppressed` | A reviewer suppressed this exact insight |
 | `rejected` | Malformed request (missing or oversize prompt) |
 | `error` | Provider or suppression-check failure |
+| `unknown` | The handler returned without classifying the request. Always a bug |
 | `ceiling_approaching` | Not a request. See the alert below |
 
 `reason` narrows the non-serving outcomes: `ceiling_reached`, `generation_disabled`,
@@ -166,6 +167,11 @@ moment, and now cover the same window as the query, so `monthlyGenerations` and 
 reservation count should agree. A persistent gap means log entries aged out of the
 default 30-day retention, which a 31-day month will always clip slightly, so trust the
 counter over the query when they disagree.
+
+One other source of drift, visible only near the monthly cap: `reserveGeneration`
+claims the daily slot before the monthly one, so a request the monthly ceiling refuses
+logs `reserved=false` after already consuming a daily slot. The daily counter can
+therefore sit slightly above what the reservation query returns.
 
 Spend is $0 while the project is on the provider's free tier, so the tokens are read
 as quota headroom rather than dollars. They are recorded per line with the model that

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -107,6 +107,11 @@ call that then fails still spent one: a provider error or an empty response logs
 `error` or `unavailable` while having consumed ceiling budget. Counting only
 `generated` would undercount the ceilings by exactly the failure rate.
 
+`model` marks a request that reached the provider, not one that succeeded, so it is
+present on `provider_error` and `no_content` lines too. Group by it, but never use its
+presence as a stand-in for a successful generation: `outcome` and `reserved` are the
+fields that answer that.
+
 **These strings are an interface.** The queries below and the alert filter match on
 them literally, so renaming one silently returns fewer rows rather than failing.
 `TestInsightRequestLogRecordsEveryOutcome` pins every outcome and every reason above,

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -136,23 +136,36 @@ deliberately best-effort and swallows errors, so treat them as refining the
 per-generation average rather than as a total.
 
 ```bash
-gcloud logging read "$FILTER jsonPayload.insight.reserved=true" \
-  --project "$PROJECT" --freshness=30d \
+# reserveGeneration keys the monthly ledger by UTC calendar month, so the window
+# has to be one too. A rolling --freshness=30d would straddle two of them and
+# could not be compared against the monthly counter or the monthly ceiling.
+MONTH_START=$(date -u +%Y-%m-01T00:00:00Z)
+
+gcloud logging read "$FILTER jsonPayload.insight.reserved=true timestamp>=\"$MONTH_START\"" \
+  --project "$PROJECT" \
   --format='value(jsonPayload.insight.outcome,jsonPayload.insight.promptTokens,jsonPayload.insight.outputTokens)' \
 | awk -F'\t' '{n++; if ($1=="generated") s++; i+=$2; o+=$3}
        END {print n" reservations ("s" produced an insight), "i" input tokens, "o" output tokens"}'
 ```
 
-`-F'\t'` is load-bearing: `value()` emits tab-separated fields, and a zero token count
-is omitted from the JSON entirely, so under awk's default whitespace splitting the
-empty field would collapse and shift every column after it.
+Two details that are easy to get wrong here:
+
+- `--freshness` is dropped on purpose, not forgotten. It applies only to filters with
+  no timestamp restriction, so leaving it alongside one is misleading rather than
+  additive.
+- `-F'\t'` is load-bearing: `value()` emits tab-separated fields, and a zero token
+  count is omitted from the JSON entirely, so under awk's default whitespace splitting
+  the empty field would collapse and shift every column after it.
 
 The gap between the two counts is the provider failure rate, and it is ceiling budget
 spent on nothing. A widening gap is worth chasing on its own.
 
 Cross-check against the ledger without reading GCS: the newest line's
 `dailyGenerations` and `monthlyGenerations` are the ledger's own counters at that
-moment, so they should track the reservation count above.
+moment, and now cover the same window as the query, so `monthlyGenerations` and the
+reservation count should agree. A persistent gap means log entries aged out of the
+default 30-day retention, which a 31-day month will always clip slightly, so trust the
+counter over the query when they disagree.
 
 Spend is $0 while the project is on the provider's free tier, so the tokens are read
 as quota headroom rather than dollars. They are recorded per line with the model that

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -35,7 +35,7 @@ go test ./...
 | `GEMINI_MODEL` | No | `gemini-3.1-flash-lite` | Gemini model used for insight generation |
 | `INSIGHT_MAX_GENERATIONS_PER_DAY` | No | `400` | Daily generation ceiling, tracked in the usage ledger |
 | `INSIGHT_MAX_GENERATIONS_PER_MONTH` | No | `8000` | Monthly generation ceiling, tracked in the usage ledger |
-| `INSIGHT_CEILING_WARN_PERCENT` | No | `80` | Share of a ceiling at which a `ceiling_approaching` warning is logged |
+| `INSIGHT_CEILING_WARN_PERCENT` | No | `80` | Share of a ceiling at which a `ceiling_approaching` warning is logged. Must be `1`-`100`; anything else falls back to the default |
 | `INSIGHT_ALLOWED_ORIGINS` | No | prod, www, dev, `localhost:3000`, `*.netlify.app` | Comma-separated origins permitted to request generation |
 | `WEBFLOW_API_TOKEN` | No | - | Required for `/het-news` |
 | `INSIGHT_NEGATIVE_EXAMPLES_ENABLED` | No | `false` | Feed prior flagged outputs back into prompts |
@@ -189,6 +189,12 @@ gcloud logging read \
 `INSIGHT_CEILING_WARN_PERCENT` of the ceiling. The ledger's compare-and-swap hands out
 each count exactly once, so it cannot double-fire across Cloud Run instances and cannot
 degrade into a line per request for the rest of the period.
+
+Because the signal is a single exact count, a percent outside `1`-`100` would put the
+threshold where no count can reach it and turn the alert off with no error, so an
+out-of-range value is ignored in favor of the default. The threshold is also not wired
+through Terraform on purpose: `terraform apply` rolls a new revision anyway, so an env
+var would not buy a deploy-free way to change it.
 
 A daily ceiling needs a real-time signal. The weekly `cronReviewFlaggedInsights.yml` is
 too coarse for it: a Tuesday overrun would not surface until the following Monday, long

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -35,6 +35,7 @@ go test ./...
 | `GEMINI_MODEL` | No | `gemini-3.1-flash-lite` | Gemini model used for insight generation |
 | `INSIGHT_MAX_GENERATIONS_PER_DAY` | No | `400` | Daily generation ceiling, tracked in the usage ledger |
 | `INSIGHT_MAX_GENERATIONS_PER_MONTH` | No | `8000` | Monthly generation ceiling, tracked in the usage ledger |
+| `INSIGHT_CEILING_WARN_PERCENT` | No | `80` | Share of a ceiling at which a `ceiling_approaching` warning is logged |
 | `INSIGHT_ALLOWED_ORIGINS` | No | prod, www, dev, `localhost:3000`, `*.netlify.app` | Comma-separated origins permitted to request generation |
 | `WEBFLOW_API_TOKEN` | No | - | Required for `/het-news` |
 | `INSIGHT_NEGATIVE_EXAMPLES_ENABLED` | No | `false` | Feed prior flagged outputs back into prompts |
@@ -63,6 +64,140 @@ The server handles all traffic on a single port:
   - `index.html` — `no-store` (shell must always be fresh)
   - Everything else — `public, max-age=7200`
   - Unknown paths → `index.html` (SPA client-side routing fallback)
+
+## Insight request logs
+
+Every `/fetch-ai-insight` request emits exactly one JSON line to stdout, which Cloud
+Run ships to Cloud Logging as a structured payload under `jsonPayload.insight`. That
+line is the only reporting surface for this feature. **The usage ledger is not a
+reporting surface**: `reserveGeneration` writes it before the provider call so it can
+refuse a generation, and it stays write-only. Cache hits in particular must never be
+routed through it, since `mutateLedger` is a compare-and-swap against a single GCS
+object and hits are the hot path.
+
+```json
+{"severity":"INFO","message":"insight generated","insight":{
+  "outcome":"generated","cacheKey":"a1b2c3","topic":"hiv",
+  "model":"gemini-3.1-flash-lite","promptTokens":1840,"outputTokens":96,
+  "dailyGenerations":42,"dailyLimit":400,
+  "monthlyGenerations":903,"monthlyLimit":8000,"durationMs":812}}
+```
+
+`outcome` is one of:
+
+| Outcome | Meaning |
+|---|---|
+| `memory_hit` | Served from the in-process `sync.Map` |
+| `gcs_hit` | Served from the GCS persistent cache |
+| `generated` | Called the provider. Carries `model` and token counts |
+| `unavailable` | No insight shown. `reason` says which gate closed |
+| `suppressed` | A reviewer suppressed this exact insight |
+| `rejected` | Malformed request (missing or oversize prompt) |
+| `error` | Provider or suppression-check failure |
+| `ceiling_approaching` | Not a request. See the alert below |
+
+`reason` narrows the non-serving outcomes: `ceiling_reached`, `generation_disabled`,
+`no_api_key`, `no_cache_bucket`, `ledger_error`, `no_content`, `provider_quota`,
+`provider_error`, `suppression_check`, `missing_prompt`, `prompt_too_large`.
+
+**These strings are an interface.** The queries below and the alert filter match on
+them literally, so renaming one silently returns fewer rows rather than failing.
+`TestInsightRequestLogRecordsEveryOutcome` pins every one of them.
+
+### Queries
+
+The Cloud Run service is named `frontend-service`, not `het-server` (see the domain
+mapping note in `config/run.tf`). All three queries share this prefix:
+
+```bash
+PROJECT=$(gcloud projects list --filter='name~het-infra-prod' --format='value(projectId)')
+FILTER='resource.type="cloud_run_revision"
+resource.labels.service_name="frontend-service"'
+```
+
+**Generation volume and tokens this month.** Generations are the reliable number:
+`reserveGeneration` claims a slot before the call and cannot lose one. Tokens are
+approximate, because `recordTokenUsage` is deliberately best-effort and swallows
+errors, so treat them as refining the per-generation average rather than as a total.
+
+```bash
+gcloud logging read "$FILTER jsonPayload.insight.outcome=\"generated\"" \
+  --project "$PROJECT" --freshness=30d \
+  --format='value(jsonPayload.insight.promptTokens,jsonPayload.insight.outputTokens)' \
+| awk '{n++; i+=$1; o+=$2} END {print n" generations, "i" input tokens, "o" output tokens"}'
+```
+
+Spend is $0 while the project is on the provider's free tier, so the tokens are read
+as quota headroom rather than dollars. They are recorded per line with the model that
+produced them so that a move to a paid tier, or a `GEMINI_MODEL` change, needs no code
+change to price: group by `jsonPayload.insight.model` and apply that model's published
+input and output rates. Never apply a single blended rate, since input and output
+price differently and the model is configurable.
+
+**Cache hit rate.** This is the dominant factor in what the feature costs, and the
+reason steady-state cost approaches zero.
+
+```bash
+gcloud logging read \
+  "$FILTER jsonPayload.insight.outcome=(\"memory_hit\" OR \"gcs_hit\" OR \"generated\")" \
+  --project "$PROJECT" --freshness=7d \
+  --format='value(jsonPayload.insight.outcome)' | sort | uniq -c
+```
+
+Hit rate is `(memory_hit + gcs_hit) / (memory_hit + gcs_hit + generated)`. Those three
+outcomes are the whole denominator on purpose: `suppressed` and `rejected` requests
+never consulted the cache, so counting them would understate the rate.
+
+**Ceiling events.** Every request refused for hitting a cap, plus the threshold crossing:
+
+```bash
+gcloud logging read \
+  "$FILTER (jsonPayload.insight.reason=\"ceiling_reached\" OR jsonPayload.insight.outcome=\"ceiling_approaching\")" \
+  --project "$PROJECT" --freshness=30d --format='value(timestamp,jsonPayload.message)'
+```
+
+### Ceiling alert
+
+`ceiling_approaching` fires once per period, on the single request whose count lands on
+`INSIGHT_CEILING_WARN_PERCENT` of the ceiling. The ledger's compare-and-swap hands out
+each count exactly once, so it cannot double-fire across Cloud Run instances and cannot
+degrade into a line per request for the rest of the period.
+
+A daily ceiling needs a real-time signal. The weekly `cronReviewFlaggedInsights.yml` is
+too coarse for it: a Tuesday overrun would not surface until the following Monday, long
+after uncached views had stopped showing insights.
+
+Create the log-based alert once per project, against this filter:
+
+```plaintext
+resource.type="cloud_run_revision"
+resource.labels.service_name="frontend-service"
+jsonPayload.insight.outcome="ceiling_approaching"
+```
+
+```bash
+gcloud alpha monitoring channels list --project "$PROJECT"   # get the channel ID
+gcloud alpha monitoring policies create --project "$PROJECT" --policy-from-file=- <<'YAML'
+displayName: Insight generation ceiling approaching
+combiner: OR
+conditions:
+  - displayName: 80% of an insight generation ceiling reached
+    conditionMatchedLog:
+      filter: >-
+        resource.type="cloud_run_revision"
+        resource.labels.service_name="frontend-service"
+        jsonPayload.insight.outcome="ceiling_approaching"
+alertStrategy:
+  notificationRateLimit:
+    period: 3600s
+notificationChannels:
+  - projects/PROJECT/notificationChannels/CHANNEL_ID
+YAML
+```
+
+Alerting on `ceiling_approaching` rather than on `ceiling_reached` is the point: by the
+time reservations are being refused, uncached views are already rendering no insight
+section. Raising `INSIGHT_MAX_GENERATIONS_PER_DAY` is the immediate lever.
 
 ## Insight prompt fixtures
 

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -77,7 +77,7 @@ object and hits are the hot path.
 
 ```json
 {"severity":"INFO","message":"insight generated","insight":{
-  "outcome":"generated","cacheKey":"a1b2c3","topic":"hiv",
+  "outcome":"generated","cacheKey":"a1b2c3","topic":"hiv","reserved":true,
   "model":"gemini-3.1-flash-lite","promptTokens":1840,"outputTokens":96,
   "dailyGenerations":42,"dailyLimit":400,
   "monthlyGenerations":903,"monthlyLimit":8000,"durationMs":812}}
@@ -100,9 +100,17 @@ object and hits are the hot path.
 `no_api_key`, `no_cache_bucket`, `ledger_error`, `no_content`, `provider_quota`,
 `provider_error`, `suppression_check`, `missing_prompt`, `prompt_too_large`.
 
+`reserved` is true when the request claimed a slot against the ceilings. **This is not
+the same as `outcome="generated"`**, and the difference is what makes the volume query
+below correct. `reserveGeneration` claims the slot *before* the provider call, so a
+call that then fails still spent one: a provider error or an empty response logs
+`error` or `unavailable` while having consumed ceiling budget. Counting only
+`generated` would undercount the ceilings by exactly the failure rate.
+
 **These strings are an interface.** The queries below and the alert filter match on
 them literally, so renaming one silently returns fewer rows rather than failing.
-`TestInsightRequestLogRecordsEveryOutcome` pins every one of them.
+`TestInsightRequestLogRecordsEveryOutcome` pins every outcome and every reason above,
+along with its severity and its `reserved` value.
 
 ### Queries
 
@@ -115,17 +123,31 @@ FILTER='resource.type="cloud_run_revision"
 resource.labels.service_name="frontend-service"'
 ```
 
-**Generation volume and tokens this month.** Generations are the reliable number:
-`reserveGeneration` claims a slot before the call and cannot lose one. Tokens are
-approximate, because `recordTokenUsage` is deliberately best-effort and swallows
-errors, so treat them as refining the per-generation average rather than as a total.
+**Generation volume and tokens this month.** Filter on `reserved`, not on
+`outcome="generated"`, so failed provider calls that still consumed ceiling budget are
+counted. Reservations are the reliable number: `reserveGeneration` claims a slot before
+the call and cannot lose one. Tokens are approximate, because `recordTokenUsage` is
+deliberately best-effort and swallows errors, so treat them as refining the
+per-generation average rather than as a total.
 
 ```bash
-gcloud logging read "$FILTER jsonPayload.insight.outcome=\"generated\"" \
+gcloud logging read "$FILTER jsonPayload.insight.reserved=true" \
   --project "$PROJECT" --freshness=30d \
-  --format='value(jsonPayload.insight.promptTokens,jsonPayload.insight.outputTokens)' \
-| awk '{n++; i+=$1; o+=$2} END {print n" generations, "i" input tokens, "o" output tokens"}'
+  --format='value(jsonPayload.insight.outcome,jsonPayload.insight.promptTokens,jsonPayload.insight.outputTokens)' \
+| awk -F'\t' '{n++; if ($1=="generated") s++; i+=$2; o+=$3}
+       END {print n" reservations ("s" produced an insight), "i" input tokens, "o" output tokens"}'
 ```
+
+`-F'\t'` is load-bearing: `value()` emits tab-separated fields, and a zero token count
+is omitted from the JSON entirely, so under awk's default whitespace splitting the
+empty field would collapse and shift every column after it.
+
+The gap between the two counts is the provider failure rate, and it is ceiling budget
+spent on nothing. A widening gap is worth chasing on its own.
+
+Cross-check against the ledger without reading GCS: the newest line's
+`dailyGenerations` and `monthlyGenerations` are the ledger's own counters at that
+moment, so they should track the reservation count above.
 
 Spend is $0 while the project is on the provider's free tier, so the tokens are read
 as quota headroom rather than dollars. They are recorded per line with the model that
@@ -176,12 +198,17 @@ jsonPayload.insight.outcome="ceiling_approaching"
 ```
 
 ```bash
-gcloud alpha monitoring channels list --project "$PROJECT"   # get the channel ID
-gcloud alpha monitoring policies create --project "$PROJECT" --policy-from-file=- <<'YAML'
+# Pick the channel to notify, then create the policy. The heredoc is unquoted so
+# CHANNEL and PROJECT expand; a quoted <<'YAML' would post the literal names and
+# the policy would be created with no working notification target.
+CHANNEL=$(gcloud alpha monitoring channels list --project "$PROJECT" \
+  --format='value(name)' --limit=1)
+
+gcloud alpha monitoring policies create --project "$PROJECT" --policy-from-file=- <<YAML
 displayName: Insight generation ceiling approaching
 combiner: OR
 conditions:
-  - displayName: 80% of an insight generation ceiling reached
+  - displayName: Insight generation ceiling warn threshold reached
     conditionMatchedLog:
       filter: >-
         resource.type="cloud_run_revision"
@@ -191,9 +218,14 @@ alertStrategy:
   notificationRateLimit:
     period: 3600s
 notificationChannels:
-  - projects/PROJECT/notificationChannels/CHANNEL_ID
+  - $CHANNEL
 YAML
 ```
+
+`gcloud alpha monitoring channels list` returns the full
+`projects/<project>/notificationChannels/<id>` resource name, which is the form the
+policy wants. Confirm it is the channel the team actually watches before creating the
+policy; `--limit=1` just takes the first one.
 
 Alerting on `ceiling_approaching` rather than on `ceiling_reached` is the point: by the
 time reservations are being refused, uncached views are already rendering no insight

--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -158,8 +158,11 @@ Two details that are easy to get wrong here:
   count is omitted from the JSON entirely, so under awk's default whitespace splitting
   the empty field would collapse and shift every column after it.
 
-The gap between the two counts is the provider failure rate, and it is ceiling budget
-spent on nothing. A widening gap is worth chasing on its own.
+The gap between the two counts is reservations that produced no insight, and it is
+ceiling budget spent on nothing. Group the gap by `reason` before reading anything into
+it: `provider_error`, `provider_quota`, and `no_content` are provider failures, while
+`unknown` is a bug in the handler and means an outcome went unset. A widening gap is
+worth chasing on its own.
 
 Cross-check against the ledger without reading GCS: the newest line's
 `dailyGenerations` and `monthlyGenerations` are the ledger's own counters at that

--- a/server/insight_budget.go
+++ b/server/insight_budget.go
@@ -143,8 +143,16 @@ func mutateLedger(ctx context.Context, bucket, path string, apply func(*usageLed
 
 // ceilingWarnAt is the generation count at which a period's usage is considered
 // close enough to its ceiling to be worth an alert.
+//
+// A percent outside 1..100 lands the threshold at zero or past the ceiling, and
+// either one silently disables the alert rather than moving it, so an
+// out-of-range value falls back to the default instead of being honored.
 func ceilingWarnAt(limit int) int {
-	return limit * envInt("INSIGHT_CEILING_WARN_PERCENT", defaultCeilingWarnPercent) / 100
+	percent := envInt("INSIGHT_CEILING_WARN_PERCENT", defaultCeilingWarnPercent)
+	if percent < 1 || percent > 100 {
+		percent = defaultCeilingWarnPercent
+	}
+	return limit * percent / 100
 }
 
 // reserveOne reports the post-increment count alongside the verdict, which is

--- a/server/insight_budget.go
+++ b/server/insight_budget.go
@@ -30,6 +30,10 @@ const (
 	defaultMaxGenerationsPerDay   = 400
 	defaultMaxGenerationsPerMonth = 8000
 
+	// Warn at this share of a ceiling. Late enough not to cry wolf, early enough
+	// that a fifth of the period's budget is still available to act with.
+	defaultCeilingWarnPercent = 80
+
 	insightRatePerMinute = 5
 	insightRateBurst     = 10
 	maxTrackedClients    = 10000
@@ -137,29 +141,62 @@ func mutateLedger(ctx context.Context, bucket, path string, apply func(*usageLed
 	return false, errLedgerContention
 }
 
-func reserveOne(ctx context.Context, bucket, path string, limit int) (bool, error) {
-	return mutateLedger(ctx, bucket, path, func(l *usageLedger) bool {
+// ceilingWarnAt is the generation count at which a period's usage is considered
+// close enough to its ceiling to be worth an alert.
+func ceilingWarnAt(limit int) int {
+	return limit * envInt("INSIGHT_CEILING_WARN_PERCENT", defaultCeilingWarnPercent) / 100
+}
+
+// reserveOne reports the post-increment count alongside the verdict, which is
+// what lets the caller tell "45 of 400 used" from "at the cap" without a second
+// read of the ledger.
+func reserveOne(ctx context.Context, bucket, path string, limit int) (count int, ok bool, err error) {
+	ok, err = mutateLedger(ctx, bucket, path, func(l *usageLedger) bool {
 		if l.Generations >= limit {
+			count = l.Generations
 			return false
 		}
 		l.Generations++
+		count = l.Generations
 		return true
 	})
+	return count, ok, err
+}
+
+// usageSnapshot is what a reservation attempt observed, so the request log can
+// carry period usage without re-reading the ledger. A period the attempt never
+// reached stays zero, rather than reporting a limit against a count that was
+// never read.
+type usageSnapshot struct {
+	dayCount, dayLimit     int
+	monthCount, monthLimit int
 }
 
 // reserveGeneration claims one generation against both the daily and monthly
 // ceilings. It returns false when either is exhausted.
-func reserveGeneration(ctx context.Context, bucket string) (bool, error) {
+func reserveGeneration(ctx context.Context, bucket string) (bool, usageSnapshot, error) {
 	now := time.Now().UTC()
+	var snap usageSnapshot
 
-	ok, err := reserveOne(ctx, bucket, ledgerObject(now.Format("2006-01-02")), envInt("INSIGHT_MAX_GENERATIONS_PER_DAY", defaultMaxGenerationsPerDay))
+	snap.dayLimit = envInt("INSIGHT_MAX_GENERATIONS_PER_DAY", defaultMaxGenerationsPerDay)
+	dayCount, ok, err := reserveOne(ctx, bucket, ledgerObject(now.Format("2006-01-02")), snap.dayLimit)
+	snap.dayCount = dayCount
 	if err != nil || !ok {
-		return false, err
+		return false, snap, err
 	}
+	logCeilingApproach("daily", snap.dayCount, snap.dayLimit)
+
 	// A monthly rejection after the daily increment leaves the daily count one
 	// high for the rest of the day. That errs toward generating less, which is
 	// the safe direction to be wrong in.
-	return reserveOne(ctx, bucket, ledgerObject(now.Format("2006-01")), envInt("INSIGHT_MAX_GENERATIONS_PER_MONTH", defaultMaxGenerationsPerMonth))
+	snap.monthLimit = envInt("INSIGHT_MAX_GENERATIONS_PER_MONTH", defaultMaxGenerationsPerMonth)
+	monthCount, ok, err := reserveOne(ctx, bucket, ledgerObject(now.Format("2006-01")), snap.monthLimit)
+	snap.monthCount = monthCount
+	if err != nil || !ok {
+		return false, snap, err
+	}
+	logCeilingApproach("monthly", snap.monthCount, snap.monthLimit)
+	return true, snap, nil
 }
 
 // recordTokenUsage attributes token counts to both period ledgers. Best effort:

--- a/server/insight_generate.go
+++ b/server/insight_generate.go
@@ -24,6 +24,7 @@ var insightMemCache sync.Map
 var (
 	insightCacheRead  = cachedInsightContent
 	insightCacheWrite = uploadBlob
+	insightFlagRead   = flaggedRecord
 )
 
 type insightMemEntry struct {
@@ -95,17 +96,24 @@ func writeInsightUnavailable(w http.ResponseWriter) {
 }
 
 func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+	var ev insightEvent
+	defer func() { logInsightEvent(&ev, start) }()
+
 	body := jsonBody(r)
 	prompt, _ := body["prompt"].(string)
 	clientKey, _ := body["cacheKey"].(string)
 	topic, _ := body["topic"].(string)
+	ev.Topic = topic
 
 	if prompt == "" {
+		ev.Outcome, ev.Reason = outcomeRejected, reasonMissingPrompt
 		w.Header().Set("Content-Type", "application/json")
 		http.Error(w, `{"error":"Missing prompt parameter"}`, http.StatusBadRequest)
 		return
 	}
 	if len(prompt) > insightPromptMaxBytes {
+		ev.Outcome, ev.Reason = outcomeRejected, reasonPromptTooLarge
 		w.Header().Set("Content-Type", "application/json")
 		http.Error(w, `{"error":"Prompt too large"}`, http.StatusRequestEntityTooLarge)
 		return
@@ -115,6 +123,7 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	if cacheKey == "" {
 		cacheKey = sanitizeInsightKey(prompt)
 	}
+	ev.CacheKey = cacheKey
 
 	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
@@ -125,14 +134,16 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	// Suppression check runs first, because a suppressed insight must never be
 	// served even if it is still warm in the in-process cache.
 	if flaggedBucket != "" {
-		record, err := flaggedRecord(ctx, flaggedBucket, cacheKey)
+		record, err := insightFlagRead(ctx, flaggedBucket, cacheKey)
 		if err != nil {
+			ev.Outcome, ev.Reason = outcomeError, reasonSuppressionRead
 			log.Printf("[insight] suppression check error: %v", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 		if record != nil {
 			if status, _ := record["status"].(string); suppressingStatuses[status] {
+				ev.Outcome = outcomeSuppressed
 				writeJSON(w, map[string]bool{"suppressed": true})
 				return
 			}
@@ -143,6 +154,7 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	if v, ok := insightMemCache.Load(cacheKey); ok {
 		entry := v.(insightMemEntry)
 		if time.Since(entry.ts) < insightMemTTL {
+			ev.Outcome = outcomeMemoryHit
 			writeJSON(w, map[string]string{"content": entry.content})
 			return
 		}
@@ -154,6 +166,7 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 		content := insightCacheRead(ctx, cacheBucket, cacheKey)
 		if content != "" {
 			insightMemCache.Store(cacheKey, insightMemEntry{content: content, ts: time.Now()})
+			ev.Outcome = outcomeGCSHit
 			writeJSON(w, map[string]string{"content": content})
 			return
 		}
@@ -163,18 +176,21 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	// No ledger bucket means no way to meter, and unmetered generation is not an
 	// acceptable fallback.
 	if cacheBucket == "" {
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonNoCacheBucket
 		log.Print("[insight] INSIGHTS_CACHE_BUCKET unset, generation disabled")
 		writeInsightUnavailable(w)
 		return
 	}
 
 	if generationDisabled(ctx, cacheBucket) {
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonGenerationOff
 		writeInsightUnavailable(w)
 		return
 	}
 
 	apiKey := os.Getenv("GEMINI_API_KEY")
 	if apiKey == "" {
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonNoAPIKey
 		log.Print("[insight] GEMINI_API_KEY unset, generation disabled")
 		writeInsightUnavailable(w)
 		return
@@ -182,13 +198,17 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Reserved before the call rather than after, so a crash mid-flight cannot
 	// leave a generation unaccounted for.
-	reserved, err := reserveGeneration(ctx, cacheBucket)
+	reserved, usage, err := reserveGeneration(ctx, cacheBucket)
+	ev.DailyGenerations, ev.DailyLimit = usage.dayCount, usage.dayLimit
+	ev.MonthlyGenerations, ev.MonthlyLimit = usage.monthCount, usage.monthLimit
 	if err != nil {
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonLedgerError
 		log.Printf("[insight] usage ledger error: %v", err)
 		writeInsightUnavailable(w)
 		return
 	}
 	if !reserved {
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonCeilingReached
 		log.Print("[insight] usage ceiling reached, serving cached insights only")
 		writeInsightUnavailable(w)
 		return
@@ -197,6 +217,8 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	finalPrompt := buildNegativeExamplesBlock(ctx, flaggedBucket, topic) + prompt
 
 	result, err := generateInsight(ctx, apiKey, insightSystemPrompt, finalPrompt)
+	ev.Model = geminiModel()
+	ev.PromptTokens, ev.OutputTokens = result.promptTokens, result.outputTokens
 	// Detached from the request context: a slow generation can leave ctx at or
 	// past its deadline, and ledger bookkeeping must not be starved by the same
 	// budget the generation call just used up.
@@ -206,6 +228,7 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 
 	switch {
 	case errors.Is(err, errInsightQuota):
+		ev.Outcome, ev.Reason = outcomeError, reasonProviderQuota
 		log.Print("[insight] provider quota reached")
 		w.WriteHeader(http.StatusTooManyRequests)
 		writeJSON(w, map[string]string{"error": "Rate limit reached"})
@@ -213,14 +236,17 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	case errors.Is(err, errInsightNoContent):
 		// Never cached: a blank insight persisted for the full TTL is worse than
 		// no insight, since nothing would retry it.
+		ev.Outcome, ev.Reason = outcomeUnavailable, reasonNoContent
 		writeInsightUnavailable(w)
 		return
 	case err != nil:
+		ev.Outcome, ev.Reason = outcomeError, reasonProviderError
 		log.Printf("[insight] generation error: %v", err)
 		http.Error(w, `{"error":"Failed to fetch AI insight"}`, http.StatusInternalServerError)
 		return
 	}
 
+	ev.Outcome = outcomeGenerated
 	insightMemCache.Store(cacheKey, insightMemEntry{content: result.text, ts: time.Now()})
 
 	// Persist to GCS in a background goroutine, best effort, never blocking the

--- a/server/insight_generate.go
+++ b/server/insight_generate.go
@@ -199,6 +199,7 @@ func fetchAIInsightHandler(w http.ResponseWriter, r *http.Request) {
 	// Reserved before the call rather than after, so a crash mid-flight cannot
 	// leave a generation unaccounted for.
 	reserved, usage, err := reserveGeneration(ctx, cacheBucket)
+	ev.Reserved = reserved
 	ev.DailyGenerations, ev.DailyLimit = usage.dayCount, usage.dayLimit
 	ev.MonthlyGenerations, ev.MonthlyLimit = usage.monthCount, usage.monthLimit
 	if err != nil {

--- a/server/insight_log.go
+++ b/server/insight_log.go
@@ -104,8 +104,11 @@ func writeInsightLog(severity, message string, payload any) {
 
 func logInsightEvent(ev *insightEvent, start time.Time) {
 	ev.DurationMs = time.Since(start).Milliseconds()
-	if len(ev.Topic) > insightTopicMaxLen {
-		ev.Topic = ev.Topic[:insightTopicMaxLen]
+	// Truncated by rune, not by byte: a byte slice can cut a multi-byte rune in
+	// half, and json.Marshal then swaps the fragment for U+FFFD, so the logged
+	// topic would not match the one the client sent.
+	if runes := []rune(ev.Topic); len(runes) > insightTopicMaxLen {
+		ev.Topic = string(runes[:insightTopicMaxLen])
 	}
 	writeInsightLog(insightSeverity(ev.Outcome), "insight "+ev.Outcome, ev)
 }

--- a/server/insight_log.go
+++ b/server/insight_log.go
@@ -53,8 +53,14 @@ type insightEvent struct {
 	CacheKey string `json:"cacheKey,omitempty"`
 	Topic    string `json:"topic,omitempty"`
 
-	// Set only on the generated path. Tokens are what the provider's free tier
-	// meters, and are the input to a spend figure if this ever moves off it.
+	// Reserved marks a request that claimed a slot against the ceilings, which is
+	// not the same as one that produced an insight: reserveGeneration claims
+	// before the provider call, so a slot is spent even when the call then fails.
+	// Counting outcome="generated" alone would undercount the ceilings.
+	Reserved bool `json:"reserved,omitempty"`
+
+	// Set only once the provider was called. Tokens are what the provider's free
+	// tier meters, and are the input to a spend figure if this ever moves off it.
 	Model        string `json:"model,omitempty"`
 	PromptTokens int    `json:"promptTokens,omitempty"`
 	OutputTokens int    `json:"outputTokens,omitempty"`

--- a/server/insight_log.go
+++ b/server/insight_log.go
@@ -23,6 +23,12 @@ const (
 	// Not a request outcome: emitted on its own line when usage crosses the warn
 	// threshold, which is the signal the ceiling alert matches on.
 	outcomeCeilingApproaching = "ceiling_approaching"
+
+	// Stands in when the handler returned without classifying the request, which
+	// means a panic or a return path that was added without an outcome. Every
+	// query here is a ratio over outcomes, so an unlabeled line would silently
+	// leave one out rather than show up as a gap.
+	outcomeUnknown = "unknown"
 )
 
 // Reasons narrow an unavailable, rejected, or error outcome to the specific gate
@@ -59,8 +65,11 @@ type insightEvent struct {
 	// Counting outcome="generated" alone would undercount the ceilings.
 	Reserved bool `json:"reserved,omitempty"`
 
-	// Set only once the provider was called. Tokens are what the provider's free
-	// tier meters, and are the input to a spend figure if this ever moves off it.
+	// Set only once the provider was called, which is not the same as one that
+	// succeeded: all three ride on a failed call too, so presence marks an
+	// attempt and never a successful generation. Tokens are what the provider's
+	// free tier meters, and are the input to a spend figure if this ever moves
+	// off it.
 	Model        string `json:"model,omitempty"`
 	PromptTokens int    `json:"promptTokens,omitempty"`
 	OutputTokens int    `json:"outputTokens,omitempty"`
@@ -80,7 +89,7 @@ var insightLogOut io.Writer = os.Stdout
 
 func insightSeverity(outcome string) string {
 	switch outcome {
-	case outcomeError:
+	case outcomeError, outcomeUnknown:
 		return "ERROR"
 	case outcomeUnavailable:
 		return "WARNING"
@@ -104,6 +113,9 @@ func writeInsightLog(severity, message string, payload any) {
 
 func logInsightEvent(ev *insightEvent, start time.Time) {
 	ev.DurationMs = time.Since(start).Milliseconds()
+	if ev.Outcome == "" {
+		ev.Outcome = outcomeUnknown
+	}
 	// Truncated by rune, not by byte: a byte slice can cut a multi-byte rune in
 	// half, and json.Marshal then swaps the fragment for U+FFFD, so the logged
 	// topic would not match the one the client sent.

--- a/server/insight_log.go
+++ b/server/insight_log.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Outcomes of a single /fetch-ai-insight request. Every request records exactly
+// one of these, so cache hit rate is a ratio over the three cache-relevant ones
+// and needs no separate counter.
+const (
+	outcomeMemoryHit   = "memory_hit"
+	outcomeGCSHit      = "gcs_hit"
+	outcomeGenerated   = "generated"
+	outcomeSuppressed  = "suppressed"
+	outcomeUnavailable = "unavailable"
+	outcomeRejected    = "rejected"
+	outcomeError       = "error"
+
+	// Not a request outcome: emitted on its own line when usage crosses the warn
+	// threshold, which is the signal the ceiling alert matches on.
+	outcomeCeilingApproaching = "ceiling_approaching"
+)
+
+// Reasons narrow an unavailable, rejected, or error outcome to the specific gate
+// that produced it, so "no insight was shown" can be told apart from "the cap was
+// reached" without reading the surrounding lines.
+const (
+	reasonMissingPrompt   = "missing_prompt"
+	reasonPromptTooLarge  = "prompt_too_large"
+	reasonNoCacheBucket   = "no_cache_bucket"
+	reasonGenerationOff   = "generation_disabled"
+	reasonNoAPIKey        = "no_api_key"
+	reasonLedgerError     = "ledger_error"
+	reasonCeilingReached  = "ceiling_reached"
+	reasonProviderQuota   = "provider_quota"
+	reasonProviderError   = "provider_error"
+	reasonNoContent       = "no_content"
+	reasonSuppressionRead = "suppression_check"
+)
+
+const insightTopicMaxLen = 64
+
+// insightEvent is the queryable payload of one insight request. Fields are
+// omitempty so a cache hit does not carry a wall of zeroed generation fields.
+type insightEvent struct {
+	Outcome string `json:"outcome"`
+	Reason  string `json:"reason,omitempty"`
+
+	CacheKey string `json:"cacheKey,omitempty"`
+	Topic    string `json:"topic,omitempty"`
+
+	// Set only on the generated path. Tokens are what the provider's free tier
+	// meters, and are the input to a spend figure if this ever moves off it.
+	Model        string `json:"model,omitempty"`
+	PromptTokens int    `json:"promptTokens,omitempty"`
+	OutputTokens int    `json:"outputTokens,omitempty"`
+
+	DailyGenerations   int `json:"dailyGenerations,omitempty"`
+	DailyLimit         int `json:"dailyLimit,omitempty"`
+	MonthlyGenerations int `json:"monthlyGenerations,omitempty"`
+	MonthlyLimit       int `json:"monthlyLimit,omitempty"`
+
+	DurationMs int64 `json:"durationMs"`
+}
+
+// Written directly rather than through the log package: Cloud Logging only parses
+// a stdout line as structured when the whole line is a JSON object, and log's
+// date prefix would leave every line an unparsed string.
+var insightLogOut io.Writer = os.Stdout
+
+func insightSeverity(outcome string) string {
+	switch outcome {
+	case outcomeError:
+		return "ERROR"
+	case outcomeUnavailable:
+		return "WARNING"
+	default:
+		return "INFO"
+	}
+}
+
+func writeInsightLog(severity, message string, payload any) {
+	line, err := json.Marshal(map[string]any{
+		"severity": severity,
+		"message":  message,
+		"insight":  payload,
+	})
+	if err != nil {
+		return
+	}
+	// One Write, so concurrent requests cannot interleave within a line.
+	insightLogOut.Write(append(line, '\n'))
+}
+
+func logInsightEvent(ev *insightEvent, start time.Time) {
+	ev.DurationMs = time.Since(start).Milliseconds()
+	if len(ev.Topic) > insightTopicMaxLen {
+		ev.Topic = ev.Topic[:insightTopicMaxLen]
+	}
+	writeInsightLog(insightSeverity(ev.Outcome), "insight "+ev.Outcome, ev)
+}
+
+// logCeilingApproach fires once per period, on the single request whose
+// post-increment count lands on the threshold. The ledger's compare-and-swap
+// hands out each count exactly once, so this cannot double-fire across instances
+// and cannot degrade into a line per request for the rest of the period.
+func logCeilingApproach(period string, count, limit int) {
+	if limit <= 0 || count != ceilingWarnAt(limit) {
+		return
+	}
+	writeInsightLog("WARNING",
+		fmt.Sprintf("insight %s generation ceiling approaching: %d of %d", period, count, limit),
+		map[string]any{
+			"outcome":     outcomeCeilingApproaching,
+			"period":      period,
+			"generations": count,
+			"limit":       limit,
+		})
+}

--- a/server/insight_test.go
+++ b/server/insight_test.go
@@ -1087,3 +1087,31 @@ func TestCeilingApproachWarnsExactlyOncePerPeriod(t *testing.T) {
 		t.Errorf("message = %q, want it to name the daily period", warnings[0].Message)
 	}
 }
+
+// A misconfigured percent must not be honored. Zero, a negative, or anything
+// over 100 would put the threshold outside the range a count can reach, which
+// turns off the alert with no error and no log line, the exact failure the
+// alert exists to prevent.
+func TestCeilingWarnPercentIgnoresOutOfRangeValues(t *testing.T) {
+	for _, tc := range []struct {
+		percent string
+		want    int
+	}{
+		{"80", 320},
+		{"50", 200},
+		{"1", 4},
+		{"100", 400},
+		{"0", 320},
+		{"101", 320},
+		{"-1", 320},
+		{"abc", 320},
+		{"", 320},
+	} {
+		t.Run(tc.percent, func(t *testing.T) {
+			t.Setenv("INSIGHT_CEILING_WARN_PERCENT", tc.percent)
+			if got := ceilingWarnAt(400); got != tc.want {
+				t.Errorf("ceilingWarnAt(400) with percent %q = %d, want %d", tc.percent, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/insight_test.go
+++ b/server/insight_test.go
@@ -1088,6 +1088,32 @@ func TestCeilingApproachWarnsExactlyOncePerPeriod(t *testing.T) {
 	}
 }
 
+// Every query in the docs is a ratio over outcomes, so a line with no outcome
+// would drop out of both the numerator and the denominator instead of showing up
+// as a gap. An unclassified request is also a bug worth an ERROR.
+func TestInsightLogLabelsAnUnclassifiedRequest(t *testing.T) {
+	var buf bytes.Buffer
+	orig := insightLogOut
+	insightLogOut = &buf
+	t.Cleanup(func() { insightLogOut = orig })
+
+	logInsightEvent(&insightEvent{}, time.Now())
+
+	var got loggedInsight
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal %q: %v", buf.String(), err)
+	}
+	if got.Insight.Outcome != outcomeUnknown {
+		t.Errorf("outcome = %q, want %q", got.Insight.Outcome, outcomeUnknown)
+	}
+	if got.Severity != "ERROR" {
+		t.Errorf("severity = %q, want ERROR", got.Severity)
+	}
+	if got.Message != "insight "+outcomeUnknown {
+		t.Errorf("message = %q, want it to name the unknown outcome", got.Message)
+	}
+}
+
 // A misconfigured percent must not be honored. Zero, a negative, or anything
 // over 100 would put the threshold outside the range a count can reach, which
 // turns off the alert with no error and no log line, the exact failure the

--- a/server/insight_test.go
+++ b/server/insight_test.go
@@ -518,6 +518,15 @@ func (e *insightTestEnv) post(t *testing.T, body map[string]any) *httptest.Respo
 	return rr
 }
 
+// setKillSwitch forces the operator off switch without a network check, by
+// priming the same memo newInsightTestEnv primes.
+func setKillSwitch(t *testing.T, on bool) {
+	t.Helper()
+	killSwitchMu.Lock()
+	defer killSwitchMu.Unlock()
+	killSwitchChecked, killSwitchOn = time.Now(), on
+}
+
 func stubFlaggedRecord(t *testing.T, record map[string]any, err error) {
 	t.Helper()
 	orig := insightFlagRead
@@ -820,6 +829,10 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 		outcome  string
 		reason   string
 		severity string
+		// reserved is the ceiling accounting, which is deliberately not the same
+		// as "an insight was produced": the slot is claimed before the provider
+		// call, so a failed call still spends one.
+		reserved bool
 	}{
 		{
 			name:     "missing prompt",
@@ -839,6 +852,7 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			name:     "generated",
 			outcome:  outcomeGenerated,
 			severity: "INFO",
+			reserved: true,
 		},
 		{
 			name: "memory cache hit",
@@ -903,6 +917,24 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			severity: "WARNING",
 		},
 		{
+			name: "no ledger bucket",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				t.Setenv("INSIGHTS_CACHE_BUCKET", "")
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonNoCacheBucket,
+			severity: "WARNING",
+		},
+		{
+			name: "kill switch on",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				setKillSwitch(t, true)
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonGenerationOff,
+			severity: "WARNING",
+		},
+		{
 			name: "provider returned nothing",
 			setup: func(_ *testing.T, env *insightTestEnv) {
 				env.stubGeneration(func() (insightGeneration, error) {
@@ -912,6 +944,7 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			outcome:  outcomeUnavailable,
 			reason:   reasonNoContent,
 			severity: "WARNING",
+			reserved: true,
 		},
 		{
 			name: "provider error",
@@ -923,6 +956,7 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			outcome:  outcomeError,
 			reason:   reasonProviderError,
 			severity: "ERROR",
+			reserved: true,
 		},
 		{
 			name: "provider quota",
@@ -934,6 +968,7 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			outcome:  outcomeError,
 			reason:   reasonProviderQuota,
 			severity: "ERROR",
+			reserved: true,
 		},
 	}
 
@@ -959,6 +994,9 @@ func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
 			}
 			if got.Severity != tt.severity {
 				t.Errorf("severity = %q, want %q", got.Severity, tt.severity)
+			}
+			if got.Insight.Reserved != tt.reserved {
+				t.Errorf("reserved = %v, want %v", got.Insight.Reserved, tt.reserved)
 			}
 		})
 	}

--- a/server/insight_test.go
+++ b/server/insight_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"google.golang.org/api/googleapi"
 )
@@ -1032,11 +1033,28 @@ func TestInsightRequestLogCarriesSpendInputsOnGeneration(t *testing.T) {
 }
 
 func TestInsightRequestLogTruncatesTopic(t *testing.T) {
-	env := newInsightTestEnv(t)
-	env.post(t, map[string]any{"prompt": "p", "cacheKey": "k", "topic": strings.Repeat("t", 500)})
+	tests := []struct {
+		name  string
+		topic string
+	}{
+		{"ascii", strings.Repeat("t", 500)},
+		// A byte-index truncation would land mid-rune here, and json.Marshal would
+		// swap the fragment for U+FFFD.
+		{"multi-byte", strings.Repeat("é", 500)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newInsightTestEnv(t)
+			env.post(t, map[string]any{"prompt": "p", "cacheKey": "k", "topic": tt.topic})
 
-	if got := len(env.lastRequestEvent(t).Insight.Topic); got != insightTopicMaxLen {
-		t.Errorf("logged topic length = %d, want %d", got, insightTopicMaxLen)
+			got := env.lastRequestEvent(t).Insight.Topic
+			if len([]rune(got)) != insightTopicMaxLen {
+				t.Errorf("logged topic = %d runes, want %d", len([]rune(got)), insightTopicMaxLen)
+			}
+			if !utf8.ValidString(got) || strings.ContainsRune(got, utf8.RuneError) {
+				t.Errorf("logged topic %q is not intact UTF-8", got)
+			}
+		})
 	}
 }
 

--- a/server/insight_test.go
+++ b/server/insight_test.go
@@ -152,7 +152,7 @@ func TestReserveOneConcurrentIncrementsDoNotCollide(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			ok, err := reserveOne(context.Background(), "b", "budget/day.json", 100)
+			_, ok, err := reserveOne(context.Background(), "b", "budget/day.json", 100)
 			if err != nil {
 				errs <- err
 			} else if !ok {
@@ -176,7 +176,7 @@ func TestMutateLedgerRetriesPreconditionFailure(t *testing.T) {
 	store.failWrites = 2
 	useFakeLedger(t, store)
 
-	ok, err := reserveOne(context.Background(), "b", "budget/day.json", 10)
+	_, ok, err := reserveOne(context.Background(), "b", "budget/day.json", 10)
 	if err != nil || !ok {
 		t.Fatalf("reserveOne = %v, %v; want true, nil", ok, err)
 	}
@@ -193,7 +193,7 @@ func TestMutateLedgerGivesUpAfterSustainedContention(t *testing.T) {
 	store.failWrites = ledgerCASAttempts
 	useFakeLedger(t, store)
 
-	ok, err := reserveOne(context.Background(), "b", "budget/day.json", 10)
+	_, ok, err := reserveOne(context.Background(), "b", "budget/day.json", 10)
 	if ok || !errors.Is(err, errLedgerContention) {
 		t.Fatalf("reserveOne = %v, %v; want false, errLedgerContention", ok, err)
 	}
@@ -204,20 +204,28 @@ func TestReserveOneStopsAtLimit(t *testing.T) {
 	useFakeLedger(t, store)
 
 	for i := range 3 {
-		ok, err := reserveOne(context.Background(), "b", "budget/day.json", 3)
+		count, ok, err := reserveOne(context.Background(), "b", "budget/day.json", 3)
 		if err != nil {
 			t.Fatalf("reservation %d: %v", i, err)
 		}
 		if !ok {
 			t.Fatalf("reservation %d declined below the limit", i)
 		}
+		if count != i+1 {
+			t.Errorf("reservation %d reported count %d, want %d", i, count, i+1)
+		}
 	}
-	ok, err := reserveOne(context.Background(), "b", "budget/day.json", 3)
+	count, ok, err := reserveOne(context.Background(), "b", "budget/day.json", 3)
 	if err != nil {
 		t.Fatalf("unexpected error at the limit: %v", err)
 	}
 	if ok {
 		t.Error("reservation granted at the limit")
+	}
+	// A declined reservation still reports where the period stands, which is what
+	// the request log records on the ceiling_reached path.
+	if count != 3 {
+		t.Errorf("declined reservation reported count %d, want 3", count)
 	}
 }
 
@@ -226,7 +234,7 @@ func TestReserveGenerationFailsClosedOnLoadError(t *testing.T) {
 	store.loadErr = errors.New("bucket unreachable")
 	useFakeLedger(t, store)
 
-	ok, err := reserveGeneration(context.Background(), "b")
+	ok, _, err := reserveGeneration(context.Background(), "b")
 	if ok {
 		t.Error("reservation granted while the ledger was unreadable")
 	}
@@ -428,6 +436,7 @@ type insightTestEnv struct {
 	cacheWrites   chan []byte
 	lastPersisted []byte
 	upstream      int
+	logs          *bytes.Buffer
 }
 
 // newInsightTestEnv isolates the handler from GCS and from the provider: the
@@ -442,8 +451,12 @@ func newInsightTestEnv(t *testing.T) *insightTestEnv {
 	t.Setenv("INSIGHT_MAX_GENERATIONS_PER_DAY", "50")
 	t.Setenv("INSIGHT_MAX_GENERATIONS_PER_MONTH", "50")
 
-	env := &insightTestEnv{store: newFakeLedgerStore(), cacheWrites: make(chan []byte, 4)}
+	env := &insightTestEnv{store: newFakeLedgerStore(), cacheWrites: make(chan []byte, 4), logs: &bytes.Buffer{}}
 	useFakeLedger(t, env.store)
+
+	origLogOut := insightLogOut
+	insightLogOut = env.logs
+	t.Cleanup(func() { insightLogOut = origLogOut })
 
 	origRead, origWrite, origGen := insightCacheRead, insightCacheWrite, generateInsight
 	killSwitchMu.Lock()
@@ -503,6 +516,52 @@ func (e *insightTestEnv) post(t *testing.T, body map[string]any) *httptest.Respo
 		}
 	}
 	return rr
+}
+
+func stubFlaggedRecord(t *testing.T, record map[string]any, err error) {
+	t.Helper()
+	orig := insightFlagRead
+	insightFlagRead = func(context.Context, string, string) (map[string]any, error) {
+		return record, err
+	}
+	t.Cleanup(func() { insightFlagRead = orig })
+}
+
+type loggedInsight struct {
+	Severity string       `json:"severity"`
+	Message  string       `json:"message"`
+	Insight  insightEvent `json:"insight"`
+}
+
+// events decodes every structured line emitted so far. Each must parse as a
+// standalone JSON object, since that is the only shape Cloud Logging promotes to
+// a queryable payload.
+func (e *insightTestEnv) events(t *testing.T) []loggedInsight {
+	t.Helper()
+	var out []loggedInsight
+	for _, line := range strings.Split(strings.TrimSpace(e.logs.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec loggedInsight
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("insight log line %q is not valid JSON: %v", line, err)
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// lastRequestEvent is the one line the most recent request emitted. It fails
+// when a request emitted anything other than exactly one, since "one line per
+// request" is what makes the ratios in the documented queries correct.
+func (e *insightTestEnv) lastRequestEvent(t *testing.T) loggedInsight {
+	t.Helper()
+	events := e.events(t)
+	if len(events) != 1 {
+		t.Fatalf("got %d insight log lines, want exactly 1: %s", len(events), e.logs.String())
+	}
+	return events[0]
 }
 
 func decodeBody(t *testing.T, rr *httptest.ResponseRecorder) map[string]any {
@@ -745,5 +804,230 @@ func TestInsightHandlerFallsBackToPromptAsCacheKey(t *testing.T) {
 	}
 	if env.upstream != 1 {
 		t.Errorf("upstream calls = %d, want 1", env.upstream)
+	}
+}
+
+// --- request logging ---
+
+// Every outcome a query might filter on is pinned here, because a renamed or
+// dropped outcome breaks the documented spend and hit-rate queries silently:
+// they would keep running and just return fewer rows.
+func TestInsightRequestLogRecordsEveryOutcome(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(t *testing.T, env *insightTestEnv)
+		body     map[string]any
+		outcome  string
+		reason   string
+		severity string
+	}{
+		{
+			name:     "missing prompt",
+			body:     map[string]any{"cacheKey": "k"},
+			outcome:  outcomeRejected,
+			reason:   reasonMissingPrompt,
+			severity: "INFO",
+		},
+		{
+			name:     "oversize prompt",
+			body:     map[string]any{"prompt": strings.Repeat("x", insightPromptMaxBytes+1)},
+			outcome:  outcomeRejected,
+			reason:   reasonPromptTooLarge,
+			severity: "INFO",
+		},
+		{
+			name:     "generated",
+			outcome:  outcomeGenerated,
+			severity: "INFO",
+		},
+		{
+			name: "memory cache hit",
+			setup: func(_ *testing.T, _ *insightTestEnv) {
+				insightMemCache.Store("k", insightMemEntry{content: "warm", ts: time.Now()})
+			},
+			outcome:  outcomeMemoryHit,
+			severity: "INFO",
+		},
+		{
+			name: "gcs cache hit",
+			setup: func(_ *testing.T, _ *insightTestEnv) {
+				insightCacheRead = func(context.Context, string, string) string { return "persisted" }
+			},
+			outcome:  outcomeGCSHit,
+			severity: "INFO",
+		},
+		{
+			name: "suppressed",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				t.Setenv("FLAGGED_INSIGHTS_BUCKET", "flagged")
+				stubFlaggedRecord(t, map[string]any{"status": "suppressed"}, nil)
+			},
+			outcome:  outcomeSuppressed,
+			severity: "INFO",
+		},
+		{
+			name: "suppression check failed",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				t.Setenv("FLAGGED_INSIGHTS_BUCKET", "flagged")
+				stubFlaggedRecord(t, nil, errors.New("bucket unreachable"))
+			},
+			outcome:  outcomeError,
+			reason:   reasonSuppressionRead,
+			severity: "ERROR",
+		},
+		{
+			name: "ceiling reached",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				t.Setenv("INSIGHT_MAX_GENERATIONS_PER_DAY", "0")
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonCeilingReached,
+			severity: "WARNING",
+		},
+		{
+			name: "ledger unreadable",
+			setup: func(_ *testing.T, env *insightTestEnv) {
+				env.store.loadErr = errors.New("bucket unreachable")
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonLedgerError,
+			severity: "WARNING",
+		},
+		{
+			name: "no api key",
+			setup: func(t *testing.T, _ *insightTestEnv) {
+				t.Setenv("GEMINI_API_KEY", "")
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonNoAPIKey,
+			severity: "WARNING",
+		},
+		{
+			name: "provider returned nothing",
+			setup: func(_ *testing.T, env *insightTestEnv) {
+				env.stubGeneration(func() (insightGeneration, error) {
+					return insightGeneration{}, errInsightNoContent
+				})
+			},
+			outcome:  outcomeUnavailable,
+			reason:   reasonNoContent,
+			severity: "WARNING",
+		},
+		{
+			name: "provider error",
+			setup: func(_ *testing.T, env *insightTestEnv) {
+				env.stubGeneration(func() (insightGeneration, error) {
+					return insightGeneration{}, errors.New("upstream exploded")
+				})
+			},
+			outcome:  outcomeError,
+			reason:   reasonProviderError,
+			severity: "ERROR",
+		},
+		{
+			name: "provider quota",
+			setup: func(_ *testing.T, env *insightTestEnv) {
+				env.stubGeneration(func() (insightGeneration, error) {
+					return insightGeneration{}, errInsightQuota
+				})
+			},
+			outcome:  outcomeError,
+			reason:   reasonProviderQuota,
+			severity: "ERROR",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := newInsightTestEnv(t)
+			if tt.setup != nil {
+				tt.setup(t, env)
+			}
+			body := tt.body
+			if body == nil {
+				body = map[string]any{"prompt": "p", "cacheKey": "k", "topic": "hiv"}
+			}
+
+			env.post(t, body)
+
+			got := env.lastRequestEvent(t)
+			if got.Insight.Outcome != tt.outcome {
+				t.Errorf("outcome = %q, want %q", got.Insight.Outcome, tt.outcome)
+			}
+			if got.Insight.Reason != tt.reason {
+				t.Errorf("reason = %q, want %q", got.Insight.Reason, tt.reason)
+			}
+			if got.Severity != tt.severity {
+				t.Errorf("severity = %q, want %q", got.Severity, tt.severity)
+			}
+		})
+	}
+}
+
+func TestInsightRequestLogCarriesSpendInputsOnGeneration(t *testing.T) {
+	env := newInsightTestEnv(t)
+	t.Setenv("GEMINI_MODEL", "gemini-test-model")
+	env.stubGeneration(func() (insightGeneration, error) {
+		return insightGeneration{text: "generated", promptTokens: 1840, outputTokens: 96}, nil
+	})
+
+	env.post(t, map[string]any{"prompt": "p", "cacheKey": "k", "topic": "hiv"})
+
+	got := env.lastRequestEvent(t).Insight
+	if got.Model != "gemini-test-model" {
+		t.Errorf("model = %q, want the configured model", got.Model)
+	}
+	if got.PromptTokens != 1840 || got.OutputTokens != 96 {
+		t.Errorf("tokens = %d/%d, want 1840/96", got.PromptTokens, got.OutputTokens)
+	}
+	if got.Topic != "hiv" {
+		t.Errorf("topic = %q, want hiv", got.Topic)
+	}
+	// Period usage rides along so a line is self-contained: how close this
+	// generation left the ceiling needs no second query against the ledger.
+	if got.DailyGenerations != 1 || got.DailyLimit != 50 {
+		t.Errorf("daily usage = %d/%d, want 1/50", got.DailyGenerations, got.DailyLimit)
+	}
+	if got.MonthlyGenerations != 1 || got.MonthlyLimit != 50 {
+		t.Errorf("monthly usage = %d/%d, want 1/50", got.MonthlyGenerations, got.MonthlyLimit)
+	}
+}
+
+func TestInsightRequestLogTruncatesTopic(t *testing.T) {
+	env := newInsightTestEnv(t)
+	env.post(t, map[string]any{"prompt": "p", "cacheKey": "k", "topic": strings.Repeat("t", 500)})
+
+	if got := len(env.lastRequestEvent(t).Insight.Topic); got != insightTopicMaxLen {
+		t.Errorf("logged topic length = %d, want %d", got, insightTopicMaxLen)
+	}
+}
+
+// The threshold line is the only signal the ceiling alert matches on, so it must
+// fire once and only once per period. Firing on every request past the threshold
+// would bury it; firing on none would leave the alert permanently silent.
+func TestCeilingApproachWarnsExactlyOncePerPeriod(t *testing.T) {
+	env := newInsightTestEnv(t)
+	t.Setenv("INSIGHT_MAX_GENERATIONS_PER_DAY", "10")
+	t.Setenv("INSIGHT_MAX_GENERATIONS_PER_MONTH", "1000")
+	t.Setenv("INSIGHT_CEILING_WARN_PERCENT", "80")
+
+	for i := range 10 {
+		env.post(t, map[string]any{"prompt": "p", "cacheKey": fmt.Sprintf("k%d", i)})
+	}
+
+	var warnings []loggedInsight
+	for _, e := range env.events(t) {
+		if e.Insight.Outcome == outcomeCeilingApproaching {
+			warnings = append(warnings, e)
+		}
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("got %d ceiling warnings across 10 generations of a 10 ceiling, want 1", len(warnings))
+	}
+	if warnings[0].Severity != "WARNING" {
+		t.Errorf("severity = %q, want WARNING", warnings[0].Severity)
+	}
+	if !strings.Contains(warnings[0].Message, "daily") {
+		t.Errorf("message = %q, want it to name the daily period", warnings[0].Message)
 	}
 }


### PR DESCRIPTION
## Summary

- Every `/fetch-ai-insight` request now emits one JSON line to stdout, which Cloud Run promotes to a queryable `jsonPayload.insight`. Generations, cache hit rate, token volume, and ceiling events all become derivable from that one line.
- `server/insight_log.go` (new) writes the line directly to stdout rather than through `log`, because Cloud Logging only parses a line as structured when the whole line is a JSON object, and `log`'s date prefix would leave every line an unparsed string.
- The emitter is deferred on the handler, so every return path records exactly one line and none can be added later without one.
- `reserveOne` now reports the post-increment count, so a line carries where the period stands without a second read of the ledger.
- `server/CLAUDE.md` documents the three queries the team will actually run, plus the one-time alert setup.

**The usage ledger does not change and stays write-only.** It is the enforcement mechanism: `reserveGeneration` writes it before the provider call, which is what lets it refuse a generation. Cache hits in particular stay off it, since `mutateLedger` is a compare-and-swap against a single GCS object and routing hits through it would put a network round trip on a `sync.Map` read that currently returns in microseconds.

## Impact

| | Before | After |
|---|---|---|
| Request outcomes observable | 0 of 5 | 5 of 5, plus 11 `reason` values narrowing the non-serving ones |
| Cache hit rate | not measured | derivable from a single query; it is the dominant factor in what the feature costs |
| Worst-case ceiling detection lag | up to 6 days (weekly cron) | real time, at 80% of the ceiling |
| Added hot-path cost per request | | one `json.Marshal` and one `Write`; no network call, no GCS read, no new state |

A Tuesday ceiling overrun previously would not have surfaced until the following Monday, long after uncached views had stopped showing insights. `ceiling_approaching` fires at `INSIGHT_CEILING_WARN_PERCENT` of a ceiling (default 80), **once per period**, on the single request whose count lands on the threshold. The ledger's compare-and-swap hands out each count exactly once, so it cannot double-fire across Cloud Run instances and cannot degrade into a line per request for the rest of the period. Alerting on the approach rather than on `ceiling_reached` is the point: by the time reservations are being refused, uncached views are already rendering no insight section.

The `gcloud alpha monitoring policies create` command lives in `server/CLAUDE.md`. It is one-time setup per project and is not applied by this PR.

## Outcomes

| Outcome | Meaning |
|---|---|
| `memory_hit` | Served from the in-process `sync.Map` |
| `gcs_hit` | Served from the GCS persistent cache |
| `generated` | Called the provider. Carries `model` and token counts |
| `unavailable` | No insight shown. `reason` says which gate closed |
| `suppressed` | A reviewer suppressed this exact insight |
| `rejected` | Malformed request (missing or oversize prompt) |
| `error` | Provider or suppression-check failure |
| `ceiling_approaching` | Not a request. The alert signal |

These strings are an interface: the documented queries and the alert filter match on them literally, so a rename would silently return fewer rows rather than fail. `TestInsightRequestLogRecordsEveryOutcome` pins every one of them.

## Two deviations from the issue

**No dollar figure.** The issue framed this around spend. The project is on the provider's free tier, so spend is $0 and a computed cost column would be a hardcoded zero pretending to be a measurement. Instead the model and token counts ride on every generated line, and the docs explain how to price by model if that ever changes. This satisfies the issue's "price by model, not by constant" note without a rate compiled into the binary that could go silently stale after a `GEMINI_MODEL` change.

**Generations remain the primary number.** `reserveGeneration` claims a slot before the call and cannot lose one, so the volume query filters on `reserved` rather than on `outcome="generated"`; the gap between the two is ceiling budget spent on failed provider calls. `recordTokenUsage` is deliberately best-effort and swallows errors, so tokens can undercount and are documented as refining the per-generation average rather than as a total.

## Test plan

- [x] `cd server && go test ./...` passes (90 cases)
- [x] Every outcome and reason string asserted, including severity and `reserved`, via a 15-case table test
- [x] Ceiling warning asserted to fire exactly once across ten generations against a ceiling of ten
- [x] Out-of-range `INSIGHT_CEILING_WARN_PERCENT` asserted to fall back to the default, so a typo can't silently disable the alert
- [x] Every emitted line asserted to parse as standalone JSON, which is what makes it queryable
- [x] Handler tests assert exactly one line per request, so the hit-rate denominator stays correct
- [x] Topic truncation asserted to stay valid UTF-8 on a multi-byte topic, so the logged topic matches what the client sent
- [ ] Confirm on dev that lines land in Cloud Logging as `jsonPayload.insight` rather than as a text payload

Closes #5062

🤖 Generated with [Claude Code](https://claude.com/claude-code)
