### PR TITLE
feat(frontend): add Sentry error monitoring with source map uploads

### DIFF
--- a/.github/actions/buildAllAndDeploy/action.yml
+++ b/.github/actions/buildAllAndDeploy/action.yml
@@ -17,6 +17,10 @@ inputs:
   tf-state-bucket:
     description: "Terraform state bucket"
     required: true
+  sentry-auth-token:
+    description: "Sentry auth token for source map upload during frontend build"
+    required: false
+    default: ""
 
 outputs:
   ingestion-url:
@@ -80,6 +84,7 @@ runs:
         dockerfile: "server/Dockerfile"
         image-path: "gcr.io/${{ inputs.project-id }}/server"
         deploy-context: ${{ inputs.environment }}
+        sentry-auth-token: ${{ inputs.sentry-auth-token }}
 
     # Terraform and deployment
     - name: Setup Terraform

--- a/.github/actions/buildAndPush/action.yml
+++ b/.github/actions/buildAndPush/action.yml
@@ -14,6 +14,10 @@ inputs:
   deploy-context:
     description: 'String value for deploy context. Should be "prod" or "dev". Only used for the frontend'
     required: false
+  sentry-auth-token:
+    description: "Sentry auth token for source map upload during frontend build"
+    required: false
+    default: ""
 
 outputs:
   image-digest:
@@ -27,7 +31,8 @@ runs:
       shell: bash
     - run: |
         docker build -t ${{ inputs.image-path }} -f ${{ inputs.dockerfile }} ${{ inputs.build-directory }} \
-        --build-arg="DEPLOY_CONTEXT=${{ inputs.deploy-context }}"
+        --build-arg="DEPLOY_CONTEXT=${{ inputs.deploy-context }}" \
+        --build-arg="SENTRY_AUTH_TOKEN=${{ inputs.sentry-auth-token }}"
       shell: bash
     - run: docker push ${{ inputs.image-path }}
       shell: bash

--- a/.github/workflows/deployInfraTest.yml
+++ b/.github/workflows/deployInfraTest.yml
@@ -36,3 +36,4 @@ jobs:
           deployer-sa-key: ${{ secrets.DEPLOYER_SA_KEY }}
           project-id: ${{ secrets.TEST_PROJECT_ID }}
           tf-state-bucket: ${{ secrets.TEST_TF_STATE_BUCKET }}
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/testBackendChangesInfraTest.yml
+++ b/.github/workflows/testBackendChangesInfraTest.yml
@@ -24,3 +24,4 @@ jobs:
           deployer-sa-key: ${{ secrets.DEPLOYER_SA_KEY }}
           project-id: ${{ secrets.TEST_PROJECT_ID }}
           tf-state-bucket: ${{ secrets.TEST_TF_STATE_BUCKET }}
+          sentry-auth-token: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/frontend/.env.deploy_preview
+++ b/frontend/.env.deploy_preview
@@ -10,6 +10,9 @@ VITE_DEPLOY_CONTEXT=deploy_preview
 # Base URL for API requests in preview environments
 VITE_BASE_API_URL=https://dev.healthequitytracker.org
 
+# Error monitoring (empty = disabled for previews)
+VITE_SENTRY_DSN=
+
 # Feature flags
 VITE_SHOW_CORRELATION_CARD=1
 VITE_SHOW_INSIGHT_GENERATION=1

--- a/frontend/.env.dev
+++ b/frontend/.env.dev
@@ -9,6 +9,9 @@ VITE_DEPLOY_CONTEXT=dev
 # API configuration
 # Note: VITE_BASE_API_URL is not needed as API calls will be relative to the frontend domain
 
+# Error monitoring
+VITE_SENTRY_DSN=https://33c166fcaeaa40abbc398c9df5f76c1c@o4505014650863616.ingest.us.sentry.io/4505014690381824
+
 # Feature flags
 VITE_SHOW_CORRELATION_CARD=1
 VITE_SHOW_INSIGHT_GENERATION=1

--- a/frontend/.env.localhost
+++ b/frontend/.env.localhost
@@ -15,6 +15,9 @@ VITE_BASE_API_URL=https://dev.healthequitytracker.org
 # Comma-separated list of filenames
 VITE_FORCE_STATIC=
 
