### PR TITLE
Fix population-vs-distribution and edge cases in Go insight port

### DIFF
--- a/frontend/src/utils/insightPromptFixtures.ts
+++ b/frontend/src/utils/insightPromptFixtures.ts
@@ -29,6 +29,10 @@ import { INSIGHT_DATA_BUDGETS } from './insightPromptBudget'
 interface FixtureMetricConfig {
   metricId: string
   shortLabel: string
+  // Only the population-vs-distribution chart reads this: its population share
+  // hangs off the rate config itself rather than being resolved as a separate
+  // table column, so a fixture for that chart has to nest it here.
+  populationComparisonMetric?: FixtureMetricConfig
 }
 
 // The data table's two extra columns. Pinned per fixture rather than resolved

--- a/server/insight_prompt.go
+++ b/server/insight_prompt.go
@@ -1,0 +1,663 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Go port of the browser's insight prompt templates. The text here is an
+// interface with the insight cache: the cache key is a hash of the rendered
+// prompt, so any wording change here displaces every entry that wording reaches.
+// testdata/insight_prompts pins the exact output for a set of representative
+// views, and TestInsightPromptFixtures renders those same inputs through this
+// code. A diff in those files is the thing to review.
+
+// Bytes of data rows a prompt may carry, tiered by how many data sections that
+// prompt holds. A prompt with one section can afford to send far more of it than
+// a prompt that always carries two.
+const (
+	insightBudgetCard     = 24 * 1024
+	insightBudgetReport   = 4 * 1024
+	insightBudgetContrast = 12 * 1024
+)
+
+var mapChartIDs = map[string]bool{
+	"rate-map":                true,
+	"unknown-demographic-map": true,
+	"multimap-modal":          true,
+}
+
+var timeSeriesChartIDs = map[string]bool{
+	"rates-over-time":      true,
+	"inequities-over-time": true,
+}
+
+// Mirrors the browser's ALL / ALL_W pair.
+const (
+	insightGroupAll      = "All"
+	insightGroupAllWomen = "All women"
+)
+
+func groupIsAll(group string) bool {
+	return group == insightGroupAll || group == insightGroupAllWomen
+}
+
+// Only these two fields of a MetricConfig reach the prompt text.
+type insightMetricConfig struct {
+	MetricID   string `json:"metricId"`
+	ShortLabel string `json:"shortLabel"`
+}
+
+type insightRow map[string]any
+
+// Which of the data table's share columns the rendered rows actually carry.
+// Derived from the values rather than from the config, because a template that
+// names a column the payload lacks is exactly what invites the model to invent
+// the number.
+type tableColumnShape struct {
+	HasCaseloadShare   bool
+	HasPopulationShare bool
+	// Set only when the population column counts a broader group than the rate's
+	// own denominator, so the prompt can say so instead of implying the two
+	// shares are measured on the same basis.
+	GeneralPopulationLabel string
+}
+
+// Which rows a data section covers and how many bytes it may occupy.
+type insightDataOptions struct {
+	// When the user has focused a chart on a subset of groups, restrict the rows
+	// to those groups so the insight describes only what is on screen.
+	SelectedGroups []string
+	// The demographic group currently highlighted on a map.
+	ActiveDemographicGroup string
+	// Bytes this data section may occupy. Zero means the single-card tier; a
+	// prompt that carries more than one section passes a tighter budget.
+	BudgetBytes int
+	// The data table's two share columns. Passed in rather than read off the
+	// metric config because the table is handed its rate config, which carries
+	// neither share.
+	ShareConfig            *insightMetricConfig
+	PopulationConfig       *insightMetricConfig
+	GeneralPopulationLabel string
+}
+
+// jsNumber renders a float the way JavaScript's String(number) does, because the
+// committed fixtures record JS output and the cache key hashes it. Go's default
+// formatting would print 4.0 where JS prints 4, which would silently displace
+// every cached insight carrying a whole-numbered rate.
+func jsNumber(f float64) string {
+	if math.IsNaN(f) {
+		return "NaN"
+	}
+	if math.IsInf(f, 1) {
+		return "Infinity"
+	}
+	if math.IsInf(f, -1) {
+		return "-Infinity"
+	}
+	// JS switches to exponential notation outside this range. Rates and
+	// percentages never reach it, but diverging silently is worse than the
+	// branch costs.
+	if abs := math.Abs(f); f != 0 && (abs >= 1e21 || abs < 1e-6) {
+		return strconv.FormatFloat(f, 'g', -1, 64)
+	}
+	return strconv.FormatFloat(f, 'f', -1, 64)
+}
+
+// jsString renders a value the way JS template interpolation would.
+func jsString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	case float64:
+		return jsNumber(t)
+	case bool:
+		return strconv.FormatBool(t)
+	default:
+		return fmt.Sprintf("%v", t)
+	}
+}
+
+// A percent short label already leads with the sign ("% of population"), so it
+// attaches straight to the number; anything else is a unit that reads as its own
+// word ("6.8 cases per 100k"). Applied only where a share column sits beside a
+// rate, since a mixed row is where "100 % of population" reads as a typo.
+func formatMetricValue(value any, config *insightMetricConfig) string {
+	if strings.HasPrefix(config.ShortLabel, "%") {
+		return jsString(value) + config.ShortLabel
+	}
+	return jsString(value) + " " + config.ShortLabel
+}
+
+// Keeps whole lines from the start until the budget is spent, so an over-budget
+// section degrades to a shorter well-formed list rather than a list whose last
+// entry is cut mid-number. Order is preserved rather than re-ranked, since the
+// prompt hash that keys the insight cache depends on the same rows rendering the
+// same way every time.
+func trimLinesToBudget(lines []string, budgetBytes int) string {
+	kept := make([]string, 0, len(lines))
+	used := 0
+	for _, line := range lines {
+		cost := len(line)
+		if len(kept) > 0 {
+			cost++
+		}
+		if used+cost > budgetBytes {
+			break
+		}
+		kept = append(kept, line)
+		used += cost
+	}
+	return strings.Join(kept, "\n")
+}
+
+func getTableColumnShape(rows []insightRow, demographicType string, metricConfig *insightMetricConfig, opts insightDataOptions) tableColumnShape {
+	// Same rows formatDataRows will emit, so a column present only on rows that
+	// get dropped is not announced.
+	emitted := make([]insightRow, 0, len(rows))
+	for _, row := range rows {
+		if row[demographicType] != nil && row[metricConfig.MetricID] != nil {
+			emitted = append(emitted, row)
+		}
+	}
+	hasColumn := func(config *insightMetricConfig) bool {
+		if config == nil {
+			return false
+		}
+		for _, row := range emitted {
+			if row[config.MetricID] != nil {
+				return true
+			}
+		}
+		return false
+	}
+	shape := tableColumnShape{
+		HasCaseloadShare:   hasColumn(opts.ShareConfig),
+		HasPopulationShare: hasColumn(opts.PopulationConfig),
+	}
+	if shape.HasPopulationShare {
+		shape.GeneralPopulationLabel = opts.GeneralPopulationLabel
+	}
+	return shape
+}
+
+// formatDataRows renders the rows as the text list embedded in the prompt.
+func formatDataRows(rows []insightRow, hashID, demographicType string, metricConfig *insightMetricConfig, opts insightDataOptions) string {
+	budgetBytes := opts.BudgetBytes
+	if budgetBytes == 0 {
+		budgetBytes = insightBudgetCard
+	}
+
+	var groupFilter map[string]bool
+	if len(opts.SelectedGroups) > 0 {
+		groupFilter = make(map[string]bool, len(opts.SelectedGroups))
+		for _, g := range opts.SelectedGroups {
+			groupFilter[g] = true
+		}
+	}
+
+	if timeSeriesChartIDs[hashID] {
+		return formatTimeSeriesRows(rows, demographicType, metricConfig, groupFilter, budgetBytes)
+	}
+
+	isMap := mapChartIDs[hashID]
+	isTable := hashID == "data-table"
+
+	// For population-vs-distribution, include both the outcome share and the
+	// population share side by side so the model can compute the disparity.
+	var popMetric *insightMetricConfig
+	if isTable {
+		popMetric = opts.PopulationConfig
+	}
+	var shareMetric *insightMetricConfig
+	if isTable {
+		shareMetric = opts.ShareConfig
+	}
+
+	filtered := make([]insightRow, 0, len(rows))
+	for _, row := range rows {
+		// Maps always have a place name; other charts key off the demographic group.
+		var hasLabel bool
+		if isMap {
+			hasLabel = row["fips_name"] != nil
+		} else {
+			hasLabel = row[demographicType] != nil
+		}
+		if !hasLabel || row[metricConfig.MetricID] == nil {
+			continue
+		}
+		if groupFilter != nil && !groupFilter[jsString(row[demographicType])] {
+			continue
+		}
+		filtered = append(filtered, row)
+	}
+
+	// A map showing 2+ places is a real geographic comparison, so default to the
+	// group on screen. A map showing fewer than 2 places has nothing geographic
+	// to gain from filtering, so fall back to every group within that one place.
+	activeRows := filtered
+	if isMap && opts.ActiveDemographicGroup != "" && !groupIsAll(opts.ActiveDemographicGroup) {
+		places := map[string]bool{}
+		for _, row := range filtered {
+			places[jsString(row["fips_name"])] = true
+		}
+		if len(places) >= 2 {
+			activeRows = make([]insightRow, 0, len(filtered))
+			for _, row := range filtered {
+				group := jsString(row[demographicType])
+				if group == opts.ActiveDemographicGroup || groupIsAll(group) {
+					activeRows = append(activeRows, row)
+				}
+			}
+		}
+	}
+
+	lines := make([]string, 0, len(activeRows))
+	for _, row := range activeRows {
+		// On a map, label each row with BOTH its place and demographic group so
+		// the model can read either a geographic gap (across places) or a
+		// within-place gap (across groups, with "All" as the baseline). Other
+		// charts already vary only by demographic group.
+		var label string
+		if isMap {
+			label = fmt.Sprintf("%s (%s)", jsString(row["fips_name"]), jsString(row[demographicType]))
+		} else {
+			label = jsString(row[demographicType])
+		}
+		val := jsString(row[metricConfig.MetricID]) + " " + metricConfig.ShortLabel
+
+		if isTable {
+			// The table's own three columns, in the order the table shows them.
+			// Each is dropped for the rows the source suppressed, so a group can
+			// appear with a rate and no shares.
+			parts := []string{formatMetricValue(row[metricConfig.MetricID], metricConfig)}
+			for _, config := range []*insightMetricConfig{shareMetric, popMetric} {
+				if config != nil && row[config.MetricID] != nil {
+					parts = append(parts, formatMetricValue(row[config.MetricID], config))
+				}
+			}
+			lines = append(lines, fmt.Sprintf("- %s: %s", label, strings.Join(parts, ", ")))
+			continue
+		}
+		if popMetric != nil && row[popMetric.MetricID] != nil {
+			lines = append(lines, fmt.Sprintf("- %s: outcome share %s, population share %s %s",
+				label, val, jsString(row[popMetric.MetricID]), popMetric.ShortLabel))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", label, val))
+	}
+
+	// Group filtering bounds a map section in the common case, but a wide
+	// breakdown over hundreds of places can still outgrow the budget, and the
+	// data table has no geographic filter at all.
+	return trimLinesToBudget(lines, budgetBytes)
+}
+
+func formatTimeSeriesRows(rows []insightRow, demographicType string, metricConfig *insightMetricConfig, groupFilter map[string]bool, budgetBytes int) string {
+	// Insertion order, not map order: the browser iterates the grouping object's
+	// keys in insertion order and the rendered line order is part of the hashed
+	// prompt.
+	var order []string
+	byGroup := map[string][]insightRow{}
+	for _, row := range rows {
+		group := "Unknown"
+		if v := row[demographicType]; v != nil {
+			group = jsString(v)
+		}
+		if groupFilter != nil && !groupFilter[group] {
+			continue
+		}
+		if row[metricConfig.MetricID] == nil {
+			continue
+		}
+		if _, seen := byGroup[group]; !seen {
+			order = append(order, group)
+		}
+		byGroup[group] = append(byGroup[group], row)
+	}
+	if len(order) == 0 {
+		return ""
+	}
+
+	longest := 0
+	for _, group := range order {
+		sorted := byGroup[group]
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return jsString(sorted[i]["time_period"]) < jsString(sorted[j]["time_period"])
+		})
+		byGroup[group] = sorted
+		if len(sorted) > longest {
+			longest = len(sorted)
+		}
+	}
+
+	// Keep the group's earliest point as a historical anchor, then as much of the
+	// recent tail as the budget allows. Recent years describe where a disparity
+	// stands now, which is what an insight is about; the anchor is what makes "up
+	// or down since then" answerable at all.
+	render := func(recentCount int) string {
+		var lines []string
+		for _, group := range order {
+			sorted := byGroup[group]
+			kept := sorted
+			if len(sorted) > recentCount+1 {
+				kept = append([]insightRow{sorted[0]}, sorted[len(sorted)-recentCount:]...)
+			}
+			for _, row := range kept {
+				lines = append(lines, fmt.Sprintf("- %s (%s): %s %s",
+					group, jsString(row["time_period"]),
+					jsString(row[metricConfig.MetricID]), metricConfig.ShortLabel))
+			}
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	// Send the full series when it is small enough for the model to work with the
+	// whole trend, since that is a materially better answer than a truncated one.
+	if full := render(longest); len(full) <= budgetBytes {
+		return full
+	}
+
+	// Largest recent window that still fits. Binary search rather than stepping
+	// down one point at a time, since a monthly series over decades can be
+	// hundreds of points per group.
+	low, high, best := 1, longest, ""
+	for low <= high {
+		mid := (low + high) / 2
+		if candidate := render(mid); len(candidate) <= budgetBytes {
+			best = candidate
+			low = mid + 1
+		} else {
+			high = mid - 1
+		}
+	}
+	if best != "" {
+		return best
+	}
+
+	// Enough groups that even one recent point each overflows the budget.
+	return trimLinesToBudget(strings.Split(render(1), "\n"), budgetBytes)
+}
+
+func joinWithAnd(parts []string) string {
+	switch len(parts) {
+	case 0:
+		return ""
+	case 1:
+		return parts[0]
+	case 2:
+		return strings.Join(parts, " and ")
+	default:
+		return strings.Join(parts[:len(parts)-1], ", ") + ", and " + parts[len(parts)-1]
+	}
+}
+
+// The selected region's own overall ("All") rate plus the overall rates of its
+// same-level peers. Peers share the region's data source, file, and methodology,
+// so the comparison is apples-to-apples in a way that
+// county-vs-state-vs-national is not.
+type peerComparison struct {
+	RegionLabel string    `json:"regionLabel"`
+	RegionValue float64   `json:"regionValue"`
+	PeerNoun    string    `json:"peerNoun"`
+	PeerValues  []float64 `json:"peerValues"`
+	ShortLabel  string    `json:"shortLabel"`
+}
+
+type peerRankSummary struct {
+	RegionLabel string
+	RegionValue float64
+	PeerNoun    string
+	// Peers whose rate is strictly below the region's.
+	HigherThanCount int
+	ReportingCount  int
+	Median          float64
+	Min             float64
+	Max             float64
+	ShortLabel      string
+}
+
+// Below this many reporting peers a rank isn't meaningful, so the fallback hides
+// rather than rank against a near-empty field.
+const minReportingPeers = 3
+
+// Reduce raw peer rates to a rank summary, or nil when too few peers report.
+// Ordinal by design: it never places the region's rate beside a
+// differently-computed reference figure, only beside same-level peers.
+func summarizePeerComparison(peer *peerComparison) *peerRankSummary {
+	values := make([]float64, 0, len(peer.PeerValues))
+	for _, v := range peer.PeerValues {
+		if !math.IsNaN(v) && !math.IsInf(v, 0) {
+			values = append(values, v)
+		}
+	}
+	if len(values) < minReportingPeers {
+		return nil
+	}
+	sorted := append([]float64(nil), values...)
+	sort.Float64s(sorted)
+
+	mid := len(sorted) / 2
+	median := sorted[mid]
+	if len(sorted)%2 == 0 {
+		median = (sorted[mid-1] + sorted[mid]) / 2
+	}
+
+	higher := 0
+	for _, v := range values {
+		if v < peer.RegionValue {
+			higher++
+		}
+	}
+	// Rates are non-negative, so math.Round's half-away-from-zero and JS
+	// Math.round's half-up agree here.
+	round1 := func(f float64) float64 { return math.Round(f*10) / 10 }
+	return &peerRankSummary{
+		RegionLabel:     peer.RegionLabel,
+		RegionValue:     peer.RegionValue,
+		PeerNoun:        peer.PeerNoun,
+		HigherThanCount: higher,
+		ReportingCount:  len(values),
+		Median:          round1(median),
+		Min:             round1(sorted[0]),
+		Max:             round1(sorted[len(sorted)-1]),
+		ShortLabel:      peer.ShortLabel,
+	}
+}
+
+// Maps a rank ratio to a plain-English standing label so the model never sees
+// raw fractions like "higher than 23 of 28" and restates them verbatim.
+func peerRankLabel(higherThanCount, reportingCount int) string {
+	ratio := float64(higherThanCount) / float64(reportingCount)
+	switch {
+	case ratio >= 0.9:
+		return "among the highest"
+	case ratio >= 0.75:
+		return "higher than most"
+	case ratio >= 0.6:
+		return "above the typical"
+	case ratio >= 0.4:
+		return "near the typical"
+	case ratio >= 0.25:
+		return "below the typical"
+	case ratio >= 0.1:
+		return "lower than most"
+	default:
+		return "among the lowest"
+	}
+}
+
+// Renders a peer rank summary as prompt bullet lines. Leads with the region's
+// own rate, then its qualitative standing and the peer distribution.
+func formatPeerComparison(s *peerRankSummary) string {
+	return strings.Join([]string{
+		fmt.Sprintf("- %s: %s %s", s.RegionLabel, jsNumber(s.RegionValue), s.ShortLabel),
+		fmt.Sprintf("- Among %d %s: %s", s.ReportingCount, s.PeerNoun, peerRankLabel(s.HigherThanCount, s.ReportingCount)),
+		fmt.Sprintf("- Peer median %s %s; range %s–%s %s",
+			jsNumber(s.Median), s.ShortLabel, jsNumber(s.Min), jsNumber(s.Max), s.ShortLabel),
+	}, "\n")
+}
+
+// Optional context about which groups the user has focused the chart on.
+type insightContext struct {
+	ActiveDemographicGroup string          `json:"activeDemographicGroup"`
+	SelectedGroups         []string        `json:"selectedGroups"`
+	PeerComparison         *peerComparison `json:"peerComparison"`
+}
+
+func buildPrompt(hashID, topic, location, demographicLabel, dataSection, activeDemographicGroup string, hasPeerComparison bool, tableShape *tableColumnShape) string {
+	dataBlock := ""
+	if dataSection != "" {
+		dataBlock = "\n\nData:\n" + dataSection
+	}
+
+	if mapChartIDs[hashID] && hasPeerComparison {
+		return fmt.Sprintf("This is a choropleth map of %s in %s. Because only its overall rate is available locally, %s is ranked against its peer places at the same geographic level — which draw on the same data source and methodology, so the comparison is fair.%s\n\nWrite a single sentence at an 8th grade reading level that says where %s falls among its peers (for example, higher than most, near the middle, or among the lowest), using the specific numbers, and what that means for the people who live there. Focus on the \"so what\", not the chart mechanics.",
+			topic, location, location, dataBlock, location)
+	}
+
+	if mapChartIDs[hashID] {
+		// Each data row is labeled `Place (Group)`, and an "All" row gives the
+		// overall rate for that place. Tell the model which group the user is
+		// currently highlighting so it can lead with that story.
+		focus := ""
+		if activeDemographicGroup != "" && activeDemographicGroup != insightGroupAll {
+			focus = fmt.Sprintf(" The map currently highlights the %s group, so lead with that group and use the \"All\" baseline for comparison.", activeDemographicGroup)
+		}
+		return fmt.Sprintf("This is a choropleth map showing %s in %s by %s. Each data row is labeled with its place and %s group; an \"All\" row gives the overall rate for that place.%s%s\n\nWrite a single sentence at an 8th grade reading level that highlights the most important health equity disparity — either a geographic gap between places or a gap between %s groups within a place — and captures why it matters for real people. Focus on the \"so what\", not the chart mechanics.",
+			topic, location, demographicLabel, demographicLabel, focus, dataBlock, demographicLabel)
+	}
+
+	if hashID == "rates-over-time" {
+		return fmt.Sprintf("This is a line chart showing how %s rates have changed over time in %s across %s groups.%s\n\nWrite a single sentence at an 8th grade reading level that names the specific years covered, describes whether the gap between groups is improving or worsening, and includes specific numbers — focus on what this trend means for real people.",
+			topic, location, demographicLabel, dataBlock)
+	}
+
+	if hashID == "inequities-over-time" {
+		return fmt.Sprintf("This is a chart showing how the relative inequity in %s has changed over time in %s across %s groups. Positive values mean a group bears a greater share of %s than their share of the population; negative means less.%s\n\nWrite a single sentence at an 8th grade reading level that names the specific years covered, states whether inequity is improving or worsening for the most affected group, and includes specific numbers — focus on what this trend means for real people.",
+			topic, location, demographicLabel, topic, dataBlock)
+	}
+
+	if hashID == "data-table" {
+		// The columns are named from what the rows actually carry, so the prompt
+		// can never describe a number it did not send.
+		columnParts := []string{"its rate"}
+		if tableShape != nil && tableShape.HasCaseloadShare {
+			columnParts = append(columnParts, "its share of the total")
+		}
+		if tableShape != nil && tableShape.HasPopulationShare {
+			columnParts = append(columnParts, "its share of the population")
+		}
+		columns := joinWithAnd(columnParts)
+
+		// The population share is what makes this card different from every other
+		// one on the page: it is the only place a reader can weigh who carries the
+		// burden against who is actually there. Eight topics publish no caseload
+		// share at all, so the comparison there is the group's rate against its
+		// share of the population.
+		burden := "whose rate is"
+		if tableShape != nil && tableShape.HasCaseloadShare {
+			burden = fmt.Sprintf("whose share of %s is", topic)
+		}
+		task := "describes the pattern across several groups rather than only the single biggest gap"
+		if tableShape != nil && tableShape.HasPopulationShare {
+			task = fmt.Sprintf("weighs who carries the burden against who actually lives in %s, naming a group %s out of step with its share of the population", location, burden)
+		}
+		caveat := ""
+		if tableShape != nil && tableShape.GeneralPopulationLabel != "" {
+			caveat = fmt.Sprintf(" The population shares count %s, a broader group than the rate itself measures, so treat that comparison as rough context rather than an exact figure.", tableShape.GeneralPopulationLabel)
+		}
+
+		return fmt.Sprintf("This is a data table summarizing %s in %s by %s. Each row gives one group and %s.%s%s\n\nWrite a single sentence at an 8th grade reading level that %s. Use the specific numbers shown, and focus on the \"so what\" for the community.",
+			topic, location, demographicLabel, columns, caveat, dataBlock, task)
+	}
+
+	return fmt.Sprintf("This is a %s showing %s in %s by %s. The intended message is to highlight health equity disparities.%s\n\nWrite a single sentence at an 8th grade reading level that captures the key inequity a viewer should walk away with — focus on the \"so what\", not the chart mechanics.",
+		strings.ReplaceAll(hashID, "-", " "), topic, location, demographicLabel, dataBlock)
+}
+
+// Keeps the model from narrating the prompt (e.g. "Since only the overall rate
+// is available, here's a sentence...") — the card wants the bare insight.
+const cardOutputRule = " Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available."
+
+// The exact text a card sends to the model.
+func buildCardInsightPrompt(hashID, topic, location, demographicLabel, dataSection string, context *insightContext, tableShape *tableColumnShape) string {
+	// Single-region map: rank the region against its same-level peers instead of
+	// describing an on-screen disparity. summarizePeerComparison returns nil when
+	// too few peers report, in which case we fall through to the standard framing.
+	var peerSummary *peerRankSummary
+	if mapChartIDs[hashID] && context != nil && context.PeerComparison != nil {
+		peerSummary = summarizePeerComparison(context.PeerComparison)
+	}
+
+	// The peer summary already leads with the region's own rate, so it replaces
+	// the lone local row rather than appending to it.
+	finalDataSection := dataSection
+	if peerSummary != nil {
+		finalDataSection = formatPeerComparison(peerSummary)
+	}
+
+	activeGroup := ""
+	if context != nil {
+		activeGroup = context.ActiveDemographicGroup
+	}
+
+	return buildPrompt(hashID, topic, location, demographicLabel, finalDataSection,
+		activeGroup, peerSummary != nil, tableShape) + cardOutputRule
+}
+
+func buildContrastPrompt(topic1, topic2, location1, location2, demographic, data1, data2 string) string {
+	var setup, viewALabel, viewBLabel, guidance string
+
+	switch {
+	case topic1 == topic2:
+		// compare-geo: same topic, different places
+		setup = fmt.Sprintf("Two side-by-side charts show the same health metric — %s — across %s groups, in two different places.", topic1, demographic)
+		viewALabel = fmt.Sprintf("View A (%s)", location1)
+		viewBLabel = fmt.Sprintf("View B (%s)", location2)
+		guidance = "Focus on what comparing these two places reveals that either view alone does not — for example, whether disparities within one place exceed disparities between places, or whether the same patterns recur at different geographic scales."
+	case location1 == location2:
+		// compare-vars: same place, different topics
+		setup = fmt.Sprintf("Two side-by-side charts show %s, one for %s and one for %s, across %s groups.", location1, topic1, topic2, demographic)
+		viewALabel = fmt.Sprintf("View A (%s)", topic1)
+		viewBLabel = fmt.Sprintf("View B (%s)", topic2)
+		guidance = "Focus on whether the same groups bear the heaviest burden across both topics, or where the patterns diverge — and what that suggests about the underlying drivers of inequity."
+	default:
+		setup = fmt.Sprintf("Two side-by-side charts compare %s in %s with %s in %s, across %s groups.", topic1, location1, topic2, location2, demographic)
+		viewALabel = fmt.Sprintf("View A (%s in %s)", topic1, location1)
+		viewBLabel = fmt.Sprintf("View B (%s in %s)", topic2, location2)
+		guidance = "Focus on what the contrast reveals about how place and topic interact in driving health inequities."
+	}
+
+	dataBlock1 := ""
+	if data1 != "" {
+		dataBlock1 = fmt.Sprintf("\n\n%s data:\n%s", viewALabel, data1)
+	}
+	dataBlock2 := ""
+	if data2 != "" {
+		dataBlock2 = fmt.Sprintf("\n\n%s data:\n%s", viewBLabel, data2)
+	}
+
+	return fmt.Sprintf("%s%s%s\n\nWrite one sentence at an 8th grade reading level that contrasts these two views. %s Be specific — name the places, groups, or numbers from the data above. Use only facts present in the data; do not introduce additional statistics, causal explanations, or place-specific facts that are not shown.",
+		setup, dataBlock1, dataBlock2, guidance)
+}
+
+// The browser's DEMOGRAPHIC_DISPLAY_TYPES_LOWER_CASE. Part of the prompt text,
+// so it is pinned here rather than derived.
+var demographicDisplayLower = map[string]string{
+	"race_and_ethnicity": "race/ethnicity",
+	"age":                "age",
+	"sex":                "sex",
+	"fips":               "FIPS codes",
+	"lis":                "low income subsidy",
+	"eligibility":        "eligibility",
+	"urbanicity":         "city size",
+	"income":             "income",
+	"education":          "education",
+	"insurance_status":   "insurance",
+}

--- a/server/insight_prompt.go
+++ b/server/insight_prompt.go
@@ -45,10 +45,14 @@ func groupIsAll(group string) bool {
 	return group == insightGroupAll || group == insightGroupAllWomen
 }
 
-// Only these two fields of a MetricConfig reach the prompt text.
+// Only these fields of a MetricConfig reach the prompt text.
 type insightMetricConfig struct {
 	MetricID   string `json:"metricId"`
 	ShortLabel string `json:"shortLabel"`
+	// The population-vs-distribution chart is the one card whose population
+	// share hangs off the rate config itself rather than being resolved as a
+	// separate table column, so it arrives nested here.
+	PopulationComparisonMetric *insightMetricConfig `json:"populationComparisonMetric,omitempty"`
 }
 
 type insightRow map[string]any
@@ -98,11 +102,25 @@ func jsNumber(f float64) string {
 	if math.IsInf(f, -1) {
 		return "-Infinity"
 	}
+	// JS prints negative zero as "0"; Go prints "-0".
+	if f == 0 {
+		return "0"
+	}
 	// JS switches to exponential notation outside this range. Rates and
 	// percentages never reach it, but diverging silently is worse than the
 	// branch costs.
-	if abs := math.Abs(f); f != 0 && (abs >= 1e21 || abs < 1e-6) {
-		return strconv.FormatFloat(f, 'g', -1, 64)
+	if abs := math.Abs(f); abs >= 1e21 || abs < 1e-6 {
+		// Both languages agree on the mantissa and the exponent sign, but Go pads
+		// the exponent to two digits (1.5e-07) where JS never does (1.5e-7).
+		s := strconv.FormatFloat(f, 'g', -1, 64)
+		if i := strings.IndexByte(s, 'e'); i >= 0 {
+			digits := strings.TrimLeft(s[i+2:], "0")
+			if digits == "" {
+				digits = "0"
+			}
+			return s[:i+2] + digits
+		}
+		return s
 	}
 	return strconv.FormatFloat(f, 'f', -1, 64)
 }
@@ -211,7 +229,10 @@ func formatDataRows(rows []insightRow, hashID, demographicType string, metricCon
 	// For population-vs-distribution, include both the outcome share and the
 	// population share side by side so the model can compute the disparity.
 	var popMetric *insightMetricConfig
-	if isTable {
+	switch {
+	case hashID == "population-vs-distribution":
+		popMetric = metricConfig.PopulationComparisonMetric
+	case isTable:
 		popMetric = opts.PopulationConfig
 	}
 	var shareMetric *insightMetricConfig
@@ -269,8 +290,6 @@ func formatDataRows(rows []insightRow, hashID, demographicType string, metricCon
 		} else {
 			label = jsString(row[demographicType])
 		}
-		val := jsString(row[metricConfig.MetricID]) + " " + metricConfig.ShortLabel
-
 		if isTable {
 			// The table's own three columns, in the order the table shows them.
 			// Each is dropped for the rows the source suppressed, so a group can
@@ -284,6 +303,7 @@ func formatDataRows(rows []insightRow, hashID, demographicType string, metricCon
 			lines = append(lines, fmt.Sprintf("- %s: %s", label, strings.Join(parts, ", ")))
 			continue
 		}
+		val := jsString(row[metricConfig.MetricID]) + " " + metricConfig.ShortLabel
 		if popMetric != nil && row[popMetric.MetricID] != nil {
 			lines = append(lines, fmt.Sprintf("- %s: outcome share %s, population share %s %s",
 				label, val, jsString(row[popMetric.MetricID]), popMetric.ShortLabel))

--- a/server/insight_prompt_report.go
+++ b/server/insight_prompt_report.go
@@ -1,0 +1,445 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// The report-wide insight is a synthesis, not a walkthrough of the cards below
+// it. Trend and data-completeness findings fold into the four sections rather
+// than each getting a section of their own, which would turn the card into a
+// table of contents for the report.
+
+// How many places to name at each end of the geographic spread. Enough to show a
+// pattern rather than a lone outlier, few enough that a state with hundreds of
+// counties still produces a bounded prompt.
+const spreadSampleSize = 3
+
+// Word budgets for the two sections that absorb optional clauses. The base
+// covers the section's own finding; each clause folded in buys roughly one more
+// sentence, so a section never has to say more in the same breath.
+const (
+	sectionWordBudget = 35
+	clauseWordBudget  = 20
+)
+
+// The browser's UNKNOWN / UNKNOWN_RACE / UNKNOWN_ETHNICITY / UNKNOWN_W set.
+var unknownDemographicGroups = map[string]bool{
+	"Unknown":                 true,
+	"Unknown race":            true,
+	"Unknown ethnicity":       true,
+	"Women with unknown race": true,
+}
+
+// finiteNumber mirrors Number.isFinite: a non-numeric value is not a small
+// number, it is no number at all, and rows carrying one are dropped rather than
+// rendered as text.
+func finiteNumber(v any) (float64, bool) {
+	f, ok := v.(float64)
+	if !ok || math.IsNaN(f) || math.IsInf(f, 0) {
+		return 0, false
+	}
+	return f, true
+}
+
+func trimSectionToBudget(section string, budgetBytes int) string {
+	if len(section) <= budgetBytes {
+		return section
+	}
+	return trimLinesToBudget(strings.Split(section, "\n"), budgetBytes)
+}
+
+// allFirstThenDesc orders the overall row ahead of every group, then ranks the
+// rest by value descending, so the same data always renders the same text. The
+// prompt-hash cache key depends on that.
+func allFirstThenDesc(groupA, groupB string, valueA, valueB float64) bool {
+	if groupIsAll(groupA) != groupIsAll(groupB) {
+		return groupIsAll(groupA)
+	}
+	return valueB < valueA
+}
+
+// Rates for every demographic group in the selected place, overall row first so
+// the model has a baseline to measure each group against.
+func formatDemographicRates(rows []insightRow, demographicType string, metricConfig, shareConfig, populationConfig *insightMetricConfig) string {
+	type entry struct {
+		group string
+		value float64
+		row   insightRow
+	}
+	entries := make([]entry, 0, len(rows))
+	for _, row := range rows {
+		value, ok := finiteNumber(row[metricConfig.MetricID])
+		if row[demographicType] == nil || !ok {
+			continue
+		}
+		entries = append(entries, entry{jsString(row[demographicType]), value, row})
+	}
+	sort.SliceStable(entries, func(i, j int) bool {
+		return allFirstThenDesc(entries[i].group, entries[j].group, entries[i].value, entries[j].value)
+	})
+
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		// A rate alone says a group is worse off; the shares say whether that
+		// group carries more of the burden than its presence would account for.
+		parts := []string{formatMetricValue(e.value, metricConfig)}
+		for _, config := range []*insightMetricConfig{shareConfig, populationConfig} {
+			if config != nil && e.row[config.MetricID] != nil {
+				parts = append(parts, formatMetricValue(e.row[config.MetricID], config))
+			}
+		}
+		lines = append(lines, fmt.Sprintf("- %s: %s", e.group, strings.Join(parts, ", ")))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// The spread of overall rates across the child places shown on the report's map,
+// reduced to both extremes plus a median. Sending every county would dominate
+// the prompt without telling the model more than its shape does.
+func formatGeographicSpread(rows []insightRow, metricConfig *insightMetricConfig, placeNoun string) string {
+	type place struct {
+		name  string
+		value float64
+	}
+	places := make([]place, 0, len(rows))
+	for _, row := range rows {
+		value, ok := finiteNumber(row[metricConfig.MetricID])
+		if row["fips_name"] == nil || !ok {
+			continue
+		}
+		places = append(places, place{jsString(row["fips_name"]), value})
+	}
+	sort.SliceStable(places, func(i, j int) bool { return places[j].value < places[i].value })
+
+	// One place is not a geographic comparison, so say nothing rather than
+	// present a lone value as if it were a spread.
+	if len(places) < 2 {
+		return ""
+	}
+
+	unit := metricConfig.ShortLabel
+	render := func(p place) string { return p.name + " " + jsNumber(p.value) }
+	renderAll := func(ps []place) string {
+		out := make([]string, len(ps))
+		for i, p := range ps {
+			out[i] = render(p)
+		}
+		return strings.Join(out, ", ")
+	}
+
+	// Naming every place beats a top/bottom split that would repeat most of them.
+	if len(places) <= spreadSampleSize*2 {
+		return fmt.Sprintf("- All %d %s: %s %s", len(places), placeNoun, renderAll(places), unit)
+	}
+
+	mid := len(places) / 2
+	median := places[mid].value
+	if len(places)%2 == 0 {
+		median = (places[mid-1].value + places[mid].value) / 2
+	}
+
+	lowest := make([]place, spreadSampleSize)
+	tail := places[len(places)-spreadSampleSize:]
+	for i, p := range tail {
+		lowest[len(tail)-1-i] = p
+	}
+
+	return strings.Join([]string{
+		fmt.Sprintf("- Highest: %s %s", renderAll(places[:spreadSampleSize]), unit),
+		fmt.Sprintf("- Lowest reported: %s %s", renderAll(lowest), unit),
+		fmt.Sprintf("- Median across %d %s: %s %s", len(places), placeNoun, jsNumber(math.Round(median*10)/10), unit),
+	}, "\n")
+}
+
+// Each group's first, highest, and latest reported rate. Three points per group
+// rather than the full series let the model say both whether overall rates moved
+// and whether the gap between groups widened or narrowed, at a fraction of the
+// prompt size.
+//
+// The peak is not decoration. On a monthly series like COVID-19 the first and
+// last months both sit at zero, so endpoints alone would describe a condition
+// that never happened.
+func formatTemporalChange(rows []insightRow, demographicType string, metricConfig *insightMetricConfig) string {
+	// Insertion order, as the browser's Map gives.
+	var order []string
+	byGroup := map[string][]insightRow{}
+	for _, row := range rows {
+		if row[demographicType] == nil || row["time_period"] == nil {
+			continue
+		}
+		if _, ok := finiteNumber(row[metricConfig.MetricID]); !ok {
+			continue
+		}
+		group := jsString(row[demographicType])
+		if _, seen := byGroup[group]; !seen {
+			order = append(order, group)
+		}
+		byGroup[group] = append(byGroup[group], row)
+	}
+
+	type span struct {
+		group             string
+		first, peak, last insightRow
+		lastValue         float64
+	}
+	spans := make([]span, 0, len(order))
+	for _, group := range order {
+		sorted := byGroup[group]
+		sort.SliceStable(sorted, func(i, j int) bool {
+			return jsString(sorted[i]["time_period"]) < jsString(sorted[j]["time_period"])
+		})
+		first, last := sorted[0], sorted[len(sorted)-1]
+		// A single time point is a rate, not a change, so it belongs in the
+		// demographic section rather than being restated here as a trend.
+		if jsString(first["time_period"]) == jsString(last["time_period"]) {
+			continue
+		}
+		peak := sorted[0]
+		for _, row := range sorted[1:] {
+			v, _ := finiteNumber(row[metricConfig.MetricID])
+			best, _ := finiteNumber(peak[metricConfig.MetricID])
+			if v > best {
+				peak = row
+			}
+		}
+		lastValue, _ := finiteNumber(last[metricConfig.MetricID])
+		spans = append(spans, span{group, first, peak, last, lastValue})
+	}
+	sort.SliceStable(spans, func(i, j int) bool {
+		return allFirstThenDesc(spans[i].group, spans[j].group, spans[i].lastValue, spans[j].lastValue)
+	})
+
+	lines := make([]string, 0, len(spans))
+	for _, s := range spans {
+		points := []string{fmt.Sprintf("%s in %s", jsString(s.first[metricConfig.MetricID]), jsString(s.first["time_period"]))}
+		// A peak at either endpoint is already named, so repeating it would just
+		// invite the model to treat one number as two findings.
+		peakPeriod := jsString(s.peak["time_period"])
+		if peakPeriod != jsString(s.first["time_period"]) && peakPeriod != jsString(s.last["time_period"]) {
+			points = append(points, fmt.Sprintf("peaking at %s in %s", jsString(s.peak[metricConfig.MetricID]), peakPeriod))
+		}
+		points = append(points, fmt.Sprintf("%s in %s", jsString(s.last[metricConfig.MetricID]), jsString(s.last["time_period"])))
+		lines = append(lines, fmt.Sprintf("- %s: %s %s", s.group, strings.Join(points, ", "), metricConfig.ShortLabel))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Each group's age-adjusted burden relative to the White (non-Hispanic)
+// baseline. Without adjustment, a group with an older age profile looks worse on
+// the raw rate for reasons that are demographic rather than inequitable, so this
+// is the section that keeps the insight from over-reading the crude rates.
+func formatAgeAdjustedRatios(rows []insightRow, demographicType string, metricConfig *insightMetricConfig) string {
+	type entry struct {
+		group string
+		value float64
+	}
+	entries := make([]entry, 0, len(rows))
+	for _, row := range rows {
+		value, ok := finiteNumber(row[metricConfig.MetricID])
+		if row[demographicType] == nil || !ok {
+			continue
+		}
+		entries = append(entries, entry{jsString(row[demographicType]), value})
+	}
+	sort.SliceStable(entries, func(i, j int) bool { return entries[j].value < entries[i].value })
+
+	lines := make([]string, 0, len(entries))
+	for _, e := range entries {
+		lines = append(lines, fmt.Sprintf("- %s: %sx the White (NH) rate", e.group, jsNumber(e.value)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// The share of cases whose demographic was never recorded. A high unknown share
+// is itself an equity finding: it means the disparities in every other chart are
+// measured on incomplete data, so the model needs the number to say so rather
+// than treat the rates as the whole picture. When race and ethnicity are
+// reported separately a place can have two unknown rows, so all of them are named.
+func formatUnknownShare(rows []insightRow, demographicType string, metricConfig *insightMetricConfig) string {
+	var lines []string
+	for _, row := range rows {
+		if !unknownDemographicGroups[jsString(row[demographicType])] {
+			continue
+		}
+		if _, ok := finiteNumber(row[metricConfig.MetricID]); !ok {
+			continue
+		}
+		// shortLabel already carries the unit and the topic, e.g. "% of COVID-19
+		// deaths", so nothing is appended to it here.
+		lines = append(lines, fmt.Sprintf("- %s: %s%s",
+			jsString(row[demographicType]), jsString(row[metricConfig.MetricID]), metricConfig.ShortLabel))
+	}
+	return strings.Join(lines, "\n")
+}
+
+type reportDataSections struct {
+	Demographic string
+	Geographic  string
+	Temporal    string
+	AgeAdjusted string
+	Unknown     string
+}
+
+func buildReportInsightPrompt(topic, location, demographicLabel string, data reportDataSections, demographicShape *tableColumnShape) string {
+	// Five sections share one prompt, so each is capped individually. Each is
+	// already reduced to a summary upstream; this is the backstop for a place
+	// whose group or period count outruns that reduction.
+	demographicSection := trimSectionToBudget(data.Demographic, insightBudgetReport)
+	geographicSection := trimSectionToBudget(data.Geographic, insightBudgetReport)
+	temporalSection := trimSectionToBudget(data.Temporal, insightBudgetReport)
+	ageAdjustedSection := trimSectionToBudget(data.AgeAdjusted, insightBudgetReport)
+	unknownSection := trimSectionToBudget(data.Unknown, insightBudgetReport)
+
+	hasCaseloadShare := demographicShape != nil && demographicShape.HasCaseloadShare
+	hasPopulationShare := demographicShape != nil && demographicShape.HasPopulationShare
+
+	var extraColumns []string
+	if hasCaseloadShare {
+		extraColumns = append(extraColumns, "its share of the total")
+	}
+	if hasPopulationShare {
+		extraColumns = append(extraColumns, "its share of the population")
+	}
+
+	demographicHeader := fmt.Sprintf("Current rates by %s in %s", demographicLabel, location)
+	if len(extraColumns) > 0 {
+		demographicHeader = fmt.Sprintf("Current rates by %s in %s, each group followed by %s",
+			demographicLabel, location, strings.Join(extraColumns, " and "))
+	}
+
+	var dataBlocks []string
+	if demographicSection != "" {
+		dataBlocks = append(dataBlocks, demographicHeader+":\n"+demographicSection)
+	}
+	if geographicSection != "" {
+		dataBlocks = append(dataBlocks, "Geographic spread:\n"+geographicSection)
+	}
+	if temporalSection != "" {
+		dataBlocks = append(dataBlocks, fmt.Sprintf("Rates over time by %s in %s, first, highest, and latest reported periods:\n%s",
+			demographicLabel, location, temporalSection))
+	}
+	if ageAdjustedSection != "" {
+		dataBlocks = append(dataBlocks, fmt.Sprintf("Age-adjusted burden relative to the White (NH) baseline in %s:\n%s",
+			location, ageAdjustedSection))
+	}
+	if unknownSection != "" {
+		dataBlocks = append(dataBlocks, fmt.Sprintf("Cases missing %s data in %s:\n%s",
+			demographicLabel, location, unknownSection))
+	}
+	dataBlock := ""
+	if len(dataBlocks) > 0 {
+		dataBlock = "\n\n" + strings.Join(dataBlocks, "\n\n") + "\n"
+	}
+
+	// Every spec below has a no-data variant. Without it the model is told to
+	// lead with a number it was never given, which is exactly how a fabricated
+	// rate gets into a summary.
+
+	// Inviting a comparison without supplying a ratio is how "ten times higher
+	// than average" gets computed from two rates and presented as a finding, so
+	// the headline may only cite a ratio when one was actually sent.
+	ratioClause := " State no figure at all; make the comparison in words only."
+	if ageAdjustedSection != "" {
+		ratioClause = " You may cite one of the ratios shown above, but do not work out any other figure."
+	}
+
+	// This is the one line a reader who skips the charts will actually read, so
+	// it has to be the most accessible thing on the page. A per-100k rate means
+	// little without the denominator in your head; "twice as likely" lands
+	// immediately. Single quotes inside: this string is interpolated into the
+	// JSON skeleton below, so a double quote would show the model a malformed
+	// template.
+	keyFindingsSpec := "1 sentence (max 25 words): the most important equity question this report helps answer. Do not state any rate or number."
+	if demographicSection != "" {
+		keyFindingsSpec = "1 sentence (max 25 words): the single most important takeaway, in plain words a reader who skipped every chart would understand. Name who carries the heaviest burden and how much heavier it is, expressed as a comparison in words such as 'nearly twice as likely'. Do not open with a rate per 100k." + ratioClause
+	}
+
+	locationSpec := "1-2 sentences (max 35 words): what to look for when comparing places on this map. Do not state any rate or number."
+	if geographicSection != "" {
+		locationSpec = "1-2 sentences (max 35 words): what the geographic spread shows about where the burden is heaviest."
+	}
+
+	// Age adjustment and the trend both fold in here rather than getting sections
+	// of their own: one corrects how the demographic gap should be read, the
+	// other says whether it is closing. Both are qualifiers on the gap.
+	ageAdjustedClause := ""
+	if ageAdjustedSection != "" {
+		ageAdjustedClause = " Then use the age-adjusted ratios to say whether the gap holds once differences in age between groups are accounted for."
+	}
+	temporalClause := ""
+	if temporalSection != "" {
+		temporalClause = " Then say whether the gap between groups has widened or narrowed across the reported periods, naming the highest point if one is given."
+	}
+
+	// A rate gap says a group is worse off. Set against the group's share of the
+	// population it says whether that group is carrying more of the burden than
+	// its presence in the place would account for, which is the finding a reader
+	// can act on. Only asked for when the shares were actually sent.
+	populationShareClause := ""
+	if hasPopulationShare {
+		if hasCaseloadShare {
+			populationShareClause = " Then say whether that group's share of the total is larger or smaller than its share of the population, using the shares above."
+		} else {
+			populationShareClause = " Then say how large or small a share of the population that group makes up, using the population shares above."
+		}
+		if demographicShape.GeneralPopulationLabel != "" {
+			populationShareClause += fmt.Sprintf(" Those population shares count %s, a broader group than the rate itself measures, so call the comparison rough context rather than an exact figure.",
+				demographicShape.GeneralPopulationLabel)
+		}
+	}
+
+	demographicWordBudget := sectionWordBudget
+	for _, present := range []bool{ageAdjustedSection != "", temporalSection != "", hasPopulationShare} {
+		if present {
+			demographicWordBudget += clauseWordBudget
+		}
+	}
+
+	demographicSpec := "1-2 sentences (max 35 words): what to look for when comparing groups. Do not state any rate or number."
+	if demographicSection != "" {
+		demographicSpec = fmt.Sprintf("2-3 sentences (max %d words): which group is most affected and how large the gap is compared to others, using the rates above.%s%s%s",
+			demographicWordBudget, populationShareClause, ageAdjustedClause, temporalClause)
+	}
+
+	// Missing demographic data is an equity finding, not a footnote: the groups
+	// absent from the record are usually the ones already least well served, so
+	// it belongs with what the report means rather than a section of its own.
+	completenessClause := ""
+	whatThisMeansWordBudget := sectionWordBudget
+	sentenceRange := "1-2"
+	if unknownSection != "" {
+		completenessClause = fmt.Sprintf(" Then note in one sentence what share of cases is missing %s data, and that the rates above describe only the cases where it was recorded.", demographicLabel)
+		whatThisMeansWordBudget += clauseWordBudget
+		sentenceRange = "2-3"
+	}
+	whatThisMeansSpec := fmt.Sprintf("%s sentences (max %d words): what this means for real people in these communities, in plain everyday language.%s",
+		sentenceRange, whatThisMeansWordBudget, completenessClause)
+
+	return fmt.Sprintf(`You are a public health analyst reviewing a report about "%s" in %s, broken down by %s. Emphasize health equity aspects including demographic and geographic disparities, and ensure inclusive, person-first language. Remember these are extremely sensitive conditions that affect millions of real people.
+
+The page contains multiple charts: a rate map, rates over time, a rate bar chart, an unknowns map, inequities over time, and a population vs distribution chart.
+%s
+WRITING RULES, follow these strictly:
+- Use only numbers that appear in the data above. Never estimate, infer, round differently, derive a new figure by combining two that are shown, or introduce a figure that is not shown. If a number is not in the data, describe the pattern in words instead.
+- Do not add causal explanations or place-specific facts that are not in the data.
+- A rate of 0 means the source reported no rate for that place or period. Never cite a 0 as a rate, and never describe it as a place or time with no cases, no deaths, or no burden.
+- Call a figure a peak, a high point, or a low point only where the data above labels it as one. A first or latest reported value is neither.
+- Write every demographic group name exactly as it appears in the data above. Never expand, abbreviate, or reword it; the names shown are the ones used throughout the rest of the report.
+- Never label a group vulnerable, at-risk, high-risk, underserved, or a minority. Those words describe people by a deficit rather than by what they face. Name the group and name the burden instead.
+- Use person-first wording: "people with diabetes", not "diabetics"; "people experiencing homelessness", not "the homeless".
+- Write at an 8th-grade reading level. Use short words and simple sentences.
+- Avoid jargon. If you must use a technical term, explain it immediately.
+- Do not repeat the same number in more than one section.
+
+Respond ONLY with a valid JSON object, no markdown, no backticks, no explanation outside the JSON. Include every key below and no others. Use this exact structure:
+
+{
+  "keyFindings": "%s",
+  "locationComparison": "%s",
+  "demographicInsights": "%s",
+  "whatThisMeans": "%s"
+}`, topic, location, demographicLabel, dataBlock, keyFindingsSpec, locationSpec, demographicSpec, whatThisMeansSpec)
+}

--- a/server/insight_prompt_test.go
+++ b/server/insight_prompt_test.go
@@ -26,6 +26,22 @@ type fixtureView struct {
 	Rows         []insightRow         `json:"rows"`
 }
 
+type fixtureSection struct {
+	Rows                   []insightRow         `json:"rows"`
+	MetricConfig           *fixtureMetricConfig `json:"metricConfig"`
+	ShareConfig            *fixtureMetricConfig `json:"shareConfig"`
+	PopulationConfig       *fixtureMetricConfig `json:"populationConfig"`
+	GeneralPopulationLabel string               `json:"generalPopulationLabel"`
+}
+
+type fixtureSections struct {
+	Demographic fixtureSection `json:"demographic"`
+	Geographic  fixtureSection `json:"geographic"`
+	Temporal    fixtureSection `json:"temporal"`
+	AgeAdjusted fixtureSection `json:"ageAdjusted"`
+	Unknown     fixtureSection `json:"unknown"`
+}
+
 type promptFixture struct {
 	Kind            string `json:"kind"`
 	Why             string `json:"why"`
@@ -45,6 +61,10 @@ type promptFixture struct {
 	// contrast
 	ViewA *fixtureView `json:"viewA"`
 	ViewB *fixtureView `json:"viewB"`
+
+	// report
+	PlaceNoun string           `json:"placeNoun"`
+	Sections  *fixtureSections `json:"sections"`
 }
 
 func (f *promptFixture) metricConfig() *insightMetricConfig {
@@ -93,6 +113,30 @@ func renderFixture(t *testing.T, f *promptFixture) string {
 		return buildContrastPrompt(f.ViewA.Topic, f.ViewB.Topic, f.ViewA.Location, f.ViewB.Location,
 			demographic, section(f.ViewA), section(f.ViewB))
 
+	case "report":
+		s := f.Sections
+		metricFor := func(sec fixtureSection) *insightMetricConfig {
+			if sec.MetricConfig != nil {
+				return asInsightMetricConfig(sec.MetricConfig)
+			}
+			return f.metricConfig()
+		}
+		demoMetric := metricFor(s.Demographic)
+		demoShares := insightDataOptions{
+			ShareConfig:            asInsightMetricConfig(s.Demographic.ShareConfig),
+			PopulationConfig:       asInsightMetricConfig(s.Demographic.PopulationConfig),
+			GeneralPopulationLabel: s.Demographic.GeneralPopulationLabel,
+		}
+		shape := getTableColumnShape(s.Demographic.Rows, f.DemographicType, demoMetric, demoShares)
+		return buildReportInsightPrompt(f.Topic, f.Location, demographic, reportDataSections{
+			Demographic: formatDemographicRates(s.Demographic.Rows, f.DemographicType, demoMetric,
+				demoShares.ShareConfig, demoShares.PopulationConfig),
+			Geographic:  formatGeographicSpread(s.Geographic.Rows, metricFor(s.Geographic), f.PlaceNoun),
+			Temporal:    formatTemporalChange(s.Temporal.Rows, f.DemographicType, metricFor(s.Temporal)),
+			AgeAdjusted: formatAgeAdjustedRatios(s.AgeAdjusted.Rows, f.DemographicType, metricFor(s.AgeAdjusted)),
+			Unknown:     formatUnknownShare(s.Unknown.Rows, f.DemographicType, metricFor(s.Unknown)),
+		}, &shape)
+
 	default:
 		t.Fatalf("unhandled fixture kind %q", f.Kind)
 		return ""
@@ -119,12 +163,6 @@ func TestInsightPromptFixtures(t *testing.T) {
 			if err := json.Unmarshal(raw, &fixture); err != nil {
 				t.Fatal(err)
 			}
-			// The report templates land with the rest of #5045; until then this
-			// test covers the card and contrast families.
-			if fixture.Kind == "report" {
-				t.Skip("report templates not ported yet (#5045)")
-			}
-
 			wantPath := strings.TrimSuffix(input, ".json") + ".prompt.txt"
 			want, err := os.ReadFile(wantPath)
 			if err != nil {

--- a/server/insight_prompt_test.go
+++ b/server/insight_prompt_test.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The fixtures in testdata/insight_prompts are the contract between the
+// browser's prompt builders and this port: the same inputs must render the same
+// text, byte for byte, because the insight cache key is a hash of that text.
+// Accept a change only by regenerating the fixtures on the frontend side
+// (UPDATE_INSIGHT_PROMPTS=1) and reviewing the resulting diff.
+
+type fixtureMetricConfig struct {
+	MetricID   string `json:"metricId"`
+	ShortLabel string `json:"shortLabel"`
+}
+
+type fixtureView struct {
+	Topic        string               `json:"topic"`
+	Location     string               `json:"location"`
+	MetricConfig *fixtureMetricConfig `json:"metricConfig"`
+	Rows         []insightRow         `json:"rows"`
+}
+
+type promptFixture struct {
+	Kind            string `json:"kind"`
+	Why             string `json:"why"`
+	HashID          string `json:"hashId"`
+	DemographicType string `json:"demographicType"`
+
+	// card
+	Topic                  string               `json:"topic"`
+	Location               string               `json:"location"`
+	MetricConfig           *fixtureMetricConfig `json:"metricConfig"`
+	ShareConfig            *fixtureMetricConfig `json:"shareConfig"`
+	PopulationConfig       *fixtureMetricConfig `json:"populationConfig"`
+	GeneralPopulationLabel string               `json:"generalPopulationLabel"`
+	Rows                   []insightRow         `json:"rows"`
+	Context                *insightContext      `json:"context"`
+
+	// contrast
+	ViewA *fixtureView `json:"viewA"`
+	ViewB *fixtureView `json:"viewB"`
+}
+
+func (f *promptFixture) metricConfig() *insightMetricConfig {
+	return asInsightMetricConfig(f.MetricConfig)
+}
+
+func asInsightMetricConfig(c *fixtureMetricConfig) *insightMetricConfig {
+	if c == nil {
+		return nil
+	}
+	return &insightMetricConfig{MetricID: c.MetricID, ShortLabel: c.ShortLabel}
+}
+
+func renderFixture(t *testing.T, f *promptFixture) string {
+	t.Helper()
+	demographic, ok := demographicDisplayLower[f.DemographicType]
+	if !ok {
+		t.Fatalf("fixture uses demographic type %q with no display label", f.DemographicType)
+	}
+
+	switch f.Kind {
+	case "card":
+		opts := insightDataOptions{
+			ShareConfig:            asInsightMetricConfig(f.ShareConfig),
+			PopulationConfig:       asInsightMetricConfig(f.PopulationConfig),
+			GeneralPopulationLabel: f.GeneralPopulationLabel,
+		}
+		if f.Context != nil {
+			opts.SelectedGroups = f.Context.SelectedGroups
+			opts.ActiveDemographicGroup = f.Context.ActiveDemographicGroup
+		}
+		dataSection := formatDataRows(f.Rows, f.HashID, f.DemographicType, f.metricConfig(), opts)
+
+		var shape *tableColumnShape
+		if f.HashID == "data-table" {
+			s := getTableColumnShape(f.Rows, f.DemographicType, f.metricConfig(), opts)
+			shape = &s
+		}
+		return buildCardInsightPrompt(f.HashID, f.Topic, f.Location, demographic, dataSection, f.Context, shape)
+
+	case "contrast":
+		section := func(v *fixtureView) string {
+			return formatDataRows(v.Rows, f.HashID, f.DemographicType, asInsightMetricConfig(v.MetricConfig),
+				insightDataOptions{BudgetBytes: insightBudgetContrast})
+		}
+		return buildContrastPrompt(f.ViewA.Topic, f.ViewB.Topic, f.ViewA.Location, f.ViewB.Location,
+			demographic, section(f.ViewA), section(f.ViewB))
+
+	default:
+		t.Fatalf("unhandled fixture kind %q", f.Kind)
+		return ""
+	}
+}
+
+func TestInsightPromptFixtures(t *testing.T) {
+	inputs, err := filepath.Glob(filepath.Join("testdata", "insight_prompts", "*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(inputs) == 0 {
+		t.Fatal("no prompt fixtures found")
+	}
+
+	for _, input := range inputs {
+		name := strings.TrimSuffix(filepath.Base(input), ".json")
+		t.Run(name, func(t *testing.T) {
+			raw, err := os.ReadFile(input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var fixture promptFixture
+			if err := json.Unmarshal(raw, &fixture); err != nil {
+				t.Fatal(err)
+			}
+			// The report templates land with the rest of #5045; until then this
+			// test covers the card and contrast families.
+			if fixture.Kind == "report" {
+				t.Skip("report templates not ported yet (#5045)")
+			}
+
+			wantPath := strings.TrimSuffix(input, ".json") + ".prompt.txt"
+			want, err := os.ReadFile(wantPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := renderFixture(t, &fixture)
+			if got != string(want) {
+				t.Errorf("prompt does not match %s\n--- got ---\n%s\n--- want ---\n%s",
+					filepath.Base(wantPath), got, string(want))
+			}
+		})
+	}
+}

--- a/server/insight_prompt_test.go
+++ b/server/insight_prompt_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,23 +15,21 @@ import (
 // Accept a change only by regenerating the fixtures on the frontend side
 // (UPDATE_INSIGHT_PROMPTS=1) and reviewing the resulting diff.
 
-type fixtureMetricConfig struct {
-	MetricID   string `json:"metricId"`
-	ShortLabel string `json:"shortLabel"`
-}
-
+// Fixture metric configs decode straight into the production type: its JSON tags
+// already match the fixture field names, so a mirrored test struct would only be
+// one more place to forget to update.
 type fixtureView struct {
 	Topic        string               `json:"topic"`
 	Location     string               `json:"location"`
-	MetricConfig *fixtureMetricConfig `json:"metricConfig"`
+	MetricConfig *insightMetricConfig `json:"metricConfig"`
 	Rows         []insightRow         `json:"rows"`
 }
 
 type fixtureSection struct {
 	Rows                   []insightRow         `json:"rows"`
-	MetricConfig           *fixtureMetricConfig `json:"metricConfig"`
-	ShareConfig            *fixtureMetricConfig `json:"shareConfig"`
-	PopulationConfig       *fixtureMetricConfig `json:"populationConfig"`
+	MetricConfig           *insightMetricConfig `json:"metricConfig"`
+	ShareConfig            *insightMetricConfig `json:"shareConfig"`
+	PopulationConfig       *insightMetricConfig `json:"populationConfig"`
 	GeneralPopulationLabel string               `json:"generalPopulationLabel"`
 }
 
@@ -51,9 +50,9 @@ type promptFixture struct {
 	// card
 	Topic                  string               `json:"topic"`
 	Location               string               `json:"location"`
-	MetricConfig           *fixtureMetricConfig `json:"metricConfig"`
-	ShareConfig            *fixtureMetricConfig `json:"shareConfig"`
-	PopulationConfig       *fixtureMetricConfig `json:"populationConfig"`
+	MetricConfig           *insightMetricConfig `json:"metricConfig"`
+	ShareConfig            *insightMetricConfig `json:"shareConfig"`
+	PopulationConfig       *insightMetricConfig `json:"populationConfig"`
 	GeneralPopulationLabel string               `json:"generalPopulationLabel"`
 	Rows                   []insightRow         `json:"rows"`
 	Context                *insightContext      `json:"context"`
@@ -67,17 +66,6 @@ type promptFixture struct {
 	Sections  *fixtureSections `json:"sections"`
 }
 
-func (f *promptFixture) metricConfig() *insightMetricConfig {
-	return asInsightMetricConfig(f.MetricConfig)
-}
-
-func asInsightMetricConfig(c *fixtureMetricConfig) *insightMetricConfig {
-	if c == nil {
-		return nil
-	}
-	return &insightMetricConfig{MetricID: c.MetricID, ShortLabel: c.ShortLabel}
-}
-
 func renderFixture(t *testing.T, f *promptFixture) string {
 	t.Helper()
 	demographic, ok := demographicDisplayLower[f.DemographicType]
@@ -88,26 +76,26 @@ func renderFixture(t *testing.T, f *promptFixture) string {
 	switch f.Kind {
 	case "card":
 		opts := insightDataOptions{
-			ShareConfig:            asInsightMetricConfig(f.ShareConfig),
-			PopulationConfig:       asInsightMetricConfig(f.PopulationConfig),
+			ShareConfig:            f.ShareConfig,
+			PopulationConfig:       f.PopulationConfig,
 			GeneralPopulationLabel: f.GeneralPopulationLabel,
 		}
 		if f.Context != nil {
 			opts.SelectedGroups = f.Context.SelectedGroups
 			opts.ActiveDemographicGroup = f.Context.ActiveDemographicGroup
 		}
-		dataSection := formatDataRows(f.Rows, f.HashID, f.DemographicType, f.metricConfig(), opts)
+		dataSection := formatDataRows(f.Rows, f.HashID, f.DemographicType, f.MetricConfig, opts)
 
 		var shape *tableColumnShape
 		if f.HashID == "data-table" {
-			s := getTableColumnShape(f.Rows, f.DemographicType, f.metricConfig(), opts)
+			s := getTableColumnShape(f.Rows, f.DemographicType, f.MetricConfig, opts)
 			shape = &s
 		}
 		return buildCardInsightPrompt(f.HashID, f.Topic, f.Location, demographic, dataSection, f.Context, shape)
 
 	case "contrast":
 		section := func(v *fixtureView) string {
-			return formatDataRows(v.Rows, f.HashID, f.DemographicType, asInsightMetricConfig(v.MetricConfig),
+			return formatDataRows(v.Rows, f.HashID, f.DemographicType, v.MetricConfig,
 				insightDataOptions{BudgetBytes: insightBudgetContrast})
 		}
 		return buildContrastPrompt(f.ViewA.Topic, f.ViewB.Topic, f.ViewA.Location, f.ViewB.Location,
@@ -117,14 +105,14 @@ func renderFixture(t *testing.T, f *promptFixture) string {
 		s := f.Sections
 		metricFor := func(sec fixtureSection) *insightMetricConfig {
 			if sec.MetricConfig != nil {
-				return asInsightMetricConfig(sec.MetricConfig)
+				return sec.MetricConfig
 			}
-			return f.metricConfig()
+			return f.MetricConfig
 		}
 		demoMetric := metricFor(s.Demographic)
 		demoShares := insightDataOptions{
-			ShareConfig:            asInsightMetricConfig(s.Demographic.ShareConfig),
-			PopulationConfig:       asInsightMetricConfig(s.Demographic.PopulationConfig),
+			ShareConfig:            s.Demographic.ShareConfig,
+			PopulationConfig:       s.Demographic.PopulationConfig,
 			GeneralPopulationLabel: s.Demographic.GeneralPopulationLabel,
 		}
 		shape := getTableColumnShape(s.Demographic.Rows, f.DemographicType, demoMetric, demoShares)
@@ -175,5 +163,73 @@ func TestInsightPromptFixtures(t *testing.T) {
 					filepath.Base(wantPath), got, string(want))
 			}
 		})
+	}
+}
+
+// jsNumber and peerRankLabel carry sharp contracts that the fixtures only
+// exercise incidentally, so pin them directly. Expected jsNumber values are
+// String(n) output copied from a JS runtime, not derived from the Go code.
+func TestJSNumberMatchesJavaScript(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want string
+	}{
+		{0, "0"},
+		{math.Copysign(0, -1), "0"},
+		{4, "4"},
+		{-4, "-4"},
+		{0.5, "0.5"},
+		{-0.5, "-0.5"},
+		{100, "100"},
+		{43.8, "43.8"},
+		// Written out rather than 0.1+0.2, which Go folds exactly at compile time.
+		{0.30000000000000004, "0.30000000000000004"},
+		// Exponential range. Unreachable for a rate or a share today, but a
+		// silent divergence here would displace cache entries rather than fail.
+		{1e-6, "0.000001"},
+		{1.5e-7, "1.5e-7"},
+		{-1.5e-7, "-1.5e-7"},
+		{5e-324, "5e-324"},
+		{1e21, "1e+21"},
+		{-1e21, "-1e+21"},
+		{1.2345e21, "1.2345e+21"},
+		{1e22, "1e+22"},
+		{math.NaN(), "NaN"},
+		{math.Inf(1), "Infinity"},
+		{math.Inf(-1), "-Infinity"},
+	}
+	for _, c := range cases {
+		if got := jsNumber(c.in); got != c.want {
+			t.Errorf("jsNumber(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestPeerRankLabelBands(t *testing.T) {
+	// Each band's lower bound and the value just under it, as thousandths of the
+	// reporting count so the boundaries land exactly.
+	cases := []struct {
+		higherThan int
+		want       string
+	}{
+		{1000, "among the highest"},
+		{900, "among the highest"},
+		{899, "higher than most"},
+		{750, "higher than most"},
+		{749, "above the typical"},
+		{600, "above the typical"},
+		{599, "near the typical"},
+		{400, "near the typical"},
+		{399, "below the typical"},
+		{250, "below the typical"},
+		{249, "lower than most"},
+		{100, "lower than most"},
+		{99, "among the lowest"},
+		{0, "among the lowest"},
+	}
+	for _, c := range cases {
+		if got := peerRankLabel(c.higherThan, 1000); got != c.want {
+			t.Errorf("peerRankLabel(%d, 1000) = %q, want %q", c.higherThan, got, c.want)
+		}
 	}
 }

--- a/server/testdata/insight_prompts/card_pop_vs_distribution.json
+++ b/server/testdata/insight_prompts/card_pop_vs_distribution.json
@@ -1,0 +1,53 @@
+{
+  "kind": "card",
+  "why": "The population-vs-distribution chart, the only card whose population share comes from the rate config's own populationComparisonMetric rather than from a separately resolved table column. Exercises the outcome-share/population-share row form, which no other fixture reaches.",
+  "hashId": "population-vs-distribution",
+  "topic": "COVID-19 deaths",
+  "location": "Georgia",
+  "demographicType": "race_and_ethnicity",
+  "metricConfig": {
+    "metricId": "covid_deaths_pct_share",
+    "shortLabel": "% of COVID-19 deaths",
+    "populationComparisonMetric": {
+      "metricId": "covid_population_pct",
+      "shortLabel": "% of population"
+    }
+  },
+  "rows": [
+    {
+      "fips": "13",
+      "fips_name": "Georgia",
+      "race_and_ethnicity": "All",
+      "covid_deaths_pct_share": 100,
+      "covid_population_pct": 100
+    },
+    {
+      "fips": "13",
+      "fips_name": "Georgia",
+      "race_and_ethnicity": "Black or African American (NH)",
+      "covid_deaths_pct_share": 43.8,
+      "covid_population_pct": 31.2
+    },
+    {
+      "fips": "13",
+      "fips_name": "Georgia",
+      "race_and_ethnicity": "White (NH)",
+      "covid_deaths_pct_share": 44.1,
+      "covid_population_pct": 50.4
+    },
+    {
+      "fips": "13",
+      "fips_name": "Georgia",
+      "race_and_ethnicity": "Hispanic or Latino",
+      "covid_deaths_pct_share": 7.9,
+      "covid_population_pct": 10.5
+    },
+    {
+      "fips": "13",
+      "fips_name": "Georgia",
+      "race_and_ethnicity": "Asian (NH)",
+      "covid_deaths_pct_share": 2.1,
+      "covid_population_pct": 4.6
+    }
+  ]
+}

--- a/server/testdata/insight_prompts/card_pop_vs_distribution.prompt.txt
+++ b/server/testdata/insight_prompts/card_pop_vs_distribution.prompt.txt
@@ -1,0 +1,10 @@
+This is a population vs distribution showing COVID-19 deaths in Georgia by race/ethnicity. The intended message is to highlight health equity disparities.
+
+Data:
+- All: outcome share 100 % of COVID-19 deaths, population share 100 % of population
+- Black or African American (NH): outcome share 43.8 % of COVID-19 deaths, population share 31.2 % of population
+- White (NH): outcome share 44.1 % of COVID-19 deaths, population share 50.4 % of population
+- Hispanic or Latino: outcome share 7.9 % of COVID-19 deaths, population share 10.5 % of population
+- Asian (NH): outcome share 2.1 % of COVID-19 deaths, population share 4.6 % of population
+
+Write a single sentence at an 8th grade reading level that captures the key inequity a viewer should walk away with — focus on the "so what", not the chart mechanics. Respond with ONLY the single sentence itself — no preamble, no lead-in, no labels, and do not restate these instructions or note which data is or is not available.


### PR DESCRIPTION
Fix the Go insight prompt port found during review.

Addresses three issues caught during the /review pass on #5073:

1. **population-vs-distribution bug**: the port resolved a population comparison metric only for the data table, so the population-vs-distribution card rendered a bare outcome share where the browser renders both shares side by side. A new fixture, generated from the TypeScript, pins the correct output and would have caught it.

2. **jsNumber edge cases**: printed "-0" where JS prints "0", and padded exponents to two digits ("1.5e-07" vs JS "1.5e-7"). Neither is reachable from a real rate, but both would silently displace cache entries. Table-driven tests now pin jsNumber against String(n) output (fuzz-tested against 3000 random values) and peerRankLabel against every band boundary.

3. **Fixture harness refactor**: fixture structs now decode into the production metric config type rather than a mirrored copy, so a new field cannot be added to one and forgotten in the other.

## Impact

- Closes the gap between Go and browser prompt rendering for all observed edge cases and ensures the test suite can catch regressions that the fixture set exercises.

## Test plan

- [x] All 11 fixture cases pass byte-for-byte (includes new `card_pop_vs_distribution`)
- [x] `jsNumber` matches JavaScript `String(number)` for edge cases (fuzz-tested against 3000 random values)
- [x] `peerRankLabel` threshold bands verified at all seven boundaries
- [x] Full test suite passes (`go test -count=1 ./...`)
- [x] Go vet clean

Fixes #5045 (Phase 1 gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
