### PR TITLE
fix(wisqars): use explicit merge keys in youth/black_men topic loops

### DIFF
--- a/python/datasources/cdc_wisqars_black_men.py
+++ b/python/datasources/cdc_wisqars_black_men.py
@@ -3,6 +3,7 @@ from datasources.data_source import DataSource
 from ingestion import gcs_to_bq_util, standardized_columns as std_col
 from ingestion.cdc_wisqars_utils import (
     generate_cols_map,
+    merge_wisqars_topic_df,
     WISQARS_YEAR,
     WISQARS_URBANICITY,
     WISQARS_STATE,
@@ -170,6 +171,6 @@ def process_wisqars_black_men_df(demographic: WISQARS_DEMO_TYPE, geo_level: GEO_
             inplace=True,
         )
 
-        output_df = output_df.merge(df, how="outer")
+        output_df = merge_wisqars_topic_df(output_df, df)
 
     return output_df

--- a/python/datasources/cdc_wisqars_youth.py
+++ b/python/datasources/cdc_wisqars_youth.py
@@ -30,6 +30,7 @@ from datasources.data_source import DataSource
 from ingestion import gcs_to_bq_util, standardized_columns as std_col
 from ingestion.cdc_wisqars_utils import (
     generate_cols_map,
+    merge_wisqars_topic_df,
     RACE_NAMES_MAPPING,
     load_wisqars_as_df_from_data_dir,
     WISQARS_ALL,
@@ -170,6 +171,6 @@ def process_wisqars_youth_df(demographic: WISQARS_DEMO_TYPE, geo_level: GEO_TYPE
             inplace=True,
         )
 
-        output_df = output_df.merge(df, how="outer")
+        output_df = merge_wisqars_topic_df(output_df, df)
 
     return output_df

--- a/python/ingestion/cdc_wisqars_utils.py
+++ b/python/ingestion/cdc_wisqars_utils.py
@@ -273,9 +273,18 @@ def remove_metadata(df: pd.DataFrame) -> pd.DataFrame:
 
 
 def _is_wisqars_value_col(col: str) -> bool:
-    """True for a per-topic measurement column (count, population, rate, suppression flag),
-    as opposed to a descriptor column (year, state, race, etc.)."""
-    value_suffixes = (f"_{std_col.RAW_SUFFIX}", f"_{std_col.POPULATION_COL}", f"_{std_col.PER_100K_SUFFIX}")
+    """True for a per-topic measurement column (count, population, rate, share, suppression flag),
+    as opposed to a descriptor column (year, state, race, etc.). Covers both the raw columns present
+    in per-topic dfs before aggregation and any derived share/rate columns a topic might compute
+    ahead of merging, so neither can become an accidental join key."""
+    value_suffixes = (
+        f"_{std_col.RAW_SUFFIX}",
+        f"_{std_col.POPULATION_COL}",
+        f"_{std_col.PER_100K_SUFFIX}",
+        f"_{std_col.PCT_RATE_SUFFIX}",
+        f"_{std_col.PCT_SHARE_SUFFIX}",
+        f"_{std_col.PCT_REL_INEQUITY_SUFFIX}",
+    )
     return (
         col.endswith(value_suffixes)
         or col == std_col.IS_SUPPRESSED_SUFFIX

--- a/python/ingestion/cdc_wisqars_utils.py
+++ b/python/ingestion/cdc_wisqars_utils.py
@@ -270,3 +270,27 @@ def remove_metadata(df: pd.DataFrame) -> pd.DataFrame:
         df = df.iloc[:metadata_start_index]
 
     return df
+
+
+def _is_wisqars_value_col(col: str) -> bool:
+    """True for a per-topic measurement column (count, population, rate, suppression flag),
+    as opposed to a descriptor column (year, state, race, etc.)."""
+    value_suffixes = (f"_{std_col.RAW_SUFFIX}", f"_{std_col.POPULATION_COL}", f"_{std_col.PER_100K_SUFFIX}")
+    return (
+        col.endswith(value_suffixes)
+        or col == std_col.IS_SUPPRESSED_SUFFIX
+        or col.endswith(f"_{std_col.IS_SUPPRESSED_SUFFIX}")
+    )
+
+
+def merge_wisqars_topic_df(output_df: pd.DataFrame, df: pd.DataFrame) -> pd.DataFrame:
+    """Outer-merges a per-topic WISQARS dataframe into the accumulating `output_df`.
+
+    Uses explicit join keys instead of pandas' default (every column common to both sides),
+    restricted to descriptor columns like year/state/race. Per-topic measurement columns (counts,
+    rates, `is_suppressed`) are excluded even when they happen to share a name across topics/loop
+    iterations, so a coincidental match (e.g. two topics both suppressed, or both not) can't
+    silently turn into an accidental join key and corrupt the merge.
+    """
+    join_keys = [col for col in output_df.columns if col in df.columns and not _is_wisqars_value_col(col)]
+    return output_df.merge(df, how="outer", on=join_keys)

--- a/python/tests/ingestion/test_cdc_wisqars_utils.py
+++ b/python/tests/ingestion/test_cdc_wisqars_utils.py
@@ -139,3 +139,55 @@ def test_merge_wisqars_topic_df_does_not_key_on_shared_value_col_names():
     ca_row = output_df[output_df["state"] == "California"].iloc[0]
     assert ca_row["topic_a_estimated_total"] == 10
     assert ca_row["topic_b_estimated_total"] == 30
+
+
+def test_merge_wisqars_topic_df_does_not_key_on_shared_prefixed_value_col_names():
+    # Same scenario as above, but for a prefixed value column (e.g. two topics that both happen to
+    # be named "shared_per_100k") rather than the unprefixed `is_suppressed` case - proves the
+    # suffix-matching rule in `_is_wisqars_value_col`, not just the exact-match `is_suppressed` case.
+    output_df = pd.DataFrame(columns=["year", "state"])
+
+    topic_a_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "shared_per_100k": 1.5},
+            {"year": "2020", "state": "Texas", "shared_per_100k": 2.5},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_a_df)
+
+    topic_b_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "shared_per_100k": 3.5},
+            {"year": "2020", "state": "Texas", "shared_per_100k": 4.5},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_b_df)
+
+    assert len(output_df) == 2
+    assert set(output_df["state"]) == {"California", "Texas"}
+
+
+def test_merge_wisqars_topic_df_does_not_key_on_shared_pct_share_col_names():
+    # `_pct_share`/`_pct_rate`/`_pct_relative_inequity` columns are typically computed after the
+    # per-topic merge (in generate_breakdown_df), not before it - but `_is_wisqars_value_col`
+    # excludes them too, so a topic that computes its share early is still safe to merge.
+    output_df = pd.DataFrame(columns=["year", "state"])
+
+    topic_a_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "topic_a_estimated_total": 10, "shared_pct_share": 40.0},
+            {"year": "2020", "state": "Texas", "topic_a_estimated_total": 20, "shared_pct_share": 60.0},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_a_df)
+
+    topic_b_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "topic_b_estimated_total": 30, "shared_pct_share": 55.0},
+            {"year": "2020", "state": "Texas", "topic_b_estimated_total": 40, "shared_pct_share": 45.0},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_b_df)
+
+    assert len(output_df) == 2
+    assert set(output_df["state"]) == {"California", "Texas"}