+# Error monitoring (empty = disabled locally)
+VITE_SENTRY_DSN=
+
 # Feature flags
 # VITE_SHOW_CORRELATION_CARD=1
 VITE_SHOW_INSIGHT_GENERATION=1

--- a/frontend/.env.prod
+++ b/frontend/.env.prod
@@ -9,5 +9,8 @@ VITE_DEPLOY_CONTEXT=prod
 # API configuration
 # Note: VITE_BASE_API_URL is not needed as API calls will be relative to the frontend domain
 
+# Error monitoring
+VITE_SENTRY_DSN=https://33c166fcaeaa40abbc398c9df5f76c1c@o4505014650863616.ingest.us.sentry.io/4505014690381824
+
 # Testing configuration
 PLAYWRIGHT_BASE_URL=https://healthequitytracker.org

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
 				"@leeoniya/ufuzzy": "^1.0.19",
 				"@mui/icons-material": "^9.2.0",
 				"@mui/material": "^9.0.0",
+				"@sentry/react": "^10.69.0",
+				"@sentry/vite-plugin": "^5.4.0",
 				"@tanstack/react-query": "^5.101.0",
 				"d3": "^7.9.0",
 				"dom-to-image-more": "^3.10.0",
@@ -140,7 +142,6 @@
 			"version": "7.29.3",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
 			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -150,7 +151,6 @@
 			"version": "7.29.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
 			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.29.0",
@@ -181,14 +181,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
 			"integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"devOptional": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -214,7 +212,6 @@
 			"version": "7.28.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
 			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/compat-data": "^7.28.6",
@@ -231,7 +228,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
 			"integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
-			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"yallist": "^3.0.2"
@@ -241,7 +237,6 @@
 			"version": "6.3.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
 			"integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-			"devOptional": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -273,7 +268,6 @@
 			"version": "7.28.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
 			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.28.6",
@@ -309,7 +303,6 @@
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
 			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -319,7 +312,6 @@
 			"version": "7.29.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
 			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/template": "^7.28.6",
@@ -1983,7 +1975,6 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -2620,6 +2611,344 @@
 			"integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@sentry/browser": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.69.0.tgz",
