### PR TITLE
fix(share-menu): consistent spacing on card export menu

### DIFF
--- a/frontend/src/cards/ui/CardShareIconButtons.tsx
+++ b/frontend/src/cards/ui/CardShareIconButtons.tsx
@@ -77,7 +77,9 @@ export default function CardShareIconButtons(props: CardShareIconButtonsProps) {
           key={label}
           Icon={Icon}
           onClick={handleClose}
-          className='p-0'
+          className='py-0 pr-0'
+          iconClassName='h-12'
+          spanClassName='py-0 pr-4'
           iconProps={shareIconAttributes}
         >
           <a

--- a/frontend/src/styles/HetComponents/HetCardExportMenuItem.tsx
+++ b/frontend/src/styles/HetComponents/HetCardExportMenuItem.tsx
@@ -24,11 +24,11 @@ export function HetCardExportMenuItem({
   return (
     <MenuItem className={`pl-3 ${className}`} onClick={onClick}>
       <ListItemIcon
-        className={`${iconClassName} flex w-full items-center px-2 py-1`}
+        className={`${iconClassName ?? ''} flex w-full items-center px-2 py-1`}
       >
         <Icon className='mx-1 w-8' {...iconProps} />
         {children && (
-          <span className={`text-alt-black text-small ${spanClassName}`}>
+          <span className={`text-alt-black text-small ${spanClassName ?? ''}`}>
             {children}
           </span>
         )}


### PR DESCRIPTION
**Preview:** [Card export menu on Asthma report](https://deploy-preview-5097--health-equity-tracker.netlify.app/exploredata?mls=1.asthma-3.00&mlp=disparity)

## Summary

- Social share menu items (Facebook, LinkedIn, Email) now use consistent spacing with copy/save items above them
- Fixed `HetCardExportMenuItem` rendering "undefined" as a CSS class when optional props are omitted

## Impact

Improved visual consistency of the card export menu on desktop. All menu items now have uniform height and alignment.

## Test plan

- [x] Biome/tsc: formatting and type checking passed
- [x] Visual inspection: open card export menu (... button) and verify Facebook/LinkedIn/Email items align with copy/save items above

🤖 Generated with [Claude Code](https://claude.com/claude-code)


![image](https://github.com/user-attachments/assets/f73e3590-95e1-4e80-81d5-359f9b349a2d)