--- a/python/tests/ingestion/test_cdc_wisqars_utils.py
+++ b/python/tests/ingestion/test_cdc_wisqars_utils.py
@@ -1,4 +1,10 @@
-from ingestion.cdc_wisqars_utils import clean_numeric, contains_unknown, convert_columns_to_numeric, generate_cols_map
+from ingestion.cdc_wisqars_utils import (
+    clean_numeric,
+    contains_unknown,
+    convert_columns_to_numeric,
+    generate_cols_map,
+    merge_wisqars_topic_df,
+)
 import pandas as pd
 from pandas.testing import assert_frame_equal
 
@@ -100,3 +106,36 @@ def test_generate_cols_map_bad_count_cols():
         "dog_estimated_total": "dog_per_100k",
         "bird": "bird_per_100k",
     }
+
+
+def test_merge_wisqars_topic_df_does_not_key_on_shared_value_col_names():
+    # Simulates the youth.py/black_men.py loop: `output_df` accumulates one topic's df per
+    # iteration. Both topics here produce an `is_suppressed` column (unprefixed, as the source
+    # loader emits it) with different True/False values per state - if `is_suppressed` were ever
+    # treated as an implicit join key, California's rows (True vs False) wouldn't match and the
+    # merge would corrupt/duplicate rows instead of joining cleanly on year/state.
+    output_df = pd.DataFrame(columns=["year", "state"])
+
+    topic_a_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "topic_a_estimated_total": 10, "is_suppressed": True},
+            {"year": "2020", "state": "Texas", "topic_a_estimated_total": 20, "is_suppressed": False},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_a_df)
+
+    topic_b_df = pd.DataFrame(
+        [
+            {"year": "2020", "state": "California", "topic_b_estimated_total": 30, "is_suppressed": False},
+            {"year": "2020", "state": "Texas", "topic_b_estimated_total": 40, "is_suppressed": True},
+        ]
+    )
+    output_df = merge_wisqars_topic_df(output_df, topic_b_df)
+
+    # exactly one row per state, not a cross-product/NaN-riddled mismatch from a bad join key
+    assert len(output_df) == 2
+    assert set(output_df["state"]) == {"California", "Texas"}
+
+    ca_row = output_df[output_df["state"] == "California"].iloc[0]
+    assert ca_row["topic_a_estimated_total"] == 10
+    assert ca_row["topic_b_estimated_total"] == 30


### PR DESCRIPTION
## Summary

- `youth.py` and `black_men.py` accumulate per-topic dataframes in a loop via `output_df.merge(df, how="outer")` with no `on=`, so pandas joins on every column name the two sides happen to share.
- That's fine today (only descriptor columns like year/state/race repeat), but it's a latent bug: a future per-topic measurement column with the same name across iterations (e.g. an `is_suppressed` flag, needed for #4439) would silently become an accidental join key and corrupt the merge instead of raising an error.
- Adds `merge_wisqars_topic_df()` + `_is_wisqars_value_col()` to `cdc_wisqars_utils.py`, which restricts the join to explicit descriptor columns and excludes per-topic value columns (counts, rates, shares, suppression flags) even when they share a name.

Prep work ahead of adding suppression columns to these two sources (related to #4439).

## Impact

- Prevents silent data corruption if a future topic computes a prefixed measurement column (e.g. `shared_per_100k`) or derived metric (e.g. `pct_share`) before merging. No user-facing change today; fix is defensive.

## Test plan

- [x] `pytest python/tests/` — 213 passed (includes 3 new regression tests)
- [x] Manually reproduced old implicit-join bug (4 corrupted rows) against the new regression test (2 clean rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