+			"integrity": "sha512-8391tnm96YbR7b8SYfEA/NEIZuyb2r3SZrtAT0bhZtjlujcYWjo7gugQvk8sWLU9cAa/euD00eJoIoJvNfpd7Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/browser-utils": "10.69.0",
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.69.0",
+				"@sentry/feedback": "10.69.0",
+				"@sentry/replay": "10.69.0",
+				"@sentry/replay-canvas": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/browser-utils": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.69.0.tgz",
+			"integrity": "sha512-e/u1Abj0zRPwR/deGZAP3GOULrsx67/XXnM5Skniqs4uxTsdNtPek1Nef0tpxwaQJYxwh6pWdhswLPPbbPOgBQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/bundler-plugins": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/bundler-plugins/-/bundler-plugins-10.69.0.tgz",
+			"integrity": "sha512-I1otnSJIH4IOugLp+kcBbT0Kcex+J8xnHuUyzMAwCYSpZ0FMVvA723uNmkMdW0PxRRw0oEhe0qDB+t+ZjHxUiA==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.18.5",
+				"@sentry/cli": "^2.58.6",
+				"@sentry/core": "10.69.0",
+				"dotenv": "^17.4.2",
+				"find-up": "^5.0.0",
+				"glob": "^13.0.6",
+				"magic-string": "~0.30.8"
+			},
+			"engines": {
+				"node": ">= 18"
+			},
+			"peerDependencies": {
+				"rollup": ">=3.2.0",
+				"webpack": ">=5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"rollup": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@sentry/cli": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.6.tgz",
+			"integrity": "sha512-baBcNPLLfUi9WuL+Tpri9BFaAdvugZIKelC5X0tt0Zdy+K0K+PCVSrnNmwMWU/HyaF/SEv6b6UHnXIdqanBlcg==",
+			"hasInstallScript": true,
+			"license": "FSL-1.1-MIT",
+			"dependencies": {
+				"https-proxy-agent": "^5.0.0",
+				"node-fetch": "^2.6.7",
+				"progress": "^2.0.3",
+				"proxy-from-env": "^1.1.0",
+				"which": "^2.0.2"
+			},
+			"bin": {
+				"sentry-cli": "bin/sentry-cli"
+			},
+			"engines": {
+				"node": ">= 10"
+			},
+			"optionalDependencies": {
+				"@sentry/cli-darwin": "2.58.6",
+				"@sentry/cli-linux-arm": "2.58.6",
+				"@sentry/cli-linux-arm64": "2.58.6",
+				"@sentry/cli-linux-i686": "2.58.6",
+				"@sentry/cli-linux-x64": "2.58.6",
+				"@sentry/cli-win32-arm64": "2.58.6",
+				"@sentry/cli-win32-i686": "2.58.6",
+				"@sentry/cli-win32-x64": "2.58.6"
+			}
+		},
+		"node_modules/@sentry/cli-darwin": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.6.tgz",
+			"integrity": "sha512-udAVvcyfNa0R+95GvPz/+43/N3TC0TYKdkQ7D7jhPSzbcMc7l2fxRNN5yB3UpCA5fWFnW4toeaqwDBhb/Wh3LA==",
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-linux-arm": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.6.tgz",
+			"integrity": "sha512-pD0LAt5PcUzAinBwvDqc66x9+2CabHEv486yP0gRjWO7SakbaxmfVq/EXd8VLq/Tzi39LAu422UYK1lpW3MILw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"linux",
+				"freebsd",
+				"android"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-linux-arm64": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.6.tgz",
+			"integrity": "sha512-q8mEcNNmeXMy5i+jWT30TVpH7LcP4HD21CD5XRSPAd/a912HF6EpK0ybf/1USO14WOhoXbAGi9txwaWabSe33g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"linux",
+				"freebsd",
+				"android"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-linux-i686": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.6.tgz",
+			"integrity": "sha512-q8vNJi1eOV/4vxAFWBsEwLHoSYapaZHIf4j76KJGJXFKTkEbsjCOOsKbwUIBTQQhRgV4DFWh3ryfsPS/que4Kg==",
+			"cpu": [
+				"x86",
+				"ia32"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"linux",
+				"freebsd",
+				"android"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-linux-x64": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.6.tgz",
+			"integrity": "sha512-DZu956Mhi3ZRjTBe1WdbGV46ldVbA8d2rgp/fh51GsI25zjBHah4wZnPTSzpc+YqxU6pJpg579B/r3jrIK530Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"linux",
+				"freebsd",
+				"android"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-win32-arm64": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.6.tgz",
+			"integrity": "sha512-nj0Ff/kmAB73EPDhR8B4O9r+NUHK5GkPCkGWC+kXVemqAJWL5jcJ5KdxG0l/S0z6RoEoltID8/43/B+TaMlT7A==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-win32-i686": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.6.tgz",
+			"integrity": "sha512-WNZiDzPbgsEMQWq4avsQ391v/xWKJDIWWWo9GYl+N/w5qcYKkoDW7wQG7T9FasI6ENn68phChTOAPXXxbfAdOg==",
+			"cpu": [
+				"x86",
+				"ia32"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli-win32-x64": {
+			"version": "2.58.6",
+			"resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.6.tgz",
+			"integrity": "sha512-R35WJ17oF4D2eqI1DR2sQQqr0fjRTt5xoP16WrTu91XM2lndRMFsnjh+/GttbxapLCBNlrjzia99MJ0PZHZpgA==",
+			"cpu": [
+				"x64"
+			],
+			"license": "FSL-1.1-MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
+			}
+		},
+		"node_modules/@sentry/cli/node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/@sentry/conventions": {
+			"version": "0.16.0",
+			"resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+			"integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@sentry/core": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.69.0.tgz",
+			"integrity": "sha512-+uuqVEeiDzYuAKjZLqsROKXvRTbl/QeH0gfGRtpYib1cud4rAFWRIkFmcR7Jb7JGFYwmReyQotiTj/hcDszTZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/conventions": "^0.16.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/feedback": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.69.0.tgz",
+			"integrity": "sha512-qrGz5Qaw93/IhMjlFN6uIaXeHwgHDaKGa6FkTAP6PonpkvSbGGqan6xfsENxzj9HUVoli1lZ6tMRDnt2qtSPhg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/react": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.69.0.tgz",
+			"integrity": "sha512-f0Il/JMteHjdWPNZQB3rtp1Pcj2Leb3p0KSZuv3rh0EUril9CbWtQVy5zJhoAppi+MWWmgRWa+6BpHbQf+ABQA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/browser": "10.69.0",
+				"@sentry/conventions": "^0.16.0",
+				"@sentry/core": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"react": "^16.14.0 || 17.x || 18.x || 19.x"
+			}
+		},
+		"node_modules/@sentry/replay": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.69.0.tgz",
+			"integrity": "sha512-uRhmNhtFGPOlM0iniVmWKAX3KVXI0le41yYK/iKdPjinT9jA3ZrmykO/Fv1v/KI5znOtwa9D6eHRnDTTMRxFrg==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/browser-utils": "10.69.0",
+				"@sentry/core": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/replay-canvas": {
+			"version": "10.69.0",
+			"resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.69.0.tgz",
+			"integrity": "sha512-VF6nXvSninHcc7dC1Zme0RjkC7VgRMCixs6jKaQX5zTNeqTW3dZGSefSOVv+ZteRi3hJvVORq985VjUC9Z/0+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "10.69.0",
+				"@sentry/replay": "10.69.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@sentry/vite-plugin": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.4.0.tgz",
+			"integrity": "sha512-fFJgCxs5hDyAm9BbZJ+LbA+LK2tjX5OoD0v0ARU4StR6KQmGUduoPs69yJ9AfqZ0om3Rlp5JDliiwFcNkasORA==",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/bundler-plugins": "^10.64.0"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
@@ -4040,11 +4369,19 @@
 				"npm": ">=6"
 			}
 		},
