### PR TITLE
Wire suppressed-vs-missing map distinction for gun deaths, black men, and youth

### DIFF
--- a/frontend/src/data/config/MetricConfigCommunitySafety.ts
+++ b/frontend/src/data/config/MetricConfigCommunitySafety.ts
@@ -27,12 +27,14 @@ export type CommunitySafetyDataTypeId =
 export type CommunitySafetyMetricId =
   | 'gun_deaths_youth_estimated_total'
   | 'gun_deaths_youth_per_100k'
+  | 'gun_deaths_youth_per_100k_is_suppressed'
   | 'gun_deaths_youth_pct_share'
   | 'gun_deaths_youth_pct_relative_inequity'
   | 'gun_deaths_youth_population'
   | 'gun_deaths_youth_population_pct'
   | 'gun_deaths_young_adults_estimated_total'
   | 'gun_deaths_young_adults_per_100k'
+  | 'gun_deaths_young_adults_per_100k_is_suppressed'
   | 'gun_deaths_young_adults_pct_share'
   | 'gun_deaths_young_adults_pct_relative_inequity'
   | 'gun_deaths_young_adults_population'
@@ -294,6 +296,7 @@ export const GUN_VIOLENCE_YOUTH_METRICS: DataTypeConfig[] = [
         chartTitle: 'Rates of gun deaths among children',
         columnTitleHeader: 'Gun deaths among children per 100k people',
         metricId: 'gun_deaths_youth_per_100k',
+        suppressionFlagMetricId: 'gun_deaths_youth_per_100k_is_suppressed',
         shortLabel: 'deaths per 100k',
         trendsCardTitleName: 'Rates of gun deaths among children over time',
         type: 'per100k',
@@ -356,6 +359,8 @@ export const GUN_VIOLENCE_YOUTH_METRICS: DataTypeConfig[] = [
         chartTitle: 'Rates of gun deaths among young adults',
         columnTitleHeader: 'Gun deaths among young adults per 100k people',
         metricId: 'gun_deaths_young_adults_per_100k',
+        suppressionFlagMetricId:
+          'gun_deaths_young_adults_per_100k_is_suppressed',
         shortLabel: 'deaths per 100k',
         trendsCardTitleName: 'Rates of gun deaths among young adults over time',
         type: 'per100k',

--- a/frontend/src/data/config/MetricConfigCommunitySafety.ts
+++ b/frontend/src/data/config/MetricConfigCommunitySafety.ts
@@ -54,10 +54,12 @@ export type CommunitySafetyMetricId =
   | 'gun_homicides_black_men_pct_relative_inequity'
   | 'gun_homicides_black_men_pct_share'
   | 'gun_homicides_black_men_per_100k'
+  | 'gun_homicides_black_men_per_100k_is_suppressed'
   | 'gun_homicides_black_men_population_estimated_total'
   | 'gun_homicides_black_men_population_pct'
   | 'gun_deaths_estimated_total'
   | 'gun_deaths_per_100k'
+  | 'gun_deaths_per_100k_is_suppressed'
   | 'gun_deaths_pct_share'
   | 'gun_deaths_pct_relative_inequity'
 
@@ -208,6 +210,7 @@ export const GUN_DEATH_METRICS: DataTypeConfig[] = [
         shortLabel: 'deaths per 100k',
         trendsCardTitleName: 'Rates of gun deaths over time',
         type: 'per100k',
+        suppressionFlagMetricId: 'gun_deaths_per_100k_is_suppressed',
         rateNumeratorMetric: {
           chartTitle: '',
           metricId: 'gun_deaths_estimated_total',
@@ -419,6 +422,8 @@ export const GUN_DEATHS_BLACK_MEN_METRICS: DataTypeConfig[] = [
         trendsCardTitleName:
           'Rates of Black male gun homicide victims over time',
         type: 'per100k',
+        suppressionFlagMetricId:
+          'gun_homicides_black_men_per_100k_is_suppressed',
         rateComparisonMetricForAlls: {
           chartTitle: '',
           metricId: 'gun_violence_homicide_per_100k',

--- a/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
+++ b/frontend/src/data/providers/GunDeathsBlackMenProvider.ts
@@ -13,6 +13,7 @@ const GUN_DEATHS_BLACK_MEN_METRIC_IDS: MetricId[] = [
   'gun_homicides_black_men_pct_relative_inequity',
   'gun_homicides_black_men_pct_share',
   'gun_homicides_black_men_per_100k',
+  'gun_homicides_black_men_per_100k_is_suppressed',
   'gun_homicides_black_men_population_estimated_total',
   'gun_homicides_black_men_population_pct',
 ]

--- a/frontend/src/data/providers/GunViolenceProvider.ts
+++ b/frontend/src/data/providers/GunViolenceProvider.ts
@@ -36,6 +36,7 @@ const GUN_DEATHS_METRIC_IDS: MetricId[] = [
   'gun_deaths_pct_relative_inequity',
   'gun_deaths_pct_share',
   'gun_deaths_per_100k',
+  'gun_deaths_per_100k_is_suppressed',
 ]
 
 const POPULATION_METRIC_IDS: MetricId[] = [

--- a/frontend/src/data/providers/GunViolenceYouthProvider.ts
+++ b/frontend/src/data/providers/GunViolenceYouthProvider.ts
@@ -20,6 +20,7 @@ const GUN_DEATHS_CHILDREN_METRIC_IDS: MetricId[] = [
   'gun_deaths_youth_pct_relative_inequity',
   'gun_deaths_youth_pct_share',
   'gun_deaths_youth_per_100k',
+  'gun_deaths_youth_per_100k_is_suppressed',
   'gun_deaths_youth_population',
   'gun_deaths_youth_population_pct',
 ]
@@ -29,6 +30,7 @@ const GUN_DEATHS_YOUNG_ADULTS_METRIC_IDS: MetricId[] = [
   'gun_deaths_young_adults_pct_relative_inequity',
   'gun_deaths_young_adults_pct_share',
   'gun_deaths_young_adults_per_100k',
+  'gun_deaths_young_adults_per_100k_is_suppressed',
   'gun_deaths_young_adults_population',
   'gun_deaths_young_adults_population_pct',
 ]


### PR DESCRIPTION
## Summary
- Wires the `is_suppressed` columns the backend now emits for the overall Gun Deaths rate (`cdc_wisqars.py`, #5107) and the Black Men gun homicide rate (`cdc_wisqars_black_men.py`, #5117) into the frontend's suppressed-vs-missing map distinction.
- Follows the exact pattern already in place for `gun_violence_homicide`/`gun_violence_suicide` (#5105): add the new `_is_suppressed` `MetricId`, declare it as `suppressionFlagMetricId` on the metric's `per100k` config, and add it to the provider's metric list so it survives `removeUnrequestedColumns`.
- Also wires the flag for Gun Deaths (Youth) and Gun Deaths (Young Adults), ahead of backend support: `cdc_wisqars_youth.py` doesn't detect suppression yet, so the column reads as `undefined` and falls through to the existing "missing data" path until a follow-up backend PR adds detection. `removeUnrequestedColumns` only filters rows, it never injects missing keys, and every downstream consumer gates strictly on `=== true`, so this degrades safely.
- `MapCard` already auto-requests `suppressionFlagMetricId` when present, so no card-level changes were needed.

Closes #5115, Closes #5114

## Test plan
- [x] Loaded `/exploredata?mls=1.gun_deaths-3.00&group1=All` against the live dev backend, map renders per-state rates with no console errors
- [x] Loaded `/exploredata?mls=1.gun_deaths_black_men-3.00&group1=All&demo=urbanicity` against the live dev backend, map renders per-state rates with no console errors
- [x] Loaded `/exploredata?mls=1.gun_violence_youth-3.00&dt1=gun_deaths_youth&group1=All` against the live dev backend, map renders with no console errors and no report-error boundary (confirms graceful degradation ahead of backend support)
- [x] Loaded `/exploredata?mls=1.gun_violence_youth-3.00&dt1=gun_deaths_young_adults&group1=All` against the live dev backend, map renders with no console errors and no report-error boundary
