### PR TITLE
fix(map): suppress No data legend swatch when orphan FIPS rows have no drawn shape

### DIFF
--- a/frontend/src/cards/MapCard.tsx
+++ b/frontend/src/cards/MapCard.tsx
@@ -1,6 +1,6 @@
 import GridView from '@mui/icons-material/GridView'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useLocation } from 'react-router'
 import { createColorScale } from '../charts/choroplethMap/colorSchemes'
 import ChoroplethMap from '../charts/choroplethMap/index'
@@ -158,6 +158,9 @@ function MapCardWithKey(props: MapCardProps) {
     ATLANTA_MODE_PARAM_KEY,
     false,
   )
+  const [renderedFipsIds, setRenderedFipsIds] = useState<
+    Set<string> | undefined
+  >()
 
   const resolvedDataTypeConfig = useMemo(
     () =>
@@ -742,6 +745,7 @@ function MapCardWithKey(props: MapCardProps) {
                       isPhrmaAdherence={isPhrmaAdherence}
                       isAtlantaMode={isAtlantaMode}
                       isSummaryLegend={isSummaryLegend}
+                      onRenderedFipsIds={setRenderedFipsIds}
                       updateFipsCallback={props.updateFipsCallback}
                       colorScale={colorScale}
                     />
@@ -763,6 +767,7 @@ function MapCardWithKey(props: MapCardProps) {
                     isPhrmaAdherence={isPhrmaAdherence}
                     fips={props.fips}
                     isCompareMode={isCompareMode}
+                    renderedFipsIds={renderedFipsIds}
                   />
                 </div>
 

--- a/frontend/src/cards/ui/MultiMapDialog.tsx
+++ b/frontend/src/cards/ui/MultiMapDialog.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { createColorScale } from '../../charts/choroplethMap/colorSchemes'
 import ChoroplethMap from '../../charts/choroplethMap/index'
 import RateMapLegend from '../../charts/choroplethMap/RateMapLegend'
@@ -105,6 +105,10 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
     },
   }
 
+  const [renderedFipsIds, setRenderedFipsIds] = useState<
+    Set<string> | undefined
+  >()
+
   const mapConfig = props.dataTypeConfig.mapConfig
 
   const colorScaleMultiMap = useMemo(() => {
@@ -198,6 +202,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
                         isExtremesMode={false}
                         isPhrmaAdherence={props.isPhrmaAdherence}
                         isAtlantaMode={props.isAtlantaMode}
+                        onRenderedFipsIds={setRenderedFipsIds}
                         updateFipsCallback={props.updateFipsCallback}
                       />
                     )}
@@ -223,6 +228,7 @@ export default function MultiMapDialog(props: MultiMapDialogProps) {
             isPhrmaAdherence={props.isPhrmaAdherence}
             fips={props.fips}
             colorScale={colorScaleMultiMap}
+            renderedFipsIds={renderedFipsIds}
           />
         </div>
 

--- a/frontend/src/charts/choroplethMap/RateMapLegend.tsx
+++ b/frontend/src/charts/choroplethMap/RateMapLegend.tsx
@@ -32,6 +32,7 @@ interface RateMapLegendProps {
   legendTitle: string
   isCompareMode?: boolean
   colorScale: ColorScale
+  renderedFipsIds?: Set<string>
 }
 
 export default function RateMapLegend(props: RateMapLegendProps) {
@@ -46,6 +47,7 @@ export default function RateMapLegend(props: RateMapLegendProps) {
     isSummaryLegend,
     isExtremesMode,
     colorScale,
+    renderedFipsIds,
   } = props
 
   const [containerRef] = useResponsiveWidth()
@@ -71,6 +73,7 @@ export default function RateMapLegend(props: RateMapLegendProps) {
     isSummaryLegend,
     isExtremesMode,
     colorScale,
+    renderedFipsIds,
   ])
 
   return (

--- a/frontend/src/charts/choroplethMap/index.tsx
+++ b/frontend/src/charts/choroplethMap/index.tsx
@@ -40,6 +40,7 @@ const ChoroplethMap = ({
   isPhrmaAdherence,
   isAtlantaMode,
   isSummaryLegend,
+  onRenderedFipsIds,
   updateFipsCallback,
   colorScale,
 }: ChoroplethMapProps) => {
@@ -185,6 +186,7 @@ const ChoroplethMap = ({
         updateFipsCallback,
       })
 
+      onRenderedFipsIds?.(result.renderedFipsIds)
       setRenderResult({
         dataMap: result.dataMap,
         mapHeight: result.mapHeight,

--- a/frontend/src/charts/choroplethMap/legendDataProcessor.test.ts
+++ b/frontend/src/charts/choroplethMap/legendDataProcessor.test.ts
@@ -110,6 +110,59 @@ describe('processLegendData absence swatches', () => {
   })
 })
 
+describe('processLegendData renderedFipsIds filtering', () => {
+  it('suppresses No data swatch when the only null rows are orphan FIPS with no drawn shape', () => {
+    expect(
+      processLegendData({
+        data: [
+          { fips: '13001', gun_violence_homicide_per_100k: 5 },
+          { fips: '13002', gun_violence_homicide_per_100k: 12 },
+          { fips: '99999', gun_violence_homicide_per_100k: null },
+        ],
+        metricConfig,
+        mapConfig,
+        colorScale,
+        renderedFipsIds: new Set(['13001', '13002']),
+      }).specialItems.map((i) => i.label),
+    ).toEqual([])
+  })
+
+  it('shows No data swatch when a rendered feature has a missing value', () => {
+    expect(
+      processLegendData({
+        data: [
+          { fips: '13001', gun_violence_homicide_per_100k: 5 },
+          { fips: '13002', gun_violence_homicide_per_100k: null },
+          { fips: '99999', gun_violence_homicide_per_100k: null },
+        ],
+        metricConfig,
+        mapConfig,
+        colorScale,
+        renderedFipsIds: new Set(['13001', '13002']),
+      }).specialItems.map((i) => i.label),
+    ).toEqual([NO_DATA_MESSAGE])
+  })
+
+  it('suppresses Suppressed swatch when the only suppressed rows are orphan FIPS', () => {
+    expect(
+      processLegendData({
+        data: [
+          { fips: '13001', gun_violence_homicide_per_100k: 5 },
+          {
+            fips: '99999',
+            gun_violence_homicide_per_100k: null,
+            gun_violence_homicide_per_100k_is_suppressed: true,
+          },
+        ],
+        metricConfig,
+        mapConfig,
+        colorScale,
+        renderedFipsIds: new Set(['13001']),
+      }).specialItems.map((i) => i.label),
+    ).toEqual([])
+  })
+})
+
 describe('processLegendData territory coverage', () => {
   const everyTerritory = Object.keys(TERRITORY_CODES).map((fips) => ({
     fips,

--- a/frontend/src/charts/choroplethMap/legendDataProcessor.ts
+++ b/frontend/src/charts/choroplethMap/legendDataProcessor.ts
@@ -26,6 +26,7 @@ export interface ProcessLegendDataParams {
   isExtremesMode?: boolean
   fipsTypeDisplayName?: GeographicBreakdown
   fips?: Fips
+  renderedFipsIds?: Set<string>
 }
 
 export interface ProcessedLegendData {
@@ -56,6 +57,7 @@ export function processLegendData(
     isExtremesMode,
     fipsTypeDisplayName,
     fips,
+    renderedFipsIds,
   } = params
 
   const labelFormat = createLabelFormatter(metricConfig)
@@ -65,11 +67,16 @@ export function processLegendData(
   const nonZeroData = data.filter((row) => row[metricConfig.metricId] > 0)
   const missingData = data.filter((row) => row[metricConfig.metricId] == null)
 
+  // Orphan rows (FIPS with no matching topojson feature) must not produce absence swatches.
+  const drawnMissingData = renderedFipsIds
+    ? missingData.filter((row) => renderedFipsIds.has(row.fips))
+    : missingData
+
   const suppressionFlag = metricConfig.suppressionFlagMetricId
   const suppressedData = suppressionFlag
-    ? missingData.filter((row) => row[suppressionFlag] === true)
+    ? drawnMissingData.filter((row) => row[suppressionFlag] === true)
     : []
-  const unexplainedMissingData = missingData.filter(
+  const unexplainedMissingData = drawnMissingData.filter(
     (row) => !suppressedData.includes(row),
   )
 

--- a/frontend/src/charts/choroplethMap/renderMap.tsx
+++ b/frontend/src/charts/choroplethMap/renderMap.tsx
@@ -114,15 +114,16 @@ export const renderMap = (options: RenderMapOptions) => {
   const isExtremesContext = (d: any) =>
     isExtremesMode && dataMap.get(d.id?.toString())?.value == null
 
+  const renderedFeatures = features.features.filter(
+    (f) => f.id && (!fips.isUsa() || !TERRITORY_CODES[f.id.toString()]),
+  )
+  const renderedFipsIds = new Set(renderedFeatures.map((f) => f.id!.toString()))
+
   // Draw main map
   mapGroup
     .selectAll('path')
     // skip territory shapes on national map
-    .data(
-      features.features.filter(
-        (f) => f.id && (!fips.isUsa() || !TERRITORY_CODES[f.id.toString()]),
-      ),
-    )
+    .data(renderedFeatures)
     .join('path')
     .attr('d', (d) => path(d) || '')
     .attr('fill', (d) =>
@@ -193,6 +194,7 @@ export const renderMap = (options: RenderMapOptions) => {
   return {
     dataMap,
     mapHeight,
+    renderedFipsIds,
   }
 }
 

--- a/frontend/src/charts/choroplethMap/types.ts
+++ b/frontend/src/charts/choroplethMap/types.ts
@@ -72,6 +72,7 @@ export interface ChoroplethMapProps {
     subtitle?: string
   }
   isAtlantaMode?: boolean
+  onRenderedFipsIds?: (ids: Set<string>) => void
   updateFipsCallback: (fips: Fips) => void
   colorScale: ColorScale | null
 }


### PR DESCRIPTION
## Summary

- `renderMap` now extracts the filtered feature list into a named variable and returns `renderedFipsIds` — the set of FIPS codes it actually drew as SVG paths
- `ChoroplethMap` passes those IDs to `RateMapLegend` via a new `onRenderedFipsIds` callback; `RateMapLegend` forwards them to `processLegendData`
- `processLegendData` filters the missing-data check against the drawn set when available, so "No data" and "Suppressed" swatches only appear when a shape on the map actually renders white or grey

Fixes #5028

## Root cause

The CDC COVID county dataset includes rows with valid-looking FIPS codes that have no matching feature in the topojson (retired county codes or similar). `processLegendData` counted those null-value rows as missing data and emitted a "No data" swatch. `renderMap` skips those FIPS when drawing because there is no feature for them, so the swatch described a shape that did not exist. Reproduced with Georgia county COVID-19 cases: legend showed "No data" but all 159 counties rendered with a value.

## Why frontend, not pipeline

`remove_bad_fips_cols` in `cdc_restricted.py` already strips rows whose county prefix doesn't match the state FIPS, but doesn't filter against the canonical topojson feature set — that's a UI concern. The frontend fix is the right boundary: it makes the legend reflect what the map draws regardless of what any dataset emits.

## Test plan

- [x] `legendDataProcessor.test.ts` — 3 new cases: orphan-only missing (no swatch), rendered feature missing (swatch shown), orphan-only suppressed (no swatch)
- [x] `npx tsc --noEmit` — clean
- [x] `npm run cleanup` — clean
- [x] Manual: reproduce the Georgia / COVID case and verify legend no longer shows "No data"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