+		"node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
 		"node_modules/baseline-browser-mapping": {
 			"version": "2.10.31",
 			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
 			"integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
-			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {
 				"baseline-browser-mapping": "dist/cli.cjs"
@@ -4053,11 +4390,22 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/brace-expansion": {
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
 		"node_modules/browserslist": {
 			"version": "4.28.2",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
 			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -4113,7 +4461,6 @@
 			"version": "1.0.30001793",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
 			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -5036,11 +5383,22 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/dotenv": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"node_modules/electron-to-chromium": {
 			"version": "1.5.360",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
 			"integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
-			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/enhanced-resolve": {
@@ -5181,7 +5539,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
 			"integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -5294,6 +5651,22 @@
 			"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==",
 			"license": "MIT"
 		},
+		"node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"license": "MIT",
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/flat-cache": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-5.0.0.tgz",
@@ -5353,7 +5726,6 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -5366,6 +5738,23 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.10"
+			}
+		},
+		"node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/global-directory": {
@@ -5616,7 +6005,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -5816,7 +6204,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
 			"integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"json5": "lib/cli.js"
@@ -6120,6 +6507,21 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"license": "MIT"
 		},
+		"node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"license": "MIT",
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6165,7 +6567,6 @@
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -6225,6 +6626,30 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/minimatch": {
+			"version": "10.2.6",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+			"integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.8"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6261,11 +6686,52 @@
 				"tslib": "^2.0.3"
 			}
 		},
+		"node_modules/node-fetch": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			},
+			"peerDependencies": {
+				"encoding": "^0.1.0"
+			},
+			"peerDependenciesMeta": {
+				"encoding": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/node-fetch/node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
+		"node_modules/node-fetch/node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/node-fetch/node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/node-releases": {
 			"version": "2.0.44",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
 			"integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
-			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/nwsapi": {
@@ -6294,6 +6760,36 @@
 				"https://opencollective.com/debug"
 			],
 			"license": "MIT"
+		},
+		"node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"license": "MIT",
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/parent-module": {
 			"version": "2.0.0",
@@ -6339,6 +6835,15 @@
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
+		"node_modules/path-exists": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -6354,6 +6859,22 @@
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
 			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
 			"license": "MIT"
+		},
+		"node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
@@ -6484,6 +7005,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/progress": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6499,6 +7029,12 @@
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"license": "MIT"
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
 			"license": "MIT"
 		},
 		"node_modules/punycode": {
@@ -7169,7 +7705,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
 			"integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
-			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7473,7 +8008,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -7565,7 +8099,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
@@ -7582,6 +8115,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		}
 	}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,8 @@
 		"@leeoniya/ufuzzy": "^1.0.19",
 		"@mui/icons-material": "^9.2.0",
 		"@mui/material": "^9.0.0",
+		"@sentry/react": "^10.69.0",
+		"@sentry/vite-plugin": "^5.4.0",
 		"@tanstack/react-query": "^5.101.0",
 		"d3": "^7.9.0",
 		"dom-to-image-more": "^3.10.0",
@@ -107,7 +109,6 @@
 		"url": "npx playwright install chromium && npx playwright test --project=URL"
 	},
 	"packageManager": "npm@11.16.0",
-	"packageManager": "npm@11.16.0",
 	"engines": {
 		"node": ">=24.0.0",
 		"npm": ">=11.16.0"
@@ -123,5 +124,8 @@
 			"last 1 firefox version",
 			"last 1 safari version"
 		]
+	},
+	"allowScripts": {
+		"@sentry/cli@2.58.6": true
 	}
 }

--- a/frontend/src/ErrorBoundary.tsx
+++ b/frontend/src/ErrorBoundary.tsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/react'
 import { Component, type ErrorInfo, type ReactNode } from 'react'
 
 interface ErrorBoundaryProps {
@@ -21,6 +22,9 @@ export default class ErrorBoundary extends Component<
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error(error, info.componentStack)
+    Sentry.captureException(error, {
+      contexts: { react: { componentStack: info.componentStack } },
+    })
   }
 
   render() {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,3 +1,4 @@
+import './sentry'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'

--- a/frontend/src/sentry.ts
+++ b/frontend/src/sentry.ts
@@ -1,0 +1,23 @@
+import * as Sentry from '@sentry/react'
+
+const NOISE_PATTERNS = [
+  'ResizeObserver loop',
+  'Loading chunk',
+  'Failed to fetch dynamically imported module',
+  'Non-Error exception captured',
+  'ChunkLoadError',
+  'Script error.',
+]
+
+if (import.meta.env.VITE_SENTRY_DSN) {
+  Sentry.init({
+    dsn: import.meta.env.VITE_SENTRY_DSN,
+    environment: import.meta.env.VITE_DEPLOY_CONTEXT,
+    tracesSampleRate: 0,
+    beforeSend(event) {
+      const message = event.exception?.values?.[0]?.value ?? ''
+      if (NOISE_PATTERNS.some((p) => message.includes(p))) return null
+      return event
+    },
+  })
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+import { sentryVitePlugin } from '@sentry/vite-plugin'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import svgrPlugin from 'vite-plugin-svgr'
@@ -30,6 +31,18 @@ export default defineConfig(({ mode }) => {
         : [
             svgrPlugin(), // Keep only for non-preview environments
           ]),
+
+      // Upload source maps to Sentry when auth token is available (dev/prod builds)
+      ...(process.env.SENTRY_AUTH_TOKEN
+        ? [
+            sentryVitePlugin({
+              org: 'morehouse-school-of-medicine',
+              project: 'health-equity-tracker',
+              authToken: process.env.SENTRY_AUTH_TOKEN,
+              sourcemaps: { filesToDeleteAfterUpload: ['./build/**/*.map'] },
+            }),
+          ]
+        : []),
     ],
     test: {
       exclude: [...configDefaults.exclude, 'playwright-tests/*'],

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,6 +2,8 @@
 FROM node:24-slim AS react_build
 ARG DEPLOY_CONTEXT
 RUN test -n "$DEPLOY_CONTEXT" || (echo "DEPLOY_CONTEXT build arg is required (dev|prod|deploy_preview)" && exit 1)
+ARG SENTRY_AUTH_TOKEN
+ENV SENTRY_AUTH_TOKEN=$SENTRY_AUTH_TOKEN
 WORKDIR /usr/src/build
 COPY ./frontend/package*.json ./
 # --ignore-scripts defers postinstall (npm run tokens) until source files exist.


### PR DESCRIPTION
## Summary

- Initializes Sentry in the React app for prod and dev environments; localhost is excluded to avoid noise
- Filters common false-positive errors (ResizeObserver, chunk load failures from stale deploys)
- Wires `SENTRY_AUTH_TOKEN` through the Docker build pipeline and Vite config so source maps are uploaded on every deploy, making stack traces in the Sentry dashboard readable

## Test plan

- [ ] Deploy to infra-test and trigger a JS error — verify it appears in Sentry with a readable stack trace
- [ ] Confirm localhost dev server does not send events to Sentry
- [ ] Confirm ResizeObserver and chunk load errors are filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
