### PR TITLE
Enable suppression detection for WISQARS Youth datasource

### DIFF
--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -33,4 +33,5 @@ tests/         Integration tests — many load real fixture CSVs from repo-root 
 |---|---|
 | DataSource base class | `datasources/data_source.py` |
 | BigQuery/GCS utilities | `ingestion/gcs_to_bq_util.py` |
+| Shared data transforms | `ingestion/dataset_utils.py` |
 | Shared type definitions | `ingestion/het_types.py` |

--- a/python/datasources/cdc_wisqars_youth.py
+++ b/python/datasources/cdc_wisqars_youth.py
@@ -25,6 +25,7 @@ Notes:
 Last Updated: 4/23
 """
 
+import numpy as np
 import pandas as pd
 from datasources.data_source import DataSource
 from ingestion import gcs_to_bq_util, standardized_columns as std_col
@@ -34,6 +35,7 @@ from ingestion.cdc_wisqars_utils import (
     RACE_NAMES_MAPPING,
     load_wisqars_as_df_from_data_dir,
     WISQARS_ALL,
+    WISQARS_IS_SUPPRESSED,
 )
 from ingestion.constants import (
     CURRENT,
@@ -57,13 +59,18 @@ PCT_SHARE_MAP = generate_cols_map(ESTIMATED_TOTALS_MAP.values(), std_col.PCT_SHA
 PCT_SHARE_MAP[std_col.GUN_DEATHS_YOUNG_ADULTS_POPULATION] = std_col.GUN_DEATHS_YOUNG_ADULTS_POP_PCT
 PCT_SHARE_MAP[std_col.GUN_DEATHS_YOUTH_POPULATION] = std_col.GUN_DEATHS_YOUTH_POP_PCT
 PER_100K_MAP = generate_cols_map(CATEGORIES_LIST, std_col.PER_100K_SUFFIX)
+IS_SUPPRESSED_MAP = generate_cols_map(CATEGORIES_LIST, f"{std_col.PER_100K_SUFFIX}_{std_col.IS_SUPPRESSED_SUFFIX}")
 
 TIME_MAP = {
     CURRENT: list(ESTIMATED_TOTALS_MAP.values())
     + list(PCT_SHARE_MAP.values())
     + list(PER_100K_MAP.values())
+    + list(IS_SUPPRESSED_MAP.values())
     + [std_col.GUN_DEATHS_YOUNG_ADULTS_POPULATION, std_col.GUN_DEATHS_YOUTH_POPULATION],
-    HISTORICAL: list(PCT_REL_INEQUITY_MAP.values()) + list(PCT_SHARE_MAP.values()) + list(PER_100K_MAP.values()),
+    HISTORICAL: list(PCT_REL_INEQUITY_MAP.values())
+    + list(PCT_SHARE_MAP.values())
+    + list(PER_100K_MAP.values())
+    + list(IS_SUPPRESSED_MAP.values()),
 }
 
 
@@ -132,7 +139,7 @@ def process_wisqars_youth_df(demographic: WISQARS_DEMO_TYPE, geo_level: GEO_TYPE
 
     for variable_string in [std_col.GUN_DEATHS_YOUNG_ADULTS_PREFIX, std_col.GUN_DEATHS_YOUTH_PREFIX]:
 
-        df = load_wisqars_as_df_from_data_dir(variable_string, geo_level, demographic)
+        df = load_wisqars_as_df_from_data_dir(variable_string, geo_level, demographic, detect_suppression=True)
 
         # Convert column names to lowercase
         df.columns = df.columns.str.lower()
@@ -148,6 +155,7 @@ def process_wisqars_youth_df(demographic: WISQARS_DEMO_TYPE, geo_level: GEO_TYPE
                 ethnicity_value="Hispanic",
                 additional_group_cols=["year", "state"],
                 treat_zero_count_as_missing=True,
+                is_suppressed_col=WISQARS_IS_SUPPRESSED,
             )
 
             # Identify rows where 'race' is 'HISP' or 'UNKNOWN'
@@ -162,11 +170,19 @@ def process_wisqars_youth_df(demographic: WISQARS_DEMO_TYPE, geo_level: GEO_TYPE
             # Update the original DataFrame with the results for the 'crude rate' column
             df.loc[subset_mask, "crude rate"] = temp_df["crude rate"]
 
+            # a combined HISP/UNKNOWN bucket whose constituents include a suppressed row can't
+            # trust its partial sum as a complete count/rate, mirroring condense_age_groups'
+            # treatment in cdc_wisqars_utils.py (numerator and rate are nulled, population isn't)
+            if WISQARS_IS_SUPPRESSED in df.columns:
+                is_suppressed = df[WISQARS_IS_SUPPRESSED].eq(True)
+                df.loc[is_suppressed, ["deaths", "crude rate"]] = np.nan
+
         df.rename(
             columns={
                 "deaths": f"{variable_string}_{std_col.RAW_SUFFIX}",
                 "population": f"{variable_string}_{std_col.POPULATION_COL}",
                 "crude rate": f"{variable_string}_{std_col.PER_100K_SUFFIX}",
+                WISQARS_IS_SUPPRESSED: IS_SUPPRESSED_MAP[variable_string],
             },
             inplace=True,
         )

--- a/python/ingestion/dataset_utils.py
+++ b/python/ingestion/dataset_utils.py
@@ -685,6 +685,7 @@ def combine_race_ethnicity(
     additional_group_cols: Union[List[str], None] = None,
     race_eth_output_col: str = std_col.RACE_CATEGORY_ID_COL,
     treat_zero_count_as_missing: bool = False,
+    is_suppressed_col: Union[str, None] = None,
 ):
     """Combines the `race` and `ethnicity` columns into a single `race_and_ethnicity` col.
 
@@ -700,6 +701,12 @@ def combine_race_ethnicity(
     - additional_group_cols (optional): List of additional columns to group by
     - race_eth_output_col (optional default='race_and_ethnicity'): str name of the added combination race and eth col
     - treat_zero_count_as_missing (optional default=False): if True, sum gets min_count=1 argument
+    - is_suppressed_col (optional): name of a tri-state (`True`/`NaN`) suppression flag column. When
+      present in `df`, a combined race/ethnicity group (e.g. the summed HISP or UNKNOWN row) is
+      flagged suppressed if any constituent row was suppressed; groups with no suppressed
+      constituent get `NaN`, not `False`, matching the raw per-row convention. Callers are
+      responsible for nulling any count columns that shouldn't be trusted for a suppressed group
+      (see `condense_age_groups` in `cdc_wisqars_utils.py` for the analogous pattern).
     """
 
     # Require std_col.RACE_COL and std_col.ETH_COL
@@ -757,11 +764,21 @@ def combine_race_ethnicity(
         for count_col in count_cols_to_sum
     }
 
+    has_suppression_col = is_suppressed_col is not None and is_suppressed_col in df.columns
+    if has_suppression_col:
+        agg_col_map[is_suppressed_col] = lambda x: x.astype("boolean").fillna(False).astype(bool).any()
+
     if not count_cols_to_sum:
         return df
 
     # if count cols were provided, we need the new HISP rows to sum the various Hispanic+Race groups
     df_aggregated = df.groupby(group_cols).agg(agg_col_map).reset_index()
+
+    if has_suppression_col:
+        is_suppressed = df_aggregated[is_suppressed_col].astype(bool)
+        final_suppressed_col = pd.Series(np.nan, index=df_aggregated.index, dtype=object)
+        final_suppressed_col[is_suppressed] = True
+        df_aggregated[is_suppressed_col] = final_suppressed_col
 
     return df_aggregated
 

--- a/python/ingestion/dataset_utils.py
+++ b/python/ingestion/dataset_utils.py
@@ -765,7 +765,7 @@ def combine_race_ethnicity(
     }
 
     has_suppression_col = is_suppressed_col is not None and is_suppressed_col in df.columns
-    if has_suppression_col:
+    if is_suppressed_col is not None and has_suppression_col:
         agg_col_map[is_suppressed_col] = lambda x: x.astype("boolean").fillna(False).astype(bool).any()
 
     if not count_cols_to_sum:
@@ -774,7 +774,7 @@ def combine_race_ethnicity(
     # if count cols were provided, we need the new HISP rows to sum the various Hispanic+Race groups
     df_aggregated = df.groupby(group_cols).agg(agg_col_map).reset_index()
 
-    if has_suppression_col:
+    if is_suppressed_col is not None and has_suppression_col:
         is_suppressed = df_aggregated[is_suppressed_col].astype(bool)
         final_suppressed_col = pd.Series(np.nan, index=df_aggregated.index, dtype=object)
         final_suppressed_col[is_suppressed] = True

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_current.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_current.csv
@@ -1,10 +1,10 @@
-state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_estimated_total,gun_deaths_youth_estimated_total,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_population_pct,gun_deaths_youth_population_pct,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_population,gun_deaths_youth_population
-United States,00,Indigenous (NH),106.0,30.0,1.3,1.2,0.8,0.8,37.41,5.36,283317.0,559819.0
-United States,00,Asian (NH),116.0,43.0,1.4,1.7,5.9,5.6,5.67,1.06,2045660.0,4070166.0
-United States,00,Black or African American (NH),3697.0,1185.0,45.9,46.3,13.7,13.9,77.59,11.72,4764927.0,10110246.0
-United States,00,Hispanic or Latino,1577.0,485.0,19.6,19.0,24.2,26.3,19.0,3.0,8440719.0,19176372.0
-United States,00,Two or more races (NH),167.0,72.0,2.1,2.8,3.5,4.8,13.63,2.05,1225064.0,3518297.0
-United States,00,Native Hawaiian and Pacific Islander (NH),16.0,,0.2,,0.2,0.2,22.38,,71485.0,159737.0
-United States,00,White (NH),2382.0,744.0,29.5,29.1,51.8,48.4,13.2,2.11,18052195.0,35237224.0
-United States,00,Unknown race,,,,,,,,,,
-United States,00,All,8086.0,2581.0,100.0,100.0,100.0,100.0,23.18,3.54,34883367.0,72831861.0
+state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_estimated_total,gun_deaths_youth_estimated_total,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_population_pct,gun_deaths_youth_population_pct,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_per_100k_is_suppressed,gun_deaths_youth_per_100k_is_suppressed,gun_deaths_young_adults_population,gun_deaths_youth_population
+United States,00,Indigenous (NH),106.0,30.0,1.6,1.4,0.8,0.8,37.41,5.36,,,283317.0,559819.0
+United States,00,Asian (NH),116.0,43.0,1.8,2.1,5.9,5.6,5.67,1.06,,,2045660.0,4070166.0
+United States,00,Black or African American (NH),3697.0,1185.0,57.0,57.1,13.7,13.9,77.59,11.72,,,4764927.0,10110246.0
+United States,00,Hispanic or Latino,,,,,24.2,26.3,,,True,True,8440719.0,19176372.0
+United States,00,Two or more races (NH),167.0,72.0,2.6,3.5,3.5,4.8,13.63,2.05,,,1225064.0,3518297.0
+United States,00,Native Hawaiian and Pacific Islander (NH),16.0,,0.2,,0.2,0.2,22.38,,,True,71485.0,159737.0
+United States,00,White (NH),2382.0,744.0,36.7,35.9,51.8,48.4,13.2,2.11,,,18052195.0,35237224.0
+United States,00,Unknown race,,,,,,,,,True,True,,
+United States,00,All,8086.0,2581.0,100.0,100.0,100.0,100.0,23.18,3.54,,,34883367.0,72831861.0

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_historical.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_national_historical.csv
@@ -1,55 +1,55 @@
-time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k
-2018,United States,00,Indigenous (NH),50.0,25.0,1.2,1.0,28.56,2.96
-2018,United States,00,Asian (NH),-77.4,-56.6,1.2,2.3,4.23,1.03
-2018,United States,00,Black or African American (NH),214.6,158.4,43.1,35.4,60.86,6.03
-2018,United States,00,Hispanic or Latino,-34.1,-37.7,16.6,15.7,15.0,1.0
-2018,United States,00,Two or more races (NH),-63.6,-45.5,1.6,2.4,10.9,1.26
-2018,United States,00,Native Hawaiian and Pacific Islander (NH),50.0,,0.3,,27.19,
-2018,United States,00,White (NH),-28.4,-14.3,36.0,43.1,13.62,2.0
-2019,United States,00,Indigenous (NH),37.5,62.5,1.1,1.3,25.59,3.82
-2019,United States,00,Asian (NH),-72.2,-72.2,1.5,1.5,5.18,0.67
-2019,United States,00,Black or African American (NH),232.8,184.7,45.6,39.0,65.43,6.69
-2019,United States,00,Hispanic or Latino,-37.8,-31.9,15.8,17.3,14.0,2.0
-2019,United States,00,Two or more races (NH),-60.0,-46.7,1.8,2.4,11.98,1.24
-2019,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,17.28,
-2019,United States,00,White (NH),-31.7,-23.0,34.1,38.4,13.04,1.81
-2020,United States,00,Indigenous (NH),50.0,100.0,1.2,1.6,38.35,6.07
-2020,United States,00,Asian (NH),-75.9,-79.6,1.3,1.1,5.82,0.65
-2020,United States,00,Black or African American (NH),259.1,207.3,49.2,42.1,92.32,9.36
-2020,United States,00,Hispanic or Latino,-37.4,-31.1,16.1,17.7,18.0,2.0
-2020,United States,00,Two or more races (NH),-63.0,-58.7,1.7,1.9,13.69,1.29
-2020,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,24.84,
-2020,United States,00,White (NH),-38.6,-28.3,30.4,35.5,15.1,2.19
-2021,United States,00,Indigenous (NH),37.5,25.0,1.1,1.0,36.44,4.46
-2021,United States,00,Asian (NH),-74.1,-74.1,1.4,1.4,6.63,0.9
-2021,United States,00,Black or African American (NH),252.2,237.7,48.6,46.6,97.14,11.78
-2021,United States,00,Hispanic or Latino,-32.8,-37.1,17.4,16.3,21.0,2.0
-2021,United States,00,Two or more races (NH),-55.3,-48.9,2.1,2.4,17.51,1.77
-2021,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,30.72,
-2021,United States,00,White (NH),-40.7,-34.6,29.2,32.2,15.32,2.28
-2022,United States,00,Indigenous (NH),75.0,75.0,1.4,1.4,41.72,6.3
-2022,United States,00,Asian (NH),-78.2,-78.2,1.2,1.2,5.3,0.74
-2022,United States,00,Black or African American (NH),250.7,252.2,48.4,48.6,88.02,12.08
-2022,United States,00,Hispanic or Latino,-31.4,-28.0,17.9,18.8,19.0,2.0
-2022,United States,00,Two or more races (NH),-58.3,-58.3,2.0,2.0,14.42,1.46
-2022,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,24.39,
-2022,United States,00,White (NH),-40.6,-42.6,29.0,28.0,13.86,1.97
-2023,United States,00,Indigenous (NH),62.5,50.0,1.3,1.2,37.41,5.36
-2023,United States,00,Asian (NH),-75.0,-69.6,1.4,1.7,5.67,1.06
-2023,United States,00,Black or African American (NH),230.2,233.1,45.9,46.3,77.59,11.72
-2023,United States,00,Hispanic or Latino,-25.5,-27.8,19.6,19.0,19.0,3.0
-2023,United States,00,Two or more races (NH),-56.2,-41.7,2.1,2.8,13.63,2.05
-2023,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,22.38,
-2023,United States,00,White (NH),-39.0,-39.9,29.5,29.1,13.2,2.11
-2018,United States,00,Unknown race,,,0.2,,,
-2019,United States,00,Unknown race,,,,,,
-2020,United States,00,Unknown race,,,,,,
-2021,United States,00,Unknown race,,,,,,
-2022,United States,00,Unknown race,,,,,,
-2023,United States,00,Unknown race,,,,,,
-2018,United States,00,All,0.0,0.0,100.0,100.0,20.35,2.36
-2019,United States,00,All,0.0,0.0,100.0,100.0,20.45,2.37
-2020,United States,00,All,0.0,0.0,100.0,100.0,26.35,3.07
-2021,United States,00,All,0.0,0.0,100.0,100.0,27.71,3.52
-2022,United States,00,All,0.0,0.0,100.0,100.0,25.06,3.47
-2023,United States,00,All,0.0,0.0,100.0,100.0,23.18,3.54
+time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_per_100k_is_suppressed,gun_deaths_youth_per_100k_is_suppressed
+2018,United States,00,Indigenous (NH),75.0,50.0,1.4,1.2,28.56,2.96,,
+2018,United States,00,Asian (NH),-73.6,-47.2,1.4,2.8,4.23,1.03,,
+2018,United States,00,Black or African American (NH),277.4,206.6,51.7,42.0,60.86,6.03,,
+2018,United States,00,Hispanic or Latino,,,,,,,True,True
+2018,United States,00,Two or more races (NH),-54.5,-36.4,2.0,2.8,10.9,1.26,,
+2018,United States,00,Native Hawaiian and Pacific Islander (NH),50.0,,0.3,,27.19,,,True
+2018,United States,00,White (NH),-14.1,1.6,43.2,51.1,13.62,2.0,,
+2019,United States,00,Indigenous (NH),62.5,100.0,1.3,1.6,25.59,3.82,,
+2019,United States,00,Asian (NH),-68.5,-66.7,1.7,1.8,5.18,0.67,,
+2019,United States,00,Black or African American (NH),294.9,244.5,54.1,47.2,65.43,6.69,,
+2019,United States,00,Hispanic or Latino,,,,,,,True,True
+2019,United States,00,Two or more races (NH),-51.1,-35.6,2.2,2.9,11.98,1.24,,
+2019,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,17.28,,,True
+2019,United States,00,White (NH),-18.8,-6.8,40.5,46.5,13.04,1.81,,
+2020,United States,00,Indigenous (NH),75.0,137.5,1.4,1.9,38.35,6.07,,
+2020,United States,00,Asian (NH),-72.2,-74.1,1.5,1.4,5.82,0.65,,
+2020,United States,00,Black or African American (NH),327.7,273.7,58.6,51.2,92.32,9.36,,
+2020,United States,00,Hispanic or Latino,,,,,,,True,True
+2020,United States,00,Two or more races (NH),-56.5,-47.8,2.0,2.4,13.69,1.29,,
+2020,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,24.84,,,True
+2020,United States,00,White (NH),-26.9,-12.9,36.2,43.1,15.1,2.19,,
+2021,United States,00,Indigenous (NH),62.5,50.0,1.3,1.2,36.44,4.46,,
+2021,United States,00,Asian (NH),-68.5,-68.5,1.7,1.7,6.63,0.9,,
+2021,United States,00,Black or African American (NH),326.8,304.3,58.9,55.8,97.14,11.78,,
+2021,United States,00,Hispanic or Latino,,,,,,,True,True
+2021,United States,00,Two or more races (NH),-44.7,-40.4,2.6,2.8,17.51,1.77,,
+2021,United States,00,Native Hawaiian and Pacific Islander (NH),50.0,,0.3,,30.72,,,True
+2021,United States,00,White (NH),-28.3,-21.7,35.3,38.5,15.32,2.28,,
+2022,United States,00,Indigenous (NH),112.5,125.0,1.7,1.8,41.72,6.3,,
+2022,United States,00,Asian (NH),-72.7,-72.7,1.5,1.5,5.3,0.74,,
+2022,United States,00,Black or African American (NH),327.5,334.1,59.0,59.9,88.02,12.08,,
+2022,United States,00,Hispanic or Latino,,,,,,,True,True
+2022,United States,00,Two or more races (NH),-50.0,-47.9,2.4,2.5,14.42,1.46,,
+2022,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,24.39,,,True
+2022,United States,00,White (NH),-27.7,-29.5,35.3,34.4,13.86,1.97,,
+2023,United States,00,Indigenous (NH),100.0,75.0,1.6,1.4,37.41,5.36,,
+2023,United States,00,Asian (NH),-67.9,-62.5,1.8,2.1,5.67,1.06,,
+2023,United States,00,Black or African American (NH),310.1,310.8,57.0,57.1,77.59,11.72,,
+2023,United States,00,Hispanic or Latino,,,,,,,True,True
+2023,United States,00,Two or more races (NH),-45.8,-27.1,2.6,3.5,13.63,2.05,,
+2023,United States,00,Native Hawaiian and Pacific Islander (NH),0.0,,0.2,,22.38,,,True
+2023,United States,00,White (NH),-24.2,-25.8,36.7,35.9,13.2,2.11,,
+2018,United States,00,Unknown race,,,,,,,True,True
+2019,United States,00,Unknown race,,,,,,,True,True
+2020,United States,00,Unknown race,,,,,,,True,True
+2021,United States,00,Unknown race,,,,,,,True,True
+2022,United States,00,Unknown race,,,,,,,True,True
+2023,United States,00,Unknown race,,,,,,,True,True
+2018,United States,00,All,0.0,0.0,100.0,100.0,20.35,2.36,,
+2019,United States,00,All,0.0,0.0,100.0,100.0,20.45,2.37,,
+2020,United States,00,All,0.0,0.0,100.0,100.0,26.35,3.07,,
+2021,United States,00,All,0.0,0.0,100.0,100.0,27.71,3.52,,
+2022,United States,00,All,0.0,0.0,100.0,100.0,25.06,3.47,,
+2023,United States,00,All,0.0,0.0,100.0,100.0,23.18,3.54,,

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_current.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_current.csv
@@ -1,418 +1,418 @@
-state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_estimated_total,gun_deaths_youth_estimated_total,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_population_pct,gun_deaths_youth_population_pct,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_population,gun_deaths_youth_population
-Alabama,01,Indigenous (NH),,0.0,,0.0,0.5,0.3,,0.0,2882.0,3874.0
-Alabama,01,Asian (NH),,0.0,,0.0,1.8,1.5,,0.0,9564.0,16414.0
-Alabama,01,Black or African American (NH),179.0,47.0,77.5,60.3,29.6,28.3,111.03,14.66,161220.0,320579.0
-Alabama,01,Hispanic or Latino,0.0,0.0,0.0,0.0,7.1,9.9,0.0,0.0,38878.0,111761.0
-Alabama,01,Two or more races (NH),,,,,2.3,3.9,,,12473.0,43588.0
-Alabama,01,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,353.0,705.0
-Alabama,01,White (NH),52.0,31.0,22.5,39.7,58.7,56.1,16.26,4.89,319858.0,633919.0
-Alaska,02,Indigenous (NH),,,,,17.0,18.1,,,13013.0,31733.0
-Alaska,02,Asian (NH),,,,,6.4,5.6,,,4897.0,9790.0
-Alaska,02,Black or African American (NH),,0.0,,,4.4,2.9,,0.0,3412.0,5045.0
-Alaska,02,Hispanic or Latino,0.0,0.0,,,9.9,10.5,0.0,0.0,7613.0,18483.0
-Alaska,02,Two or more races (NH),,,,,9.8,13.9,,,7483.0,24466.0
-Alaska,02,Native Hawaiian and Pacific Islander (NH),,0.0,,,1.9,2.5,,0.0,1468.0,4378.0
-Alaska,02,White (NH),,,,,50.6,46.5,,,38823.0,81612.0
-Arizona,04,Indigenous (NH),14.0,,7.9,,4.3,4.5,39.95,,35044.0,70913.0
-Arizona,04,Asian (NH),,0.0,,0.0,4.0,3.2,,0.0,32518.0,50770.0
-Arizona,04,Black or African American (NH),26.0,13.0,14.7,30.2,5.4,5.6,60.27,14.74,43142.0,88214.0
-Arizona,04,Hispanic or Latino,82.0,30.0,46.3,69.8,41.2,43.9,25.0,4.0,332508.0,694361.0
-Arizona,04,Two or more races (NH),,,,,3.5,4.6,,,28053.0,72818.0
-Arizona,04,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,1679.0,3229.0
-Arizona,04,White (NH),55.0,,31.1,,41.3,38.1,16.5,,333356.0,602729.0
-Arkansas,05,Indigenous (NH),0.0,0.0,0.0,0.0,0.9,0.7,0.0,0.0,2767.0,5022.0
-Arkansas,05,Asian (NH),,0.0,,0.0,1.9,1.9,,0.0,6161.0,13373.0
-Arkansas,05,Black or African American (NH),61.0,25.0,64.9,56.8,17.7,17.5,105.88,20.29,57610.0,123206.0
-Arkansas,05,Hispanic or Latino,0.0,0.0,0.0,0.0,12.5,14.1,0.0,0.0,40666.0,99348.0
-Arkansas,05,Two or more races (NH),0.0,,0.0,,2.9,4.3,0.0,,9591.0,30027.0
-Arkansas,05,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.5,0.7,0.0,0.0,1697.0,5263.0
-Arkansas,05,White (NH),33.0,19.0,35.1,43.2,63.6,60.9,15.97,4.43,206660.0,429369.0
-California,06,Indigenous (NH),,,,,0.4,0.4,,,16090.0,29633.0
-California,06,Asian (NH),17.0,11.0,3.6,7.5,13.2,13.1,3.15,1.0,539431.0,1103921.0
-California,06,Black or African American (NH),97.0,25.0,20.3,17.1,5.4,5.0,44.28,5.91,219081.0,423164.0
-California,06,Hispanic or Latino,267.0,69.0,55.9,47.3,50.0,51.9,13.0,2.0,2036320.0,4380449.0
-California,06,Two or more races (NH),14.0,13.0,2.9,8.9,4.2,5.5,8.26,2.79,169462.0,465479.0
-California,06,Native Hawaiian and Pacific Islander (NH),,,,,0.3,0.4,,,14246.0,29807.0
-California,06,White (NH),83.0,28.0,17.4,19.2,26.5,23.8,7.67,1.39,1081581.0,2013216.0
-Colorado,08,Indigenous (NH),,0.0,,0.0,0.8,0.5,,0.0,4817.0,6429.0
-Colorado,08,Asian (NH),,,,,3.6,3.6,,,22313.0,44255.0
-Colorado,08,Black or African American (NH),23.0,,16.9,,4.4,4.6,84.41,,27248.0,56093.0
-Colorado,08,Hispanic or Latino,58.0,24.0,42.6,60.0,29.5,33.2,31.0,6.0,184365.0,402771.0
-Colorado,08,Two or more races (NH),,,,,3.9,5.0,,,24298.0,60456.0
-Colorado,08,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.2,0.2,,0.0,1103.0,2509.0
-Colorado,08,White (NH),55.0,16.0,40.4,40.0,57.7,52.9,15.25,2.49,360725.0,642171.0
-Connecticut,09,Indigenous (NH),0.0,0.0,0.0,,0.2,0.3,0.0,0.0,842.0,1937.0
-Connecticut,09,Asian (NH),0.0,,0.0,,5.5,5.4,0.0,,20668.0,38925.0
-Connecticut,09,Black or African American (NH),18.0,,100.0,,11.8,12.0,40.1,,44883.0,86715.0
-Connecticut,09,Hispanic or Latino,0.0,0.0,0.0,,22.8,28.0,0.0,0.0,86198.0,202459.0
-Connecticut,09,Two or more races (NH),,0.0,,,3.2,4.1,,0.0,12170.0,29889.0
-Connecticut,09,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.04,0.1,0.0,0.0,137.0,399.0
-Connecticut,09,White (NH),,,,,56.5,50.2,,,213896.0,362662.0
-Delaware,10,Indigenous (NH),0.0,0.0,0.0,,0.3,0.2,0.0,0.0,261.0,451.0
-Delaware,10,Asian (NH),0.0,0.0,0.0,,4.1,4.4,0.0,0.0,4088.0,9290.0
-Delaware,10,Black or African American (NH),13.0,,100.0,,27.1,26.0,48.53,,26789.0,55171.0
-Delaware,10,Hispanic or Latino,0.0,0.0,0.0,,15.3,18.7,0.0,0.0,15099.0,39608.0
-Delaware,10,Two or more races (NH),,0.0,,,4.5,5.9,,0.0,4407.0,12507.0
-Delaware,10,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.04,0.0,0.0,25.0,78.0
-Delaware,10,White (NH),,0.0,,,48.8,44.7,,0.0,48220.0,94833.0
-District of Columbia,11,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,145.0,185.0
-District of Columbia,11,Asian (NH),0.0,0.0,0.0,0.0,6.2,2.6,0.0,0.0,5068.0,3274.0
-District of Columbia,11,Black or African American (NH),57.0,19.0,100.0,100.0,36.6,50.8,191.84,29.52,29713.0,64370.0
-District of Columbia,11,Hispanic or Latino,0.0,0.0,0.0,0.0,11.1,17.9,0.0,0.0,8988.0,22668.0
-District of Columbia,11,Two or more races (NH),0.0,0.0,0.0,0.0,3.3,4.8,0.0,0.0,2702.0,6057.0
-District of Columbia,11,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,66.0,84.0
-District of Columbia,11,White (NH),0.0,0.0,0.0,0.0,42.5,23.7,0.0,0.0,34531.0,29954.0
-Florida,12,Indigenous (NH),0.0,,0.0,,0.2,0.2,0.0,,5192.0,8939.0
-Florida,12,Asian (NH),,,,,3.1,2.9,,,65452.0,127489.0
-Florida,12,Black or African American (NH),236.0,70.0,53.2,58.3,18.8,19.4,60.36,8.22,390965.0,851222.0
-Florida,12,Hispanic or Latino,72.0,20.0,16.2,16.7,31.4,32.3,11.0,1.0,653670.0,1416966.0
-Florida,12,Two or more races (NH),11.0,,2.5,,2.9,4.1,18.22,,60375.0,178202.0
-Florida,12,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,1493.0,3250.0
-Florida,12,White (NH),125.0,30.0,28.2,25.0,43.4,41.0,13.83,1.67,903731.0,1794775.0
-Georgia,13,Indigenous (NH),,,,,0.2,0.2,,,2508.0,4320.0
-Georgia,13,Asian (NH),,,,,4.3,4.5,,,51831.0,114856.0
-Georgia,13,Black or African American (NH),293.0,97.0,71.3,81.5,33.9,33.8,72.38,11.3,404799.0,858418.0
-Georgia,13,Hispanic or Latino,26.0,0.0,6.3,0.0,14.3,16.1,15.0,0.0,170638.0,408948.0
-Georgia,13,Two or more races (NH),,,,,2.8,4.3,,,33826.0,108217.0
-Georgia,13,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,879.0,2349.0
-Georgia,13,White (NH),92.0,22.0,22.4,18.5,44.3,41.0,17.41,2.11,528474.0,1041573.0
-Hawaii,15,Indigenous (NH),0.0,0.0,,,0.3,0.2,0.0,0.0,447.0,476.0
-Hawaii,15,Asian (NH),0.0,0.0,,,25.0,21.8,0.0,0.0,33154.0,64046.0
-Hawaii,15,Black or African American (NH),0.0,0.0,,,3.3,1.7,0.0,0.0,4353.0,5055.0
-Hawaii,15,Hispanic or Latino,0.0,0.0,,,14.3,18.1,0.0,0.0,18975.0,53061.0
-Hawaii,15,Two or more races (NH),,,,,25.3,33.1,,,33548.0,97222.0
-Hawaii,15,Native Hawaiian and Pacific Islander (NH),,0.0,,,10.3,11.1,,0.0,13666.0,32532.0
-Hawaii,15,White (NH),0.0,0.0,,,21.5,14.0,0.0,0.0,28591.0,41221.0
-Idaho,16,Indigenous (NH),,0.0,,0.0,1.0,0.9,,0.0,2220.0,4199.0
-Idaho,16,Asian (NH),0.0,0.0,0.0,0.0,1.7,1.4,0.0,0.0,3793.0,6442.0
-Idaho,16,Black or African American (NH),,0.0,,0.0,1.3,0.9,,0.0,2758.0,4405.0
-Idaho,16,Hispanic or Latino,0.0,0.0,0.0,0.0,17.8,20.1,0.0,0.0,38989.0,93857.0
-Idaho,16,Two or more races (NH),,,,,3.2,3.9,,,6932.0,18100.0
-Idaho,16,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.3,0.2,0.0,0.0,561.0,889.0
-Idaho,16,White (NH),37.0,18.0,100.0,100.0,74.8,72.6,22.57,5.3,163960.0,339450.0
-Illinois,17,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,1967.0,3735.0
-Illinois,17,Asian (NH),,,,,6.3,5.7,,,81660.0,154013.0
-Illinois,17,Black or African American (NH),222.0,85.0,65.5,70.2,14.7,15.3,115.87,20.57,191602.0,413263.0
-Illinois,17,Hispanic or Latino,64.0,19.0,18.9,15.7,25.3,25.3,19.0,3.0,329361.0,685382.0
-Illinois,17,Two or more races (NH),,0.0,,0.0,2.9,3.8,,0.0,37234.0,103959.0
-Illinois,17,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,506.0,755.0
-Illinois,17,White (NH),53.0,17.0,15.6,14.0,50.6,49.7,8.05,1.26,658217.0,1344415.0
-Indiana,18,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,1539.0,2442.0
-Indiana,18,Asian (NH),,,,,4.0,3.0,,,30053.0,46994.0
-Indiana,18,Black or African American (NH),110.0,41.0,50.0,56.2,10.7,11.8,137.19,21.87,80182.0,187456.0
-Indiana,18,Hispanic or Latino,23.0,0.0,10.5,0.0,11.8,13.1,26.0,0.0,88090.0,207958.0
-Indiana,18,Two or more races (NH),,,,,3.3,4.6,,,24503.0,72324.0
-Indiana,18,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.05,0.05,0.0,0.0,356.0,774.0
-Indiana,18,White (NH),87.0,32.0,39.5,43.8,70.0,67.4,16.58,2.99,524850.0,1069306.0
-Iowa,19,Indigenous (NH),0.0,0.0,0.0,0.0,0.4,0.3,0.0,0.0,1330.0,2477.0
-Iowa,19,Asian (NH),0.0,0.0,0.0,0.0,3.9,2.7,0.0,0.0,14022.0,19644.0
-Iowa,19,Black or African American (NH),14.0,,31.1,,5.3,6.1,72.85,,19219.0,44384.0
-Iowa,19,Hispanic or Latino,0.0,0.0,0.0,0.0,10.0,11.8,0.0,0.0,36019.0,85928.0
-Iowa,19,Two or more races (NH),,,,,3.1,4.3,,,11097.0,31339.0
-Iowa,19,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.3,0.4,0.0,0.0,1085.0,3030.0
-Iowa,19,White (NH),31.0,11.0,68.9,100.0,77.0,74.4,11.21,2.03,276551.0,543320.0
-Kansas,20,Indigenous (NH),,0.0,,0.0,1.0,0.6,,0.0,3333.0,4234.0
-Kansas,20,Asian (NH),,,,,3.6,2.8,,,12326.0,19702.0
-Kansas,20,Black or African American (NH),25.0,,35.2,,6.5,6.1,112.95,,22134.0,42630.0
-Kansas,20,Hispanic or Latino,0.0,0.0,0.0,0.0,18.3,20.2,0.0,0.0,61912.0,140227.0
-Kansas,20,Two or more races (NH),,,,,4.2,5.5,,,14272.0,38512.0
-Kansas,20,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,443.0,993.0
-Kansas,20,White (NH),46.0,11.0,64.8,100.0,66.2,64.5,20.57,2.46,223652.0,448039.0
-Kentucky,21,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,895.0,1256.0
-Kentucky,21,Asian (NH),,,,,1.9,2.0,,,8931.0,19858.0
-Kentucky,21,Black or African American (NH),55.0,16.0,42.0,35.6,10.3,9.4,114.33,16.72,48107.0,95701.0
-Kentucky,21,Hispanic or Latino,0.0,0.0,0.0,0.0,6.5,8.1,0.0,0.0,30504.0,82564.0
-Kentucky,21,Two or more races (NH),0.0,0.0,0.0,0.0,3.2,4.7,0.0,0.0,15149.0,47391.0
-Kentucky,21,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,653.0,1171.0
-Kentucky,21,White (NH),76.0,29.0,58.0,64.4,77.6,75.6,20.99,3.77,362037.0,768954.0
-Louisiana,22,Indigenous (NH),,0.0,,0.0,0.7,0.6,,0.0,3266.0,5913.0
-Louisiana,22,Asian (NH),,,,,2.1,1.7,,,9987.0,17736.0
-Louisiana,22,Black or African American (NH),254.0,77.0,84.1,86.5,36.8,35.4,145.73,20.4,174299.0,377413.0
-Louisiana,22,Hispanic or Latino,0.0,0.0,0.0,0.0,7.8,10.1,0.0,0.0,36917.0,108021.0
-Louisiana,22,Two or more races (NH),,,,,2.3,3.4,,,10944.0,36450.0
-Louisiana,22,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,192.0,359.0
-Louisiana,22,White (NH),48.0,12.0,15.9,13.5,50.3,48.8,20.12,2.3,238577.0,521257.0
-Maine,23,Indigenous (NH),0.0,0.0,0.0,,0.7,0.7,0.0,0.0,904.0,1809.0
-Maine,23,Asian (NH),0.0,0.0,0.0,,2.1,1.4,0.0,0.0,2639.0,3402.0
-Maine,23,Black or African American (NH),,0.0,,,3.2,3.7,,0.0,3983.0,9308.0
-Maine,23,Hispanic or Latino,0.0,0.0,0.0,,3.5,3.7,0.0,0.0,4446.0,9261.0
-Maine,23,Two or more races (NH),0.0,,0.0,,3.0,4.1,0.0,,3791.0,10250.0
-Maine,23,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.04,0.04,0.0,0.0,48.0,110.0
-Maine,23,White (NH),17.0,,100.0,,87.4,86.3,15.43,,110144.0,214912.0
-Maryland,24,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,1341.0,2519.0
-Maryland,24,Asian (NH),,,,,6.5,6.5,,,38376.0,87993.0
-Maryland,24,Black or African American (NH),122.0,36.0,80.3,100.0,31.2,30.1,65.85,8.78,185278.0,410103.0
-Maryland,24,Hispanic or Latino,16.0,0.0,10.5,0.0,15.3,19.3,18.0,0.0,90674.0,262424.0
-Maryland,24,Two or more races (NH),0.0,0.0,0.0,0.0,4.2,5.5,0.0,0.0,24710.0,75110.0
-Maryland,24,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.04,0.0,0.0,225.0,567.0
-Maryland,24,White (NH),14.0,,9.2,,42.6,38.4,5.55,,252319.0,523200.0
-Massachusetts,25,Indigenous (NH),0.0,0.0,0.0,,0.2,0.2,0.0,0.0,1338.0,2330.0
-Massachusetts,25,Asian (NH),,0.0,,,9.1,8.0,,0.0,70689.0,106918.0
-Massachusetts,25,Black or African American (NH),18.0,,38.3,,8.1,9.5,28.81,,62484.0,127656.0
-Massachusetts,25,Hispanic or Latino,17.0,0.0,36.2,,16.4,21.1,13.0,0.0,127540.0,282493.0
-Massachusetts,25,Two or more races (NH),,0.0,,,3.2,4.4,,0.0,24445.0,59525.0
-Massachusetts,25,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.05,0.1,0.0,0.0,377.0,735.0
-Massachusetts,25,White (NH),12.0,,25.5,,63.0,56.8,2.46,,488513.0,762144.0
-Michigan,26,Indigenous (NH),,0.0,,0.0,0.6,0.5,,0.0,6515.0,11275.0
-Michigan,26,Asian (NH),,,,,4.5,3.6,,,47605.0,75563.0
-Michigan,26,Black or African American (NH),109.0,37.0,53.2,56.9,14.5,16.2,71.36,10.8,152742.0,342524.0
-Michigan,26,Hispanic or Latino,16.0,0.0,7.8,0.0,8.6,9.2,18.0,0.0,90005.0,193951.0
-Michigan,26,Two or more races (NH),,,,,4.0,5.2,,,41793.0,110211.0
-Michigan,26,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,399.0,617.0
-Michigan,26,White (NH),80.0,28.0,39.0,43.1,67.7,65.2,11.25,2.03,711027.0,1377770.0
-Minnesota,27,Indigenous (NH),,,,,1.3,1.3,,,7556.0,17475.0
-Minnesota,27,Asian (NH),,0.0,,0.0,6.4,6.6,,0.0,36920.0,86369.0
-Minnesota,27,Black or African American (NH),36.0,,56.2,,9.1,11.3,68.54,,52524.0,147003.0
-Minnesota,27,Hispanic or Latino,0.0,0.0,0.0,0.0,9.3,10.0,0.0,0.0,53839.0,130671.0
-Minnesota,27,Two or more races (NH),,0.0,,0.0,4.1,5.4,,0.0,23752.0,69971.0
-Minnesota,27,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,348.0,1171.0
-Minnesota,27,White (NH),28.0,10.0,43.8,100.0,69.6,65.2,6.98,1.18,401110.0,848274.0
-Mississippi,28,Indigenous (NH),,0.0,,0.0,0.6,0.6,,0.0,1918.0,3887.0
-Mississippi,28,Asian (NH),0.0,0.0,0.0,0.0,1.3,1.0,0.0,0.0,4328.0,6974.0
-Mississippi,28,Black or African American (NH),150.0,52.0,83.3,80.0,41.0,41.0,113.94,18.68,131645.0,278413.0
-Mississippi,28,Hispanic or Latino,0.0,0.0,0.0,0.0,4.6,5.9,0.0,0.0,14892.0,40080.0
-Mississippi,28,Two or more races (NH),,,,,1.9,2.9,,,6039.0,19770.0
-Mississippi,28,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.04,0.0,0.0,179.0,238.0
-Mississippi,28,White (NH),30.0,13.0,16.7,20.0,50.4,48.6,18.55,3.93,161707.0,330464.0
-Missouri,29,Indigenous (NH),,0.0,,0.0,0.4,0.3,,0.0,2870.0,4662.0
-Missouri,29,Asian (NH),,0.0,,0.0,3.0,2.1,,0.0,19353.0,28855.0
-Missouri,29,Black or African American (NH),128.0,41.0,57.1,60.3,12.7,13.3,156.41,22.51,81834.0,182147.0
-Missouri,29,Hispanic or Latino,11.0,0.0,4.9,0.0,7.5,8.2,23.0,0.0,48096.0,112360.0
-Missouri,29,Two or more races (NH),,,,,3.5,5.2,,,22743.0,71058.0
-Missouri,29,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,1445.0,3302.0
-Missouri,29,White (NH),85.0,27.0,37.9,39.7,72.6,70.7,18.21,2.78,466855.0,972086.0
-Montana,30,Indigenous (NH),,,,,7.2,8.7,,,8420.0,20477.0
-Montana,30,Asian (NH),0.0,0.0,0.0,,1.5,0.8,0.0,0.0,1728.0,1967.0
-Montana,30,Black or African American (NH),,0.0,,,1.0,0.6,,0.0,1130.0,1494.0
-Montana,30,Hispanic or Latino,0.0,0.0,0.0,,6.2,7.7,0.0,0.0,7287.0,18182.0
-Montana,30,Two or more races (NH),,0.0,,,4.0,4.9,,0.0,4620.0,11461.0
-Montana,30,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,109.0,238.0
-Montana,30,White (NH),15.0,,100.0,,80.0,77.2,16.07,,93346.0,181832.0
-Nebraska,31,Indigenous (NH),,0.0,,,1.0,1.0,,0.0,2158.0,4752.0
-Nebraska,31,Asian (NH),0.0,0.0,0.0,,3.1,2.9,0.0,0.0,6819.0,14129.0
-Nebraska,31,Black or African American (NH),,,,,5.6,6.2,,,12300.0,29608.0
-Nebraska,31,Hispanic or Latino,0.0,0.0,0.0,,16.7,20.0,0.0,0.0,36762.0,96418.0
-Nebraska,31,Two or more races (NH),0.0,0.0,0.0,,3.3,4.4,0.0,0.0,7299.0,21037.0
-Nebraska,31,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,231.0,409.0
-Nebraska,31,White (NH),26.0,,100.0,,70.2,65.4,16.82,,154617.0,314645.0
-Nevada,32,Indigenous (NH),0.0,0.0,0.0,0.0,0.8,0.7,0.0,0.0,2452.0,4803.0
-Nevada,32,Asian (NH),,,,,7.3,6.7,,,21488.0,45811.0
-Nevada,32,Black or African American (NH),31.0,,40.3,,10.4,11.6,100.39,,30880.0,79863.0
-Nevada,32,Hispanic or Latino,26.0,11.0,33.8,100.0,41.6,41.4,21.0,4.0,122951.0,283729.0
-Nevada,32,Two or more races (NH),,,,,5.6,7.7,,,16637.0,52603.0
-Nevada,32,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.7,0.8,0.0,0.0,2198.0,5560.0
-Nevada,32,White (NH),20.0,,26.0,,33.5,31.1,20.2,,99000.0,213587.0
-New Hampshire,33,Indigenous (NH),0.0,0.0,0.0,,0.2,0.1,0.0,0.0,329.0,378.0
-New Hampshire,33,Asian (NH),0.0,0.0,0.0,,3.6,3.5,0.0,0.0,4949.0,8755.0
-New Hampshire,33,Black or African American (NH),0.0,0.0,0.0,,2.3,2.1,0.0,0.0,3085.0,5419.0
-New Hampshire,33,Hispanic or Latino,0.0,0.0,0.0,,6.7,8.2,0.0,0.0,9074.0,20697.0
-New Hampshire,33,Two or more races (NH),0.0,0.0,0.0,,2.9,3.5,0.0,0.0,3983.0,8800.0
-New Hampshire,33,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.03,0.0,0.0,42.0,83.0
-New Hampshire,33,White (NH),13.0,,100.0,,84.2,82.5,11.37,,114324.0,207918.0
-New Jersey,34,Indigenous (NH),0.0,0.0,0.0,,0.2,0.2,0.0,0.0,1477.0,3473.0
-New Jersey,34,Asian (NH),,0.0,,,9.5,10.3,,0.0,83509.0,206157.0
-New Jersey,34,Black or African American (NH),32.0,,62.7,,14.1,13.4,25.62,,124924.0,269709.0
-New Jersey,34,Hispanic or Latino,19.0,0.0,37.3,,26.9,29.7,8.0,0.0,237904.0,596393.0
-New Jersey,34,Two or more races (NH),,,,,2.5,3.4,,,22458.0,67910.0
-New Jersey,34,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.05,0.0,0.0,301.0,940.0
-New Jersey,34,White (NH),,,,,46.7,43.1,,,412447.0,865708.0
-New Mexico,35,Indigenous (NH),10.0,,9.5,,9.9,10.0,44.56,,22440.0,44914.0
-New Mexico,35,Asian (NH),0.0,0.0,0.0,0.0,1.7,1.4,0.0,0.0,3799.0,6149.0
-New Mexico,35,Black or African American (NH),,0.0,,0.0,2.4,2.0,,0.0,5570.0,8814.0
-New Mexico,35,Hispanic or Latino,68.0,26.0,64.8,100.0,57.8,60.4,52.0,10.0,131409.0,272609.0
-New Mexico,35,Two or more races (NH),0.0,0.0,0.0,0.0,2.3,2.9,0.0,0.0,5325.0,12947.0
-New Mexico,35,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,194.0,244.0
-New Mexico,35,White (NH),27.0,,25.7,,25.8,23.4,46.02,,58675.0,105670.0
-New York,36,Indigenous (NH),0.0,0.0,0.0,0.0,0.3,0.3,0.0,0.0,6864.0,12050.0
-New York,36,Asian (NH),,,,,9.3,9.0,,,185969.0,355266.0
-New York,36,Black or African American (NH),73.0,20.0,58.4,66.7,14.6,14.6,25.03,3.47,291712.0,576531.0
-New York,36,Hispanic or Latino,24.0,0.0,19.2,0.0,22.3,25.4,5.0,0.0,446675.0,1006227.0
-New York,36,Two or more races (NH),,,,,2.8,4.0,,,56779.0,158759.0
-New York,36,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,1107.0,2172.0
-New York,36,White (NH),28.0,10.0,22.4,33.3,50.5,46.7,2.77,0.54,1010400.0,1848903.0
-North Carolina,37,Indigenous (NH),11.0,,3.2,,1.0,1.0,91.61,,12008.0,24408.0
-North Carolina,37,Asian (NH),,0.0,,0.0,3.4,3.9,,0.0,39251.0,91504.0
-North Carolina,37,Black or African American (NH),192.0,62.0,55.7,63.3,22.6,22.1,73.05,12.03,262847.0,515419.0
-North Carolina,37,Hispanic or Latino,34.0,11.0,9.9,11.2,15.3,18.9,19.0,2.0,178314.0,441238.0
-North Carolina,37,Two or more races (NH),10.0,,2.9,,3.3,4.8,25.75,,38833.0,113085.0
-North Carolina,37,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,972.0,1845.0
-North Carolina,37,White (NH),98.0,25.0,28.4,25.5,54.2,49.2,15.56,2.18,630036.0,1149124.0
-North Dakota,38,Indigenous (NH),,,,,5.4,6.7,,,5363.0,12383.0
-North Dakota,38,Asian (NH),0.0,0.0,0.0,,2.2,1.8,0.0,0.0,2193.0,3246.0
-North Dakota,38,Black or African American (NH),,,,,3.7,5.0,,,3617.0,9319.0
-North Dakota,38,Hispanic or Latino,0.0,0.0,0.0,,5.8,8.1,0.0,0.0,5758.0,15015.0
-North Dakota,38,Two or more races (NH),0.0,,0.0,,3.1,4.9,0.0,,3094.0,9026.0
-North Dakota,38,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.2,0.0,0.0,94.0,348.0
-North Dakota,38,White (NH),12.0,,100.0,,79.6,73.3,15.25,,78708.0,135397.0
-Ohio,39,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,1974.0,3549.0
-Ohio,39,Asian (NH),,0.0,,0.0,3.2,2.9,,0.0,38196.0,74996.0
-Ohio,39,Black or African American (NH),169.0,66.0,60.6,59.5,14.3,15.6,99.14,16.45,170462.0,401340.0
-Ohio,39,Hispanic or Latino,0.0,0.0,0.0,0.0,6.6,7.6,0.0,0.0,79152.0,194795.0
-Ohio,39,Two or more races (NH),,,,,3.9,5.4,,,46351.0,138271.0
-Ohio,39,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,718.0,1578.0
-Ohio,39,White (NH),110.0,45.0,39.4,40.5,71.8,68.4,12.83,2.55,857214.0,1763725.0
-Oklahoma,40,Indigenous (NH),10.0,,10.4,,9.4,9.1,23.42,,42697.0,88435.0
-Oklahoma,40,Asian (NH),,0.0,,0.0,3.0,2.4,,0.0,13730.0,22849.0
-Oklahoma,40,Black or African American (NH),15.0,11.0,15.6,29.7,8.6,7.8,38.32,14.56,39141.0,75530.0
-Oklahoma,40,Hispanic or Latino,12.0,0.0,12.5,0.0,16.6,20.2,16.0,0.0,75183.0,195461.0
-Oklahoma,40,Two or more races (NH),,,,,7.9,10.5,,,35715.0,101559.0
-Oklahoma,40,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.3,0.0,0.0,934.0,2943.0
-Oklahoma,40,White (NH),59.0,26.0,61.5,70.3,54.2,49.6,24.04,5.42,245391.0,479830.0
-Oregon,41,Indigenous (NH),,0.0,,,1.2,1.0,,0.0,4965.0,8108.0
-Oregon,41,Asian (NH),,,,,5.6,4.6,,,23008.0,38093.0
-Oregon,41,Black or African American (NH),11.0,,12.1,,2.4,2.5,110.31,,9972.0,20447.0
-Oregon,41,Hispanic or Latino,23.0,0.0,25.3,,22.0,24.3,25.0,0.0,90604.0,202338.0
-Oregon,41,Two or more races (NH),10.0,,11.0,,5.7,6.8,42.79,,23371.0,56502.0
-Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,0.6,0.5,,,2316.0,4491.0
-Oregon,41,White (NH),47.0,,51.6,,62.5,60.3,18.27,,257212.0,501851.0
-Pennsylvania,42,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,1988.0,3347.0
-Pennsylvania,42,Asian (NH),,,,,4.8,4.4,,,62632.0,115271.0
-Pennsylvania,42,Black or African American (NH),148.0,43.0,51.2,72.9,12.6,12.7,89.53,12.84,165303.0,334880.0
-Pennsylvania,42,Hispanic or Latino,31.0,0.0,10.7,0.0,11.7,14.5,20.0,0.0,154176.0,380161.0
-Pennsylvania,42,Two or more races (NH),,,,,3.1,4.5,,,40271.0,117924.0
-Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.04,0.0,0.0,478.0,999.0
-Pennsylvania,42,White (NH),110.0,16.0,38.1,27.1,67.7,63.8,12.34,0.95,891383.0,1676423.0
-Rhode Island,44,Indigenous (NH),0.0,0.0,,,0.4,0.4,0.0,0.0,550.0,907.0
-Rhode Island,44,Asian (NH),0.0,0.0,,,4.6,3.7,0.0,0.0,5624.0,7615.0
-Rhode Island,44,Black or African American (NH),0.0,,,,7.5,7.5,0.0,,9144.0,15261.0
-Rhode Island,44,Hispanic or Latino,0.0,0.0,,,21.4,29.9,0.0,0.0,26195.0,60864.0
-Rhode Island,44,Two or more races (NH),0.0,0.0,,,3.6,5.0,0.0,0.0,4464.0,10158.0
-Rhode Island,44,Native Hawaiian and Pacific Islander (NH),0.0,0.0,,,0.1,0.1,0.0,0.0,73.0,135.0
-Rhode Island,44,White (NH),,,,,62.4,53.4,,,76339.0,108898.0
-South Carolina,45,Indigenous (NH),0.0,0.0,0.0,0.0,0.4,0.3,0.0,0.0,2059.0,3149.0
-South Carolina,45,Asian (NH),,,,,2.2,1.9,,,12042.0,22163.0
-South Carolina,45,Black or African American (NH),135.0,36.0,65.2,67.9,27.9,27.9,87.36,11.27,154534.0,319470.0
-South Carolina,45,Hispanic or Latino,14.0,0.0,6.8,0.0,9.7,12.0,26.0,0.0,53706.0,136832.0
-South Carolina,45,Two or more races (NH),,0.0,,0.0,3.0,4.5,,0.0,16493.0,51920.0
-South Carolina,45,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,441.0,910.0
-South Carolina,45,White (NH),58.0,17.0,28.0,32.1,56.7,53.3,18.49,2.79,313696.0,609757.0
-South Dakota,46,Indigenous (NH),,,,,9.8,11.3,,,9497.0,25094.0
-South Dakota,46,Asian (NH),,0.0,,,2.6,1.8,,0.0,2565.0,4094.0
-South Dakota,46,Black or African American (NH),0.0,0.0,0.0,,2.9,3.5,0.0,0.0,2794.0,7733.0
-South Dakota,46,Hispanic or Latino,0.0,0.0,0.0,,6.5,8.6,0.0,0.0,6273.0,19122.0
-South Dakota,46,Two or more races (NH),0.0,0.0,0.0,,3.6,5.1,0.0,0.0,3455.0,11248.0
-South Dakota,46,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,77.0,316.0
-South Dakota,46,White (NH),11.0,0.0,100.0,,74.6,69.5,15.22,0.0,72288.0,154291.0
-Tennessee,47,Indigenous (NH),0.0,,0.0,,0.3,0.2,0.0,,2051.0,3005.0
-Tennessee,47,Asian (NH),,0.0,,0.0,2.1,2.0,,0.0,15554.0,31690.0
-Tennessee,47,Black or African American (NH),180.0,51.0,63.4,60.0,18.2,18.0,135.84,18.0,132514.0,283328.0
-Tennessee,47,Hispanic or Latino,14.0,0.0,4.9,0.0,9.8,12.7,20.0,0.0,71571.0,200130.0
-Tennessee,47,Two or more races (NH),,,,,2.9,4.3,,,21519.0,67001.0
-Tennessee,47,Native Hawaiian and Pacific Islander (NH),0.0,,0.0,,0.1,0.1,0.0,,476.0,1059.0
-Tennessee,47,White (NH),90.0,34.0,31.7,40.0,66.6,62.7,18.5,3.45,486388.0,984515.0
-Texas,48,Indigenous (NH),,0.0,,0.0,0.3,0.2,,0.0,10131.0,17723.0
-Texas,48,Asian (NH),17.0,,2.1,,4.7,5.1,10.65,,159684.0,388137.0
-Texas,48,Black or African American (NH),225.0,85.0,27.8,32.7,12.9,12.9,51.26,8.75,438953.0,971822.0
-Texas,48,Hispanic or Latino,352.0,102.0,43.5,39.2,47.4,48.3,22.0,3.0,1605940.0,3653571.0
-Texas,48,Two or more races (NH),,,,,2.1,3.0,,,72414.0,230221.0
-Texas,48,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,3419.0,7290.0
-Texas,48,White (NH),215.0,73.0,26.6,28.1,32.4,30.3,19.54,3.18,1100252.0,2292361.0
-Utah,49,Indigenous (NH),,,,,0.9,0.8,,,3962.0,7317.0
-Utah,49,Asian (NH),,0.0,,0.0,2.7,2.1,,0.0,12537.0,19288.0
-Utah,49,Black or African American (NH),,,,,1.4,1.3,,,6407.0,11832.0
-Utah,49,Hispanic or Latino,16.0,0.0,27.1,0.0,17.7,20.5,20.0,0.0,80577.0,190837.0
-Utah,49,Two or more races (NH),,,,,3.2,4.1,,,14491.0,38721.0
-Utah,49,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,1.1,1.2,,0.0,4992.0,11191.0
-Utah,49,White (NH),43.0,14.0,72.9,100.0,73.0,70.1,12.91,2.14,333153.0,653966.0
-Vermont,50,Indigenous (NH),0.0,0.0,,,0.2,0.2,0.0,0.0,144.0,258.0
-Vermont,50,Asian (NH),0.0,0.0,,,3.6,2.2,0.0,0.0,2575.0,2575.0
-Vermont,50,Black or African American (NH),0.0,0.0,,,2.3,2.1,0.0,0.0,1607.0,2385.0
-Vermont,50,Hispanic or Latino,0.0,0.0,,,4.0,3.7,0.0,0.0,2803.0,4227.0
-Vermont,50,Two or more races (NH),0.0,0.0,,,3.2,4.1,0.0,0.0,2256.0,4710.0
-Vermont,50,Native Hawaiian and Pacific Islander (NH),0.0,0.0,,,0.04,0.03,0.0,0.0,29.0,40.0
-Vermont,50,White (NH),,,,,86.7,87.6,,,61330.0,100441.0
-Virginia,51,Indigenous (NH),,0.0,,0.0,0.3,0.2,,0.0,2412.0,3732.0
-Virginia,51,Asian (NH),,0.0,,0.0,6.9,6.9,,0.0,62859.0,128942.0
-Virginia,51,Black or African American (NH),134.0,40.0,61.8,74.1,20.1,19.7,72.99,10.78,183593.0,371059.0
-Virginia,51,Hispanic or Latino,15.0,0.0,6.9,0.0,13.9,16.2,12.0,0.0,127015.0,305345.0
-Virginia,51,Two or more races (NH),,,,,4.5,6.3,,,41200.0,117629.0
-Virginia,51,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,804.0,1192.0
-Virginia,51,White (NH),68.0,14.0,31.3,25.9,54.3,50.7,13.71,1.47,495837.0,953645.0
-Washington,53,Indigenous (NH),,,,,1.4,1.2,,,10638.0,19084.0
-Washington,53,Asian (NH),,,,,10.3,9.1,,,78681.0,149458.0
-Washington,53,Black or African American (NH),26.0,,20.2,,4.8,4.5,70.45,,36908.0,74456.0
-Washington,53,Hispanic or Latino,31.0,11.0,24.0,36.7,21.2,23.9,19.0,3.0,161086.0,393802.0
-Washington,53,Two or more races (NH),10.0,,7.8,,6.8,8.9,19.43,,51481.0,147021.0
-Washington,53,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,1.0,1.0,,0.0,7447.0,15712.0
-Washington,53,White (NH),62.0,19.0,48.1,63.3,54.5,51.5,14.93,2.24,415306.0,848537.0
-West Virginia,54,Indigenous (NH),0.0,0.0,0.0,,0.2,0.1,0.0,0.0,276.0,463.0
-West Virginia,54,Asian (NH),0.0,0.0,0.0,,1.2,0.8,0.0,0.0,2120.0,2809.0
-West Virginia,54,Black or African American (NH),,,,,4.9,3.7,,,8558.0,13119.0
-West Virginia,54,Hispanic or Latino,0.0,0.0,0.0,,3.2,3.3,0.0,0.0,5685.0,11701.0
-West Virginia,54,Two or more races (NH),,,,,3.2,4.7,,,5610.0,16528.0
-West Virginia,54,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.02,0.0,0.0,52.0,69.0
-West Virginia,54,White (NH),23.0,,100.0,,87.3,87.3,14.94,,153916.0,307523.0
-Wisconsin,55,Indigenous (NH),,0.0,,0.0,0.9,1.0,,0.0,5923.0,12466.0
-Wisconsin,55,Asian (NH),0.0,0.0,0.0,0.0,4.4,4.1,0.0,0.0,27410.0,51323.0
-Wisconsin,55,Black or African American (NH),51.0,22.0,43.2,59.5,7.4,8.9,110.78,19.9,46039.0,110555.0
-Wisconsin,55,Hispanic or Latino,19.0,0.0,16.1,0.0,11.4,13.6,27.0,0.0,71120.0,169669.0
-Wisconsin,55,Two or more races (NH),0.0,,0.0,,3.1,4.5,0.0,,19498.0,55674.0
-Wisconsin,55,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.05,0.05,0.0,0.0,297.0,592.0
-Wisconsin,55,White (NH),48.0,15.0,40.7,40.5,72.8,68.0,10.53,1.77,455926.0,848850.0
-Wyoming,56,Indigenous (NH),0.0,0.0,0.0,,2.5,2.6,0.0,0.0,1539.0,3419.0
-Wyoming,56,Asian (NH),0.0,0.0,0.0,,1.5,0.8,0.0,0.0,911.0,1013.0
-Wyoming,56,Black or African American (NH),,0.0,,,1.5,0.9,,0.0,927.0,1195.0
-Wyoming,56,Hispanic or Latino,0.0,0.0,0.0,,13.7,16.2,0.0,0.0,8297.0,20949.0
-Wyoming,56,Two or more races (NH),,0.0,,,2.7,3.6,,0.0,1655.0,4684.0
-Wyoming,56,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,55.0,87.0
-Wyoming,56,White (NH),21.0,,100.0,,77.9,75.8,44.64,,47046.0,98202.0
-California,06,Unknown race,,,,,,,,,,
-Colorado,08,Unknown race,,,,,,,,,,
-Illinois,17,Unknown race,,,,,,,,,,
-Iowa,19,Unknown race,,,,,,,,,,
-Kansas,20,Unknown race,,,,,,,,,,
-Michigan,26,Unknown race,,,,,,,,,,
-New York,36,Unknown race,,,,,,,,,,
-North Dakota,38,Unknown race,,,,,,,,,,
-Texas,48,Unknown race,,,,,,,,,,
-Alabama,01,All,247.0,84.0,100.0,100.0,100.0,100.0,45.3,7.43,545228.0,1130840.0
-Alaska,02,All,28.0,10.0,100.0,100.0,100.0,100.0,36.5,5.7,76709.0,175507.0
-Arizona,04,All,198.0,65.0,100.0,100.0,100.0,100.0,24.56,4.11,806300.0,1583034.0
-Arkansas,05,All,101.0,46.0,100.0,100.0,100.0,100.0,31.06,6.52,325152.0,705608.0
-California,06,All,492.0,157.0,100.0,100.0,100.0,100.0,12.07,1.86,4076211.0,8445669.0
-Colorado,08,All,157.0,52.0,100.0,100.0,100.0,100.0,25.13,4.28,624869.0,1214684.0
-Connecticut,09,All,36.0,11.0,100.0,100.0,100.0,100.0,9.5,1.52,378794.0,722986.0
-Delaware,10,All,24.0,,100.0,100.0,100.0,100.0,24.27,,98889.0,211938.0
-District of Columbia,11,All,58.0,20.0,100.0,100.0,100.0,100.0,71.42,15.8,81213.0,126592.0
-Florida,12,All,459.0,132.0,100.0,100.0,100.0,100.0,22.06,3.01,2080878.0,4380843.0
-Georgia,13,All,430.0,130.0,100.0,100.0,100.0,100.0,36.05,5.12,1192955.0,2538681.0
-Hawaii,15,All,,,100.0,100.0,100.0,100.0,,,132734.0,293613.0
-Idaho,16,All,45.0,20.0,100.0,100.0,100.0,100.0,20.53,4.28,219213.0,467342.0
-Illinois,17,All,353.0,124.0,100.0,100.0,100.0,100.0,27.14,4.58,1300547.0,2705522.0
-Indiana,18,All,231.0,81.0,100.0,100.0,100.0,100.0,30.82,5.1,749573.0,1587254.0
-Iowa,19,All,49.0,18.0,100.0,100.0,100.0,100.0,13.64,2.47,359323.0,730122.0
-Kansas,20,All,88.0,30.0,100.0,100.0,100.0,100.0,26.03,4.32,338072.0,694337.0
-Kentucky,21,All,141.0,48.0,100.0,100.0,100.0,100.0,30.24,4.72,466276.0,1016895.0
-Louisiana,22,All,313.0,94.0,100.0,100.0,100.0,100.0,66.01,8.81,474182.0,1067149.0
-Maine,23,All,21.0,,100.0,100.0,100.0,100.0,16.67,,125955.0,249052.0
-Maryland,24,All,157.0,45.0,100.0,100.0,100.0,100.0,26.48,3.3,592923.0,1361916.0
-Massachusetts,25,All,57.0,10.0,100.0,100.0,100.0,100.0,7.35,0.75,775386.0,1341801.0
-Michigan,26,All,223.0,76.0,100.0,100.0,100.0,100.0,21.24,3.6,1050086.0,2111911.0
-Minnesota,27,All,78.0,21.0,100.0,100.0,100.0,100.0,13.54,1.61,576049.0,1300934.0
-Mississippi,28,All,187.0,66.0,100.0,100.0,100.0,100.0,58.31,9.71,320708.0,679826.0
-Missouri,29,All,235.0,75.0,100.0,100.0,100.0,100.0,36.54,5.46,643196.0,1374470.0
-Montana,30,All,26.0,11.0,100.0,100.0,100.0,100.0,22.29,4.67,116640.0,235651.0
-Nebraska,31,All,38.0,14.0,100.0,100.0,100.0,100.0,17.26,2.91,220186.0,480998.0
-Nevada,32,All,81.0,30.0,100.0,100.0,100.0,100.0,27.4,4.37,295606.0,685956.0
-New Hampshire,33,All,13.0,,100.0,100.0,100.0,100.0,9.57,,135786.0,252050.0
-New Jersey,34,All,71.0,21.0,100.0,100.0,100.0,100.0,8.04,1.05,883020.0,2010290.0
-New Mexico,35,All,118.0,33.0,100.0,100.0,100.0,100.0,51.89,7.31,227412.0,451347.0
-New York,36,All,141.0,44.0,100.0,100.0,100.0,100.0,7.05,1.11,1999506.0,3959908.0
-North Carolina,37,All,353.0,102.0,100.0,100.0,100.0,100.0,30.37,4.37,1162261.0,2336623.0
-North Dakota,38,All,17.0,11.0,100.0,100.0,100.0,100.0,17.2,5.96,98827.0,184734.0
-Ohio,39,All,296.0,119.0,100.0,100.0,100.0,100.0,24.79,4.62,1194067.0,2578254.0
-Oklahoma,40,All,108.0,55.0,100.0,100.0,100.0,100.0,23.85,5.69,452791.0,966607.0
-Oregon,41,All,98.0,18.0,100.0,100.0,100.0,100.0,23.82,2.16,411448.0,831830.0
-Pennsylvania,42,All,301.0,68.0,100.0,100.0,100.0,100.0,22.87,2.59,1316231.0,2629005.0
-Rhode Island,44,All,,,100.0,100.0,100.0,100.0,,,122389.0,203838.0
-South Carolina,45,All,219.0,56.0,100.0,100.0,100.0,100.0,39.6,4.89,552971.0,1144201.0
-South Dakota,46,All,23.0,,100.0,100.0,100.0,100.0,23.72,,96949.0,221898.0
-Tennessee,47,All,291.0,96.0,100.0,100.0,100.0,100.0,39.86,6.11,730073.0,1570728.0
-Texas,48,All,836.0,277.0,100.0,100.0,100.0,100.0,24.66,3.66,3390793.0,7561125.0
-Utah,49,All,74.0,26.0,100.0,100.0,100.0,100.0,16.22,2.79,456119.0,933152.0
-Vermont,50,All,,,100.0,100.0,100.0,100.0,,,70744.0,114636.0
-Virginia,51,All,239.0,58.0,100.0,100.0,100.0,100.0,26.16,3.08,913720.0,1881544.0
-Washington,53,All,142.0,45.0,100.0,100.0,100.0,100.0,18.65,2.73,761547.0,1648070.0
-West Virginia,54,All,29.0,,100.0,100.0,100.0,100.0,16.46,,176217.0,352212.0
-Wisconsin,55,All,124.0,43.0,100.0,100.0,100.0,100.0,19.8,3.44,626213.0,1249129.0
-Wyoming,56,All,24.0,,100.0,100.0,100.0,100.0,39.72,,60430.0,129549.0
+state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_estimated_total,gun_deaths_youth_estimated_total,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_population_pct,gun_deaths_youth_population_pct,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_per_100k_is_suppressed,gun_deaths_youth_per_100k_is_suppressed,gun_deaths_young_adults_population,gun_deaths_youth_population
+Alabama,01,Indigenous (NH),,0.0,,0.0,0.5,0.3,,0.0,True,,2882.0,3874.0
+Alabama,01,Asian (NH),,0.0,,0.0,1.8,1.5,,0.0,True,,9564.0,16414.0
+Alabama,01,Black or African American (NH),179.0,47.0,77.5,60.3,29.6,28.3,111.03,14.66,,,161220.0,320579.0
+Alabama,01,Hispanic or Latino,,,,,7.1,9.9,,,True,True,38878.0,111761.0
+Alabama,01,Two or more races (NH),,,,,2.3,3.9,,,True,True,12473.0,43588.0
+Alabama,01,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,353.0,705.0
+Alabama,01,White (NH),52.0,31.0,22.5,39.7,58.7,56.1,16.26,4.89,,,319858.0,633919.0
+Alaska,02,Indigenous (NH),,,,,17.0,18.1,,,True,True,13013.0,31733.0
+Alaska,02,Asian (NH),,,,,6.4,5.6,,,True,True,4897.0,9790.0
+Alaska,02,Black or African American (NH),,0.0,,,4.4,2.9,,0.0,True,,3412.0,5045.0
+Alaska,02,Hispanic or Latino,,,,,9.9,10.5,,,True,True,7613.0,18483.0
+Alaska,02,Two or more races (NH),,,,,9.8,13.9,,,True,True,7483.0,24466.0
+Alaska,02,Native Hawaiian and Pacific Islander (NH),,0.0,,,1.9,2.5,,0.0,True,,1468.0,4378.0
+Alaska,02,White (NH),,,,,50.6,46.5,,,True,True,38823.0,81612.0
+Arizona,04,Indigenous (NH),14.0,,14.7,,4.3,4.5,39.95,,,True,35044.0,70913.0
+Arizona,04,Asian (NH),,0.0,,0.0,4.0,3.2,,0.0,True,,32518.0,50770.0
+Arizona,04,Black or African American (NH),26.0,13.0,27.4,100.0,5.4,5.6,60.27,14.74,,,43142.0,88214.0
+Arizona,04,Hispanic or Latino,,,,,41.2,43.9,,,True,True,332508.0,694361.0
+Arizona,04,Two or more races (NH),,,,,3.5,4.6,,,True,True,28053.0,72818.0
+Arizona,04,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,,,1679.0,3229.0
+Arizona,04,White (NH),55.0,,57.9,,41.3,38.1,16.5,,,True,333356.0,602729.0
+Arkansas,05,Indigenous (NH),0.0,0.0,0.0,0.0,0.9,0.7,0.0,0.0,,,2767.0,5022.0
+Arkansas,05,Asian (NH),,0.0,,0.0,1.9,1.9,,0.0,True,,6161.0,13373.0
+Arkansas,05,Black or African American (NH),61.0,25.0,64.9,56.8,17.7,17.5,105.88,20.29,,,57610.0,123206.0
+Arkansas,05,Hispanic or Latino,,,,,12.5,14.1,,,True,True,40666.0,99348.0
+Arkansas,05,Two or more races (NH),0.0,,0.0,,2.9,4.3,0.0,,,True,9591.0,30027.0
+Arkansas,05,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.5,0.7,0.0,0.0,,,1697.0,5263.0
+Arkansas,05,White (NH),33.0,19.0,35.1,43.2,63.6,60.9,15.97,4.43,,,206660.0,429369.0
+California,06,Indigenous (NH),,,,,0.4,0.4,,,True,True,16090.0,29633.0
+California,06,Asian (NH),17.0,11.0,8.1,14.3,13.2,13.1,3.15,1.0,,,539431.0,1103921.0
+California,06,Black or African American (NH),97.0,25.0,46.0,32.5,5.4,5.0,44.28,5.91,,,219081.0,423164.0
+California,06,Hispanic or Latino,,,,,50.0,51.9,,,True,True,2036320.0,4380449.0
+California,06,Two or more races (NH),14.0,13.0,6.6,16.9,4.2,5.5,8.26,2.79,,,169462.0,465479.0
+California,06,Native Hawaiian and Pacific Islander (NH),,,,,0.3,0.4,,,True,True,14246.0,29807.0
+California,06,White (NH),83.0,28.0,39.3,36.4,26.5,23.8,7.67,1.39,,,1081581.0,2013216.0
+Colorado,08,Indigenous (NH),,0.0,,0.0,0.8,0.5,,0.0,True,,4817.0,6429.0
+Colorado,08,Asian (NH),,,,,3.6,3.6,,,True,True,22313.0,44255.0
+Colorado,08,Black or African American (NH),23.0,,29.5,,4.4,4.6,84.41,,,True,27248.0,56093.0
+Colorado,08,Hispanic or Latino,,,,,29.5,33.2,,,True,True,184365.0,402771.0
+Colorado,08,Two or more races (NH),,,,,3.9,5.0,,,True,True,24298.0,60456.0
+Colorado,08,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.2,0.2,,0.0,True,,1103.0,2509.0
+Colorado,08,White (NH),55.0,16.0,70.5,100.0,57.7,52.9,15.25,2.49,,,360725.0,642171.0
+Connecticut,09,Indigenous (NH),0.0,0.0,0.0,,0.2,0.3,0.0,0.0,,,842.0,1937.0
+Connecticut,09,Asian (NH),0.0,,0.0,,5.5,5.4,0.0,,,True,20668.0,38925.0
+Connecticut,09,Black or African American (NH),18.0,,100.0,,11.8,12.0,40.1,,,True,44883.0,86715.0
+Connecticut,09,Hispanic or Latino,,,,,22.8,28.0,,,True,True,86198.0,202459.0
+Connecticut,09,Two or more races (NH),,0.0,,,3.2,4.1,,0.0,True,,12170.0,29889.0
+Connecticut,09,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.04,0.1,0.0,0.0,,,137.0,399.0
+Connecticut,09,White (NH),,,,,56.5,50.2,,,True,True,213896.0,362662.0
+Delaware,10,Indigenous (NH),0.0,0.0,0.0,,0.3,0.2,0.0,0.0,,,261.0,451.0
+Delaware,10,Asian (NH),0.0,0.0,0.0,,4.1,4.4,0.0,0.0,,,4088.0,9290.0
+Delaware,10,Black or African American (NH),13.0,,100.0,,27.1,26.0,48.53,,,True,26789.0,55171.0
+Delaware,10,Hispanic or Latino,,0.0,,,15.3,18.7,,0.0,True,,15099.0,39608.0
+Delaware,10,Two or more races (NH),,0.0,,,4.5,5.9,,0.0,True,,4407.0,12507.0
+Delaware,10,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.04,0.0,0.0,,,25.0,78.0
+Delaware,10,White (NH),,0.0,,,48.8,44.7,,0.0,True,,48220.0,94833.0
+District of Columbia,11,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,,,145.0,185.0
+District of Columbia,11,Asian (NH),0.0,0.0,0.0,0.0,6.2,2.6,0.0,0.0,,,5068.0,3274.0
+District of Columbia,11,Black or African American (NH),57.0,19.0,100.0,100.0,36.6,50.8,191.84,29.52,,,29713.0,64370.0
+District of Columbia,11,Hispanic or Latino,,,,,11.1,17.9,,,True,True,8988.0,22668.0
+District of Columbia,11,Two or more races (NH),0.0,0.0,0.0,0.0,3.3,4.8,0.0,0.0,,,2702.0,6057.0
+District of Columbia,11,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,66.0,84.0
+District of Columbia,11,White (NH),0.0,0.0,0.0,0.0,42.5,23.7,0.0,0.0,,,34531.0,29954.0
+Florida,12,Indigenous (NH),0.0,,0.0,,0.2,0.2,0.0,,,True,5192.0,8939.0
+Florida,12,Asian (NH),,,,,3.1,2.9,,,True,True,65452.0,127489.0
+Florida,12,Black or African American (NH),236.0,70.0,63.4,70.0,18.8,19.4,60.36,8.22,,,390965.0,851222.0
+Florida,12,Hispanic or Latino,,,,,31.4,32.3,,,True,True,653670.0,1416966.0
+Florida,12,Two or more races (NH),11.0,,3.0,,2.9,4.1,18.22,,,True,60375.0,178202.0
+Florida,12,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,1493.0,3250.0
+Florida,12,White (NH),125.0,30.0,33.6,30.0,43.4,41.0,13.83,1.67,,,903731.0,1794775.0
+Georgia,13,Indigenous (NH),,,,,0.2,0.2,,,True,True,2508.0,4320.0
+Georgia,13,Asian (NH),,,,,4.3,4.5,,,True,True,51831.0,114856.0
+Georgia,13,Black or African American (NH),293.0,97.0,76.1,81.5,33.9,33.8,72.38,11.3,,,404799.0,858418.0
+Georgia,13,Hispanic or Latino,,,,,14.3,16.1,,,True,True,170638.0,408948.0
+Georgia,13,Two or more races (NH),,,,,2.8,4.3,,,True,True,33826.0,108217.0
+Georgia,13,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,879.0,2349.0
+Georgia,13,White (NH),92.0,22.0,23.9,18.5,44.3,41.0,17.41,2.11,,,528474.0,1041573.0
+Hawaii,15,Indigenous (NH),0.0,0.0,,,0.3,0.2,0.0,0.0,,,447.0,476.0
+Hawaii,15,Asian (NH),0.0,0.0,,,25.0,21.8,0.0,0.0,,,33154.0,64046.0
+Hawaii,15,Black or African American (NH),0.0,0.0,,,3.3,1.7,0.0,0.0,,,4353.0,5055.0
+Hawaii,15,Hispanic or Latino,,,,,14.3,18.1,,,True,True,18975.0,53061.0
+Hawaii,15,Two or more races (NH),,,,,25.3,33.1,,,True,True,33548.0,97222.0
+Hawaii,15,Native Hawaiian and Pacific Islander (NH),,0.0,,,10.3,11.1,,0.0,True,,13666.0,32532.0
+Hawaii,15,White (NH),0.0,0.0,,,21.5,14.0,0.0,0.0,,,28591.0,41221.0
+Idaho,16,Indigenous (NH),,0.0,,0.0,1.0,0.9,,0.0,True,,2220.0,4199.0
+Idaho,16,Asian (NH),0.0,0.0,0.0,0.0,1.7,1.4,0.0,0.0,,,3793.0,6442.0
+Idaho,16,Black or African American (NH),,0.0,,0.0,1.3,0.9,,0.0,True,,2758.0,4405.0
+Idaho,16,Hispanic or Latino,,,,,17.8,20.1,,,True,True,38989.0,93857.0
+Idaho,16,Two or more races (NH),,,,,3.2,3.9,,,True,True,6932.0,18100.0
+Idaho,16,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.3,0.2,0.0,0.0,,,561.0,889.0
+Idaho,16,White (NH),37.0,18.0,100.0,100.0,74.8,72.6,22.57,5.3,,,163960.0,339450.0
+Illinois,17,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,,,1967.0,3735.0
+Illinois,17,Asian (NH),,,,,6.3,5.7,,,True,True,81660.0,154013.0
+Illinois,17,Black or African American (NH),222.0,85.0,80.7,70.2,14.7,15.3,115.87,20.57,,,191602.0,413263.0
+Illinois,17,Hispanic or Latino,,19.0,,15.7,25.3,25.3,,3.0,True,,329361.0,685382.0
+Illinois,17,Two or more races (NH),,0.0,,0.0,2.9,3.8,,0.0,True,,37234.0,103959.0
+Illinois,17,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,,,506.0,755.0
+Illinois,17,White (NH),53.0,17.0,19.3,14.0,50.6,49.7,8.05,1.26,,,658217.0,1344415.0
+Indiana,18,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,,,1539.0,2442.0
+Indiana,18,Asian (NH),,,,,4.0,3.0,,,True,True,30053.0,46994.0
+Indiana,18,Black or African American (NH),110.0,41.0,55.8,56.2,10.7,11.8,137.19,21.87,,,80182.0,187456.0
+Indiana,18,Hispanic or Latino,,,,,11.8,13.1,,,True,True,88090.0,207958.0
+Indiana,18,Two or more races (NH),,,,,3.3,4.6,,,True,True,24503.0,72324.0
+Indiana,18,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.05,0.05,0.0,0.0,,,356.0,774.0
+Indiana,18,White (NH),87.0,32.0,44.2,43.8,70.0,67.4,16.58,2.99,,,524850.0,1069306.0
+Iowa,19,Indigenous (NH),0.0,0.0,0.0,0.0,0.4,0.3,0.0,0.0,,,1330.0,2477.0
+Iowa,19,Asian (NH),0.0,0.0,0.0,0.0,3.9,2.7,0.0,0.0,,,14022.0,19644.0
+Iowa,19,Black or African American (NH),14.0,,31.1,,5.3,6.1,72.85,,,True,19219.0,44384.0
+Iowa,19,Hispanic or Latino,,,,,10.0,11.8,,,True,True,36019.0,85928.0
+Iowa,19,Two or more races (NH),,,,,3.1,4.3,,,True,True,11097.0,31339.0
+Iowa,19,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.3,0.4,0.0,0.0,,,1085.0,3030.0
+Iowa,19,White (NH),31.0,11.0,68.9,100.0,77.0,74.4,11.21,2.03,,,276551.0,543320.0
+Kansas,20,Indigenous (NH),,0.0,,0.0,1.0,0.6,,0.0,True,,3333.0,4234.0
+Kansas,20,Asian (NH),,,,,3.6,2.8,,,True,True,12326.0,19702.0
+Kansas,20,Black or African American (NH),25.0,,35.2,,6.5,6.1,112.95,,,True,22134.0,42630.0
+Kansas,20,Hispanic or Latino,,,,,18.3,20.2,,,True,True,61912.0,140227.0
+Kansas,20,Two or more races (NH),,,,,4.2,5.5,,,True,True,14272.0,38512.0
+Kansas,20,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,True,,443.0,993.0
+Kansas,20,White (NH),46.0,11.0,64.8,100.0,66.2,64.5,20.57,2.46,,,223652.0,448039.0
+Kentucky,21,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,,,895.0,1256.0
+Kentucky,21,Asian (NH),,,,,1.9,2.0,,,True,True,8931.0,19858.0
+Kentucky,21,Black or African American (NH),55.0,16.0,42.0,35.6,10.3,9.4,114.33,16.72,,,48107.0,95701.0
+Kentucky,21,Hispanic or Latino,,,,,6.5,8.1,,,True,True,30504.0,82564.0
+Kentucky,21,Two or more races (NH),0.0,0.0,0.0,0.0,3.2,4.7,0.0,0.0,,,15149.0,47391.0
+Kentucky,21,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,653.0,1171.0
+Kentucky,21,White (NH),76.0,29.0,58.0,64.4,77.6,75.6,20.99,3.77,,,362037.0,768954.0
+Louisiana,22,Indigenous (NH),,0.0,,0.0,0.7,0.6,,0.0,True,,3266.0,5913.0
+Louisiana,22,Asian (NH),,,,,2.1,1.7,,,True,True,9987.0,17736.0
+Louisiana,22,Black or African American (NH),254.0,77.0,84.1,86.5,36.8,35.4,145.73,20.4,,,174299.0,377413.0
+Louisiana,22,Hispanic or Latino,,,,,7.8,10.1,,,True,True,36917.0,108021.0
+Louisiana,22,Two or more races (NH),,,,,2.3,3.4,,,True,True,10944.0,36450.0
+Louisiana,22,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,,,192.0,359.0
+Louisiana,22,White (NH),48.0,12.0,15.9,13.5,50.3,48.8,20.12,2.3,,,238577.0,521257.0
+Maine,23,Indigenous (NH),0.0,0.0,0.0,,0.7,0.7,0.0,0.0,,,904.0,1809.0
+Maine,23,Asian (NH),0.0,0.0,0.0,,2.1,1.4,0.0,0.0,,,2639.0,3402.0
+Maine,23,Black or African American (NH),,0.0,,,3.2,3.7,,0.0,True,,3983.0,9308.0
+Maine,23,Hispanic or Latino,,0.0,,,3.5,3.7,,0.0,True,,4446.0,9261.0
+Maine,23,Two or more races (NH),0.0,,0.0,,3.0,4.1,0.0,,,True,3791.0,10250.0
+Maine,23,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.04,0.04,0.0,0.0,,,48.0,110.0
+Maine,23,White (NH),17.0,,100.0,,87.4,86.3,15.43,,,True,110144.0,214912.0
+Maryland,24,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,,,1341.0,2519.0
+Maryland,24,Asian (NH),,,,,6.5,6.5,,,True,True,38376.0,87993.0
+Maryland,24,Black or African American (NH),122.0,36.0,89.7,100.0,31.2,30.1,65.85,8.78,,,185278.0,410103.0
+Maryland,24,Hispanic or Latino,,,,,15.3,19.3,,,True,True,90674.0,262424.0
+Maryland,24,Two or more races (NH),0.0,0.0,0.0,0.0,4.2,5.5,0.0,0.0,,,24710.0,75110.0
+Maryland,24,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.04,0.0,0.0,,,225.0,567.0
+Maryland,24,White (NH),14.0,,10.3,,42.6,38.4,5.55,,,True,252319.0,523200.0
+Massachusetts,25,Indigenous (NH),0.0,0.0,0.0,,0.2,0.2,0.0,0.0,,,1338.0,2330.0
+Massachusetts,25,Asian (NH),,0.0,,,9.1,8.0,,0.0,True,,70689.0,106918.0
+Massachusetts,25,Black or African American (NH),18.0,,60.0,,8.1,9.5,28.81,,,True,62484.0,127656.0
+Massachusetts,25,Hispanic or Latino,,,,,16.4,21.1,,,True,True,127540.0,282493.0
+Massachusetts,25,Two or more races (NH),,0.0,,,3.2,4.4,,0.0,True,,24445.0,59525.0
+Massachusetts,25,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.05,0.1,0.0,0.0,,,377.0,735.0
+Massachusetts,25,White (NH),12.0,,40.0,,63.0,56.8,2.46,,,True,488513.0,762144.0
+Michigan,26,Indigenous (NH),,0.0,,0.0,0.6,0.5,,0.0,True,,6515.0,11275.0
+Michigan,26,Asian (NH),,,,,4.5,3.6,,,True,True,47605.0,75563.0
+Michigan,26,Black or African American (NH),109.0,37.0,57.7,56.9,14.5,16.2,71.36,10.8,,,152742.0,342524.0
+Michigan,26,Hispanic or Latino,,,,,8.6,9.2,,,True,True,90005.0,193951.0
+Michigan,26,Two or more races (NH),,,,,4.0,5.2,,,True,True,41793.0,110211.0
+Michigan,26,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.03,0.0,0.0,,,399.0,617.0
+Michigan,26,White (NH),80.0,28.0,42.3,43.1,67.7,65.2,11.25,2.03,,,711027.0,1377770.0
+Minnesota,27,Indigenous (NH),,,,,1.3,1.3,,,True,True,7556.0,17475.0
+Minnesota,27,Asian (NH),,0.0,,0.0,6.4,6.6,,0.0,True,,36920.0,86369.0
+Minnesota,27,Black or African American (NH),36.0,,56.2,,9.1,11.3,68.54,,,True,52524.0,147003.0
+Minnesota,27,Hispanic or Latino,,,,,9.3,10.0,,,True,True,53839.0,130671.0
+Minnesota,27,Two or more races (NH),,0.0,,0.0,4.1,5.4,,0.0,True,,23752.0,69971.0
+Minnesota,27,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,348.0,1171.0
+Minnesota,27,White (NH),28.0,10.0,43.8,100.0,69.6,65.2,6.98,1.18,,,401110.0,848274.0
+Mississippi,28,Indigenous (NH),,0.0,,0.0,0.6,0.6,,0.0,True,,1918.0,3887.0
+Mississippi,28,Asian (NH),0.0,0.0,0.0,0.0,1.3,1.0,0.0,0.0,,,4328.0,6974.0
+Mississippi,28,Black or African American (NH),150.0,52.0,83.3,80.0,41.0,41.0,113.94,18.68,,,131645.0,278413.0
+Mississippi,28,Hispanic or Latino,,0.0,,0.0,4.6,5.9,,0.0,True,,14892.0,40080.0
+Mississippi,28,Two or more races (NH),,,,,1.9,2.9,,,True,True,6039.0,19770.0
+Mississippi,28,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.04,0.0,0.0,,,179.0,238.0
+Mississippi,28,White (NH),30.0,13.0,16.7,20.0,50.4,48.6,18.55,3.93,,,161707.0,330464.0
+Missouri,29,Indigenous (NH),,0.0,,0.0,0.4,0.3,,0.0,True,,2870.0,4662.0
+Missouri,29,Asian (NH),,0.0,,0.0,3.0,2.1,,0.0,True,,19353.0,28855.0
+Missouri,29,Black or African American (NH),128.0,41.0,60.1,60.3,12.7,13.3,156.41,22.51,,,81834.0,182147.0
+Missouri,29,Hispanic or Latino,,,,,7.5,8.2,,,True,True,48096.0,112360.0
+Missouri,29,Two or more races (NH),,,,,3.5,5.2,,,True,True,22743.0,71058.0
+Missouri,29,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.2,0.0,0.0,,,1445.0,3302.0
+Missouri,29,White (NH),85.0,27.0,39.9,39.7,72.6,70.7,18.21,2.78,,,466855.0,972086.0
+Montana,30,Indigenous (NH),,,,,7.2,8.7,,,True,True,8420.0,20477.0
+Montana,30,Asian (NH),0.0,0.0,0.0,,1.5,0.8,0.0,0.0,,,1728.0,1967.0
+Montana,30,Black or African American (NH),,0.0,,,1.0,0.6,,0.0,True,,1130.0,1494.0
+Montana,30,Hispanic or Latino,,0.0,,,6.2,7.7,,0.0,True,,7287.0,18182.0
+Montana,30,Two or more races (NH),,0.0,,,4.0,4.9,,0.0,True,,4620.0,11461.0
+Montana,30,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,,,109.0,238.0
+Montana,30,White (NH),15.0,,100.0,,80.0,77.2,16.07,,,True,93346.0,181832.0
+Nebraska,31,Indigenous (NH),,0.0,,,1.0,1.0,,0.0,True,,2158.0,4752.0
+Nebraska,31,Asian (NH),0.0,0.0,0.0,,3.1,2.9,0.0,0.0,,,6819.0,14129.0
+Nebraska,31,Black or African American (NH),,,,,5.6,6.2,,,True,True,12300.0,29608.0
+Nebraska,31,Hispanic or Latino,,,,,16.7,20.0,,,True,True,36762.0,96418.0
+Nebraska,31,Two or more races (NH),0.0,0.0,0.0,,3.3,4.4,0.0,0.0,,,7299.0,21037.0
+Nebraska,31,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,,,231.0,409.0
+Nebraska,31,White (NH),26.0,,100.0,,70.2,65.4,16.82,,,True,154617.0,314645.0
+Nevada,32,Indigenous (NH),0.0,0.0,0.0,,0.8,0.7,0.0,0.0,,,2452.0,4803.0
+Nevada,32,Asian (NH),,,,,7.3,6.7,,,True,True,21488.0,45811.0
+Nevada,32,Black or African American (NH),31.0,,60.8,,10.4,11.6,100.39,,,True,30880.0,79863.0
+Nevada,32,Hispanic or Latino,,,,,41.6,41.4,,,True,True,122951.0,283729.0
+Nevada,32,Two or more races (NH),,,,,5.6,7.7,,,True,True,16637.0,52603.0
+Nevada,32,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.7,0.8,0.0,0.0,,,2198.0,5560.0
+Nevada,32,White (NH),20.0,,39.2,,33.5,31.1,20.2,,,True,99000.0,213587.0
+New Hampshire,33,Indigenous (NH),0.0,0.0,0.0,,0.2,0.1,0.0,0.0,,,329.0,378.0
+New Hampshire,33,Asian (NH),0.0,0.0,0.0,,3.6,3.5,0.0,0.0,,,4949.0,8755.0
+New Hampshire,33,Black or African American (NH),0.0,0.0,0.0,,2.3,2.1,0.0,0.0,,,3085.0,5419.0
+New Hampshire,33,Hispanic or Latino,0.0,,0.0,,6.7,8.2,0.0,,,True,9074.0,20697.0
+New Hampshire,33,Two or more races (NH),0.0,0.0,0.0,,2.9,3.5,0.0,0.0,,,3983.0,8800.0
+New Hampshire,33,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.03,0.0,0.0,,,42.0,83.0
+New Hampshire,33,White (NH),13.0,,100.0,,84.2,82.5,11.37,,,True,114324.0,207918.0
+New Jersey,34,Indigenous (NH),0.0,0.0,0.0,,0.2,0.2,0.0,0.0,,,1477.0,3473.0
+New Jersey,34,Asian (NH),,0.0,,,9.5,10.3,,0.0,True,,83509.0,206157.0
+New Jersey,34,Black or African American (NH),32.0,,100.0,,14.1,13.4,25.62,,,True,124924.0,269709.0
+New Jersey,34,Hispanic or Latino,,,,,26.9,29.7,,,True,True,237904.0,596393.0
+New Jersey,34,Two or more races (NH),,,,,2.5,3.4,,,True,True,22458.0,67910.0
+New Jersey,34,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.05,0.0,0.0,,,301.0,940.0
+New Jersey,34,White (NH),,,,,46.7,43.1,,,True,True,412447.0,865708.0
+New Mexico,35,Indigenous (NH),10.0,,27.0,,9.9,10.0,44.56,,,True,22440.0,44914.0
+New Mexico,35,Asian (NH),0.0,0.0,0.0,,1.7,1.4,0.0,0.0,,,3799.0,6149.0
+New Mexico,35,Black or African American (NH),,0.0,,,2.4,2.0,,0.0,True,,5570.0,8814.0
+New Mexico,35,Hispanic or Latino,,,,,57.8,60.4,,,True,True,131409.0,272609.0
+New Mexico,35,Two or more races (NH),0.0,0.0,0.0,,2.3,2.9,0.0,0.0,,,5325.0,12947.0
+New Mexico,35,Native Hawaiian and Pacific Islander (NH),,0.0,,,0.1,0.1,,0.0,True,,194.0,244.0
+New Mexico,35,White (NH),27.0,,73.0,,25.8,23.4,46.02,,,True,58675.0,105670.0
+New York,36,Indigenous (NH),0.0,0.0,0.0,0.0,0.3,0.3,0.0,0.0,,,6864.0,12050.0
+New York,36,Asian (NH),,,,,9.3,9.0,,,True,True,185969.0,355266.0
+New York,36,Black or African American (NH),73.0,20.0,72.3,66.7,14.6,14.6,25.03,3.47,,,291712.0,576531.0
+New York,36,Hispanic or Latino,,,,,22.3,25.4,,,True,True,446675.0,1006227.0
+New York,36,Two or more races (NH),,,,,2.8,4.0,,,True,True,56779.0,158759.0
+New York,36,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,1107.0,2172.0
+New York,36,White (NH),28.0,10.0,27.7,33.3,50.5,46.7,2.77,0.54,,,1010400.0,1848903.0
+North Carolina,37,Indigenous (NH),11.0,,3.5,,1.0,1.0,91.61,,,True,12008.0,24408.0
+North Carolina,37,Asian (NH),,0.0,,0.0,3.4,3.9,,0.0,True,,39251.0,91504.0
+North Carolina,37,Black or African American (NH),192.0,62.0,61.7,71.3,22.6,22.1,73.05,12.03,,,262847.0,515419.0
+North Carolina,37,Hispanic or Latino,,,,,15.3,18.9,,,True,True,178314.0,441238.0
+North Carolina,37,Two or more races (NH),10.0,,3.2,,3.3,4.8,25.75,,,True,38833.0,113085.0
+North Carolina,37,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,972.0,1845.0
+North Carolina,37,White (NH),98.0,25.0,31.5,28.7,54.2,49.2,15.56,2.18,,,630036.0,1149124.0
+North Dakota,38,Indigenous (NH),,,,,5.4,6.7,,,True,True,5363.0,12383.0
+North Dakota,38,Asian (NH),0.0,0.0,0.0,,2.2,1.8,0.0,0.0,,,2193.0,3246.0
+North Dakota,38,Black or African American (NH),,,,,3.7,5.0,,,True,True,3617.0,9319.0
+North Dakota,38,Hispanic or Latino,,,,,5.8,8.1,,,True,True,5758.0,15015.0
+North Dakota,38,Two or more races (NH),0.0,,0.0,,3.1,4.9,0.0,,,True,3094.0,9026.0
+North Dakota,38,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.2,0.0,0.0,,,94.0,348.0
+North Dakota,38,White (NH),12.0,,100.0,,79.6,73.3,15.25,,,True,78708.0,135397.0
+Ohio,39,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,,,1974.0,3549.0
+Ohio,39,Asian (NH),,0.0,,0.0,3.2,2.9,,0.0,True,,38196.0,74996.0
+Ohio,39,Black or African American (NH),169.0,66.0,60.6,59.5,14.3,15.6,99.14,16.45,,,170462.0,401340.0
+Ohio,39,Hispanic or Latino,,,,,6.6,7.6,,,True,True,79152.0,194795.0
+Ohio,39,Two or more races (NH),,,,,3.9,5.4,,,True,True,46351.0,138271.0
+Ohio,39,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,True,,718.0,1578.0
+Ohio,39,White (NH),110.0,45.0,39.4,40.5,71.8,68.4,12.83,2.55,,,857214.0,1763725.0
+Oklahoma,40,Indigenous (NH),10.0,,11.9,,9.4,9.1,23.42,,,True,42697.0,88435.0
+Oklahoma,40,Asian (NH),,0.0,,0.0,3.0,2.4,,0.0,True,,13730.0,22849.0
+Oklahoma,40,Black or African American (NH),15.0,11.0,17.9,29.7,8.6,7.8,38.32,14.56,,,39141.0,75530.0
+Oklahoma,40,Hispanic or Latino,,,,,16.6,20.2,,,True,True,75183.0,195461.0
+Oklahoma,40,Two or more races (NH),,,,,7.9,10.5,,,True,True,35715.0,101559.0
+Oklahoma,40,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.2,0.3,0.0,0.0,,,934.0,2943.0
+Oklahoma,40,White (NH),59.0,26.0,70.2,70.3,54.2,49.6,24.04,5.42,,,245391.0,479830.0
+Oregon,41,Indigenous (NH),,0.0,,,1.2,1.0,,0.0,True,,4965.0,8108.0
+Oregon,41,Asian (NH),,,,,5.6,4.6,,,True,True,23008.0,38093.0
+Oregon,41,Black or African American (NH),11.0,,16.2,,2.4,2.5,110.31,,,True,9972.0,20447.0
+Oregon,41,Hispanic or Latino,,,,,22.0,24.3,,,True,True,90604.0,202338.0
+Oregon,41,Two or more races (NH),10.0,,14.7,,5.7,6.8,42.79,,,True,23371.0,56502.0
+Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,0.6,0.5,,,True,True,2316.0,4491.0
+Oregon,41,White (NH),47.0,,69.1,,62.5,60.3,18.27,,,True,257212.0,501851.0
+Pennsylvania,42,Indigenous (NH),0.0,0.0,0.0,0.0,0.2,0.1,0.0,0.0,,,1988.0,3347.0
+Pennsylvania,42,Asian (NH),,,,,4.8,4.4,,,True,True,62632.0,115271.0
+Pennsylvania,42,Black or African American (NH),148.0,43.0,57.4,72.9,12.6,12.7,89.53,12.84,,,165303.0,334880.0
+Pennsylvania,42,Hispanic or Latino,,,,,11.7,14.5,,,True,True,154176.0,380161.0
+Pennsylvania,42,Two or more races (NH),,,,,3.1,4.5,,,True,True,40271.0,117924.0
+Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.04,0.04,0.0,0.0,,,478.0,999.0
+Pennsylvania,42,White (NH),110.0,16.0,42.6,27.1,67.7,63.8,12.34,0.95,,,891383.0,1676423.0
+Rhode Island,44,Indigenous (NH),0.0,0.0,,,0.4,0.4,0.0,0.0,,,550.0,907.0
+Rhode Island,44,Asian (NH),0.0,0.0,,,4.6,3.7,0.0,0.0,,,5624.0,7615.0
+Rhode Island,44,Black or African American (NH),0.0,,,,7.5,7.5,0.0,,,True,9144.0,15261.0
+Rhode Island,44,Hispanic or Latino,,0.0,,,21.4,29.9,,0.0,True,,26195.0,60864.0
+Rhode Island,44,Two or more races (NH),0.0,0.0,,,3.6,5.0,0.0,0.0,,,4464.0,10158.0
+Rhode Island,44,Native Hawaiian and Pacific Islander (NH),0.0,0.0,,,0.1,0.1,0.0,0.0,,,73.0,135.0
+Rhode Island,44,White (NH),,,,,62.4,53.4,,,True,True,76339.0,108898.0
+South Carolina,45,Indigenous (NH),0.0,0.0,0.0,0.0,0.4,0.3,0.0,0.0,,,2059.0,3149.0
+South Carolina,45,Asian (NH),,,,,2.2,1.9,,,True,True,12042.0,22163.0
+South Carolina,45,Black or African American (NH),135.0,36.0,69.9,67.9,27.9,27.9,87.36,11.27,,,154534.0,319470.0
+South Carolina,45,Hispanic or Latino,,,,,9.7,12.0,,,True,True,53706.0,136832.0
+South Carolina,45,Two or more races (NH),,0.0,,0.0,3.0,4.5,,0.0,True,,16493.0,51920.0
+South Carolina,45,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,441.0,910.0
+South Carolina,45,White (NH),58.0,17.0,30.1,32.1,56.7,53.3,18.49,2.79,,,313696.0,609757.0
+South Dakota,46,Indigenous (NH),,,,,9.8,11.3,,,True,True,9497.0,25094.0
+South Dakota,46,Asian (NH),,0.0,,,2.6,1.8,,0.0,True,,2565.0,4094.0
+South Dakota,46,Black or African American (NH),0.0,0.0,0.0,,2.9,3.5,0.0,0.0,,,2794.0,7733.0
+South Dakota,46,Hispanic or Latino,,0.0,,,6.5,8.6,,0.0,True,,6273.0,19122.0
+South Dakota,46,Two or more races (NH),0.0,0.0,0.0,,3.6,5.1,0.0,0.0,,,3455.0,11248.0
+South Dakota,46,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,,,77.0,316.0
+South Dakota,46,White (NH),11.0,0.0,100.0,,74.6,69.5,15.22,0.0,,,72288.0,154291.0
+Tennessee,47,Indigenous (NH),0.0,,0.0,,0.3,0.2,0.0,,,True,2051.0,3005.0
+Tennessee,47,Asian (NH),,0.0,,0.0,2.1,2.0,,0.0,True,,15554.0,31690.0
+Tennessee,47,Black or African American (NH),180.0,51.0,66.7,60.0,18.2,18.0,135.84,18.0,,,132514.0,283328.0
+Tennessee,47,Hispanic or Latino,,,,,9.8,12.7,,,True,True,71571.0,200130.0
+Tennessee,47,Two or more races (NH),,,,,2.9,4.3,,,True,True,21519.0,67001.0
+Tennessee,47,Native Hawaiian and Pacific Islander (NH),0.0,,0.0,,0.1,0.1,0.0,,,True,476.0,1059.0
+Tennessee,47,White (NH),90.0,34.0,33.3,40.0,66.6,62.7,18.5,3.45,,,486388.0,984515.0
+Texas,48,Indigenous (NH),,0.0,,0.0,0.3,0.2,,0.0,True,,10131.0,17723.0
+Texas,48,Asian (NH),17.0,,3.7,,4.7,5.1,10.65,,,True,159684.0,388137.0
+Texas,48,Black or African American (NH),225.0,85.0,49.2,53.8,12.9,12.9,51.26,8.75,,,438953.0,971822.0
+Texas,48,Hispanic or Latino,,,,,47.4,48.3,,,True,True,1605940.0,3653571.0
+Texas,48,Two or more races (NH),,,,,2.1,3.0,,,True,True,72414.0,230221.0
+Texas,48,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,0.1,0.1,,0.0,True,,3419.0,7290.0
+Texas,48,White (NH),215.0,73.0,47.0,46.2,32.4,30.3,19.54,3.18,,,1100252.0,2292361.0
+Utah,49,Indigenous (NH),,,,,0.9,0.8,,,True,True,3962.0,7317.0
+Utah,49,Asian (NH),,0.0,,0.0,2.7,2.1,,0.0,True,,12537.0,19288.0
+Utah,49,Black or African American (NH),,,,,1.4,1.3,,,True,True,6407.0,11832.0
+Utah,49,Hispanic or Latino,,,,,17.7,20.5,,,True,True,80577.0,190837.0
+Utah,49,Two or more races (NH),,,,,3.2,4.1,,,True,True,14491.0,38721.0
+Utah,49,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,1.1,1.2,,0.0,True,,4992.0,11191.0
+Utah,49,White (NH),43.0,14.0,100.0,100.0,73.0,70.1,12.91,2.14,,,333153.0,653966.0
+Vermont,50,Indigenous (NH),0.0,0.0,,,0.2,0.2,0.0,0.0,,,144.0,258.0
+Vermont,50,Asian (NH),0.0,0.0,,,3.6,2.2,0.0,0.0,,,2575.0,2575.0
+Vermont,50,Black or African American (NH),0.0,0.0,,,2.3,2.1,0.0,0.0,,,1607.0,2385.0
+Vermont,50,Hispanic or Latino,0.0,0.0,,,4.0,3.7,0.0,0.0,,,2803.0,4227.0
+Vermont,50,Two or more races (NH),0.0,0.0,,,3.2,4.1,0.0,0.0,,,2256.0,4710.0
+Vermont,50,Native Hawaiian and Pacific Islander (NH),0.0,0.0,,,0.04,0.03,0.0,0.0,,,29.0,40.0
+Vermont,50,White (NH),,,,,86.7,87.6,,,True,True,61330.0,100441.0
+Virginia,51,Indigenous (NH),,0.0,,0.0,0.3,0.2,,0.0,True,,2412.0,3732.0
+Virginia,51,Asian (NH),,0.0,,0.0,6.9,6.9,,0.0,True,,62859.0,128942.0
+Virginia,51,Black or African American (NH),134.0,40.0,66.3,74.1,20.1,19.7,72.99,10.78,,,183593.0,371059.0
+Virginia,51,Hispanic or Latino,,,,,13.9,16.2,,,True,True,127015.0,305345.0
+Virginia,51,Two or more races (NH),,,,,4.5,6.3,,,True,True,41200.0,117629.0
+Virginia,51,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.1,0.1,0.0,0.0,,,804.0,1192.0
+Virginia,51,White (NH),68.0,14.0,33.7,25.9,54.3,50.7,13.71,1.47,,,495837.0,953645.0
+Washington,53,Indigenous (NH),,,,,1.4,1.2,,,True,True,10638.0,19084.0
+Washington,53,Asian (NH),,,,,10.3,9.1,,,True,True,78681.0,149458.0
+Washington,53,Black or African American (NH),26.0,,26.5,,4.8,4.5,70.45,,,True,36908.0,74456.0
+Washington,53,Hispanic or Latino,,,,,21.2,23.9,,,True,True,161086.0,393802.0
+Washington,53,Two or more races (NH),10.0,,10.2,,6.8,8.9,19.43,,,True,51481.0,147021.0
+Washington,53,Native Hawaiian and Pacific Islander (NH),,0.0,,0.0,1.0,1.0,,0.0,True,,7447.0,15712.0
+Washington,53,White (NH),62.0,19.0,63.3,100.0,54.5,51.5,14.93,2.24,,,415306.0,848537.0
+West Virginia,54,Indigenous (NH),0.0,0.0,0.0,,0.2,0.1,0.0,0.0,,,276.0,463.0
+West Virginia,54,Asian (NH),0.0,0.0,0.0,,1.2,0.8,0.0,0.0,,,2120.0,2809.0
+West Virginia,54,Black or African American (NH),,,,,4.9,3.7,,,True,True,8558.0,13119.0
+West Virginia,54,Hispanic or Latino,,0.0,,,3.2,3.3,,0.0,True,,5685.0,11701.0
+West Virginia,54,Two or more races (NH),,,,,3.2,4.7,,,True,True,5610.0,16528.0
+West Virginia,54,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.03,0.02,0.0,0.0,,,52.0,69.0
+West Virginia,54,White (NH),23.0,,100.0,,87.3,87.3,14.94,,,True,153916.0,307523.0
+Wisconsin,55,Indigenous (NH),,0.0,,0.0,0.9,1.0,,0.0,True,,5923.0,12466.0
+Wisconsin,55,Asian (NH),0.0,0.0,0.0,0.0,4.4,4.1,0.0,0.0,,,27410.0,51323.0
+Wisconsin,55,Black or African American (NH),51.0,22.0,51.5,59.5,7.4,8.9,110.78,19.9,,,46039.0,110555.0
+Wisconsin,55,Hispanic or Latino,,,,,11.4,13.6,,,True,True,71120.0,169669.0
+Wisconsin,55,Two or more races (NH),0.0,,0.0,,3.1,4.5,0.0,,,True,19498.0,55674.0
+Wisconsin,55,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,0.0,0.05,0.05,0.0,0.0,,,297.0,592.0
+Wisconsin,55,White (NH),48.0,15.0,48.5,40.5,72.8,68.0,10.53,1.77,,,455926.0,848850.0
+Wyoming,56,Indigenous (NH),0.0,0.0,0.0,,2.5,2.6,0.0,0.0,,,1539.0,3419.0
+Wyoming,56,Asian (NH),0.0,0.0,0.0,,1.5,0.8,0.0,0.0,,,911.0,1013.0
+Wyoming,56,Black or African American (NH),,0.0,,,1.5,0.9,,0.0,True,,927.0,1195.0
+Wyoming,56,Hispanic or Latino,,,,,13.7,16.2,,,True,True,8297.0,20949.0
+Wyoming,56,Two or more races (NH),,0.0,,,2.7,3.6,,0.0,True,,1655.0,4684.0
+Wyoming,56,Native Hawaiian and Pacific Islander (NH),0.0,0.0,0.0,,0.1,0.1,0.0,0.0,,,55.0,87.0
+Wyoming,56,White (NH),21.0,,100.0,,77.9,75.8,44.64,,,True,47046.0,98202.0
+California,06,Unknown race,,,,,,,,,True,,,
+Colorado,08,Unknown race,,,,,,,,,,True,,
+Illinois,17,Unknown race,,,,,,,,,True,True,,
+Iowa,19,Unknown race,,,,,,,,,True,,,
+Kansas,20,Unknown race,,,,,,,,,True,True,,
+Michigan,26,Unknown race,,,,,,,,,True,,,
+New York,36,Unknown race,,,,,,,,,,True,,
+North Dakota,38,Unknown race,,,,,,,,,,True,,
+Texas,48,Unknown race,,,,,,,,,True,,,
+Alabama,01,All,247.0,84.0,100.0,100.0,100.0,100.0,45.3,7.43,,,545228.0,1130840.0
+Alaska,02,All,28.0,10.0,100.0,100.0,100.0,100.0,36.5,5.7,,,76709.0,175507.0
+Arizona,04,All,198.0,65.0,100.0,100.0,100.0,100.0,24.56,4.11,,,806300.0,1583034.0
+Arkansas,05,All,101.0,46.0,100.0,100.0,100.0,100.0,31.06,6.52,,,325152.0,705608.0
+California,06,All,492.0,157.0,100.0,100.0,100.0,100.0,12.07,1.86,,,4076211.0,8445669.0
+Colorado,08,All,157.0,52.0,100.0,100.0,100.0,100.0,25.13,4.28,,,624869.0,1214684.0
+Connecticut,09,All,36.0,11.0,100.0,100.0,100.0,100.0,9.5,1.52,,,378794.0,722986.0
+Delaware,10,All,24.0,,100.0,100.0,100.0,100.0,24.27,,,True,98889.0,211938.0
+District of Columbia,11,All,58.0,20.0,100.0,100.0,100.0,100.0,71.42,15.8,,,81213.0,126592.0
+Florida,12,All,459.0,132.0,100.0,100.0,100.0,100.0,22.06,3.01,,,2080878.0,4380843.0
+Georgia,13,All,430.0,130.0,100.0,100.0,100.0,100.0,36.05,5.12,,,1192955.0,2538681.0
+Hawaii,15,All,,,100.0,100.0,100.0,100.0,,,True,True,132734.0,293613.0
+Idaho,16,All,45.0,20.0,100.0,100.0,100.0,100.0,20.53,4.28,,,219213.0,467342.0
+Illinois,17,All,353.0,124.0,100.0,100.0,100.0,100.0,27.14,4.58,,,1300547.0,2705522.0
+Indiana,18,All,231.0,81.0,100.0,100.0,100.0,100.0,30.82,5.1,,,749573.0,1587254.0
+Iowa,19,All,49.0,18.0,100.0,100.0,100.0,100.0,13.64,2.47,,,359323.0,730122.0
+Kansas,20,All,88.0,30.0,100.0,100.0,100.0,100.0,26.03,4.32,,,338072.0,694337.0
+Kentucky,21,All,141.0,48.0,100.0,100.0,100.0,100.0,30.24,4.72,,,466276.0,1016895.0
+Louisiana,22,All,313.0,94.0,100.0,100.0,100.0,100.0,66.01,8.81,,,474182.0,1067149.0
+Maine,23,All,21.0,,100.0,100.0,100.0,100.0,16.67,,,True,125955.0,249052.0
+Maryland,24,All,157.0,45.0,100.0,100.0,100.0,100.0,26.48,3.3,,,592923.0,1361916.0
+Massachusetts,25,All,57.0,10.0,100.0,100.0,100.0,100.0,7.35,0.75,,,775386.0,1341801.0
+Michigan,26,All,223.0,76.0,100.0,100.0,100.0,100.0,21.24,3.6,,,1050086.0,2111911.0
+Minnesota,27,All,78.0,21.0,100.0,100.0,100.0,100.0,13.54,1.61,,,576049.0,1300934.0
+Mississippi,28,All,187.0,66.0,100.0,100.0,100.0,100.0,58.31,9.71,,,320708.0,679826.0
+Missouri,29,All,235.0,75.0,100.0,100.0,100.0,100.0,36.54,5.46,,,643196.0,1374470.0
+Montana,30,All,26.0,11.0,100.0,100.0,100.0,100.0,22.29,4.67,,,116640.0,235651.0
+Nebraska,31,All,38.0,14.0,100.0,100.0,100.0,100.0,17.26,2.91,,,220186.0,480998.0
+Nevada,32,All,81.0,30.0,100.0,100.0,100.0,100.0,27.4,4.37,,,295606.0,685956.0
+New Hampshire,33,All,13.0,,100.0,100.0,100.0,100.0,9.57,,,True,135786.0,252050.0
+New Jersey,34,All,71.0,21.0,100.0,100.0,100.0,100.0,8.04,1.05,,,883020.0,2010290.0
+New Mexico,35,All,118.0,33.0,100.0,100.0,100.0,100.0,51.89,7.31,,,227412.0,451347.0
+New York,36,All,141.0,44.0,100.0,100.0,100.0,100.0,7.05,1.11,,,1999506.0,3959908.0
+North Carolina,37,All,353.0,102.0,100.0,100.0,100.0,100.0,30.37,4.37,,,1162261.0,2336623.0
+North Dakota,38,All,17.0,11.0,100.0,100.0,100.0,100.0,17.2,5.96,,,98827.0,184734.0
+Ohio,39,All,296.0,119.0,100.0,100.0,100.0,100.0,24.79,4.62,,,1194067.0,2578254.0
+Oklahoma,40,All,108.0,55.0,100.0,100.0,100.0,100.0,23.85,5.69,,,452791.0,966607.0
+Oregon,41,All,98.0,18.0,100.0,100.0,100.0,100.0,23.82,2.16,,,411448.0,831830.0
+Pennsylvania,42,All,301.0,68.0,100.0,100.0,100.0,100.0,22.87,2.59,,,1316231.0,2629005.0
+Rhode Island,44,All,,,100.0,100.0,100.0,100.0,,,True,True,122389.0,203838.0
+South Carolina,45,All,219.0,56.0,100.0,100.0,100.0,100.0,39.6,4.89,,,552971.0,1144201.0
+South Dakota,46,All,23.0,,100.0,100.0,100.0,100.0,23.72,,,True,96949.0,221898.0
+Tennessee,47,All,291.0,96.0,100.0,100.0,100.0,100.0,39.86,6.11,,,730073.0,1570728.0
+Texas,48,All,836.0,277.0,100.0,100.0,100.0,100.0,24.66,3.66,,,3390793.0,7561125.0
+Utah,49,All,74.0,26.0,100.0,100.0,100.0,100.0,16.22,2.79,,,456119.0,933152.0
+Vermont,50,All,,,100.0,100.0,100.0,100.0,,,True,True,70744.0,114636.0
+Virginia,51,All,239.0,58.0,100.0,100.0,100.0,100.0,26.16,3.08,,,913720.0,1881544.0
+Washington,53,All,142.0,45.0,100.0,100.0,100.0,100.0,18.65,2.73,,,761547.0,1648070.0
+West Virginia,54,All,29.0,,100.0,100.0,100.0,100.0,16.46,,,True,176217.0,352212.0
+Wisconsin,55,All,124.0,43.0,100.0,100.0,100.0,100.0,19.8,3.44,,,626213.0,1249129.0
+Wyoming,56,All,24.0,,100.0,100.0,100.0,100.0,39.72,,,True,60430.0,129549.0

--- a/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_historical.csv
+++ b/python/tests/data/cdc_wisqars/golden_data/youth_by_race_and_ethnicity_state_historical.csv
@@ -1,2507 +1,2507 @@
-time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k
-2018,Alabama,01,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Alabama,01,Asian (NH),,-100.0,,0.0,,0.0
-2018,Alabama,01,Black or African American (NH),125.2,42.4,65.3,41.3,80.76,5.99
-2018,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Alabama,01,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Alabama,01,White (NH),-40.1,1.4,34.7,58.7,22.7,4.27
-2018,Alaska,02,Indigenous (NH),446.4,,100.0,,104.76,
-2018,Alaska,02,Asian (NH),-100.0,,0.0,,0.0,
-2018,Alaska,02,Black or African American (NH),,,,,,0.0
-2018,Alaska,02,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Alaska,02,Two or more races (NH),,,,,,
-2018,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2018,Alaska,02,White (NH),,,,,,
-2018,Arizona,04,Indigenous (NH),,,,,,
-2018,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0
-2018,Arizona,04,Black or African American (NH),253.1,,17.3,,65.77,
-2018,Arizona,04,Hispanic or Latino,2.2,-0.9,45.5,44.1,22.0,2.0
-2018,Arizona,04,Two or more races (NH),,,,,,
-2018,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2018,Arizona,04,White (NH),-3.6,44.8,37.2,55.9,17.43,3.0
-2018,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Arkansas,05,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Arkansas,05,Black or African American (NH),194.4,,52.7,,81.25,
-2018,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Arkansas,05,White (NH),-24.8,59.0,47.3,100.0,20.9,3.16
-2018,California,06,Indigenous (NH),375.0,-100.0,1.9,0.0,55.64,0.0
-2018,California,06,Asian (NH),-79.7,,2.5,,2.36,
-2018,California,06,Black or African American (NH),314.0,332.0,20.7,21.6,42.21,4.2
-2018,California,06,Hispanic or Latino,2.3,-2.9,52.7,50.0,13.0,1.0
-2018,California,06,Two or more races (NH),-13.7,,4.4,,14.14,
-2018,California,06,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2018,California,06,White (NH),-29.6,12.3,17.8,28.4,7.52,1.1
-2018,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Colorado,08,Asian (NH),,,,,,
-2018,Colorado,08,Black or African American (NH),290.7,,16.8,,77.5,
-2018,Colorado,08,Hispanic or Latino,-5.4,-1.0,29.8,31.2,23.0,3.0
-2018,Colorado,08,Two or more races (NH),,,,,,
-2018,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Colorado,08,White (NH),-4.3,23.3,53.4,68.8,19.02,3.12
-2018,Connecticut,09,Indigenous (NH),,,,,0.0,0.0
-2018,Connecticut,09,Asian (NH),,,,,0.0,0.0
-2018,Connecticut,09,Black or African American (NH),,,,,,
-2018,Connecticut,09,Hispanic or Latino,,,,,0.0,0.0
-2018,Connecticut,09,Two or more races (NH),,,,,0.0,0.0
-2018,Connecticut,09,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2018,Connecticut,09,White (NH),,,,,,
-2018,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,
-2018,Delaware,10,Black or African American (NH),296.8,,100.0,,69.26,
-2018,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Delaware,10,White (NH),,,,,,
-2018,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,District of Columbia,11,Black or African American (NH),83.2,,100.0,,127.94,
-2018,District of Columbia,11,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,District of Columbia,11,White (NH),,,,,,0.0
-2018,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,
-2018,Florida,12,Asian (NH),,,,,,
-2018,Florida,12,Black or African American (NH),145.5,62.9,49.6,32.9,50.15,3.28
-2018,Florida,12,Hispanic or Latino,-38.8,-19.5,18.8,24.7,13.0,2.0
-2018,Florida,12,Two or more races (NH),,,,,,
-2018,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Florida,12,White (NH),-25.5,0.2,31.5,42.4,14.41,2.01
-2018,Georgia,13,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Georgia,13,Asian (NH),,,,,,
-2018,Georgia,13,Black or African American (NH),96.1,88.7,65.7,63.2,47.99,5.7
-2018,Georgia,13,Hispanic or Latino,-58.9,-100.0,6.0,0.0,14.0,0.0
-2018,Georgia,13,Two or more races (NH),,,,,,
-2018,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Georgia,13,White (NH),-35.2,-15.8,28.3,36.8,15.76,2.56
-2018,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2018,Hawaii,15,Asian (NH),,,,,0.0,0.0
-2018,Hawaii,15,Black or African American (NH),,,,,0.0,0.0
-2018,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2018,Hawaii,15,Two or more races (NH),,,,,0.0,0.0
-2018,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2018,Hawaii,15,White (NH),,,,,0.0,0.0
-2018,Idaho,16,Indigenous (NH),,,,,,
-2018,Idaho,16,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Idaho,16,Black or African American (NH),,,,,,0.0
-2018,Idaho,16,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Idaho,16,Two or more races (NH),-100.0,,0.0,,0.0,
-2018,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Idaho,16,White (NH),33.5,,100.0,,26.26,
-2018,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0
-2018,Illinois,17,Black or African American (NH),357.5,417.6,70.0,79.2,101.97,13.91
-2018,Illinois,17,Hispanic or Latino,-44.5,-100.0,13.6,0.0,15.0,0.0
-2018,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Illinois,17,White (NH),-67.9,-59.3,16.4,20.8,7.33,1.1
-2018,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0
-2018,Indiana,18,Black or African American (NH),312.4,360.2,46.6,52.0,107.81,14.64
-2018,Indiana,18,Hispanic or Latino,-53.1,-100.0,5.3,0.0,15.0,0.0
-2018,Indiana,18,Two or more races (NH),,,,,,
-2018,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Indiana,18,White (NH),-31.8,-31.9,48.1,48.0,16.51,2.17
-2018,Iowa,19,Indigenous (NH),,,,,,0.0
-2018,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Iowa,19,Black or African American (NH),,,,,,
-2018,Iowa,19,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Iowa,19,Two or more races (NH),-100.0,,0.0,,0.0,
-2018,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Iowa,19,White (NH),30.0,,100.0,,13.01,
-2018,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Kansas,20,Asian (NH),-100.0,,0.0,,0.0,
-2018,Kansas,20,Black or African American (NH),337.1,,27.1,,80.65,
-2018,Kansas,20,Hispanic or Latino,-9.0,-100.0,17.1,0.0,23.0,0.0
-2018,Kansas,20,Two or more races (NH),,,,,,
-2018,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Kansas,20,White (NH),-15.7,51.3,55.7,100.0,16.92,2.35
-2018,Kentucky,21,Indigenous (NH),-100.0,,0.0,,0.0,
-2018,Kentucky,21,Asian (NH),,-100.0,,0.0,,0.0
-2018,Kentucky,21,Black or African American (NH),284.6,,35.0,,70.52,
-2018,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Kentucky,21,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Kentucky,21,White (NH),-16.8,28.0,65.0,100.0,17.54,2.54
-2018,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Louisiana,22,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Louisiana,22,Black or African American (NH),99.2,64.6,73.1,60.4,82.61,7.95
-2018,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Louisiana,22,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Louisiana,22,White (NH),-47.2,-22.2,26.9,39.6,22.46,3.75
-2018,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Maine,23,Black or African American (NH),,,,,,0.0
-2018,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Maine,23,Two or more races (NH),,,,,,0.0
-2018,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Maine,23,White (NH),13.3,,100.0,,10.87,
-2018,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Maryland,24,Asian (NH),,,,,,
-2018,Maryland,24,Black or African American (NH),158.8,94.8,79.7,60.0,53.3,3.64
-2018,Maryland,24,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Maryland,24,White (NH),-51.3,-4.1,20.3,40.0,9.57,1.79
-2018,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,Massachusetts,25,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Massachusetts,25,Black or African American (NH),348.9,,39.5,,25.99,
-2018,Massachusetts,25,Hispanic or Latino,88.6,,34.9,,12.0,0.0
-2018,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Massachusetts,25,White (NH),-58.0,,25.6,,2.12,
-2018,Michigan,26,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Michigan,26,Asian (NH),,,,,,
-2018,Michigan,26,Black or African American (NH),258.1,191.9,57.3,46.7,73.4,6.08
-2018,Michigan,26,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Michigan,26,Two or more races (NH),,,,,,
-2018,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Michigan,26,White (NH),-35.9,-20.0,42.7,53.3,12.4,1.67
-2018,Minnesota,27,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0
-2018,Minnesota,27,Black or African American (NH),212.0,,31.2,,43.91,
-2018,Minnesota,27,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Minnesota,27,Two or more races (NH),,,,,,
-2018,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Minnesota,27,White (NH),1.2,47.1,68.8,100.0,10.45,1.58
-2018,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Mississippi,28,Asian (NH),,-100.0,,0.0,,0.0
-2018,Mississippi,28,Black or African American (NH),68.4,139.2,70.4,100.0,70.59,8.46
-2018,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Mississippi,28,Two or more races (NH),,,,,,
-2018,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Mississippi,28,White (NH),-40.0,,29.6,,25.63,
-2018,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Missouri,29,Asian (NH),-100.0,,0.0,,0.0,
-2018,Missouri,29,Black or African American (NH),338.5,235.6,59.2,45.3,135.62,15.61
-2018,Missouri,29,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Missouri,29,Two or more races (NH),,,,,,
-2018,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Missouri,29,White (NH),-43.6,-24.4,40.8,54.7,17.47,3.51
-2018,Montana,30,Indigenous (NH),,,,,,
-2018,Montana,30,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Montana,30,Black or African American (NH),,,,,,0.0
-2018,Montana,30,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Montana,30,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Montana,30,White (NH),28.5,,100.0,,16.36,
-2018,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,
-2018,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Nebraska,31,Black or African American (NH),,,,,,0.0
-2018,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Nebraska,31,Two or more races (NH),,,,,,0.0
-2018,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Nebraska,31,White (NH),47.1,,100.0,,12.04,
-2018,Nevada,32,Indigenous (NH),,,,,,0.0
-2018,Nevada,32,Asian (NH),,,,,,
-2018,Nevada,32,Black or African American (NH),188.3,,29.7,,70.82,
-2018,Nevada,32,Hispanic or Latino,-14.2,,35.1,,23.0,0.0
-2018,Nevada,32,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2018,Nevada,32,White (NH),1.4,,35.1,,24.63,
-2018,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,New Hampshire,33,White (NH),18.3,,100.0,,16.21,
-2018,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,New Jersey,34,Asian (NH),,,,,,0.0
-2018,New Jersey,34,Black or African American (NH),371.6,,63.2,,35.93,
-2018,New Jersey,34,Hispanic or Latino,-31.1,,18.4,,7.0,0.0
-2018,New Jersey,34,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,New Jersey,34,White (NH),-60.3,,18.4,,3.21,
-2018,New Mexico,35,Indigenous (NH),,,,,,
-2018,New Mexico,35,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,New Mexico,35,Black or African American (NH),,,,,,0.0
-2018,New Mexico,35,Hispanic or Latino,15.6,,71.2,,40.0,0.0
-2018,New Mexico,35,Two or more races (NH),,,,,,0.0
-2018,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,New Mexico,35,White (NH),24.7,,28.8,,34.88,
-2018,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,New York,36,Asian (NH),,-100.0,,0.0,,0.0
-2018,New York,36,Black or African American (NH),247.3,237.8,51.4,50.0,22.95,2.48
-2018,New York,36,Hispanic or Latino,-32.8,-100.0,16.4,0.0,5.0,0.0
-2018,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,New York,36,White (NH),-33.2,3.7,32.2,50.0,4.43,0.76
-2018,North Carolina,37,Indigenous (NH),,,,,,
-2018,North Carolina,37,Asian (NH),,,,,,
-2018,North Carolina,37,Black or African American (NH),171.6,113.8,61.1,48.1,48.82,5.02
-2018,North Carolina,37,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,North Carolina,37,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2018,North Carolina,37,White (NH),-25.0,0.0,38.9,51.9,13.4,2.34
-2018,North Dakota,38,Indigenous (NH),,,,,,0.0
-2018,North Dakota,38,Asian (NH),,,,,0.0,0.0
-2018,North Dakota,38,Black or African American (NH),,,,,0.0,0.0
-2018,North Dakota,38,Hispanic or Latino,,,,,0.0,0.0
-2018,North Dakota,38,Two or more races (NH),,,,,0.0,0.0
-2018,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2018,North Dakota,38,White (NH),,,,,,
-2018,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0
-2018,Ohio,39,Black or African American (NH),232.5,194.0,50.2,44.4,76.03,8.17
-2018,Ohio,39,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Ohio,39,White (NH),-29.7,-21.5,49.8,55.6,15.05,2.18
-2018,Oklahoma,40,Indigenous (NH),,,,,,
-2018,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0
-2018,Oklahoma,40,Black or African American (NH),361.0,,35.5,,54.51,
-2018,Oklahoma,40,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Oklahoma,40,Two or more races (NH),,,,,,
-2018,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Oklahoma,40,White (NH),23.6,91.6,64.5,100.0,16.35,3.41
-2018,Oregon,41,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Oregon,41,Asian (NH),,-100.0,,0.0,,0.0
-2018,Oregon,41,Black or African American (NH),,,,,,
-2018,Oregon,41,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Oregon,41,Two or more races (NH),,,,,,
-2018,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Oregon,41,White (NH),57.7,57.7,100.0,100.0,16.25,2.91
-2018,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Pennsylvania,42,Asian (NH),,,,,,
-2018,Pennsylvania,42,Black or African American (NH),286.0,351.9,49.8,58.3,84.74,8.16
-2018,Pennsylvania,42,Hispanic or Latino,-26.8,-100.0,9.3,0.0,21.0,0.0
-2018,Pennsylvania,42,Two or more races (NH),,,,,,
-2018,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Pennsylvania,42,White (NH),-38.2,-37.0,40.9,41.7,13.37,1.14
-2018,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2018,Rhode Island,44,Asian (NH),,,,,,0.0
-2018,Rhode Island,44,Black or African American (NH),,,,,,
-2018,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2018,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2018,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2018,Rhode Island,44,White (NH),,,,,,0.0
-2018,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,South Carolina,45,Asian (NH),,-100.0,,0.0,,0.0
-2018,South Carolina,45,Black or African American (NH),90.5,133.9,56.2,69.0,60.41,8.86
-2018,South Carolina,45,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,South Carolina,45,White (NH),-19.8,-43.2,43.8,31.0,24.98,2.15
-2018,South Dakota,46,Indigenous (NH),,,,,,
-2018,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,South Dakota,46,Black or African American (NH),,,,,,0.0
-2018,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,South Dakota,46,Two or more races (NH),,,,,,0.0
-2018,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,South Dakota,46,White (NH),41.2,,100.0,,23.35,
-2018,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Tennessee,47,Asian (NH),-100.0,,0.0,,0.0,
-2018,Tennessee,47,Black or African American (NH),230.5,143.7,62.8,46.3,103.14,8.72
-2018,Tennessee,47,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Tennessee,47,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Tennessee,47,White (NH),-42.8,-17.4,37.2,53.7,18.37,2.95
-2018,Texas,48,Indigenous (NH),,,,,,
-2018,Texas,48,Asian (NH),-56.5,,2.0,,8.54,
-2018,Texas,48,Black or African American (NH),173.1,60.5,32.5,19.1,47.27,3.86
-2018,Texas,48,Hispanic or Latino,-26.5,-9.6,36.1,44.4,15.0,2.0
-2018,Texas,48,Two or more races (NH),,,,,,
-2018,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Texas,48,White (NH),-6.1,16.2,29.5,36.5,16.45,2.81
-2018,Utah,49,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Utah,49,Asian (NH),,,,,,
-2018,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0
-2018,Utah,49,Hispanic or Latino,4.5,-100.0,18.5,0.0,15.0,0.0
-2018,Utah,49,Two or more races (NH),,,,,,
-2018,Utah,49,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2018,Utah,49,White (NH),10.3,35.3,81.5,100.0,14.54,2.76
-2018,Vermont,50,Indigenous (NH),,,,,0.0,0.0
-2018,Vermont,50,Asian (NH),,,,,0.0,0.0
-2018,Vermont,50,Black or African American (NH),,,,,,0.0
-2018,Vermont,50,Hispanic or Latino,,,,,0.0,0.0
-2018,Vermont,50,Two or more races (NH),,,,,0.0,0.0
-2018,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2018,Vermont,50,White (NH),,,,,,0.0
-2018,Virginia,51,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Virginia,51,Asian (NH),,,,,,
-2018,Virginia,51,Black or African American (NH),147.7,117.1,49.3,43.2,54.18,4.31
-2018,Virginia,51,Hispanic or Latino,-43.2,-100.0,7.9,0.0,16.0,0.0
-2018,Virginia,51,Two or more races (NH),,,,,,
-2018,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Virginia,51,White (NH),-19.7,6.6,42.8,56.8,17.5,2.11
-2018,Washington,53,Indigenous (NH),,,,,,
-2018,Washington,53,Asian (NH),,,,,,
-2018,Washington,53,Black or African American (NH),119.0,,9.2,,30.16,
-2018,Washington,53,Hispanic or Latino,23.4,-100.0,26.9,0.0,23.0,0.0
-2018,Washington,53,Two or more races (NH),,,,,,
-2018,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2018,Washington,53,White (NH),15.1,80.2,63.9,100.0,16.65,1.85
-2018,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,West Virginia,54,Black or African American (NH),,,,,,0.0
-2018,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,West Virginia,54,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,West Virginia,54,White (NH),12.6,,100.0,,20.23,
-2018,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0
-2018,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0
-2018,Wisconsin,55,Black or African American (NH),369.7,,41.8,,75.35,
-2018,Wisconsin,55,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2018,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0
-2018,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2018,Wisconsin,55,White (NH),-16.3,43.9,58.2,100.0,11.17,1.13
-2018,Wyoming,56,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2018,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0
-2018,Wyoming,56,Black or African American (NH),,,,,,0.0
-2018,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2018,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2018,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2018,Wyoming,56,White (NH),30.0,,100.0,,40.2,
-2019,Alabama,01,Indigenous (NH),,,,,,
-2019,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Alabama,01,Black or African American (NH),131.8,77.5,67.0,51.3,80.03,6.35
-2019,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Alabama,01,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Alabama,01,White (NH),-42.7,-15.5,33.0,48.7,20.5,3.03
-2019,Alaska,02,Indigenous (NH),117.4,,40.0,,76.23,
-2019,Alaska,02,Asian (NH),-100.0,,0.0,,0.0,
-2019,Alaska,02,Black or African American (NH),,,,,,0.0
-2019,Alaska,02,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Alaska,02,Two or more races (NH),,,,,,
-2019,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Alaska,02,White (NH),26.3,,60.0,,36.38,
-2019,Arizona,04,Indigenous (NH),,,,,,
-2019,Arizona,04,Asian (NH),,,,,,
-2019,Arizona,04,Black or African American (NH),152.0,,12.6,,45.63,
-2019,Arizona,04,Hispanic or Latino,8.1,24.4,48.3,55.6,22.0,2.0
-2019,Arizona,04,Two or more races (NH),,,,,,
-2019,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Arizona,04,White (NH),2.1,15.9,39.1,44.4,17.64,1.91
-2019,Arkansas,05,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0
-2019,Arkansas,05,Black or African American (NH),157.9,461.8,45.9,100.0,84.05,9.61
-2019,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2019,Arkansas,05,White (NH),-13.6,,54.1,,28.31,
-2019,California,06,Indigenous (NH),,,,,,
-2019,California,06,Asian (NH),-68.0,,4.0,,3.48,
-2019,California,06,Black or African American (NH),360.0,308.0,23.0,20.4,44.05,4.28
-2019,California,06,Hispanic or Latino,-0.8,25.2,51.1,64.5,12.0,1.0
-2019,California,06,Two or more races (NH),-23.1,,4.0,,11.61,
-2019,California,06,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2019,California,06,White (NH),-28.4,-39.6,17.9,15.1,7.09,0.63
-2019,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Colorado,08,Asian (NH),,,,,,
-2019,Colorado,08,Black or African American (NH),251.2,,15.1,,67.56,
-2019,Colorado,08,Hispanic or Latino,-22.2,22.5,24.6,38.7,18.0,3.0
-2019,Colorado,08,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2019,Colorado,08,White (NH),8.6,10.5,60.3,61.3,20.73,2.72
-2019,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Connecticut,09,Black or African American (NH),769.6,,100.0,,21.79,
-2019,Connecticut,09,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Connecticut,09,White (NH),,,,,,
-2019,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Delaware,10,Black or African American (NH),295.3,,100.0,,46.47,
-2019,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Delaware,10,White (NH),,,,,,0.0
-2019,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,District of Columbia,11,Black or African American (NH),88.0,,100.0,,165.05,
-2019,District of Columbia,11,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0
-2019,Florida,12,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Florida,12,Asian (NH),,-100.0,,0.0,,0.0
-2019,Florida,12,Black or African American (NH),170.6,151.7,54.4,50.6,57.07,5.29
-2019,Florida,12,Hispanic or Latino,-45.7,-49.5,16.9,15.7,12.0,1.0
-2019,Florida,12,Two or more races (NH),,,,,,
-2019,Florida,12,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2019,Florida,12,White (NH),-31.9,-19.8,28.6,33.7,13.56,1.69
-2019,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Georgia,13,Asian (NH),,,,,,
-2019,Georgia,13,Black or African American (NH),108.6,74.1,70.1,58.5,57.33,4.51
-2019,Georgia,13,Hispanic or Latino,-65.5,-100.0,5.1,0.0,13.0,0.0
-2019,Georgia,13,Two or more races (NH),,,,,,
-2019,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Georgia,13,White (NH),-42.6,-3.9,24.8,41.5,15.35,2.5
-2019,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2019,Hawaii,15,Asian (NH),,,,,0.0,0.0
-2019,Hawaii,15,Black or African American (NH),,,,,0.0,0.0
-2019,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2019,Hawaii,15,Two or more races (NH),,,,,,0.0
-2019,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Hawaii,15,White (NH),,,,,,0.0
-2019,Idaho,16,Indigenous (NH),,,,,,0.0
-2019,Idaho,16,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Idaho,16,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2019,Idaho,16,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Idaho,16,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Idaho,16,White (NH),33.9,,100.0,,22.43,
-2019,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0
-2019,Illinois,17,Black or African American (NH),363.4,326.8,70.9,65.3,103.78,14.83
-2019,Illinois,17,Hispanic or Latino,-41.5,-29.7,14.4,17.3,15.0,2.0
-2019,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Illinois,17,White (NH),-71.1,-66.0,14.7,17.3,6.5,1.19
-2019,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0
-2019,Indiana,18,Black or African American (NH),358.8,400.9,52.3,57.1,126.57,13.46
-2019,Indiana,18,Hispanic or Latino,-42.6,-100.0,6.6,0.0,19.0,0.0
-2019,Indiana,18,Two or more races (NH),,,,,,
-2019,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Indiana,18,White (NH),-41.3,-38.7,41.1,42.9,14.82,1.64
-2019,Iowa,19,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,
-2019,Iowa,19,Black or African American (NH),,,,,,
-2019,Iowa,19,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Iowa,19,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Iowa,19,White (NH),30.7,,100.0,,13.51,
-2019,Kansas,20,Indigenous (NH),,,,,,
-2019,Kansas,20,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Kansas,20,Black or African American (NH),208.1,,19.1,,57.22,
-2019,Kansas,20,Hispanic or Latino,-22.2,-100.0,14.7,0.0,19.0,0.0
-2019,Kansas,20,Two or more races (NH),,,,,,
-2019,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Kansas,20,White (NH),0.5,51.7,66.2,100.0,19.81,2.38
-2019,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Kentucky,21,Asian (NH),,-100.0,,0.0,,0.0
-2019,Kentucky,21,Black or African American (NH),408.7,426.1,46.8,48.4,86.57,16.27
-2019,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Kentucky,21,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Kentucky,21,White (NH),-31.6,-33.7,53.2,51.6,13.19,2.05
-2019,Louisiana,22,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0
-2019,Louisiana,22,Black or African American (NH),102.7,84.4,74.0,67.3,82.02,9.3
-2019,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Louisiana,22,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Louisiana,22,White (NH),-48.7,-35.5,26.0,32.7,21.18,3.26
-2019,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Maine,23,Black or African American (NH),,,,,,0.0
-2019,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Maine,23,Two or more races (NH),,,,,,0.0
-2019,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Maine,23,White (NH),13.8,,100.0,,13.79,
-2019,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Maryland,24,Asian (NH),,-100.0,,0.0,,0.0
-2019,Maryland,24,Black or African American (NH),196.4,225.7,91.0,100.0,77.28,4.39
-2019,Maryland,24,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Maryland,24,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Maryland,24,White (NH),-78.1,,9.0,,5.42,
-2019,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,Massachusetts,25,Asian (NH),,,,,,0.0
-2019,Massachusetts,25,Black or African American (NH),300.0,,35.6,,24.64,
-2019,Massachusetts,25,Hispanic or Latino,63.7,,31.1,,11.0,0.0
-2019,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Massachusetts,25,White (NH),-44.7,,33.3,,2.92,
-2019,Michigan,26,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Michigan,26,Asian (NH),,-100.0,,0.0,,0.0
-2019,Michigan,26,Black or African American (NH),287.5,252.5,62.0,56.4,74.75,6.41
-2019,Michigan,26,Hispanic or Latino,-19.5,-100.0,7.0,0.0,18.0,0.0
-2019,Michigan,26,Two or more races (NH),,,,,,
-2019,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Michigan,26,White (NH),-53.2,-34.2,31.0,43.6,8.32,1.2
-2019,Minnesota,27,Indigenous (NH),,,,,,
-2019,Minnesota,27,Asian (NH),,,,,,
-2019,Minnesota,27,Black or African American (NH),285.4,,39.7,,53.75,
-2019,Minnesota,27,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Minnesota,27,White (NH),-10.7,48.1,60.3,100.0,9.15,1.25
-2019,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Mississippi,28,Asian (NH),,,,,,
-2019,Mississippi,28,Black or African American (NH),74.3,16.8,72.5,48.6,74.44,5.83
-2019,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Mississippi,28,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Mississippi,28,White (NH),-44.1,4.5,27.5,51.4,24.01,5.23
-2019,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Missouri,29,Asian (NH),,,,,,
-2019,Missouri,29,Black or African American (NH),326.7,410.4,57.6,68.9,157.16,22.68
-2019,Missouri,29,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Missouri,29,Two or more races (NH),,,,,,
-2019,Missouri,29,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2019,Missouri,29,White (NH),-41.2,-56.9,42.4,31.1,21.19,1.92
-2019,Montana,30,Indigenous (NH),,,,,,
-2019,Montana,30,Asian (NH),-100.0,,0.0,,0.0,
-2019,Montana,30,Black or African American (NH),,,,,,0.0
-2019,Montana,30,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Montana,30,Two or more races (NH),-100.0,,0.0,,0.0,
-2019,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Montana,30,White (NH),28.7,,100.0,,21.98,
-2019,Nebraska,31,Indigenous (NH),,,,,,0.0
-2019,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Nebraska,31,Black or African American (NH),473.3,,34.4,,89.16,
-2019,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,
-2019,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Nebraska,31,White (NH),-3.0,,65.6,,13.46,
-2019,Nevada,32,Indigenous (NH),,,,,,0.0
-2019,Nevada,32,Asian (NH),,,,,,0.0
-2019,Nevada,32,Black or African American (NH),69.8,,18.0,,35.45,
-2019,Nevada,32,Hispanic or Latino,-20.0,,32.8,,17.0,0.0
-2019,Nevada,32,Two or more races (NH),,,,,,
-2019,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Nevada,32,White (NH),44.3,,49.2,,28.6,
-2019,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2019,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2019,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,New Hampshire,33,Two or more races (NH),,,,,,0.0
-2019,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,New Hampshire,33,White (NH),19.0,,100.0,,14.04,0.0
-2019,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New Jersey,34,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New Jersey,34,Black or African American (NH),526.3,651.9,83.3,100.0,38.36,4.63
-2019,New Jersey,34,Hispanic or Latino,-38.6,-100.0,16.7,0.0,5.0,0.0
-2019,New Jersey,34,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New Jersey,34,White (NH),,,,,,
-2019,New Mexico,35,Indigenous (NH),,,,,,
-2019,New Mexico,35,Asian (NH),,-100.0,,0.0,,0.0
-2019,New Mexico,35,Black or African American (NH),,,,,,
-2019,New Mexico,35,Hispanic or Latino,11.5,62.1,68.8,100.0,34.0,5.0
-2019,New Mexico,35,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New Mexico,35,White (NH),36.2,,31.2,,33.82,
-2019,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New York,36,Asian (NH),,,,,,
-2019,New York,36,Black or African American (NH),270.7,240.1,54.5,50.0,21.17,1.85
-2019,New York,36,Hispanic or Latino,-40.7,-100.0,14.6,0.0,4.0,0.0
-2019,New York,36,Two or more races (NH),,,,,,
-2019,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,New York,36,White (NH),-35.5,4.4,30.9,50.0,3.65,0.57
-2019,North Carolina,37,Indigenous (NH),,,,,,
-2019,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0
-2019,North Carolina,37,Black or African American (NH),161.2,213.4,58.5,70.2,57.85,6.38
-2019,North Carolina,37,Hispanic or Latino,-58.6,-100.0,7.0,0.0,14.0,0.0
-2019,North Carolina,37,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,North Carolina,37,White (NH),-33.1,-42.0,34.4,29.8,14.48,1.18
-2019,North Dakota,38,Indigenous (NH),,,,,0.0,0.0
-2019,North Dakota,38,Asian (NH),,,,,0.0,0.0
-2019,North Dakota,38,Black or African American (NH),,,,,0.0,0.0
-2019,North Dakota,38,Hispanic or Latino,,,,,0.0,0.0
-2019,North Dakota,38,Two or more races (NH),,,,,,0.0
-2019,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2019,North Dakota,38,White (NH),,,,,,
-2019,Ohio,39,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Ohio,39,Asian (NH),,,,,,
-2019,Ohio,39,Black or African American (NH),272.4,213.8,56.6,47.7,87.79,7.92
-2019,Ohio,39,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Ohio,39,White (NH),-38.4,-25.7,43.4,52.3,13.3,1.87
-2019,Oklahoma,40,Indigenous (NH),,,,,,
-2019,Oklahoma,40,Asian (NH),-100.0,,0.0,,0.0,
-2019,Oklahoma,40,Black or African American (NH),457.9,,42.4,,90.63,
-2019,Oklahoma,40,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Oklahoma,40,Two or more races (NH),,,,,,
-2019,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2019,Oklahoma,40,White (NH),11.2,93.1,57.6,100.0,20.17,5.26
-2019,Oregon,41,Indigenous (NH),,,,,,0.0
-2019,Oregon,41,Asian (NH),,,,,,0.0
-2019,Oregon,41,Black or African American (NH),,,,,,0.0
-2019,Oregon,41,Hispanic or Latino,-27.1,,16.4,,13.0,0.0
-2019,Oregon,41,Two or more races (NH),,,,,,0.0
-2019,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Oregon,41,White (NH),32.5,,83.6,,20.47,
-2019,Pennsylvania,42,Indigenous (NH),-100.0,,0.0,,0.0,
-2019,Pennsylvania,42,Asian (NH),,-100.0,,0.0,,0.0
-2019,Pennsylvania,42,Black or African American (NH),331.0,296.9,55.6,51.2,83.07,6.45
-2019,Pennsylvania,42,Hispanic or Latino,-28.5,-100.0,9.3,0.0,18.0,0.0
-2019,Pennsylvania,42,Two or more races (NH),,,,,,
-2019,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2019,Pennsylvania,42,White (NH),-46.7,-25.7,35.0,48.8,10.0,1.21
-2019,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2019,Rhode Island,44,Asian (NH),,,,,0.0,0.0
-2019,Rhode Island,44,Black or African American (NH),,,,,0.0,
-2019,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2019,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2019,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2019,Rhode Island,44,White (NH),,,,,,0.0
-2019,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,South Carolina,45,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,South Carolina,45,Black or African American (NH),137.5,51.5,69.6,44.4,88.36,6.13
-2019,South Carolina,45,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,South Carolina,45,White (NH),-44.1,2.2,30.4,55.6,20.13,4.13
-2019,South Dakota,46,Indigenous (NH),,,,,,
-2019,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2019,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,South Dakota,46,Two or more races (NH),,,,,,0.0
-2019,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,South Dakota,46,White (NH),41.6,,100.0,,22.18,
-2019,Tennessee,47,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0
-2019,Tennessee,47,Black or African American (NH),209.0,158.2,58.4,48.8,82.99,7.35
-2019,Tennessee,47,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Tennessee,47,Two or more races (NH),,,,,,
-2019,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Tennessee,47,White (NH),-35.7,-20.9,41.6,51.2,17.43,2.25
-2019,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Texas,48,Asian (NH),-61.7,,1.8,,8.37,
-2019,Texas,48,Black or African American (NH),161.7,146.7,31.4,29.6,49.34,6.74
-2019,Texas,48,Hispanic or Latino,-27.8,-37.0,35.5,31.0,16.0,2.0
-2019,Texas,48,Two or more races (NH),,,,,,
-2019,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2019,Texas,48,White (NH),0.6,26.7,31.3,39.4,18.8,3.47
-2019,Utah,49,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Utah,49,Asian (NH),,,,,,
-2019,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0
-2019,Utah,49,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2019,Utah,49,White (NH),36.1,36.1,100.0,100.0,17.22,2.05
-2019,Vermont,50,Indigenous (NH),,,,,0.0,0.0
-2019,Vermont,50,Asian (NH),,,,,0.0,0.0
-2019,Vermont,50,Black or African American (NH),,,,,,0.0
-2019,Vermont,50,Hispanic or Latino,,,,,0.0,0.0
-2019,Vermont,50,Two or more races (NH),,,,,0.0,0.0
-2019,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2019,Vermont,50,White (NH),,,,,,
-2019,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Virginia,51,Asian (NH),,-100.0,,0.0,,0.0
-2019,Virginia,51,Black or African American (NH),184.4,235.2,56.6,66.7,51.53,7.01
-2019,Virginia,51,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Virginia,51,Two or more races (NH),,,,,,
-2019,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Virginia,51,White (NH),-17.8,-36.9,43.4,33.3,14.59,1.32
-2019,Washington,53,Indigenous (NH),,,,,,
-2019,Washington,53,Asian (NH),,-100.0,,0.0,,0.0
-2019,Washington,53,Black or African American (NH),355.8,,19.6,,51.55,
-2019,Washington,53,Hispanic or Latino,3.2,-100.0,22.7,0.0,16.0,0.0
-2019,Washington,53,Two or more races (NH),,,,,,
-2019,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2019,Washington,53,White (NH),5.1,82.1,57.7,100.0,12.44,1.43
-2019,West Virginia,54,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,West Virginia,54,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,West Virginia,54,Black or African American (NH),,-100.0,,0.0,,0.0
-2019,West Virginia,54,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,West Virginia,54,Two or more races (NH),,-100.0,,0.0,,0.0
-2019,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,West Virginia,54,White (NH),12.9,12.9,100.0,100.0,20.5,3.13
-2019,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0
-2019,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0
-2019,Wisconsin,55,Black or African American (NH),274.2,,33.3,,56.74,
-2019,Wisconsin,55,Hispanic or Latino,23.0,-100.0,15.5,0.0,23.0,0.0
-2019,Wisconsin,55,Two or more races (NH),,,,,,
-2019,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2019,Wisconsin,55,White (NH),-26.1,44.3,51.2,100.0,9.19,1.37
-2019,Wyoming,56,Indigenous (NH),,,,,,
-2019,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0
-2019,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2019,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2019,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2019,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2019,Wyoming,56,White (NH),30.5,,100.0,,32.03,
-2020,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Alabama,01,Black or African American (NH),139.4,79.1,68.7,51.4,105.32,5.87
-2020,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Alabama,01,Two or more races (NH),,,,,,
-2020,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Alabama,01,White (NH),-44.7,-14.1,31.3,48.6,24.98,2.81
-2020,Alaska,02,Indigenous (NH),228.9,,61.5,,121.03,
-2020,Alaska,02,Asian (NH),,,,,,
-2020,Alaska,02,Black or African American (NH),,,,,,0.0
-2020,Alaska,02,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Alaska,02,Two or more races (NH),,,,,,
-2020,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2020,Alaska,02,White (NH),-19.3,,38.5,,25.07,
-2020,Arizona,04,Indigenous (NH),70.2,,8.0,,40.0,
-2020,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0
-2020,Arizona,04,Black or African American (NH),242.3,369.2,17.8,24.4,75.19,13.11
-2020,Arizona,04,Hispanic or Latino,-11.1,-2.5,38.5,42.2,22.0,3.0
-2020,Arizona,04,Two or more races (NH),,,,,,
-2020,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Arizona,04,White (NH),-9.0,-14.8,35.6,33.3,18.8,2.4
-2020,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Arkansas,05,Asian (NH),-100.0,,0.0,,0.0,
-2020,Arkansas,05,Black or African American (NH),219.2,222.6,56.5,57.1,119.87,19.16
-2020,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Arkansas,05,Two or more races (NH),,,,,,
-2020,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Arkansas,05,White (NH),-29.5,-30.5,43.5,42.9,26.49,4.13
-2020,California,06,Indigenous (NH),,,,,,
-2020,California,06,Asian (NH),-73.2,,3.4,,3.89,
-2020,California,06,Black or African American (NH),392.0,392.0,24.6,24.6,64.31,6.73
-2020,California,06,Hispanic or Latino,2.5,2.1,52.7,52.5,16.0,1.0
-2020,California,06,Two or more races (NH),-11.3,,4.7,,17.63,
-2020,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,California,06,White (NH),-41.4,-7.6,14.6,23.0,7.81,1.26
-2020,Colorado,08,Indigenous (NH),,,,,,
-2020,Colorado,08,Asian (NH),-100.0,,0.0,,0.0,
-2020,Colorado,08,Black or African American (NH),295.3,,17.0,,87.67,
-2020,Colorado,08,Hispanic or Latino,-6.0,37.5,29.8,43.6,25.0,4.0
-2020,Colorado,08,Two or more races (NH),,,,,,
-2020,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Colorado,08,White (NH),-3.8,2.0,53.2,56.4,20.55,3.16
-2020,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,Connecticut,09,Black or African American (NH),762.1,,100.0,,59.57,
-2020,Connecticut,09,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Connecticut,09,White (NH),,,,,,
-2020,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,Delaware,10,Black or African American (NH),296.8,,100.0,,104.25,
-2020,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Delaware,10,Two or more races (NH),,,,,,0.0
-2020,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Delaware,10,White (NH),,,,,,
-2020,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,District of Columbia,11,Black or African American (NH),90.8,,100.0,,200.01,
-2020,District of Columbia,11,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0
-2020,Florida,12,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Florida,12,Asian (NH),,,,,,
-2020,Florida,12,Black or African American (NH),183.1,101.5,56.9,40.5,76.09,5.71
-2020,Florida,12,Hispanic or Latino,-52.2,-28.5,14.9,22.3,13.0,2.0
-2020,Florida,12,Two or more races (NH),,,,,,
-2020,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Florida,12,White (NH),-32.5,-11.0,28.2,37.2,16.65,2.52
-2020,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Georgia,13,Asian (NH),,,,,,
-2020,Georgia,13,Black or African American (NH),114.9,113.4,72.2,71.7,71.98,7.71
-2020,Georgia,13,Hispanic or Latino,-77.6,-100.0,3.5,0.0,10.0,0.0
-2020,Georgia,13,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Georgia,13,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Georgia,13,White (NH),-42.6,-33.1,24.3,28.3,18.4,2.41
-2020,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2020,Hawaii,15,Asian (NH),,,,,0.0,0.0
-2020,Hawaii,15,Black or African American (NH),,,,,0.0,0.0
-2020,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2020,Hawaii,15,Two or more races (NH),,,,,,0.0
-2020,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2020,Hawaii,15,White (NH),,,,,,0.0
-2020,Idaho,16,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Idaho,16,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Idaho,16,Black or African American (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Idaho,16,Hispanic or Latino,25.9,-100.0,23.8,0.0,29.0,0.0
-2020,Idaho,16,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Idaho,16,White (NH),2.4,34.4,76.2,100.0,20.67,3.81
-2020,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Illinois,17,Asian (NH),,,,,,
-2020,Illinois,17,Black or African American (NH),369.3,315.7,71.8,63.6,147.26,14.39
-2020,Illinois,17,Hispanic or Latino,-37.2,-16.2,15.9,21.2,22.0,3.0
-2020,Illinois,17,Two or more races (NH),,,,,,
-2020,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Illinois,17,White (NH),-75.4,-69.7,12.3,15.2,7.57,1.04
-2020,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0
-2020,Indiana,18,Black or African American (NH),368.1,314.2,52.9,46.8,186.98,15.97
-2020,Indiana,18,Hispanic or Latino,-52.0,-100.0,6.1,0.0,22.0,0.0
-2020,Indiana,18,Two or more races (NH),,,,,,
-2020,Indiana,18,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Indiana,18,White (NH),-40.3,-22.7,41.1,53.2,21.65,2.99
-2020,Iowa,19,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Iowa,19,Asian (NH),,-100.0,,0.0,,0.0
-2020,Iowa,19,Black or African American (NH),505.5,1718.2,33.3,100.0,92.35,24.35
-2020,Iowa,19,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Iowa,19,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Iowa,19,White (NH),-12.1,,66.7,,12.15,
-2020,Kansas,20,Indigenous (NH),,,,,,
-2020,Kansas,20,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kansas,20,Black or African American (NH),241.0,,20.8,,92.2,
-2020,Kansas,20,Hispanic or Latino,30.5,106.6,25.7,40.7,46.0,8.0
-2020,Kansas,20,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kansas,20,White (NH),-17.8,-8.9,53.5,59.3,23.86,3.45
-2020,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kentucky,21,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kentucky,21,Black or African American (NH),394.6,390.2,45.5,45.1,145.24,24.43
-2020,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kentucky,21,Two or more races (NH),,,,,,
-2020,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Kentucky,21,White (NH),-28.9,-28.4,54.5,54.9,22.75,3.56
-2020,Louisiana,22,Indigenous (NH),-100.0,,0.0,,0.0,
-2020,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0
-2020,Louisiana,22,Black or African American (NH),144.3,118.2,87.2,77.9,148.8,13.45
-2020,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Louisiana,22,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Louisiana,22,White (NH),-74.1,-55.3,12.8,22.1,15.95,2.75
-2020,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,Maine,23,Black or African American (NH),,,,,,0.0
-2020,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Maine,23,White (NH),14.2,,100.0,,13.91,
-2020,Maryland,24,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Maryland,24,Asian (NH),,,,,,
-2020,Maryland,24,Black or African American (NH),192.7,230.0,88.7,100.0,90.48,4.04
-2020,Maryland,24,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Maryland,24,White (NH),-71.6,,11.3,,8.3,
-2020,Massachusetts,25,Indigenous (NH),,,,,,0.0
-2020,Massachusetts,25,Asian (NH),,,,,,0.0
-2020,Massachusetts,25,Black or African American (NH),403.4,,44.8,,41.63,
-2020,Massachusetts,25,Hispanic or Latino,42.3,,27.6,,13.0,0.0
-2020,Massachusetts,25,Two or more races (NH),,,,,,0.0
-2020,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Massachusetts,25,White (NH),-53.7,,27.6,,3.27,
-2020,Michigan,26,Indigenous (NH),,,,,,
-2020,Michigan,26,Asian (NH),,-100.0,,0.0,,0.0
-2020,Michigan,26,Black or African American (NH),286.3,321.7,62.2,67.9,105.85,10.25
-2020,Michigan,26,Hispanic or Latino,-35.6,-100.0,5.8,0.0,19.0,0.0
-2020,Michigan,26,Two or more races (NH),,,,,,
-2020,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Michigan,26,White (NH),-51.4,-51.3,32.0,32.1,11.98,1.18
-2020,Minnesota,27,Indigenous (NH),,,,,,
-2020,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0
-2020,Minnesota,27,Black or African American (NH),365.4,861.5,48.4,100.0,63.53,8.67
-2020,Minnesota,27,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Minnesota,27,Two or more races (NH),,,,,,
-2020,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Minnesota,27,White (NH),-22.8,,51.6,,7.84,
-2020,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Mississippi,28,Black or African American (NH),91.3,70.6,79.4,70.8,99.87,11.71
-2020,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Mississippi,28,Two or more races (NH),-100.0,,0.0,,0.0,
-2020,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Mississippi,28,White (NH),-57.8,-40.2,20.6,29.2,21.61,4.1
-2020,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0
-2020,Missouri,29,Black or African American (NH),321.5,352.6,56.9,61.1,194.56,23.45
-2020,Missouri,29,Hispanic or Latino,-51.3,-100.0,3.8,0.0,26.0,0.0
-2020,Missouri,29,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Missouri,29,White (NH),-45.0,-45.4,39.2,38.9,24.1,2.82
-2020,Montana,30,Indigenous (NH),,,,,,
-2020,Montana,30,Asian (NH),,,,,,0.0
-2020,Montana,30,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2020,Montana,30,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Montana,30,Two or more races (NH),,,,,,
-2020,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Montana,30,White (NH),28.9,,100.0,,36.49,
-2020,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,
-2020,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,Nebraska,31,Black or African American (NH),583.6,,41.7,,82.34,
-2020,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Nebraska,31,Two or more races (NH),,,,,,
-2020,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Nebraska,31,White (NH),-12.9,,58.3,,9.04,
-2020,Nevada,32,Indigenous (NH),,,,,,0.0
-2020,Nevada,32,Asian (NH),,,,,,0.0
-2020,Nevada,32,Black or African American (NH),186.1,,30.9,,68.5,
-2020,Nevada,32,Hispanic or Latino,-30.6,,27.9,,16.0,0.0
-2020,Nevada,32,Two or more races (NH),,,,,,
-2020,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2020,Nevada,32,White (NH),20.8,,41.2,,26.85,
-2020,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2020,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,New Hampshire,33,Two or more races (NH),,,,,,0.0
-2020,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,New Hampshire,33,White (NH),19.8,,100.0,,13.37,
-2020,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,New Jersey,34,Asian (NH),,,,,,
-2020,New Jersey,34,Black or African American (NH),387.3,,65.3,,47.47,
-2020,New Jersey,34,Hispanic or Latino,-47.9,,14.7,,6.0,0.0
-2020,New Jersey,34,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,New Jersey,34,White (NH),-55.4,,20.0,,4.37,
-2020,New Mexico,35,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,New Mexico,35,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,New Mexico,35,Black or African American (NH),,,,,,
-2020,New Mexico,35,Hispanic or Latino,20.6,-5.5,72.1,56.5,39.0,5.0
-2020,New Mexico,35,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,New Mexico,35,White (NH),15.8,80.5,27.9,43.5,31.09,8.72
-2020,New York,36,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,New York,36,Asian (NH),,-100.0,,0.0,,0.0
-2020,New York,36,Black or African American (NH),321.5,571.1,62.8,100.0,44.18,3.19
-2020,New York,36,Hispanic or Latino,-39.0,-100.0,15.2,0.0,8.0,0.0
-2020,New York,36,Two or more races (NH),,,,,,
-2020,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,New York,36,White (NH),-53.4,,22.0,,4.73,
-2020,North Carolina,37,Indigenous (NH),,,,,,
-2020,North Carolina,37,Asian (NH),,,,,,
-2020,North Carolina,37,Black or African American (NH),162.4,119.5,58.0,48.5,75.39,9.77
-2020,North Carolina,37,Hispanic or Latino,-72.7,-47.0,5.0,9.7,11.0,2.0
-2020,North Carolina,37,Two or more races (NH),,,,,,
-2020,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,North Carolina,37,White (NH),-26.6,-17.3,37.0,41.7,20.33,3.68
-2020,North Dakota,38,Indigenous (NH),,,,,,
-2020,North Dakota,38,Asian (NH),,,,,0.0,0.0
-2020,North Dakota,38,Black or African American (NH),,,,,0.0,
-2020,North Dakota,38,Hispanic or Latino,,,,,0.0,0.0
-2020,North Dakota,38,Two or more races (NH),,,,,,0.0
-2020,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2020,North Dakota,38,White (NH),,,,,,
-2020,Ohio,39,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0
-2020,Ohio,39,Black or African American (NH),332.9,302.0,65.8,61.1,141.06,14.51
-2020,Ohio,39,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Ohio,39,White (NH),-50.9,-44.2,34.2,38.9,14.46,2.02
-2020,Oklahoma,40,Indigenous (NH),16.5,,11.3,,40.09,
-2020,Oklahoma,40,Asian (NH),,,,,,
-2020,Oklahoma,40,Black or African American (NH),178.9,,21.2,,81.59,
-2020,Oklahoma,40,Hispanic or Latino,-61.8,-100.0,7.3,0.0,17.0,0.0
-2020,Oklahoma,40,Two or more races (NH),-27.0,-100.0,7.3,0.0,33.81,0.0
-2020,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Oklahoma,40,White (NH),3.5,95.3,53.0,100.0,33.0,3.45
-2020,Oregon,41,Indigenous (NH),,,,,,0.0
-2020,Oregon,41,Asian (NH),,,,,,
-2020,Oregon,41,Black or African American (NH),,,,,,
-2020,Oregon,41,Hispanic or Latino,44.8,,33.3,,26.0,0.0
-2020,Oregon,41,Two or more races (NH),,,,,,
-2020,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2020,Oregon,41,White (NH),6.7,,66.7,,16.39,
-2020,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Pennsylvania,42,Asian (NH),,,,,,
-2020,Pennsylvania,42,Black or African American (NH),401.6,362.8,64.7,59.7,132.84,12.35
-2020,Pennsylvania,42,Hispanic or Latino,-34.6,-100.0,8.7,0.0,21.0,0.0
-2020,Pennsylvania,42,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Pennsylvania,42,White (NH),-59.2,-38.2,26.6,40.3,10.27,1.65
-2020,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2020,Rhode Island,44,Asian (NH),,,,,0.0,0.0
-2020,Rhode Island,44,Black or African American (NH),,,,,,0.0
-2020,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2020,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2020,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2020,Rhode Island,44,White (NH),,,,,,0.0
-2020,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,South Carolina,45,Asian (NH),,-100.0,,0.0,,0.0
-2020,South Carolina,45,Black or African American (NH),131.9,120.5,66.8,63.5,105.72,12.4
-2020,South Carolina,45,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,South Carolina,45,White (NH),-37.9,-31.8,33.2,36.5,26.78,3.84
-2020,South Dakota,46,Indigenous (NH),303.4,,47.6,,110.19,
-2020,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,South Dakota,46,Black or African American (NH),,,,,,
-2020,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,South Dakota,46,Two or more races (NH),,,,,,0.0
-2020,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,South Dakota,46,White (NH),-26.3,,52.4,,15.75,
-2020,Tennessee,47,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0
-2020,Tennessee,47,Black or African American (NH),235.1,254.6,62.0,65.6,118.24,14.59
-2020,Tennessee,47,Hispanic or Latino,-49.6,-100.0,6.1,0.0,26.0,0.0
-2020,Tennessee,47,Two or more races (NH),,,,,,
-2020,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Tennessee,47,White (NH),-49.5,-45.6,31.9,34.4,17.6,2.24
-2020,Texas,48,Indigenous (NH),,,,,,
-2020,Texas,48,Asian (NH),-52.1,,2.3,,13.75,
-2020,Texas,48,Black or African American (NH),171.5,95.9,33.4,24.1,69.09,6.63
-2020,Texas,48,Hispanic or Latino,-26.2,-19.4,35.8,39.1,21.0,3.0
-2020,Texas,48,Two or more races (NH),,,,,,
-2020,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,
-2020,Texas,48,White (NH),-8.7,17.9,28.5,36.8,22.75,3.99
-2020,Utah,49,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Utah,49,Asian (NH),,-100.0,,0.0,,0.0
-2020,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0
-2020,Utah,49,Hispanic or Latino,78.8,-100.0,33.8,0.0,32.0,0.0
-2020,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Utah,49,White (NH),-8.6,38.1,66.2,100.0,14.34,2.91
-2020,Vermont,50,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2020,Vermont,50,Asian (NH),-100.0,,0.0,,0.0,
-2020,Vermont,50,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2020,Vermont,50,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Vermont,50,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,Vermont,50,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Vermont,50,White (NH),13.1,,100.0,,17.38,
-2020,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Virginia,51,Asian (NH),,,,,,
-2020,Virginia,51,Black or African American (NH),199.0,177.8,59.2,55.0,75.61,8.73
-2020,Virginia,51,Hispanic or Latino,-50.3,-100.0,7.6,0.0,15.0,0.0
-2020,Virginia,51,Two or more races (NH),,,,,,
-2020,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Virginia,51,White (NH),-36.0,-13.3,33.2,45.0,15.55,2.73
-2020,Washington,53,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Washington,53,Asian (NH),,-100.0,,0.0,,0.0
-2020,Washington,53,Black or African American (NH),318.6,,18.0,,65.85,
-2020,Washington,53,Hispanic or Latino,19.4,-100.0,27.1,0.0,24.0,0.0
-2020,Washington,53,Two or more races (NH),,,,,,
-2020,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,Washington,53,White (NH),1.7,85.2,54.9,100.0,16.58,1.85
-2020,West Virginia,54,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,West Virginia,54,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,West Virginia,54,Black or African American (NH),,-100.0,,0.0,,0.0
-2020,West Virginia,54,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,West Virginia,54,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2020,West Virginia,54,White (NH),13.5,13.5,100.0,100.0,21.91,4.07
-2020,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0
-2020,Wisconsin,55,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Wisconsin,55,Black or African American (NH),470.1,666.7,49.6,66.7,117.82,17.77
-2020,Wisconsin,55,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0
-2020,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2020,Wisconsin,55,White (NH),-26.9,-51.7,50.4,33.3,12.26,1.13
-2020,Wyoming,56,Indigenous (NH),,,,,,0.0
-2020,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0
-2020,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2020,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2020,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2020,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2020,Wyoming,56,White (NH),30.4,,100.0,,34.84,
-2021,Alabama,01,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Alabama,01,Black or African American (NH),176.2,136.0,79.0,67.5,123.35,16.1
-2021,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Alabama,01,Two or more races (NH),,,,,,
-2021,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Alabama,01,White (NH),-62.8,-42.4,21.0,32.5,16.67,3.93
-2021,Alaska,02,Indigenous (NH),119.5,,40.6,,97.8,
-2021,Alaska,02,Asian (NH),,,,,,0.0
-2021,Alaska,02,Black or African American (NH),,,,,,0.0
-2021,Alaska,02,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Alaska,02,Two or more races (NH),,,,,,
-2021,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Alaska,02,White (NH),26.1,,59.4,,47.6,
-2021,Arizona,04,Indigenous (NH),51.1,,7.1,,43.46,
-2021,Arizona,04,Asian (NH),,,,,,
-2021,Arizona,04,Black or African American (NH),190.7,,15.7,,80.22,
-2021,Arizona,04,Hispanic or Latino,-7.8,49.8,40.0,65.0,27.0,4.0
-2021,Arizona,04,Two or more races (NH),29.5,,5.7,,46.33,
-2021,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Arizona,04,White (NH),-19.3,-10.0,31.4,35.0,20.3,2.25
-2021,Arkansas,05,Indigenous (NH),,,,,,
-2021,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0
-2021,Arkansas,05,Black or African American (NH),232.8,200.0,58.9,53.1,126.19,13.64
-2021,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Arkansas,05,White (NH),-33.1,-23.6,41.1,46.9,24.75,3.47
-2021,California,06,Indigenous (NH),,,,,,
-2021,California,06,Asian (NH),-69.3,,3.9,,5.09,
-2021,California,06,Black or African American (NH),454.0,416.0,27.7,25.8,82.44,7.3
-2021,California,06,Hispanic or Latino,-0.4,17.2,51.4,60.5,17.0,2.0
-2021,California,06,Two or more races (NH),-48.1,,2.8,,11.85,
-2021,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,California,06,White (NH),-42.7,-44.3,14.1,13.7,8.72,0.79
-2021,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Colorado,08,Asian (NH),,,,,,
-2021,Colorado,08,Black or African American (NH),145.5,,10.8,,63.04,
-2021,Colorado,08,Hispanic or Latino,23.1,75.1,39.5,56.2,36.0,5.0
-2021,Colorado,08,Two or more races (NH),,,,,,
-2021,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Colorado,08,White (NH),-8.8,-19.6,49.7,43.8,21.76,2.06
-2021,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,Connecticut,09,Asian (NH),,,,,,0.0
-2021,Connecticut,09,Black or African American (NH),494.9,,69.6,,71.91,
-2021,Connecticut,09,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Connecticut,09,White (NH),-41.4,,30.4,,6.32,
-2021,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,Delaware,10,Black or African American (NH),293.7,,100.0,,120.61,
-2021,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Delaware,10,Two or more races (NH),,,,,,0.0
-2021,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Delaware,10,White (NH),,,,,,0.0
-2021,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,District of Columbia,11,Black or African American (NH),91.6,,100.0,,144.56,
-2021,District of Columbia,11,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0
-2021,Florida,12,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Florida,12,Asian (NH),,,,,,
-2021,Florida,12,Black or African American (NH),177.4,162.3,55.2,52.2,69.47,7.05
-2021,Florida,12,Hispanic or Latino,-47.3,-44.8,16.6,17.4,13.0,1.0
-2021,Florida,12,Two or more races (NH),,,,,,
-2021,Florida,12,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Florida,12,White (NH),-32.2,-26.9,28.2,30.4,15.46,1.97
-2021,Georgia,13,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Georgia,13,Asian (NH),,,,,,
-2021,Georgia,13,Black or African American (NH),108.0,101.8,70.1,68.0,77.77,9.95
-2021,Georgia,13,Hispanic or Latino,-54.8,-100.0,7.1,0.0,20.0,0.0
-2021,Georgia,13,Two or more races (NH),,,,,,
-2021,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Georgia,13,White (NH),-45.6,-23.6,22.8,32.0,19.01,3.76
-2021,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2021,Hawaii,15,Asian (NH),,,,,,0.0
-2021,Hawaii,15,Black or African American (NH),,,,,0.0,0.0
-2021,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2021,Hawaii,15,Two or more races (NH),,,,,,0.0
-2021,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,
-2021,Hawaii,15,White (NH),,,,,,0.0
-2021,Idaho,16,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Idaho,16,Asian (NH),,-100.0,,0.0,,0.0
-2021,Idaho,16,Black or African American (NH),,-100.0,,0.0,,0.0
-2021,Idaho,16,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Idaho,16,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Idaho,16,White (NH),35.3,35.3,100.0,100.0,17.54,3.49
-2021,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Illinois,17,Asian (NH),,,,,,
-2021,Illinois,17,Black or African American (NH),368.6,359.5,71.7,70.3,168.45,20.95
-2021,Illinois,17,Hispanic or Latino,-36.8,-53.8,16.0,11.7,24.0,2.0
-2021,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Illinois,17,White (NH),-75.4,-64.0,12.3,18.0,8.59,1.64
-2021,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Indiana,18,Asian (NH),,,,,,
-2021,Indiana,18,Black or African American (NH),323.5,200.0,48.7,34.5,164.88,10.37
-2021,Indiana,18,Hispanic or Latino,-44.5,-100.0,7.1,0.0,24.0,0.0
-2021,Indiana,18,Two or more races (NH),,,,,,
-2021,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Indiana,18,White (NH),-35.3,-4.1,44.2,65.5,22.37,3.3
-2021,Iowa,19,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,
-2021,Iowa,19,Black or African American (NH),319.3,,23.9,,58.93,
-2021,Iowa,19,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Iowa,19,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Iowa,19,White (NH),0.9,32.6,76.1,100.0,12.48,2.16
-2021,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Kansas,20,Asian (NH),,-100.0,,0.0,,0.0
-2021,Kansas,20,Black or African American (NH),268.9,,22.5,,88.66,
-2021,Kansas,20,Hispanic or Latino,18.6,73.4,23.6,34.5,36.0,7.0
-2021,Kansas,20,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Kansas,20,White (NH),-16.9,0.9,53.9,65.5,21.23,4.15
-2021,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Kentucky,21,Asian (NH),-100.0,,0.0,,0.0,
-2021,Kentucky,21,Black or African American (NH),395.7,482.8,46.1,54.2,162.5,27.48
-2021,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Kentucky,21,Two or more races (NH),,,,,,
-2021,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Kentucky,21,White (NH),-29.5,-40.1,53.9,45.8,24.65,2.82
-2021,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Louisiana,22,Asian (NH),,,,,,
-2021,Louisiana,22,Black or African American (NH),132.5,123.5,83.0,79.8,149.48,22.33
-2021,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Louisiana,22,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Louisiana,22,White (NH),-65.4,-58.9,17.0,20.2,22.14,4.1
-2021,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,Maine,23,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2021,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Maine,23,White (NH),14.7,,100.0,,11.82,
-2021,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Maryland,24,Asian (NH),,-100.0,,0.0,,0.0
-2021,Maryland,24,Black or African American (NH),166.3,230.0,80.7,100.0,86.53,5.28
-2021,Maryland,24,Hispanic or Latino,-59.6,-100.0,7.4,0.0,18.0,0.0
-2021,Maryland,24,Two or more races (NH),,,,,,
-2021,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Maryland,24,White (NH),-69.8,,11.9,,9.12,
-2021,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,Massachusetts,25,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,Massachusetts,25,Black or African American (NH),379.1,,43.6,,27.23,
-2021,Massachusetts,25,Hispanic or Latino,41.7,,28.2,,9.0,0.0
-2021,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Massachusetts,25,White (NH),-52.0,,28.2,,2.2,
-2021,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Michigan,26,Asian (NH),,,,,,
-2021,Michigan,26,Black or African American (NH),297.5,186.4,64.4,46.4,117.36,7.45
-2021,Michigan,26,Hispanic or Latino,-45.6,-100.0,4.9,0.0,17.0,0.0
-2021,Michigan,26,Two or more races (NH),,,,,,
-2021,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Michigan,26,White (NH),-53.4,-18.4,30.6,53.6,12.19,2.12
-2021,Minnesota,27,Indigenous (NH),,,,,,
-2021,Minnesota,27,Asian (NH),,,,,,
-2021,Minnesota,27,Black or African American (NH),379.4,,51.3,,82.31,
-2021,Minnesota,27,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Minnesota,27,Two or more races (NH),,,,,,
-2021,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Minnesota,27,White (NH),-26.5,,48.7,,9.34,
-2021,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Mississippi,28,Black or African American (NH),96.9,77.0,81.3,73.1,130.81,17.12
-2021,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Mississippi,28,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Mississippi,28,White (NH),-61.7,-44.9,18.7,26.9,24.61,5.33
-2021,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Missouri,29,Asian (NH),-100.0,,0.0,,0.0,
-2021,Missouri,29,Black or African American (NH),307.5,309.7,54.6,54.9,163.14,24.19
-2021,Missouri,29,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Missouri,29,Two or more races (NH),,,,,,
-2021,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Missouri,29,White (NH),-36.1,-36.5,45.4,45.1,23.99,3.75
-2021,Montana,30,Indigenous (NH),,,,,,
-2021,Montana,30,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Montana,30,Black or African American (NH),,-100.0,,0.0,,0.0
-2021,Montana,30,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Montana,30,Two or more races (NH),,,,,,
-2021,Montana,30,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Montana,30,White (NH),29.2,29.2,100.0,100.0,37.92,8.23
-2021,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,
-2021,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,Nebraska,31,Black or African American (NH),463.9,,34.4,,91.36,
-2021,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Nebraska,31,White (NH),-1.4,,65.6,,13.71,
-2021,Nevada,32,Indigenous (NH),-100.0,,0.0,,0.0,
-2021,Nevada,32,Asian (NH),,,,,,
-2021,Nevada,32,Black or African American (NH),250.5,,38.9,,120.69,
-2021,Nevada,32,Hispanic or Latino,-22.2,,31.6,,25.0,0.0
-2021,Nevada,32,Two or more races (NH),,,,,,
-2021,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2021,Nevada,32,White (NH),-11.1,,29.5,,27.12,
-2021,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,New Hampshire,33,Black or African American (NH),,,,,,0.0
-2021,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,New Hampshire,33,White (NH),20.3,,100.0,,11.32,
-2021,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New Jersey,34,Asian (NH),,,,,,
-2021,New Jersey,34,Black or African American (NH),389.6,646.3,65.6,100.0,46.15,5.15
-2021,New Jersey,34,Hispanic or Latino,-45.5,-100.0,15.6,0.0,6.0,0.0
-2021,New Jersey,34,Two or more races (NH),,,,,,
-2021,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New Jersey,34,White (NH),-57.3,,18.9,,3.98,
-2021,New Mexico,35,Indigenous (NH),,,,,,
-2021,New Mexico,35,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New Mexico,35,Black or African American (NH),,-100.0,,0.0,,0.0
-2021,New Mexico,35,Hispanic or Latino,31.8,-100.0,79.1,0.0,53.0,0.0
-2021,New Mexico,35,Two or more races (NH),,,,,,
-2021,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New Mexico,35,White (NH),-12.2,320.2,20.9,100.0,29.92,12.58
-2021,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New York,36,Asian (NH),,,,,,
-2021,New York,36,Black or African American (NH),348.0,382.4,66.3,71.4,39.75,4.92
-2021,New York,36,Hispanic or Latino,-28.7,-100.0,17.9,0.0,7.0,0.0
-2021,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,New York,36,White (NH),-66.5,-39.3,15.8,28.6,2.82,0.62
-2021,North Carolina,37,Indigenous (NH),,,,,,
-2021,North Carolina,37,Asian (NH),,,,,,
-2021,North Carolina,37,Black or African American (NH),164.7,176.5,58.5,61.1,83.78,13.47
-2021,North Carolina,37,Hispanic or Latino,-51.1,-32.6,9.0,12.4,21.0,3.0
-2021,North Carolina,37,Two or more races (NH),,,,,,
-2021,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,North Carolina,37,White (NH),-35.3,-47.1,32.4,26.5,19.4,2.59
-2021,North Dakota,38,Indigenous (NH),,,,,,
-2021,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,North Dakota,38,Black or African American (NH),,,,,,
-2021,North Dakota,38,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,North Dakota,38,Two or more races (NH),,,,,,0.0
-2021,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,North Dakota,38,White (NH),33.9,,100.0,,17.89,
-2021,Ohio,39,Indigenous (NH),-100.0,,0.0,,0.0,
-2021,Ohio,39,Asian (NH),,,,,,
-2021,Ohio,39,Black or African American (NH),290.2,349.7,59.7,68.8,133.0,18.73
-2021,Ohio,39,Hispanic or Latino,-62.5,-100.0,2.7,0.0,14.0,0.0
-2021,Ohio,39,Two or more races (NH),,,,,,
-2021,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Ohio,39,White (NH),-45.6,-55.0,37.7,31.2,16.6,1.88
-2021,Oklahoma,40,Indigenous (NH),36.8,,13.0,,39.83,
-2021,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0
-2021,Oklahoma,40,Black or African American (NH),207.8,493.5,23.7,45.7,79.21,21.45
-2021,Oklahoma,40,Hispanic or Latino,-52.6,-100.0,9.2,0.0,17.0,0.0
-2021,Oklahoma,40,Two or more races (NH),-2.9,-100.0,9.9,0.0,38.66,0.0
-2021,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Oklahoma,40,White (NH),-12.6,7.1,44.3,54.3,23.68,3.89
-2021,Oregon,41,Indigenous (NH),-100.0,,0.0,,0.0,
-2021,Oregon,41,Asian (NH),,,,,,0.0
-2021,Oregon,41,Black or African American (NH),552.2,,15.0,,124.42,
-2021,Oregon,41,Hispanic or Latino,12.0,,26.2,,24.0,0.0
-2021,Oregon,41,Two or more races (NH),,,,,,
-2021,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Oregon,41,White (NH),-4.9,,58.8,,17.66,
-2021,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Pennsylvania,42,Asian (NH),,,,,,
-2021,Pennsylvania,42,Black or African American (NH),395.3,369.8,63.9,60.6,132.24,17.4
-2021,Pennsylvania,42,Hispanic or Latino,-32.8,-100.0,9.2,0.0,22.0,0.0
-2021,Pennsylvania,42,Two or more races (NH),,,,,,
-2021,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Pennsylvania,42,White (NH),-58.4,-39.1,26.9,39.4,10.28,2.25
-2021,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2021,Rhode Island,44,Asian (NH),,,,,,0.0
-2021,Rhode Island,44,Black or African American (NH),,,,,,0.0
-2021,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2021,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2021,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2021,Rhode Island,44,White (NH),,,,,,0.0
-2021,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,South Carolina,45,Asian (NH),,,,,,
-2021,South Carolina,45,Black or African American (NH),144.8,135.0,70.0,67.2,105.11,13.39
-2021,South Carolina,45,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,South Carolina,45,White (NH),-43.8,-38.6,30.0,32.8,22.49,3.5
-2021,South Dakota,46,Indigenous (NH),346.2,,52.2,,130.24,
-2021,South Dakota,46,Asian (NH),,,,,,0.0
-2021,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2021,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,South Dakota,46,Two or more races (NH),,,,,,
-2021,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,South Dakota,46,White (NH),-32.3,,47.8,,15.57,
-2021,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0
-2021,Tennessee,47,Black or African American (NH),227.2,284.2,60.2,70.7,130.4,20.22
-2021,Tennessee,47,Hispanic or Latino,-43.9,-100.0,6.9,0.0,32.0,0.0
-2021,Tennessee,47,Two or more races (NH),,-100.0,,0.0,,0.0
-2021,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Tennessee,47,White (NH),-47.8,-53.5,32.9,29.3,20.0,2.45
-2021,Texas,48,Indigenous (NH),,,,,,
-2021,Texas,48,Asian (NH),-50.0,,2.4,,16.08,
-2021,Texas,48,Black or African American (NH),176.8,144.8,34.6,30.6,81.0,8.37
-2021,Texas,48,Hispanic or Latino,-27.6,-14.2,35.1,41.6,23.0,3.0
-2021,Texas,48,Two or more races (NH),-48.3,-100.0,1.5,0.0,22.85,0.0
-2021,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Texas,48,White (NH),-14.8,-10.3,26.4,27.8,23.89,3.07
-2021,Utah,49,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Utah,49,Asian (NH),,,,,,
-2021,Utah,49,Black or African American (NH),,,,,,
-2021,Utah,49,Hispanic or Latino,9.8,-100.0,21.2,0.0,19.0,0.0
-2021,Utah,49,Two or more races (NH),-100.0,,0.0,,0.0,
-2021,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Utah,49,White (NH),9.7,39.3,78.8,100.0,16.15,2.2
-2021,Vermont,50,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,Vermont,50,White (NH),13.5,,100.0,,15.85,
-2021,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Virginia,51,Asian (NH),,,,,,
-2021,Virginia,51,Black or African American (NH),208.1,219.7,61.0,63.3,82.82,10.12
-2021,Virginia,51,Hispanic or Latino,-56.4,-100.0,6.8,0.0,14.0,0.0
-2021,Virginia,51,Two or more races (NH),,,,,,
-2021,Virginia,51,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Virginia,51,White (NH),-37.3,-28.7,32.3,36.7,16.01,2.26
-2021,Washington,53,Indigenous (NH),,,,,,
-2021,Washington,53,Asian (NH),,,,,,
-2021,Washington,53,Black or African American (NH),255.8,,15.3,,53.19,
-2021,Washington,53,Hispanic or Latino,-12.6,-100.0,20.2,0.0,17.0,0.0
-2021,Washington,53,Two or more races (NH),11.5,,9.7,,24.47,
-2021,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2021,Washington,53,White (NH),2.8,87.6,54.8,100.0,16.17,2.68
-2021,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2021,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0
-2021,West Virginia,54,Black or African American (NH),,,,,,
-2021,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2021,West Virginia,54,Two or more races (NH),-100.0,,0.0,,0.0,
-2021,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2021,West Virginia,54,White (NH),13.9,,100.0,,17.36,
-2021,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0
-2021,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0
-2021,Wisconsin,55,Black or African American (NH),479.5,613.6,51.0,62.8,163.4,24.1
-2021,Wisconsin,55,Hispanic or Latino,-43.6,-100.0,7.5,0.0,17.0,0.0
-2021,Wisconsin,55,Two or more races (NH),,,,,,
-2021,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wisconsin,55,White (NH),-39.5,-45.8,41.5,37.2,13.54,1.83
-2021,Wyoming,56,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,Black or African American (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2021,Wyoming,56,White (NH),31.1,31.1,100.0,100.0,38.72,9.89
-2022,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Alabama,01,Black or African American (NH),167.4,164.6,76.2,75.4,119.06,16.17
-2022,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Alabama,01,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Alabama,01,White (NH),-57.7,-56.2,23.8,24.6,18.84,2.68
-2022,Alaska,02,Indigenous (NH),183.6,,51.9,,107.14,
-2022,Alaska,02,Asian (NH),,,,,,0.0
-2022,Alaska,02,Black or African American (NH),,,,,,
-2022,Alaska,02,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Alaska,02,Two or more races (NH),,,,,,
-2022,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Alaska,02,White (NH),2.6,,48.1,,33.52,
-2022,Arizona,04,Indigenous (NH),97.8,,9.1,,57.34,
-2022,Arizona,04,Asian (NH),,,,,,
-2022,Arizona,04,Black or African American (NH),205.5,,16.8,,86.76,
-2022,Arizona,04,Hispanic or Latino,-14.4,65.4,37.3,72.1,25.0,4.0
-2022,Arizona,04,Two or more races (NH),,,,,,
-2022,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Arizona,04,White (NH),-4.2,-27.3,36.8,27.9,24.32,1.96
-2022,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0
-2022,Arkansas,05,Black or African American (NH),272.2,268.8,65.5,64.9,131.65,19.35
-2022,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Arkansas,05,Two or more races (NH),,,,,,
-2022,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Arkansas,05,White (NH),-43.6,-42.6,34.5,35.1,19.44,3.01
-2022,California,06,Indigenous (NH),,,,,,
-2022,California,06,Asian (NH),-74.4,,3.3,,3.19,
-2022,California,06,Black or African American (NH),420.0,400.0,26.0,25.0,60.5,6.28
-2022,California,06,Hispanic or Latino,2.7,16.2,53.2,60.2,14.0,1.0
-2022,California,06,Two or more races (NH),-35.2,,3.5,,10.8,
-2022,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2022,California,06,White (NH),-41.7,-38.8,14.1,14.8,6.64,0.77
-2022,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Colorado,08,Asian (NH),,,,,,
-2022,Colorado,08,Black or African American (NH),308.9,344.4,18.4,20.0,103.11,21.67
-2022,Colorado,08,Hispanic or Latino,20.8,52.9,39.5,50.0,33.0,7.0
-2022,Colorado,08,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Colorado,08,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2022,Colorado,08,White (NH),-21.6,-44.1,42.1,30.0,17.66,2.73
-2022,Connecticut,09,Indigenous (NH),,,,,,0.0
-2022,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,Connecticut,09,Black or African American (NH),332.8,,51.5,,38.02,
-2022,Connecticut,09,Hispanic or Latino,77.0,,48.5,,19.0,0.0
-2022,Connecticut,09,Two or more races (NH),,,,,,0.0
-2022,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Connecticut,09,White (NH),,,,,,
-2022,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,Delaware,10,Black or African American (NH),287.6,,100.0,,64.13,
-2022,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2022,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Delaware,10,White (NH),,,,,,0.0
-2022,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,
-2022,District of Columbia,11,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,District of Columbia,11,Black or African American (NH),94.6,94.6,100.0,100.0,124.78,20.11
-2022,District of Columbia,11,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,District of Columbia,11,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,District of Columbia,11,White (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,
-2022,Florida,12,Asian (NH),,,,,,
-2022,Florida,12,Black or African American (NH),156.6,182.1,50.3,55.3,63.88,7.97
-2022,Florida,12,Hispanic or Latino,-27.3,-43.9,23.2,17.9,18.0,2.0
-2022,Florida,12,Two or more races (NH),-50.0,,2.0,,17.29,
-2022,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Florida,12,White (NH),-40.9,-35.1,24.4,26.8,13.45,1.84
-2022,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Georgia,13,Asian (NH),,,,,,
-2022,Georgia,13,Black or African American (NH),110.9,110.9,71.3,71.3,78.73,12.46
-2022,Georgia,13,Hispanic or Latino,-56.0,-54.1,7.0,7.3,19.0,3.0
-2022,Georgia,13,Two or more races (NH),,,,,,
-2022,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Georgia,13,White (NH),-47.6,-48.6,21.7,21.3,18.18,3.04
-2022,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2022,Hawaii,15,Asian (NH),,,,,,
-2022,Hawaii,15,Black or African American (NH),,,,,,0.0
-2022,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2022,Hawaii,15,Two or more races (NH),,,,,,
-2022,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2022,Hawaii,15,White (NH),,,,,0.0,
-2022,Idaho,16,Indigenous (NH),-100.0,,0.0,,0.0,
-2022,Idaho,16,Asian (NH),,-100.0,,0.0,,0.0
-2022,Idaho,16,Black or African American (NH),,,,,,
-2022,Idaho,16,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Idaho,16,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2022,Idaho,16,White (NH),36.4,36.4,100.0,100.0,21.65,2.92
-2022,Illinois,17,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0
-2022,Illinois,17,Black or African American (NH),355.6,434.0,69.7,81.7,136.02,21.17
-2022,Illinois,17,Hispanic or Latino,-36.6,-28.0,16.1,18.3,19.0,3.0
-2022,Illinois,17,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Illinois,17,White (NH),-71.5,,14.2,,8.15,
-2022,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Indiana,18,Asian (NH),,,,,,
-2022,Indiana,18,Black or African American (NH),350.9,404.3,52.3,58.5,145.55,16.74
-2022,Indiana,18,Hispanic or Latino,-33.8,-100.0,8.6,0.0,23.0,0.0
-2022,Indiana,18,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Indiana,18,White (NH),-42.2,-38.8,39.2,41.5,16.51,2.04
-2022,Iowa,19,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,Iowa,19,Asian (NH),,,,,,0.0
-2022,Iowa,19,Black or African American (NH),474.6,,33.9,,99.87,
-2022,Iowa,19,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Iowa,19,Two or more races (NH),,,,,,
-2022,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Iowa,19,White (NH),-11.7,,66.1,,13.32,
-2022,Kansas,20,Indigenous (NH),,,,,,
-2022,Kansas,20,Asian (NH),,,,,,
-2022,Kansas,20,Black or African American (NH),200.0,,18.3,,58.22,
-2022,Kansas,20,Hispanic or Latino,-29.5,,14.1,,17.0,0.0
-2022,Kansas,20,Two or more races (NH),,,,,,
-2022,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2022,Kansas,20,White (NH),4.5,,67.6,,21.4,
-2022,Kentucky,21,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Kentucky,21,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Kentucky,21,Black or African American (NH),402.2,269.9,46.7,34.4,134.31,11.56
-2022,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Kentucky,21,Two or more races (NH),,,,,,
-2022,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Kentucky,21,White (NH),-29.9,-13.7,53.3,65.6,20.15,2.71
-2022,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0
-2022,Louisiana,22,Black or African American (NH),131.8,130.4,82.3,81.8,138.4,21.19
-2022,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Louisiana,22,Two or more races (NH),,,,,,
-2022,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Louisiana,22,White (NH),-63.9,-62.9,17.7,18.2,21.66,3.41
-2022,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,
-2022,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,Maine,23,Black or African American (NH),,,,,,0.0
-2022,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Maine,23,Two or more races (NH),,,,,,0.0
-2022,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Maine,23,White (NH),15.3,,100.0,,10.84,
-2022,Maryland,24,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Maryland,24,Asian (NH),,,,,,
-2022,Maryland,24,Black or African American (NH),189.1,231.1,87.3,100.0,81.16,9.69
-2022,Maryland,24,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Maryland,24,White (NH),-67.4,,12.7,,8.58,
-2022,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,Massachusetts,25,Asian (NH),,,,,,0.0
-2022,Massachusetts,25,Black or African American (NH),393.5,,45.9,,27.31,
-2022,Massachusetts,25,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Massachusetts,25,Two or more races (NH),,,,,,0.0
-2022,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Massachusetts,25,White (NH),-6.4,,54.1,,4.06,
-2022,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Michigan,26,Asian (NH),,,,,,
-2022,Michigan,26,Black or African American (NH),242.0,318.5,55.4,67.8,86.88,11.58
-2022,Michigan,26,Hispanic or Latino,-23.1,-100.0,7.0,0.0,20.0,0.0
-2022,Michigan,26,Two or more races (NH),,,,,,
-2022,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Michigan,26,White (NH),-42.5,-50.8,37.6,32.2,12.72,1.36
-2022,Minnesota,27,Indigenous (NH),,,,,,
-2022,Minnesota,27,Asian (NH),-100.0,,0.0,,0.0,
-2022,Minnesota,27,Black or African American (NH),334.5,295.5,47.8,43.5,65.92,6.92
-2022,Minnesota,27,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Minnesota,27,White (NH),-20.5,-14.0,52.2,56.5,9.04,1.51
-2022,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Mississippi,28,Black or African American (NH),92.9,79.6,79.3,73.8,104.75,15.97
-2022,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Mississippi,28,Two or more races (NH),,,,,,
-2022,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Mississippi,28,White (NH),-57.6,-46.3,20.7,26.2,22.29,4.79
-2022,Missouri,29,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0
-2022,Missouri,29,Black or African American (NH),333.8,332.3,57.7,57.5,204.04,22.86
-2022,Missouri,29,Hispanic or Latino,-49.4,-100.0,4.1,0.0,26.0,0.0
-2022,Missouri,29,Two or more races (NH),,,,,,
-2022,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Missouri,29,White (NH),-46.3,-40.1,38.1,42.5,23.75,3.16
-2022,Montana,30,Indigenous (NH),,,,,,
-2022,Montana,30,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Montana,30,Black or African American (NH),,-100.0,,0.0,,0.0
-2022,Montana,30,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Montana,30,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Montana,30,White (NH),29.4,29.4,100.0,100.0,24.74,6.56
-2022,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,Nebraska,31,Black or African American (NH),,,,,,
-2022,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Nebraska,31,Two or more races (NH),,,,,,
-2022,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Nebraska,31,White (NH),51.5,,100.0,,21.46,
-2022,Nevada,32,Indigenous (NH),,,,,,0.0
-2022,Nevada,32,Asian (NH),,,,,,
-2022,Nevada,32,Black or African American (NH),142.6,,27.9,,61.4,
-2022,Nevada,32,Hispanic or Latino,-17.6,,33.8,,19.0,0.0
-2022,Nevada,32,Two or more races (NH),,,,,,0.0
-2022,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2022,Nevada,32,White (NH),19.4,,38.2,,25.77,
-2022,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,
-2022,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2022,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,New Hampshire,33,White (NH),20.9,,100.0,,11.19,
-2022,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,New Jersey,34,Asian (NH),,-100.0,,0.0,,0.0
-2022,New Jersey,34,Black or African American (NH),380.6,646.3,64.4,100.0,44.46,4.44
-2022,New Jersey,34,Hispanic or Latino,-48.8,-100.0,14.9,0.0,6.0,0.0
-2022,New Jersey,34,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,New Jersey,34,White (NH),-52.6,,20.7,,4.31,
-2022,New Mexico,35,Indigenous (NH),,,,,,
-2022,New Mexico,35,Asian (NH),,-100.0,,0.0,,0.0
-2022,New Mexico,35,Black or African American (NH),,,,,,
-2022,New Mexico,35,Hispanic or Latino,15.8,66.1,69.7,100.0,36.0,8.0
-2022,New Mexico,35,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,New Mexico,35,White (NH),28.4,,30.3,,33.88,
-2022,New York,36,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,New York,36,Asian (NH),,-100.0,,0.0,,0.0
-2022,New York,36,Black or African American (NH),312.2,385.7,60.6,71.4,33.59,5.07
-2022,New York,36,Hispanic or Latino,-37.5,-100.0,15.8,0.0,6.0,0.0
-2022,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,New York,36,White (NH),-49.7,-39.0,23.6,28.6,3.83,0.64
-2022,North Carolina,37,Indigenous (NH),209.1,,3.4,,99.42,
-2022,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0
-2022,North Carolina,37,Black or African American (NH),186.4,188.7,63.3,63.8,85.44,13.02
-2022,North Carolina,37,Hispanic or Latino,-50.3,-33.7,9.3,12.4,20.0,3.0
-2022,North Carolina,37,Two or more races (NH),,,,,,
-2022,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,North Carolina,37,White (NH),-51.6,-52.0,24.0,23.8,13.55,2.17
-2022,North Dakota,38,Indigenous (NH),,,,,,0.0
-2022,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,North Dakota,38,Black or African American (NH),-100.0,,0.0,,0.0,
-2022,North Dakota,38,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,North Dakota,38,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2022,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,North Dakota,38,White (NH),34.8,,100.0,,21.69,
-2022,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Ohio,39,Asian (NH),,,,,,
-2022,Ohio,39,Black or African American (NH),291.0,323.9,60.6,65.7,126.75,16.23
-2022,Ohio,39,Hispanic or Latino,-50.0,-100.0,3.7,0.0,17.0,0.0
-2022,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Ohio,39,White (NH),-48.0,-50.1,35.8,34.3,14.8,1.91
-2022,Oklahoma,40,Indigenous (NH),33.3,,12.4,,25.75,
-2022,Oklahoma,40,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Oklahoma,40,Black or African American (NH),216.7,494.9,24.7,46.4,56.32,17.32
-2022,Oklahoma,40,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Oklahoma,40,Two or more races (NH),,,,,,
-2022,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Oklahoma,40,White (NH),25.5,7.0,62.9,53.6,22.86,3.1
-2022,Oregon,41,Indigenous (NH),,,,,,0.0
-2022,Oregon,41,Asian (NH),-100.0,,0.0,,0.0,
-2022,Oregon,41,Black or African American (NH),1045.8,,27.5,,192.72,
-2022,Oregon,41,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Oregon,41,Two or more races (NH),,,,,,
-2022,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2022,Oregon,41,White (NH),18.9,,72.5,,19.15,
-2022,Pennsylvania,42,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Pennsylvania,42,Asian (NH),,,,,,
-2022,Pennsylvania,42,Black or African American (NH),371.1,249.2,60.3,44.7,117.3,12.37
-2022,Pennsylvania,42,Hispanic or Latino,-10.6,20.6,12.6,17.0,28.0,4.0
-2022,Pennsylvania,42,Two or more races (NH),,,,,,
-2022,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Pennsylvania,42,White (NH),-57.8,-40.3,27.1,38.3,9.77,2.11
-2022,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2022,Rhode Island,44,Asian (NH),,,,,0.0,0.0
-2022,Rhode Island,44,Black or African American (NH),,,,,,
-2022,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2022,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2022,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2022,Rhode Island,44,White (NH),,,,,0.0,0.0
-2022,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,South Carolina,45,Asian (NH),,,,,,
-2022,South Carolina,45,Black or African American (NH),146.8,179.8,69.6,78.9,86.35,17.48
-2022,South Carolina,45,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,South Carolina,45,White (NH),-43.1,-60.5,30.4,21.1,18.7,2.48
-2022,South Dakota,46,Indigenous (NH),301.7,,46.2,,128.78,
-2022,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2022,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,South Dakota,46,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2022,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,South Dakota,46,White (NH),-23.1,,53.8,,19.59,
-2022,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0
-2022,Tennessee,47,Black or African American (NH),231.3,256.0,60.3,64.8,120.67,16.15
-2022,Tennessee,47,Hispanic or Latino,-52.0,-100.0,6.0,0.0,24.0,0.0
-2022,Tennessee,47,Two or more races (NH),,,,,,
-2022,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Tennessee,47,White (NH),-46.4,-44.0,33.7,35.2,18.68,2.54
-2022,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Texas,48,Asian (NH),-78.0,,1.1,,6.53,
-2022,Texas,48,Black or African American (NH),175.6,112.6,35.0,27.0,72.1,8.17
-2022,Texas,48,Hispanic or Latino,-20.2,-3.5,38.6,46.7,22.0,4.0
-2022,Texas,48,Two or more races (NH),,,,,,
-2022,Texas,48,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2022,Texas,48,White (NH),-17.6,-14.3,25.3,26.3,20.47,3.3
-2022,Utah,49,Indigenous (NH),,,,,,
-2022,Utah,49,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Utah,49,Black or African American (NH),,,,,,
-2022,Utah,49,Hispanic or Latino,8.0,-100.0,21.5,0.0,18.0,0.0
-2022,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,
-2022,Utah,49,White (NH),10.7,41.0,78.5,100.0,15.56,1.65
-2022,Vermont,50,Indigenous (NH),,,,,,0.0
-2022,Vermont,50,Asian (NH),,,,,0.0,0.0
-2022,Vermont,50,Black or African American (NH),,,,,,0.0
-2022,Vermont,50,Hispanic or Latino,,,,,0.0,0.0
-2022,Vermont,50,Two or more races (NH),,,,,0.0,0.0
-2022,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2022,Vermont,50,White (NH),,,,,,
-2022,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0
-2022,Virginia,51,Asian (NH),,,,,,
-2022,Virginia,51,Black or African American (NH),235.4,219.2,66.4,63.2,90.19,11.51
-2022,Virginia,51,Hispanic or Latino,-62.3,-100.0,6.0,0.0,12.0,0.0
-2022,Virginia,51,Two or more races (NH),,,,,,
-2022,Virginia,51,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2022,Virginia,51,White (NH),-45.9,-27.8,27.6,36.8,13.83,2.6
-2022,Washington,53,Indigenous (NH),,,,,,
-2022,Washington,53,Asian (NH),,,,,,
-2022,Washington,53,Black or African American (NH),293.2,,17.3,,49.42,
-2022,Washington,53,Hispanic or Latino,50.8,323.7,35.6,100.0,24.0,3.0
-2022,Washington,53,Two or more races (NH),,,,,,
-2022,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,
-2022,Washington,53,White (NH),-9.9,,47.1,,11.63,
-2022,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2022,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,West Virginia,54,Black or African American (NH),,,,,,0.0
-2022,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,West Virginia,54,Two or more races (NH),,,,,,0.0
-2022,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,West Virginia,54,White (NH),14.3,,100.0,,14.93,
-2022,Wisconsin,55,Indigenous (NH),,,,,,
-2022,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0
-2022,Wisconsin,55,Black or African American (NH),650.0,526.1,66.0,55.1,135.27,24.32
-2022,Wisconsin,55,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0
-2022,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2022,Wisconsin,55,White (NH),-50.2,-34.3,34.0,44.9,7.01,2.56
-2022,Wyoming,56,Indigenous (NH),,,,,,0.0
-2022,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0
-2022,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2022,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2022,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2022,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2022,Wyoming,56,White (NH),31.6,,100.0,,47.09,
-2023,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Alabama,01,Asian (NH),,-100.0,,0.0,,0.0
-2023,Alabama,01,Black or African American (NH),173.9,113.1,77.5,60.3,111.03,14.66
-2023,Alabama,01,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Alabama,01,Two or more races (NH),,,,,,
-2023,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Alabama,01,White (NH),-59.9,-29.2,22.5,39.7,16.26,4.89
-2023,Alaska,02,Indigenous (NH),,,,,,
-2023,Alaska,02,Asian (NH),,,,,,
-2023,Alaska,02,Black or African American (NH),,,,,,0.0
-2023,Alaska,02,Hispanic or Latino,,,,,0.0,0.0
-2023,Alaska,02,Two or more races (NH),,,,,,
-2023,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2023,Alaska,02,White (NH),,,,,,
-2023,Arizona,04,Indigenous (NH),75.6,,7.9,,39.95,
-2023,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0
-2023,Arizona,04,Black or African American (NH),162.5,439.3,14.7,30.2,60.27,14.74
-2023,Arizona,04,Hispanic or Latino,5.5,59.0,46.3,69.8,25.0,4.0
-2023,Arizona,04,Two or more races (NH),,,,,,
-2023,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Arizona,04,White (NH),-18.4,,31.1,,16.5,
-2023,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0
-2023,Arkansas,05,Black or African American (NH),270.9,224.6,64.9,56.8,105.88,20.29
-2023,Arkansas,05,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Arkansas,05,Two or more races (NH),-100.0,,0.0,,0.0,
-2023,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Arkansas,05,White (NH),-42.4,-29.1,35.1,43.2,15.97,4.43
-2023,California,06,Indigenous (NH),,,,,,
-2023,California,06,Asian (NH),-72.5,-42.7,3.6,7.5,3.15,1.0
-2023,California,06,Black or African American (NH),306.0,242.0,20.3,17.1,44.28,5.91
-2023,California,06,Hispanic or Latino,7.7,-8.9,55.9,47.3,13.0,2.0
-2023,California,06,Two or more races (NH),-47.3,61.8,2.9,8.9,8.26,2.79
-2023,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,
-2023,California,06,White (NH),-26.9,-19.3,17.4,19.2,7.67,1.39
-2023,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Colorado,08,Asian (NH),,,,,,
-2023,Colorado,08,Black or African American (NH),267.4,,16.9,,84.41,
-2023,Colorado,08,Hispanic or Latino,28.3,80.7,42.6,60.0,31.0,6.0
-2023,Colorado,08,Two or more races (NH),,,,,,
-2023,Colorado,08,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Colorado,08,White (NH),-23.6,-24.4,40.4,40.0,15.25,2.49
-2023,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,
-2023,Connecticut,09,Black or African American (NH),733.3,,100.0,,40.1,
-2023,Connecticut,09,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Connecticut,09,Two or more races (NH),,,,,,0.0
-2023,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Connecticut,09,White (NH),,,,,,
-2023,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,Delaware,10,Black or African American (NH),284.6,,100.0,,48.53,
-2023,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Delaware,10,Two or more races (NH),,,,,,0.0
-2023,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Delaware,10,White (NH),,,,,,0.0
-2023,District of Columbia,11,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,District of Columbia,11,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,District of Columbia,11,Black or African American (NH),96.9,96.9,100.0,100.0,191.84,29.52
-2023,District of Columbia,11,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,District of Columbia,11,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,District of Columbia,11,White (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,
-2023,Florida,12,Asian (NH),,,,,,
-2023,Florida,12,Black or African American (NH),174.2,200.5,53.2,58.3,60.36,8.22
-2023,Florida,12,Hispanic or Latino,-49.8,-48.3,16.2,16.7,11.0,1.0
-2023,Florida,12,Two or more races (NH),-39.0,,2.5,,18.22,
-2023,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Florida,12,White (NH),-31.2,-39.0,28.2,25.0,13.83,1.67
-2023,Georgia,13,Indigenous (NH),,,,,,
-2023,Georgia,13,Asian (NH),,,,,,
-2023,Georgia,13,Black or African American (NH),110.9,141.1,71.3,81.5,72.38,11.3
-2023,Georgia,13,Hispanic or Latino,-60.9,-100.0,6.3,0.0,15.0,0.0
-2023,Georgia,13,Two or more races (NH),,,,,,
-2023,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Georgia,13,White (NH),-45.4,-54.9,22.4,18.5,17.41,2.11
-2023,Hawaii,15,Indigenous (NH),,,,,0.0,0.0
-2023,Hawaii,15,Asian (NH),,,,,0.0,0.0
-2023,Hawaii,15,Black or African American (NH),,,,,0.0,0.0
-2023,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0
-2023,Hawaii,15,Two or more races (NH),,,,,,
-2023,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,0.0
-2023,Hawaii,15,White (NH),,,,,0.0,0.0
-2023,Idaho,16,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Idaho,16,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Idaho,16,Black or African American (NH),,-100.0,,0.0,,0.0
-2023,Idaho,16,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Idaho,16,Two or more races (NH),,,,,,
-2023,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Idaho,16,White (NH),37.7,37.7,100.0,100.0,22.57,5.3
-2023,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Illinois,17,Asian (NH),,,,,,
-2023,Illinois,17,Black or African American (NH),328.1,358.8,65.5,70.2,115.87,20.57
-2023,Illinois,17,Hispanic or Latino,-25.3,-37.9,18.9,15.7,19.0,3.0
-2023,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0
-2023,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Illinois,17,White (NH),-68.6,-71.8,15.6,14.0,8.05,1.26
-2023,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Indiana,18,Asian (NH),,,,,,
-2023,Indiana,18,Black or African American (NH),323.7,376.3,50.0,56.2,137.19,21.87
-2023,Indiana,18,Hispanic or Latino,-19.8,-100.0,10.5,0.0,26.0,0.0
-2023,Indiana,18,Two or more races (NH),,,,,,
-2023,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Indiana,18,White (NH),-41.4,-35.0,39.5,43.8,16.58,2.99
-2023,Iowa,19,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Iowa,19,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Iowa,19,Black or African American (NH),409.8,,31.1,,72.85,
-2023,Iowa,19,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Iowa,19,Two or more races (NH),,,,,,
-2023,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Iowa,19,White (NH),-7.4,34.4,68.9,100.0,11.21,2.03
-2023,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Kansas,20,Asian (NH),,,,,,
-2023,Kansas,20,Black or African American (NH),477.0,,35.2,,112.95,
-2023,Kansas,20,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Kansas,20,Two or more races (NH),,,,,,
-2023,Kansas,20,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Kansas,20,White (NH),0.5,55.0,64.8,100.0,20.57,2.46
-2023,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Kentucky,21,Asian (NH),,,,,,
-2023,Kentucky,21,Black or African American (NH),346.8,278.7,42.0,35.6,114.33,16.72
-2023,Kentucky,21,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Kentucky,21,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Kentucky,21,White (NH),-23.3,-14.8,58.0,64.4,20.99,3.77
-2023,Louisiana,22,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Louisiana,22,Asian (NH),,,,,,
-2023,Louisiana,22,Black or African American (NH),137.6,144.4,84.1,86.5,145.73,20.4
-2023,Louisiana,22,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Louisiana,22,Two or more races (NH),,,,,,
-2023,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Louisiana,22,White (NH),-67.4,-72.3,15.9,13.5,20.12,2.3
-2023,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,Maine,23,Black or African American (NH),,,,,,0.0
-2023,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,
-2023,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Maine,23,White (NH),15.9,,100.0,,15.43,
-2023,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Maryland,24,Asian (NH),,,,,,
-2023,Maryland,24,Black or African American (NH),166.8,232.2,80.3,100.0,65.85,8.78
-2023,Maryland,24,Hispanic or Latino,-45.6,-100.0,10.5,0.0,18.0,0.0
-2023,Maryland,24,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Maryland,24,White (NH),-76.0,,9.2,,5.55,
-2023,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,Massachusetts,25,Asian (NH),,,,,,0.0
-2023,Massachusetts,25,Black or African American (NH),303.2,,38.3,,28.81,
-2023,Massachusetts,25,Hispanic or Latino,71.6,,36.2,,13.0,0.0
-2023,Massachusetts,25,Two or more races (NH),,,,,,0.0
-2023,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Massachusetts,25,White (NH),-55.1,,25.5,,2.46,
-2023,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Michigan,26,Asian (NH),,,,,,
-2023,Michigan,26,Black or African American (NH),228.4,251.2,53.2,56.9,71.36,10.8
-2023,Michigan,26,Hispanic or Latino,-15.2,-100.0,7.8,0.0,18.0,0.0
-2023,Michigan,26,Two or more races (NH),,,,,,
-2023,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Michigan,26,White (NH),-40.2,-33.9,39.0,43.1,11.25,2.03
-2023,Minnesota,27,Indigenous (NH),,,,,,
-2023,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0
-2023,Minnesota,27,Black or African American (NH),397.3,,56.2,,68.54,
-2023,Minnesota,27,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0
-2023,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Minnesota,27,White (NH),-32.8,53.4,43.8,100.0,6.98,1.18
-2023,Mississippi,28,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Mississippi,28,Black or African American (NH),103.2,95.1,83.3,80.0,113.94,18.68
-2023,Mississippi,28,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Mississippi,28,Two or more races (NH),,,,,,
-2023,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Mississippi,28,White (NH),-65.6,-58.8,16.7,20.0,18.55,3.93
-2023,Missouri,29,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0
-2023,Missouri,29,Black or African American (NH),329.3,353.4,57.1,60.3,156.41,22.51
-2023,Missouri,29,Hispanic or Latino,-40.2,-100.0,4.9,0.0,23.0,0.0
-2023,Missouri,29,Two or more races (NH),,,,,,
-2023,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Missouri,29,White (NH),-46.4,-43.8,37.9,39.7,18.21,2.78
-2023,Montana,30,Indigenous (NH),,,,,,
-2023,Montana,30,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,Montana,30,Black or African American (NH),,,,,,0.0
-2023,Montana,30,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Montana,30,Two or more races (NH),,,,,,0.0
-2023,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Montana,30,White (NH),29.5,,100.0,,16.07,
-2023,Nebraska,31,Indigenous (NH),,,,,,0.0
-2023,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,Nebraska,31,Black or African American (NH),,,,,,
-2023,Nebraska,31,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2023,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Nebraska,31,White (NH),52.9,,100.0,,16.82,
-2023,Nevada,32,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Nevada,32,Asian (NH),,,,,,
-2023,Nevada,32,Black or African American (NH),247.4,,40.3,,100.39,
-2023,Nevada,32,Hispanic or Latino,-18.4,141.5,33.8,100.0,21.0,4.0
-2023,Nevada,32,Two or more races (NH),,,,,,
-2023,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Nevada,32,White (NH),-16.4,,26.0,,20.2,
-2023,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,New Hampshire,33,White (NH),21.2,,100.0,,11.37,
-2023,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,New Jersey,34,Asian (NH),,,,,,0.0
-2023,New Jersey,34,Black or African American (NH),367.9,,62.7,,25.62,
-2023,New Jersey,34,Hispanic or Latino,25.6,,37.3,,8.0,0.0
-2023,New Jersey,34,Two or more races (NH),,,,,,
-2023,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,New Jersey,34,White (NH),,,,,,
-2023,New Mexico,35,Indigenous (NH),-5.0,,9.5,,44.56,
-2023,New Mexico,35,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,New Mexico,35,Black or African American (NH),,-100.0,,0.0,,0.0
-2023,New Mexico,35,Hispanic or Latino,7.3,65.6,64.8,100.0,52.0,10.0
-2023,New Mexico,35,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,New Mexico,35,White (NH),9.8,,25.7,,46.02,
-2023,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,New York,36,Asian (NH),,,,,,
-2023,New York,36,Black or African American (NH),300.0,356.8,58.4,66.7,25.03,3.47
-2023,New York,36,Hispanic or Latino,-24.4,-100.0,19.2,0.0,5.0,0.0
-2023,New York,36,Two or more races (NH),,,,,,
-2023,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,New York,36,White (NH),-52.0,-28.7,22.4,33.3,2.77,0.54
-2023,North Carolina,37,Indigenous (NH),220.0,,3.2,,91.61,
-2023,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0
-2023,North Carolina,37,Black or African American (NH),152.0,186.4,55.7,63.3,73.05,12.03
-2023,North Carolina,37,Hispanic or Latino,-47.6,-40.7,9.9,11.2,19.0,2.0
-2023,North Carolina,37,Two or more races (NH),-39.6,,2.9,,25.75,
-2023,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,North Carolina,37,White (NH),-42.3,-48.2,28.4,25.5,15.56,2.18
-2023,North Dakota,38,Indigenous (NH),,,,,,
-2023,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,North Dakota,38,Black or African American (NH),,,,,,
-2023,North Dakota,38,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,North Dakota,38,Two or more races (NH),-100.0,,0.0,,0.0,
-2023,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,North Dakota,38,White (NH),36.4,,100.0,,15.25,
-2023,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0
-2023,Ohio,39,Black or African American (NH),288.5,281.4,60.6,59.5,99.14,16.45
-2023,Ohio,39,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Ohio,39,Two or more races (NH),,,,,,
-2023,Ohio,39,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Ohio,39,White (NH),-42.4,-40.8,39.4,40.5,12.83,2.55
-2023,Oklahoma,40,Indigenous (NH),14.3,,10.4,,23.42,
-2023,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0
-2023,Oklahoma,40,Black or African American (NH),100.0,280.8,15.6,29.7,38.32,14.56
-2023,Oklahoma,40,Hispanic or Latino,-38.1,-100.0,12.5,0.0,16.0,0.0
-2023,Oklahoma,40,Two or more races (NH),,,,,,
-2023,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Oklahoma,40,White (NH),24.0,41.7,61.5,70.3,24.04,5.42
-2023,Oregon,41,Indigenous (NH),,,,,,0.0
-2023,Oregon,41,Asian (NH),,,,,,
-2023,Oregon,41,Black or African American (NH),384.0,,12.1,,110.31,
-2023,Oregon,41,Hispanic or Latino,4.1,,25.3,,25.0,0.0
-2023,Oregon,41,Two or more races (NH),61.8,,11.0,,42.79,
-2023,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,
-2023,Oregon,41,White (NH),-14.4,,51.6,,18.27,
-2023,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Pennsylvania,42,Asian (NH),,,,,,
-2023,Pennsylvania,42,Black or African American (NH),303.1,474.0,51.2,72.9,89.53,12.84
-2023,Pennsylvania,42,Hispanic or Latino,-26.2,-100.0,10.7,0.0,20.0,0.0
-2023,Pennsylvania,42,Two or more races (NH),,,,,,
-2023,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Pennsylvania,42,White (NH),-40.3,-57.5,38.1,27.1,12.34,0.95
-2023,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0
-2023,Rhode Island,44,Asian (NH),,,,,0.0,0.0
-2023,Rhode Island,44,Black or African American (NH),,,,,0.0,
-2023,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0
-2023,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0
-2023,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2023,Rhode Island,44,White (NH),,,,,,
-2023,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,South Carolina,45,Asian (NH),,,,,,
-2023,South Carolina,45,Black or African American (NH),133.7,143.4,65.2,67.9,87.36,11.27
-2023,South Carolina,45,Hispanic or Latino,-43.3,-100.0,6.8,0.0,26.0,0.0
-2023,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0
-2023,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,South Carolina,45,White (NH),-47.5,-39.8,28.0,32.1,18.49,2.79
-2023,South Dakota,46,Indigenous (NH),,,,,,
-2023,South Dakota,46,Asian (NH),,,,,,0.0
-2023,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0
-2023,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,South Dakota,46,Two or more races (NH),-100.0,,0.0,,0.0,0.0
-2023,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,South Dakota,46,White (NH),43.9,,100.0,,15.22,0.0
-2023,Tennessee,47,Indigenous (NH),-100.0,,0.0,,0.0,
-2023,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0
-2023,Tennessee,47,Black or African American (NH),252.2,233.3,63.4,60.0,135.84,18.0
-2023,Tennessee,47,Hispanic or Latino,-61.4,-100.0,4.9,0.0,20.0,0.0
-2023,Tennessee,47,Two or more races (NH),,,,,,
-2023,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,
-2023,Tennessee,47,White (NH),-49.4,-36.2,31.7,40.0,18.5,3.45
-2023,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Texas,48,Asian (NH),-58.8,,2.1,,10.65,
-2023,Texas,48,Black or African American (NH),115.5,153.5,27.8,32.7,51.26,8.75
-2023,Texas,48,Hispanic or Latino,-9.9,-18.8,43.5,39.2,22.0,3.0
-2023,Texas,48,Two or more races (NH),,,,,,
-2023,Texas,48,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Texas,48,White (NH),-12.2,-7.3,26.6,28.1,19.54,3.18
-2023,Utah,49,Indigenous (NH),,,,,,
-2023,Utah,49,Asian (NH),,-100.0,,0.0,,0.0
-2023,Utah,49,Black or African American (NH),,,,,,
-2023,Utah,49,Hispanic or Latino,32.2,-100.0,27.1,0.0,20.0,0.0
-2023,Utah,49,Two or more races (NH),,,,,,
-2023,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Utah,49,White (NH),4.0,42.7,72.9,100.0,12.91,2.14
-2023,Vermont,50,Indigenous (NH),,,,,0.0,0.0
-2023,Vermont,50,Asian (NH),,,,,0.0,0.0
-2023,Vermont,50,Black or African American (NH),,,,,0.0,0.0
-2023,Vermont,50,Hispanic or Latino,,,,,0.0,0.0
-2023,Vermont,50,Two or more races (NH),,,,,0.0,0.0
-2023,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0
-2023,Vermont,50,White (NH),,,,,,
-2023,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Virginia,51,Asian (NH),,-100.0,,0.0,,0.0
-2023,Virginia,51,Black or African American (NH),213.7,276.1,61.8,74.1,72.99,10.78
-2023,Virginia,51,Hispanic or Latino,-57.4,-100.0,6.9,0.0,12.0,0.0
-2023,Virginia,51,Two or more races (NH),,,,,,
-2023,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Virginia,51,White (NH),-38.3,-48.9,31.3,25.9,13.71,1.47
-2023,Washington,53,Indigenous (NH),,,,,,
-2023,Washington,53,Asian (NH),,,,,,
-2023,Washington,53,Black or African American (NH),348.9,,20.2,,70.45,
-2023,Washington,53,Hispanic or Latino,0.4,53.6,24.0,36.7,19.0,3.0
-2023,Washington,53,Two or more races (NH),-12.4,,7.8,,19.43,
-2023,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0
-2023,Washington,53,White (NH),-6.6,22.9,48.1,63.3,14.93,2.24
-2023,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,West Virginia,54,Black or African American (NH),,,,,,
-2023,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,West Virginia,54,Two or more races (NH),,,,,,
-2023,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,West Virginia,54,White (NH),14.5,,100.0,,14.94,
-2023,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0
-2023,Wisconsin,55,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Wisconsin,55,Black or African American (NH),385.4,568.5,43.2,59.5,110.78,19.9
-2023,Wisconsin,55,Hispanic or Latino,18.4,-100.0,16.1,0.0,27.0,0.0
-2023,Wisconsin,55,Two or more races (NH),-100.0,,0.0,,0.0,
-2023,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0
-2023,Wisconsin,55,White (NH),-40.1,-40.4,40.7,40.5,10.53,1.77
-2023,Wyoming,56,Indigenous (NH),-100.0,,0.0,,0.0,0.0
-2023,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0
-2023,Wyoming,56,Black or African American (NH),,,,,,0.0
-2023,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0
-2023,Wyoming,56,Two or more races (NH),,,,,,0.0
-2023,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0
-2023,Wyoming,56,White (NH),31.9,,100.0,,44.64,
-2018,Arizona,04,Unknown race,,,,,,
-2018,California,06,Unknown race,,,,,,
-2018,Florida,12,Unknown race,,,,,,
-2018,Illinois,17,Unknown race,,,,,,
-2018,Indiana,18,Unknown race,,,,,,
-2018,Iowa,19,Unknown race,,,,,,
-2018,Kansas,20,Unknown race,,,,,,
-2018,Massachusetts,25,Unknown race,,,,,,
-2018,Mississippi,28,Unknown race,,,,,,
-2018,Missouri,29,Unknown race,,,,,,
-2018,New York,36,Unknown race,,,,,,
-2018,North Carolina,37,Unknown race,,,,,,
-2018,Ohio,39,Unknown race,,,,,,
-2018,Oklahoma,40,Unknown race,,,,,,
-2018,Rhode Island,44,Unknown race,,,,,,
-2019,Alabama,01,Unknown race,,,,,,
-2019,California,06,Unknown race,,,,,,
-2019,Colorado,08,Unknown race,,,,,,
-2019,Delaware,10,Unknown race,,,,,,
-2019,Kansas,20,Unknown race,,,,,,
-2019,Maryland,24,Unknown race,,,,,,
-2019,Massachusetts,25,Unknown race,,,,,,
-2019,New York,36,Unknown race,,,,,,
-2019,Pennsylvania,42,Unknown race,,,,,,
-2019,Texas,48,Unknown race,,,,,,
-2019,Virginia,51,Unknown race,,,,,,
-2020,Alabama,01,Unknown race,,,,,,
-2020,Colorado,08,Unknown race,,,,,,
-2020,District of Columbia,11,Unknown race,,,,,,
-2020,Illinois,17,Unknown race,,,,,,
-2020,Kansas,20,Unknown race,,,,,,
-2020,Michigan,26,Unknown race,,,,,,
-2020,Minnesota,27,Unknown race,,,,,,
-2020,New York,36,Unknown race,,,,,,
-2020,Pennsylvania,42,Unknown race,,,,,,
-2020,Virginia,51,Unknown race,,,,,,
-2021,Arizona,04,Unknown race,,,,,,
-2021,Arkansas,05,Unknown race,,,,,,
-2021,California,06,Unknown race,,,,,,
-2021,Kansas,20,Unknown race,,,,,,
-2021,Minnesota,27,Unknown race,,,,,,
-2021,New York,36,Unknown race,,,,,,
-2021,Pennsylvania,42,Unknown race,,,,,,
-2021,Virginia,51,Unknown race,,,,,,
-2022,Arizona,04,Unknown race,,,,,,
-2022,Kansas,20,Unknown race,,,,,,
-2022,Maine,23,Unknown race,,,,,,
-2022,Missouri,29,Unknown race,,,,,,
-2022,New York,36,Unknown race,,,,,,
-2023,California,06,Unknown race,,,,,,
-2023,Colorado,08,Unknown race,,,,,,
-2023,Illinois,17,Unknown race,,,,,,
-2023,Iowa,19,Unknown race,,,,,,
-2023,Kansas,20,Unknown race,,,,,,
-2023,Michigan,26,Unknown race,,,,,,
-2023,New York,36,Unknown race,,,,,,
-2023,North Dakota,38,Unknown race,,,,,,
-2023,Texas,48,Unknown race,,,,,,
-2018,Alabama,01,All,0.0,0.0,100.0,100.0,39.83,4.3
-2018,Alaska,02,All,0.0,0.0,100.0,100.0,42.81,
-2018,Arizona,04,All,0.0,0.0,100.0,100.0,23.54,2.56
-2018,Arkansas,05,All,0.0,0.0,100.0,100.0,30.86,3.27
-2018,California,06,All,0.0,0.0,100.0,100.0,12.31,1.2
-2018,Colorado,08,All,0.0,0.0,100.0,100.0,23.55,3.4
-2018,Connecticut,09,All,0.0,0.0,100.0,100.0,4.84,
-2018,Delaware,10,All,0.0,0.0,100.0,100.0,28.18,
-2018,District of Columbia,11,All,0.0,0.0,100.0,100.0,53.81,7.89
-2018,Florida,12,All,0.0,0.0,100.0,100.0,21.21,2.2
-2018,Georgia,13,All,0.0,0.0,100.0,100.0,26.67,3.11
-2018,Hawaii,15,All,0.0,0.0,100.0,100.0,,0.0
-2018,Idaho,16,All,0.0,0.0,100.0,100.0,27.33,2.7
-2018,Illinois,17,All,0.0,0.0,100.0,100.0,24.34,2.98
-2018,Indiana,18,All,0.0,0.0,100.0,100.0,25.56,3.43
-2018,Iowa,19,All,0.0,0.0,100.0,100.0,12.56,1.78
-2018,Kansas,20,All,0.0,0.0,100.0,100.0,24.07,2.41
-2018,Kentucky,21,All,0.0,0.0,100.0,100.0,22.58,2.88
-2018,Louisiana,22,All,0.0,0.0,100.0,100.0,43.95,4.83
-2018,Maine,23,All,0.0,0.0,100.0,100.0,11.31,
-2018,Maryland,24,All,0.0,0.0,100.0,100.0,23.87,2.09
-2018,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.02,
-2018,Michigan,26,All,0.0,0.0,100.0,100.0,21.37,2.31
-2018,Minnesota,27,All,0.0,0.0,100.0,100.0,13.74,1.54
-2018,Mississippi,28,All,0.0,0.0,100.0,100.0,45.04,4.95
-2018,Missouri,29,All,0.0,0.0,100.0,100.0,33.7,5.29
-2018,Montana,30,All,0.0,0.0,100.0,100.0,18.6,
-2018,Nebraska,31,All,0.0,0.0,100.0,100.0,12.94,
-2018,Nevada,32,All,0.0,0.0,100.0,100.0,27.16,3.19
-2018,New Hampshire,33,All,0.0,0.0,100.0,100.0,13.99,
-2018,New Jersey,34,All,0.0,0.0,100.0,100.0,8.99,0.67
-2018,New Mexico,35,All,0.0,0.0,100.0,100.0,39.29,3.52
-2018,New York,36,All,0.0,0.0,100.0,100.0,7.63,0.81
-2018,North Carolina,37,All,0.0,0.0,100.0,100.0,22.01,2.69
-2018,North Dakota,38,All,0.0,0.0,100.0,100.0,12.28,
-2018,Ohio,39,All,0.0,0.0,100.0,100.0,23.36,2.89
-2018,Oklahoma,40,All,0.0,0.0,100.0,100.0,19.08,3.45
-2018,Oregon,41,All,0.0,0.0,100.0,100.0,15.41,2.76
-2018,Pennsylvania,42,All,0.0,0.0,100.0,100.0,23.4,2.07
-2018,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
-2018,South Carolina,45,All,0.0,0.0,100.0,100.0,34.86,3.88
-2018,South Dakota,46,All,0.0,0.0,100.0,100.0,28.31,
-2018,Tennessee,47,All,0.0,0.0,100.0,100.0,35.71,4.24
-2018,Texas,48,All,0.0,0.0,100.0,100.0,19.37,2.52
-2018,Utah,49,All,0.0,0.0,100.0,100.0,15.52,3.01
-2018,Vermont,50,All,0.0,0.0,100.0,100.0,,0.0
-2018,Virginia,51,All,0.0,0.0,100.0,100.0,24.04,2.51
-2018,Washington,53,All,0.0,0.0,100.0,100.0,17.95,2.05
-2018,West Virginia,54,All,0.0,0.0,100.0,100.0,21.31,
-2018,Wisconsin,55,All,0.0,0.0,100.0,100.0,16.68,1.33
-2018,Wyoming,56,All,0.0,0.0,100.0,100.0,36.49,
-2019,Alabama,01,All,0.0,0.0,100.0,100.0,38.15,3.95
-2019,Alaska,02,All,0.0,0.0,100.0,100.0,42.54,6.1
-2019,Arizona,04,All,0.0,0.0,100.0,100.0,22.4,2.13
-2019,Arkansas,05,All,0.0,0.0,100.0,100.0,36.68,3.28
-2019,California,06,All,0.0,0.0,100.0,100.0,11.59,1.25
-2019,Colorado,08,All,0.0,0.0,100.0,100.0,21.67,3.42
-2019,Connecticut,09,All,0.0,0.0,100.0,100.0,6.45,
-2019,Delaware,10,All,0.0,0.0,100.0,100.0,16.79,
-2019,District of Columbia,11,All,0.0,0.0,100.0,100.0,68.32,
-2019,Florida,12,All,0.0,0.0,100.0,100.0,21.79,2.22
-2019,Georgia,13,All,0.0,0.0,100.0,100.0,29.4,3.11
-2019,Hawaii,15,All,0.0,0.0,100.0,100.0,,
-2019,Idaho,16,All,0.0,0.0,100.0,100.0,20.6,
-2019,Illinois,17,All,0.0,0.0,100.0,100.0,24.16,3.51
-2019,Indiana,18,All,0.0,0.0,100.0,100.0,26.93,3.06
-2019,Iowa,19,All,0.0,0.0,100.0,100.0,13.17,2.34
-2019,Kansas,20,All,0.0,0.0,100.0,100.0,22.53,3.56
-2019,Kentucky,21,All,0.0,0.0,100.0,100.0,21.63,3.09
-2019,Louisiana,22,All,0.0,0.0,100.0,100.0,44.36,5.14
-2019,Maine,23,All,0.0,0.0,100.0,100.0,13.87,
-2019,Maryland,24,All,0.0,0.0,100.0,100.0,29.05,1.79
-2019,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.06,
-2019,Michigan,26,All,0.0,0.0,100.0,100.0,19.22,2.15
-2019,Minnesota,27,All,0.0,0.0,100.0,100.0,12.77,1.61
-2019,Mississippi,28,All,0.0,0.0,100.0,100.0,45.35,5.14
-2019,Missouri,29,All,0.0,0.0,100.0,100.0,39.43,5.17
-2019,Montana,30,All,0.0,0.0,100.0,100.0,24.94,4.81
-2019,Nebraska,31,All,0.0,0.0,100.0,100.0,16.72,
-2019,Nevada,32,All,0.0,0.0,100.0,100.0,24.12,1.87
-2019,New Hampshire,33,All,0.0,0.0,100.0,100.0,14.18,
-2019,New Jersey,34,All,0.0,0.0,100.0,100.0,8.18,0.88
-2019,New Mexico,35,All,0.0,0.0,100.0,100.0,36.86,5.24
-2019,New York,36,All,0.0,0.0,100.0,100.0,6.37,0.69
-2019,North Carolina,37,All,0.0,0.0,100.0,100.0,24.78,2.43
-2019,North Dakota,38,All,0.0,0.0,100.0,100.0,,
-2019,Ohio,39,All,0.0,0.0,100.0,100.0,23.93,2.75
-2019,Oklahoma,40,All,0.0,0.0,100.0,100.0,25.53,4.19
-2019,Oregon,41,All,0.0,0.0,100.0,100.0,17.84,1.16
-2019,Pennsylvania,42,All,0.0,0.0,100.0,100.0,20.43,2.05
-2019,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
-2019,South Carolina,45,All,0.0,0.0,100.0,100.0,40.33,4.31
-2019,South Dakota,46,All,0.0,0.0,100.0,100.0,24.22,
-2019,Tennessee,47,All,0.0,0.0,100.0,100.0,30.64,3.04
-2019,Texas,48,All,0.0,0.0,100.0,100.0,20.9,2.85
-2019,Utah,49,All,0.0,0.0,100.0,100.0,17.39,1.83
-2019,Vermont,50,All,0.0,0.0,100.0,100.0,,
-2019,Virginia,51,All,0.0,0.0,100.0,100.0,21.18,2.25
-2019,Washington,53,All,0.0,0.0,100.0,100.0,15.19,1.63
-2019,West Virginia,54,All,0.0,0.0,100.0,100.0,22.71,2.77
-2019,Wisconsin,55,All,0.0,0.0,100.0,100.0,14.74,1.81
-2019,Wyoming,56,All,0.0,0.0,100.0,100.0,26.81,
-2020,Alabama,01,All,0.0,0.0,100.0,100.0,48.85,3.36
-2020,Alaska,02,All,0.0,0.0,100.0,100.0,46.33,8.32
-2020,Arizona,04,All,0.0,0.0,100.0,100.0,25.27,3.44
-2020,Arkansas,05,All,0.0,0.0,100.0,100.0,42.11,6.37
-2020,California,06,All,0.0,0.0,100.0,100.0,15.15,1.61
-2020,Colorado,08,All,0.0,0.0,100.0,100.0,24.35,4.21
-2020,Connecticut,09,All,0.0,0.0,100.0,100.0,10.91,
-2020,Delaware,10,All,0.0,0.0,100.0,100.0,34.78,
-2020,District of Columbia,11,All,0.0,0.0,100.0,100.0,89.21,7.91
-2020,Florida,12,All,0.0,0.0,100.0,100.0,26.93,3.09
-2020,Georgia,13,All,0.0,0.0,100.0,100.0,35.59,3.85
-2020,Hawaii,15,All,0.0,0.0,100.0,100.0,,
-2020,Idaho,16,All,0.0,0.0,100.0,100.0,21.99,3.49
-2020,Illinois,17,All,0.0,0.0,100.0,100.0,32.79,3.56
-2020,Indiana,18,All,0.0,0.0,100.0,100.0,38.66,4.24
-2020,Iowa,19,All,0.0,0.0,100.0,100.0,16.54,2.29
-2020,Kansas,20,All,0.0,0.0,100.0,100.0,33.06,4.77
-2020,Kentucky,21,All,0.0,0.0,100.0,100.0,35.07,5.26
-2020,Louisiana,22,All,0.0,0.0,100.0,100.0,65.25,6.34
-2020,Maine,23,All,0.0,0.0,100.0,100.0,13.94,
-2020,Maryland,24,All,0.0,0.0,100.0,100.0,35.18,1.87
-2020,Massachusetts,25,All,0.0,0.0,100.0,100.0,8.92,
-2020,Michigan,26,All,0.0,0.0,100.0,100.0,26.53,2.89
-2020,Minnesota,27,All,0.0,0.0,100.0,100.0,13.87,2.1
-2020,Mississippi,28,All,0.0,0.0,100.0,100.0,54.16,7.15
-2020,Missouri,29,All,0.0,0.0,100.0,100.0,46.66,5.38
-2020,Montana,30,All,0.0,0.0,100.0,100.0,36.67,4.27
-2020,Nebraska,31,All,0.0,0.0,100.0,100.0,13.92,2.66
-2020,Nevada,32,All,0.0,0.0,100.0,100.0,27.13,3.59
-2020,New Hampshire,33,All,0.0,0.0,100.0,100.0,12.87,
-2020,New Jersey,34,All,0.0,0.0,100.0,100.0,11.1,0.63
-2020,New Mexico,35,All,0.0,0.0,100.0,100.0,36.2,5.25
-2020,New York,36,All,0.0,0.0,100.0,100.0,11.32,0.76
-2020,North Carolina,37,All,0.0,0.0,100.0,100.0,31.93,4.7
-2020,North Dakota,38,All,0.0,0.0,100.0,100.0,12.49,
-2020,Ohio,39,All,0.0,0.0,100.0,100.0,32.18,3.69
-2020,Oklahoma,40,All,0.0,0.0,100.0,100.0,35.46,4.15
-2020,Oregon,41,All,0.0,0.0,100.0,100.0,19.22,1.83
-2020,Pennsylvania,42,All,0.0,0.0,100.0,100.0,27.37,3.04
-2020,Rhode Island,44,All,0.0,0.0,100.0,100.0,11.11,0.0
-2020,South Carolina,45,All,0.0,0.0,100.0,100.0,47.8,5.9
-2020,South Dakota,46,All,0.0,0.0,100.0,100.0,26.02,
-2020,Tennessee,47,All,0.0,0.0,100.0,100.0,37.96,4.5
-2020,Texas,48,All,0.0,0.0,100.0,100.0,27.52,3.51
-2020,Utah,49,All,0.0,0.0,100.0,100.0,18.57,3.26
-2020,Vermont,50,All,0.0,0.0,100.0,100.0,16.59,
-2020,Virginia,51,All,0.0,0.0,100.0,100.0,28.1,3.51
-2020,Washington,53,All,0.0,0.0,100.0,100.0,20.46,1.65
-2020,West Virginia,54,All,0.0,0.0,100.0,100.0,22.74,3.59
-2020,Wisconsin,55,All,0.0,0.0,100.0,100.0,19.55,2.71
-2020,Wyoming,56,All,0.0,0.0,100.0,100.0,34.21,
-2021,Alabama,01,All,0.0,0.0,100.0,100.0,48.92,7.18
-2021,Alaska,02,All,0.0,0.0,100.0,100.0,57.58,
-2021,Arizona,04,All,0.0,0.0,100.0,100.0,28.85,3.57
-2021,Arkansas,05,All,0.0,0.0,100.0,100.0,42.55,4.82
-2021,California,06,All,0.0,0.0,100.0,100.0,16.99,1.66
-2021,Colorado,08,All,0.0,0.0,100.0,100.0,28.55,3.78
-2021,Connecticut,09,All,0.0,0.0,100.0,100.0,14.45,1.37
-2021,Delaware,10,All,0.0,0.0,100.0,100.0,46.82,
-2021,District of Columbia,11,All,0.0,0.0,100.0,100.0,59.75,
-2021,Florida,12,All,0.0,0.0,100.0,100.0,25.62,2.87
-2021,Georgia,13,All,0.0,0.0,100.0,100.0,39.6,5.28
-2021,Hawaii,15,All,0.0,0.0,100.0,100.0,7.37,
-2021,Idaho,16,All,0.0,0.0,100.0,100.0,17.95,2.79
-2021,Illinois,17,All,0.0,0.0,100.0,100.0,36.6,4.62
-2021,Indiana,18,All,0.0,0.0,100.0,100.0,37.43,4.01
-2021,Iowa,19,All,0.0,0.0,100.0,100.0,13.92,2.71
-2021,Kansas,20,All,0.0,0.0,100.0,100.0,28.77,5.96
-2021,Kentucky,21,All,0.0,0.0,100.0,100.0,38.8,5.28
-2021,Louisiana,22,All,0.0,0.0,100.0,100.0,68.72,10.17
-2021,Maine,23,All,0.0,0.0,100.0,100.0,10.43,
-2021,Maryland,24,All,0.0,0.0,100.0,100.0,34.99,2.62
-2021,Massachusetts,25,All,0.0,0.0,100.0,100.0,5.28,
-2021,Michigan,26,All,0.0,0.0,100.0,100.0,28.64,2.97
-2021,Minnesota,27,All,0.0,0.0,100.0,100.0,17.32,1.67
-2021,Mississippi,28,All,0.0,0.0,100.0,100.0,68.02,9.96
-2021,Missouri,29,All,0.0,0.0,100.0,100.0,40.17,6.27
-2021,Montana,30,All,0.0,0.0,100.0,100.0,41.96,7.22
-2021,Nebraska,31,All,0.0,0.0,100.0,100.0,15.83,3.09
-2021,Nevada,32,All,0.0,0.0,100.0,100.0,36.17,2.59
-2021,New Hampshire,33,All,0.0,0.0,100.0,100.0,10.36,
-2021,New Jersey,34,All,0.0,0.0,100.0,100.0,11.17,1.23
-2021,New Mexico,35,All,0.0,0.0,100.0,100.0,45.46,5.13
-2021,New York,36,All,0.0,0.0,100.0,100.0,10.21,1.26
-2021,North Carolina,37,All,0.0,0.0,100.0,100.0,34.82,5.13
-2021,North Dakota,38,All,0.0,0.0,100.0,100.0,19.52,
-2021,Ohio,39,All,0.0,0.0,100.0,100.0,32.94,4.67
-2021,Oklahoma,40,All,0.0,0.0,100.0,100.0,30.65,4.98
-2021,Oregon,41,All,0.0,0.0,100.0,100.0,20.9,1.97
-2021,Pennsylvania,42,All,0.0,0.0,100.0,100.0,27.28,4.14
-2021,Rhode Island,44,All,0.0,0.0,100.0,100.0,12.03,0.0
-2021,South Carolina,45,All,0.0,0.0,100.0,100.0,45.17,6.32
-2021,South Dakota,46,All,0.0,0.0,100.0,100.0,29.89,
-2021,Tennessee,47,All,0.0,0.0,100.0,100.0,42.11,5.53
-2021,Texas,48,All,0.0,0.0,100.0,100.0,30.47,3.49
-2021,Utah,49,All,0.0,0.0,100.0,100.0,18.07,2.11
-2021,Vermont,50,All,0.0,0.0,100.0,100.0,13.85,
-2021,Virginia,51,All,0.0,0.0,100.0,100.0,29.71,4.01
-2021,Washington,53,All,0.0,0.0,100.0,100.0,18.61,2.68
-2021,West Virginia,54,All,0.0,0.0,100.0,100.0,20.38,
-2021,Wisconsin,55,All,0.0,0.0,100.0,100.0,26.71,3.69
-2021,Wyoming,56,All,0.0,0.0,100.0,100.0,32.1,9.06
-2022,Alabama,01,All,0.0,0.0,100.0,100.0,47.91,6.29
-2022,Alaska,02,All,0.0,0.0,100.0,100.0,43.02,6.2
-2022,Arizona,04,All,0.0,0.0,100.0,100.0,30.56,3.7
-2022,Arkansas,05,All,0.0,0.0,100.0,100.0,39.48,5.8
-2022,California,06,All,0.0,0.0,100.0,100.0,13.16,1.52
-2022,Colorado,08,All,0.0,0.0,100.0,100.0,27.08,5.05
-2022,Connecticut,09,All,0.0,0.0,100.0,100.0,11.61,1.37
-2022,Delaware,10,All,0.0,0.0,100.0,100.0,24.55,
-2022,District of Columbia,11,All,0.0,0.0,100.0,100.0,46.85,11.14
-2022,Florida,12,All,0.0,0.0,100.0,100.0,24.88,3.02
-2022,Georgia,13,All,0.0,0.0,100.0,100.0,38.66,6.06
-2022,Hawaii,15,All,0.0,0.0,100.0,100.0,,
-2022,Idaho,16,All,0.0,0.0,100.0,100.0,22.79,2.99
-2022,Illinois,17,All,0.0,0.0,100.0,100.0,29.86,4.29
-2022,Indiana,18,All,0.0,0.0,100.0,100.0,32.08,3.64
-2022,Iowa,19,All,0.0,0.0,100.0,100.0,19.26,2.18
-2022,Kansas,20,All,0.0,0.0,100.0,100.0,25.23,3.86
-2022,Kentucky,21,All,0.0,0.0,100.0,100.0,30.44,3.24
-2022,Louisiana,22,All,0.0,0.0,100.0,100.0,63.98,9.47
-2022,Maine,23,All,0.0,0.0,100.0,100.0,12.71,
-2022,Maryland,24,All,0.0,0.0,100.0,100.0,32.12,3.73
-2022,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.73,0.89
-2022,Michigan,26,All,0.0,0.0,100.0,100.0,24.57,3.33
-2022,Minnesota,27,All,0.0,0.0,100.0,100.0,14.66,1.99
-2022,Mississippi,28,All,0.0,0.0,100.0,100.0,55.48,9.19
-2022,Missouri,29,All,0.0,0.0,100.0,100.0,47.01,5.57
-2022,Montana,30,All,0.0,0.0,100.0,100.0,32.0,5.92
-2022,Nebraska,31,All,0.0,0.0,100.0,100.0,20.75,2.07
-2022,Nevada,32,All,0.0,0.0,100.0,100.0,28.16,2.59
-2022,New Hampshire,33,All,0.0,0.0,100.0,100.0,10.91,
-2022,New Jersey,34,All,0.0,0.0,100.0,100.0,10.91,0.79
-2022,New Mexico,35,All,0.0,0.0,100.0,100.0,37.35,6.74
-2022,New York,36,All,0.0,0.0,100.0,100.0,8.87,1.24
-2022,North Carolina,37,All,0.0,0.0,100.0,100.0,32.13,4.72
-2022,North Dakota,38,All,0.0,0.0,100.0,100.0,18.42,
-2022,Ohio,39,All,0.0,0.0,100.0,100.0,30.5,4.01
-2022,Oklahoma,40,All,0.0,0.0,100.0,100.0,24.13,4.97
-2022,Oregon,41,All,0.0,0.0,100.0,100.0,20.58,1.77
-2022,Pennsylvania,42,All,0.0,0.0,100.0,100.0,25.47,3.77
-2022,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
-2022,South Carolina,45,All,0.0,0.0,100.0,100.0,38.05,6.52
-2022,South Dakota,46,All,0.0,0.0,100.0,100.0,27.26,4.52
-2022,Tennessee,47,All,0.0,0.0,100.0,100.0,38.74,5.05
-2022,Texas,48,All,0.0,0.0,100.0,100.0,27.21,3.94
-2022,Utah,49,All,0.0,0.0,100.0,100.0,16.13,1.91
-2022,Vermont,50,All,0.0,0.0,100.0,100.0,,
-2022,Virginia,51,All,0.0,0.0,100.0,100.0,29.55,3.97
-2022,Washington,53,All,0.0,0.0,100.0,100.0,17.37,2.04
-2022,West Virginia,54,All,0.0,0.0,100.0,100.0,18.77,
-2022,Wisconsin,55,All,0.0,0.0,100.0,100.0,18.7,4.36
-2022,Wyoming,56,All,0.0,0.0,100.0,100.0,41.84,
-2023,Alabama,01,All,0.0,0.0,100.0,100.0,45.3,7.43
-2023,Alaska,02,All,0.0,0.0,100.0,100.0,36.5,5.7
-2023,Arizona,04,All,0.0,0.0,100.0,100.0,24.56,4.11
-2023,Arkansas,05,All,0.0,0.0,100.0,100.0,31.06,6.52
-2023,California,06,All,0.0,0.0,100.0,100.0,12.07,1.86
-2023,Colorado,08,All,0.0,0.0,100.0,100.0,25.13,4.28
-2023,Connecticut,09,All,0.0,0.0,100.0,100.0,9.5,1.52
-2023,Delaware,10,All,0.0,0.0,100.0,100.0,24.27,
-2023,District of Columbia,11,All,0.0,0.0,100.0,100.0,71.42,15.8
-2023,Florida,12,All,0.0,0.0,100.0,100.0,22.06,3.01
-2023,Georgia,13,All,0.0,0.0,100.0,100.0,36.05,5.12
-2023,Hawaii,15,All,0.0,0.0,100.0,100.0,,
-2023,Idaho,16,All,0.0,0.0,100.0,100.0,20.53,4.28
-2023,Illinois,17,All,0.0,0.0,100.0,100.0,27.14,4.58
-2023,Indiana,18,All,0.0,0.0,100.0,100.0,30.82,5.1
-2023,Iowa,19,All,0.0,0.0,100.0,100.0,13.64,2.47
-2023,Kansas,20,All,0.0,0.0,100.0,100.0,26.03,4.32
-2023,Kentucky,21,All,0.0,0.0,100.0,100.0,30.24,4.72
-2023,Louisiana,22,All,0.0,0.0,100.0,100.0,66.01,8.81
-2023,Maine,23,All,0.0,0.0,100.0,100.0,16.67,
-2023,Maryland,24,All,0.0,0.0,100.0,100.0,26.48,3.3
-2023,Massachusetts,25,All,0.0,0.0,100.0,100.0,7.35,0.75
-2023,Michigan,26,All,0.0,0.0,100.0,100.0,21.24,3.6
-2023,Minnesota,27,All,0.0,0.0,100.0,100.0,13.54,1.61
-2023,Mississippi,28,All,0.0,0.0,100.0,100.0,58.31,9.71
-2023,Missouri,29,All,0.0,0.0,100.0,100.0,36.54,5.46
-2023,Montana,30,All,0.0,0.0,100.0,100.0,22.29,4.67
-2023,Nebraska,31,All,0.0,0.0,100.0,100.0,17.26,2.91
-2023,Nevada,32,All,0.0,0.0,100.0,100.0,27.4,4.37
-2023,New Hampshire,33,All,0.0,0.0,100.0,100.0,9.57,
-2023,New Jersey,34,All,0.0,0.0,100.0,100.0,8.04,1.05
-2023,New Mexico,35,All,0.0,0.0,100.0,100.0,51.89,7.31
-2023,New York,36,All,0.0,0.0,100.0,100.0,7.05,1.11
-2023,North Carolina,37,All,0.0,0.0,100.0,100.0,30.37,4.37
-2023,North Dakota,38,All,0.0,0.0,100.0,100.0,17.2,5.96
-2023,Ohio,39,All,0.0,0.0,100.0,100.0,24.79,4.62
-2023,Oklahoma,40,All,0.0,0.0,100.0,100.0,23.85,5.69
-2023,Oregon,41,All,0.0,0.0,100.0,100.0,23.82,2.16
-2023,Pennsylvania,42,All,0.0,0.0,100.0,100.0,22.87,2.59
-2023,Rhode Island,44,All,0.0,0.0,100.0,100.0,,
-2023,South Carolina,45,All,0.0,0.0,100.0,100.0,39.6,4.89
-2023,South Dakota,46,All,0.0,0.0,100.0,100.0,23.72,
-2023,Tennessee,47,All,0.0,0.0,100.0,100.0,39.86,6.11
-2023,Texas,48,All,0.0,0.0,100.0,100.0,24.66,3.66
-2023,Utah,49,All,0.0,0.0,100.0,100.0,16.22,2.79
-2023,Vermont,50,All,0.0,0.0,100.0,100.0,,
-2023,Virginia,51,All,0.0,0.0,100.0,100.0,26.16,3.08
-2023,Washington,53,All,0.0,0.0,100.0,100.0,18.65,2.73
-2023,West Virginia,54,All,0.0,0.0,100.0,100.0,16.46,
-2023,Wisconsin,55,All,0.0,0.0,100.0,100.0,19.8,3.44
-2023,Wyoming,56,All,0.0,0.0,100.0,100.0,39.72,
+time_period,state_name,state_fips,race_and_ethnicity,gun_deaths_young_adults_pct_relative_inequity,gun_deaths_youth_pct_relative_inequity,gun_deaths_young_adults_pct_share,gun_deaths_youth_pct_share,gun_deaths_young_adults_per_100k,gun_deaths_youth_per_100k,gun_deaths_young_adults_per_100k_is_suppressed,gun_deaths_youth_per_100k_is_suppressed
+2018,Alabama,01,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Alabama,01,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Alabama,01,Black or African American (NH),125.2,42.4,65.3,41.3,80.76,5.99,,
+2018,Alabama,01,Hispanic or Latino,,,,,,,True,True
+2018,Alabama,01,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Alabama,01,White (NH),-40.1,1.4,34.7,58.7,22.7,4.27,,
+2018,Alaska,02,Indigenous (NH),446.4,,100.0,,104.76,,,True
+2018,Alaska,02,Asian (NH),-100.0,,0.0,,0.0,,,True
+2018,Alaska,02,Black or African American (NH),,,,,,0.0,True,
+2018,Alaska,02,Hispanic or Latino,,,,,,,True,True
+2018,Alaska,02,Two or more races (NH),,,,,,,True,True
+2018,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2018,Alaska,02,White (NH),,,,,,,True,True
+2018,Arizona,04,Indigenous (NH),,,,,,,True,True
+2018,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Arizona,04,Black or African American (NH),549.0,,31.8,,65.77,,,True
+2018,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2018,Arizona,04,Two or more races (NH),,,,,,,True,True
+2018,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2018,Arizona,04,White (NH),76.7,159.1,68.2,100.0,17.43,3.0,,
+2018,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Arkansas,05,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Arkansas,05,Black or African American (NH),194.4,,52.7,,81.25,,,True
+2018,Arkansas,05,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2018,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Arkansas,05,White (NH),-24.8,59.0,47.3,100.0,20.9,3.16,,
+2018,California,06,Indigenous (NH),900.0,-100.0,4.0,0.0,55.64,0.0,,
+2018,California,06,Asian (NH),-56.9,,5.3,,2.36,,,True
+2018,California,06,Black or African American (NH),774.0,764.0,43.7,43.2,42.21,4.2,,
+2018,California,06,Hispanic or Latino,,,,,,,True,True
+2018,California,06,Two or more races (NH),82.4,,9.3,,14.14,,,True
+2018,California,06,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2018,California,06,White (NH),49.0,124.5,37.7,56.8,7.52,1.1,,
+2018,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Colorado,08,Asian (NH),,,,,,,True,True
+2018,Colorado,08,Black or African American (NH),455.8,,23.9,,77.5,,,True
+2018,Colorado,08,Hispanic or Latino,,,,,,,True,True
+2018,Colorado,08,Two or more races (NH),,,,,,,True,True
+2018,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Colorado,08,White (NH),36.4,79.2,76.1,100.0,19.02,3.12,,
+2018,Connecticut,09,Indigenous (NH),,,,,0.0,0.0,,
+2018,Connecticut,09,Asian (NH),,,,,0.0,0.0,,
+2018,Connecticut,09,Black or African American (NH),,,,,,,True,True
+2018,Connecticut,09,Hispanic or Latino,,,,,,0.0,True,
+2018,Connecticut,09,Two or more races (NH),,,,,0.0,0.0,,
+2018,Connecticut,09,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2018,Connecticut,09,White (NH),,,,,,,True,True
+2018,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,,,True
+2018,Delaware,10,Black or African American (NH),296.8,,100.0,,69.26,,,True
+2018,Delaware,10,Hispanic or Latino,,,,,,0.0,True,
+2018,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Delaware,10,White (NH),,,,,,,True,True
+2018,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,District of Columbia,11,Black or African American (NH),83.2,,100.0,,127.94,,,True
+2018,District of Columbia,11,Hispanic or Latino,-100.0,,0.0,,0.0,,,True
+2018,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,District of Columbia,11,White (NH),,,,,,0.0,True,
+2018,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2018,Florida,12,Asian (NH),,,,,,,True,True
+2018,Florida,12,Black or African American (NH),202.5,116.8,61.1,43.8,50.15,3.28,,
+2018,Florida,12,Hispanic or Latino,,,,,,,True,True
+2018,Florida,12,Two or more races (NH),,,,,,,True,True
+2018,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Florida,12,White (NH),-8.0,32.9,38.9,56.2,14.41,2.01,,
+2018,Georgia,13,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Georgia,13,Asian (NH),,,,,,,True,True
+2018,Georgia,13,Black or African American (NH),108.7,88.7,69.9,63.2,47.99,5.7,,
+2018,Georgia,13,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2018,Georgia,13,Two or more races (NH),,,,,,,True,True
+2018,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Georgia,13,White (NH),-31.1,-15.8,30.1,36.8,15.76,2.56,,
+2018,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2018,Hawaii,15,Asian (NH),,,,,0.0,0.0,,
+2018,Hawaii,15,Black or African American (NH),,,,,0.0,0.0,,
+2018,Hawaii,15,Hispanic or Latino,,,,,,0.0,True,
+2018,Hawaii,15,Two or more races (NH),,,,,0.0,0.0,,
+2018,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2018,Hawaii,15,White (NH),,,,,0.0,0.0,,
+2018,Idaho,16,Indigenous (NH),,,,,,,True,True
+2018,Idaho,16,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Idaho,16,Black or African American (NH),,,,,,0.0,True,
+2018,Idaho,16,Hispanic or Latino,,,,,,,True,True
+2018,Idaho,16,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2018,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Idaho,16,White (NH),33.5,,100.0,,26.26,,,True
+2018,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Illinois,17,Black or African American (NH),429.4,417.6,81.0,79.2,101.97,13.91,,
+2018,Illinois,17,Hispanic or Latino,,,,,,,True,True
+2018,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Illinois,17,White (NH),-62.8,-59.3,19.0,20.8,7.33,1.1,,
+2018,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Indiana,18,Black or African American (NH),312.4,360.2,46.6,52.0,107.81,14.64,,
+2018,Indiana,18,Hispanic or Latino,-53.1,,5.3,,15.0,,,True
+2018,Indiana,18,Two or more races (NH),,,,,,,True,True
+2018,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Indiana,18,White (NH),-31.8,-31.9,48.1,48.0,16.51,2.17,,
+2018,Iowa,19,Indigenous (NH),,,,,,0.0,True,
+2018,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Iowa,19,Black or African American (NH),,,,,,,True,True
+2018,Iowa,19,Hispanic or Latino,,,,,,,True,True
+2018,Iowa,19,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2018,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Iowa,19,White (NH),30.0,,100.0,,13.01,,,True
+2018,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Kansas,20,Asian (NH),-100.0,,0.0,,0.0,,,True
+2018,Kansas,20,Black or African American (NH),429.0,,32.8,,80.65,,,True
+2018,Kansas,20,Hispanic or Latino,,,,,,,True,True
+2018,Kansas,20,Two or more races (NH),,,,,,,True,True
+2018,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Kansas,20,White (NH),1.7,51.3,67.2,100.0,16.92,2.35,,
+2018,Kentucky,21,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2018,Kentucky,21,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Kentucky,21,Black or African American (NH),284.6,,35.0,,70.52,,,True
+2018,Kentucky,21,Hispanic or Latino,,,,,,,True,True
+2018,Kentucky,21,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Kentucky,21,White (NH),-16.8,28.0,65.0,100.0,17.54,2.54,,
+2018,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Louisiana,22,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Louisiana,22,Black or African American (NH),99.2,64.6,73.1,60.4,82.61,7.95,,
+2018,Louisiana,22,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2018,Louisiana,22,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Louisiana,22,White (NH),-47.2,-22.2,26.9,39.6,22.46,3.75,,
+2018,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Maine,23,Black or African American (NH),,,,,,0.0,True,
+2018,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2018,Maine,23,Two or more races (NH),,,,,,0.0,True,
+2018,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Maine,23,White (NH),13.3,,100.0,,10.87,,,True
+2018,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Maryland,24,Asian (NH),,,,,,,True,True
+2018,Maryland,24,Black or African American (NH),158.8,94.8,79.7,60.0,53.3,3.64,,
+2018,Maryland,24,Hispanic or Latino,,,,,,,True,True
+2018,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Maryland,24,White (NH),-51.3,-4.1,20.3,40.0,9.57,1.79,,
+2018,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Massachusetts,25,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Massachusetts,25,Black or African American (NH),589.8,,60.7,,25.99,,,True
+2018,Massachusetts,25,Hispanic or Latino,,,,,,0.0,True,
+2018,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Massachusetts,25,White (NH),-35.6,,39.3,,2.12,,,True
+2018,Michigan,26,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Michigan,26,Asian (NH),,,,,,,True,True
+2018,Michigan,26,Black or African American (NH),258.1,191.9,57.3,46.7,73.4,6.08,,
+2018,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2018,Michigan,26,Two or more races (NH),,,,,,,True,True
+2018,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Michigan,26,White (NH),-35.9,-20.0,42.7,53.3,12.4,1.67,,
+2018,Minnesota,27,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Minnesota,27,Black or African American (NH),212.0,,31.2,,43.91,,,True
+2018,Minnesota,27,Hispanic or Latino,,,,,,,True,True
+2018,Minnesota,27,Two or more races (NH),,,,,,,True,True
+2018,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Minnesota,27,White (NH),1.2,47.1,68.8,100.0,10.45,1.58,,
+2018,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Mississippi,28,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Mississippi,28,Black or African American (NH),68.4,139.2,70.4,100.0,70.59,8.46,,
+2018,Mississippi,28,Hispanic or Latino,,,,,,,True,True
+2018,Mississippi,28,Two or more races (NH),,,,,,,True,True
+2018,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Mississippi,28,White (NH),-40.0,,29.6,,25.63,,,True
+2018,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Missouri,29,Asian (NH),-100.0,,0.0,,0.0,,,True
+2018,Missouri,29,Black or African American (NH),338.5,235.6,59.2,45.3,135.62,15.61,,
+2018,Missouri,29,Hispanic or Latino,,,,,,,True,True
+2018,Missouri,29,Two or more races (NH),,,,,,,True,True
+2018,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Missouri,29,White (NH),-43.6,-24.4,40.8,54.7,17.47,3.51,,
+2018,Montana,30,Indigenous (NH),,,,,,,True,True
+2018,Montana,30,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Montana,30,Black or African American (NH),,,,,,0.0,True,
+2018,Montana,30,Hispanic or Latino,,,,,,0.0,True,
+2018,Montana,30,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Montana,30,White (NH),28.5,,100.0,,16.36,,,True
+2018,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2018,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Nebraska,31,Black or African American (NH),,,,,,0.0,True,
+2018,Nebraska,31,Hispanic or Latino,,,,,,0.0,True,
+2018,Nebraska,31,Two or more races (NH),,,,,,0.0,True,
+2018,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Nebraska,31,White (NH),47.1,,100.0,,12.04,,,True
+2018,Nevada,32,Indigenous (NH),,,,,,0.0,True,
+2018,Nevada,32,Asian (NH),,,,,,,True,True
+2018,Nevada,32,Black or African American (NH),344.7,,45.8,,70.82,,,True
+2018,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2018,Nevada,32,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2018,Nevada,32,White (NH),56.6,,54.2,,24.63,,,True
+2018,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Hampshire,33,White (NH),18.3,,100.0,,16.21,,,True
+2018,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Jersey,34,Asian (NH),,,,,,0.0,True,
+2018,New Jersey,34,Black or African American (NH),477.6,,77.4,,35.93,,,True
+2018,New Jersey,34,Hispanic or Latino,,,,,,,True,True
+2018,New Jersey,34,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Jersey,34,White (NH),-51.3,,22.6,,3.21,,,True
+2018,New Mexico,35,Indigenous (NH),,,,,,,True,True
+2018,New Mexico,35,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Mexico,35,Black or African American (NH),,,,,,0.0,True,
+2018,New Mexico,35,Hispanic or Latino,,,,,,,True,True
+2018,New Mexico,35,Two or more races (NH),,,,,,0.0,True,
+2018,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,New Mexico,35,White (NH),332.9,,100.0,,34.88,,,True
+2018,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,New York,36,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,New York,36,Black or African American (NH),315.5,237.8,61.5,50.0,22.95,2.48,,
+2018,New York,36,Hispanic or Latino,,,,,,,True,True
+2018,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,New York,36,White (NH),-20.1,3.7,38.5,50.0,4.43,0.76,,
+2018,North Carolina,37,Indigenous (NH),,,,,,,True,True
+2018,North Carolina,37,Asian (NH),,,,,,,True,True
+2018,North Carolina,37,Black or African American (NH),171.6,113.8,61.1,48.1,48.82,5.02,,
+2018,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2018,North Carolina,37,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2018,North Carolina,37,White (NH),-25.0,0.0,38.9,51.9,13.4,2.34,,
+2018,North Dakota,38,Indigenous (NH),,,,,,0.0,True,
+2018,North Dakota,38,Asian (NH),,,,,0.0,0.0,,
+2018,North Dakota,38,Black or African American (NH),,,,,0.0,0.0,,
+2018,North Dakota,38,Hispanic or Latino,,,,,,0.0,True,
+2018,North Dakota,38,Two or more races (NH),,,,,0.0,0.0,,
+2018,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2018,North Dakota,38,White (NH),,,,,,,True,True
+2018,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Ohio,39,Black or African American (NH),232.5,194.0,50.2,44.4,76.03,8.17,,
+2018,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2018,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Ohio,39,White (NH),-29.7,-21.5,49.8,55.6,15.05,2.18,,
+2018,Oklahoma,40,Indigenous (NH),,,,,,,True,True
+2018,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Oklahoma,40,Black or African American (NH),361.0,,35.5,,54.51,,,True
+2018,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2018,Oklahoma,40,Two or more races (NH),,,,,,,True,True
+2018,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Oklahoma,40,White (NH),23.6,91.6,64.5,100.0,16.35,3.41,,
+2018,Oregon,41,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Oregon,41,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Oregon,41,Black or African American (NH),,,,,,,True,True
+2018,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2018,Oregon,41,Two or more races (NH),,,,,,,True,True
+2018,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Oregon,41,White (NH),57.7,57.7,100.0,100.0,16.25,2.91,,
+2018,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Pennsylvania,42,Asian (NH),,,,,,,True,True
+2018,Pennsylvania,42,Black or African American (NH),325.6,351.9,54.9,58.3,84.74,8.16,,
+2018,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2018,Pennsylvania,42,Two or more races (NH),,,,,,,True,True
+2018,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Pennsylvania,42,White (NH),-31.9,-37.0,45.1,41.7,13.37,1.14,,
+2018,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2018,Rhode Island,44,Asian (NH),,,,,,0.0,True,
+2018,Rhode Island,44,Black or African American (NH),,,,,,,True,True
+2018,Rhode Island,44,Hispanic or Latino,,,,,,0.0,True,
+2018,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2018,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2018,Rhode Island,44,White (NH),,,,,,0.0,True,
+2018,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,South Carolina,45,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,South Carolina,45,Black or African American (NH),90.5,133.9,56.2,69.0,60.41,8.86,,
+2018,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2018,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,South Carolina,45,White (NH),-19.8,-43.2,43.8,31.0,24.98,2.15,,
+2018,South Dakota,46,Indigenous (NH),,,,,,,True,True
+2018,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,South Dakota,46,Black or African American (NH),,,,,,0.0,True,
+2018,South Dakota,46,Hispanic or Latino,,,,,,0.0,True,
+2018,South Dakota,46,Two or more races (NH),,,,,,0.0,True,
+2018,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,South Dakota,46,White (NH),41.2,,100.0,,23.35,,,True
+2018,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Tennessee,47,Asian (NH),-100.0,,0.0,,0.0,,,True
+2018,Tennessee,47,Black or African American (NH),230.5,143.7,62.8,46.3,103.14,8.72,,
+2018,Tennessee,47,Hispanic or Latino,,,,,,,True,True
+2018,Tennessee,47,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Tennessee,47,White (NH),-42.8,-17.4,37.2,53.7,18.37,2.95,,
+2018,Texas,48,Indigenous (NH),,,,,,,True,True
+2018,Texas,48,Asian (NH),-32.6,,3.1,,8.54,,,True
+2018,Texas,48,Black or African American (NH),326.9,188.2,50.8,34.3,47.27,3.86,,
+2018,Texas,48,Hispanic or Latino,,,,,,,True,True
+2018,Texas,48,Two or more races (NH),,,,,,,True,True
+2018,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Texas,48,White (NH),47.1,109.2,46.2,65.7,16.45,2.81,,
+2018,Utah,49,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Utah,49,Asian (NH),,,,,,,True,True
+2018,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2018,Utah,49,Hispanic or Latino,,,,,,,True,True
+2018,Utah,49,Two or more races (NH),,,,,,,True,True
+2018,Utah,49,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2018,Utah,49,White (NH),35.3,35.3,100.0,100.0,14.54,2.76,,
+2018,Vermont,50,Indigenous (NH),,,,,0.0,0.0,,
+2018,Vermont,50,Asian (NH),,,,,0.0,0.0,,
+2018,Vermont,50,Black or African American (NH),,,,,,0.0,True,
+2018,Vermont,50,Hispanic or Latino,,,,,0.0,0.0,,
+2018,Vermont,50,Two or more races (NH),,,,,0.0,0.0,,
+2018,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2018,Vermont,50,White (NH),,,,,,0.0,True,
+2018,Virginia,51,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Virginia,51,Asian (NH),,,,,,,True,True
+2018,Virginia,51,Black or African American (NH),168.8,117.1,53.5,43.2,54.18,4.31,,
+2018,Virginia,51,Hispanic or Latino,,,,,,,True,True
+2018,Virginia,51,Two or more races (NH),,,,,,,True,True
+2018,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2018,Virginia,51,White (NH),-12.8,6.6,46.5,56.8,17.5,2.11,,
+2018,Washington,53,Indigenous (NH),,,,,,,True,True
+2018,Washington,53,Asian (NH),,,,,,,True,True
+2018,Washington,53,Black or African American (NH),200.0,,12.6,,30.16,,,True
+2018,Washington,53,Hispanic or Latino,,,,,,,True,True
+2018,Washington,53,Two or more races (NH),,,,,,,True,True
+2018,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2018,Washington,53,White (NH),57.5,80.2,87.4,100.0,16.65,1.85,,
+2018,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,West Virginia,54,Black or African American (NH),,,,,,0.0,True,
+2018,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2018,West Virginia,54,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,West Virginia,54,White (NH),12.6,,100.0,,20.23,,,True
+2018,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2018,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0,True,
+2018,Wisconsin,55,Black or African American (NH),369.7,,41.8,,75.35,,,True
+2018,Wisconsin,55,Hispanic or Latino,,,,,,,True,True
+2018,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2018,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2018,Wisconsin,55,White (NH),-16.3,43.9,58.2,100.0,11.17,1.13,,
+2018,Wyoming,56,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Wyoming,56,Black or African American (NH),,,,,,0.0,True,
+2018,Wyoming,56,Hispanic or Latino,,,,,,0.0,True,
+2018,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2018,Wyoming,56,White (NH),30.0,,100.0,,40.2,,,True
+2019,Alabama,01,Indigenous (NH),,,,,,,True,True
+2019,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Alabama,01,Black or African American (NH),131.8,77.5,67.0,51.3,80.03,6.35,,
+2019,Alabama,01,Hispanic or Latino,,,,,,,True,True
+2019,Alabama,01,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Alabama,01,White (NH),-42.7,-15.5,33.0,48.7,20.5,3.03,,
+2019,Alaska,02,Indigenous (NH),117.4,,40.0,,76.23,,,True
+2019,Alaska,02,Asian (NH),-100.0,,0.0,,0.0,,,True
+2019,Alaska,02,Black or African American (NH),,,,,,0.0,True,
+2019,Alaska,02,Hispanic or Latino,,,,,,,True,True
+2019,Alaska,02,Two or more races (NH),,,,,,,True,True
+2019,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2019,Alaska,02,White (NH),26.3,,60.0,,36.38,,,True
+2019,Arizona,04,Indigenous (NH),,,,,,,True,True
+2019,Arizona,04,Asian (NH),,,,,,,True,True
+2019,Arizona,04,Black or African American (NH),388.0,,24.4,,45.63,,,True
+2019,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2019,Arizona,04,Two or more races (NH),,,,,,,True,True
+2019,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Arizona,04,White (NH),97.4,161.1,75.6,100.0,17.64,1.91,,
+2019,Arkansas,05,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Arkansas,05,Black or African American (NH),157.9,461.8,45.9,100.0,84.05,9.61,,
+2019,Arkansas,05,Hispanic or Latino,,,,,,,True,True
+2019,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2019,Arkansas,05,White (NH),-13.6,,54.1,,28.31,,,True
+2019,California,06,Indigenous (NH),,,,,,,True,True
+2019,California,06,Asian (NH),-34.4,,8.2,,3.48,,,True
+2019,California,06,Black or African American (NH),840.0,1052.0,47.0,57.6,44.05,4.28,,
+2019,California,06,Hispanic or Latino,,,,,,,True,True
+2019,California,06,Two or more races (NH),57.7,,8.2,,11.61,,,True
+2019,California,06,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2019,California,06,White (NH),46.4,69.6,36.6,42.4,7.09,0.63,,
+2019,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Colorado,08,Asian (NH),,,,,,,True,True
+2019,Colorado,08,Black or African American (NH),365.1,,20.0,,67.56,,,True
+2019,Colorado,08,Hispanic or Latino,,,,,,,True,True
+2019,Colorado,08,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2019,Colorado,08,White (NH),44.1,80.2,80.0,100.0,20.73,2.72,,
+2019,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Connecticut,09,Black or African American (NH),769.6,,100.0,,21.79,,,True
+2019,Connecticut,09,Hispanic or Latino,,,,,,,True,True
+2019,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Connecticut,09,White (NH),,,,,,,True,True
+2019,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Delaware,10,Black or African American (NH),295.3,,100.0,,46.47,,,True
+2019,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2019,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Delaware,10,White (NH),,,,,,0.0,True,
+2019,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,District of Columbia,11,Black or African American (NH),88.0,,100.0,,165.05,,,True
+2019,District of Columbia,11,Hispanic or Latino,,,,,,0.0,True,
+2019,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Florida,12,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Florida,12,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Florida,12,Black or African American (NH),225.9,151.7,65.5,50.6,57.07,5.29,,
+2019,Florida,12,Hispanic or Latino,,-49.5,,15.7,,1.0,True,
+2019,Florida,12,Two or more races (NH),,,,,,,True,True
+2019,Florida,12,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2019,Florida,12,White (NH),-17.9,-19.8,34.5,33.7,13.56,1.69,,
+2019,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Georgia,13,Asian (NH),,,,,,,True,True
+2019,Georgia,13,Black or African American (NH),119.9,74.1,73.9,58.5,57.33,4.51,,
+2019,Georgia,13,Hispanic or Latino,,,,,,,True,True
+2019,Georgia,13,Two or more races (NH),,,,,,,True,True
+2019,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Georgia,13,White (NH),-39.6,-3.9,26.1,41.5,15.35,2.5,,
+2019,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2019,Hawaii,15,Asian (NH),,,,,0.0,0.0,,
+2019,Hawaii,15,Black or African American (NH),,,,,0.0,0.0,,
+2019,Hawaii,15,Hispanic or Latino,,,,,0.0,0.0,,
+2019,Hawaii,15,Two or more races (NH),,,,,,0.0,True,
+2019,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2019,Hawaii,15,White (NH),,,,,,0.0,True,
+2019,Idaho,16,Indigenous (NH),,,,,,0.0,True,
+2019,Idaho,16,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Idaho,16,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Idaho,16,Hispanic or Latino,,,,,,0.0,True,
+2019,Idaho,16,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Idaho,16,White (NH),33.9,,100.0,,22.43,,,True
+2019,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Illinois,17,Black or African American (NH),441.2,416.3,82.8,79.0,103.78,14.83,,
+2019,Illinois,17,Hispanic or Latino,,,,,,,True,True
+2019,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Illinois,17,White (NH),-66.2,-58.7,17.2,21.0,6.5,1.19,,
+2019,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Indiana,18,Black or African American (NH),358.8,400.9,52.3,57.1,126.57,13.46,,
+2019,Indiana,18,Hispanic or Latino,-42.6,,6.6,,19.0,,,True
+2019,Indiana,18,Two or more races (NH),,,,,,,True,True
+2019,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Indiana,18,White (NH),-41.3,-38.7,41.1,42.9,14.82,1.64,,
+2019,Iowa,19,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,,,True
+2019,Iowa,19,Black or African American (NH),,,,,,,True,True
+2019,Iowa,19,Hispanic or Latino,,,,,,,True,True
+2019,Iowa,19,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Iowa,19,White (NH),30.7,,100.0,,13.51,,,True
+2019,Kansas,20,Indigenous (NH),,,,,,,True,True
+2019,Kansas,20,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Kansas,20,Black or African American (NH),208.1,,19.1,,57.22,,,True
+2019,Kansas,20,Hispanic or Latino,-22.2,,14.7,,19.0,,,True
+2019,Kansas,20,Two or more races (NH),,,,,,,True,True
+2019,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Kansas,20,White (NH),0.5,51.7,66.2,100.0,19.81,2.38,,
+2019,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Kentucky,21,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Kentucky,21,Black or African American (NH),408.7,426.1,46.8,48.4,86.57,16.27,,
+2019,Kentucky,21,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,Kentucky,21,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Kentucky,21,White (NH),-31.6,-33.7,53.2,51.6,13.19,2.05,,
+2019,Louisiana,22,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Louisiana,22,Black or African American (NH),102.7,84.4,74.0,67.3,82.02,9.3,,
+2019,Louisiana,22,Hispanic or Latino,,,,,,,True,True
+2019,Louisiana,22,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Louisiana,22,White (NH),-48.7,-35.5,26.0,32.7,21.18,3.26,,
+2019,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Maine,23,Black or African American (NH),,,,,,0.0,True,
+2019,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2019,Maine,23,Two or more races (NH),,,,,,0.0,True,
+2019,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Maine,23,White (NH),13.8,,100.0,,13.79,,,True
+2019,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Maryland,24,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Maryland,24,Black or African American (NH),196.4,225.7,91.0,100.0,77.28,4.39,,
+2019,Maryland,24,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,Maryland,24,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Maryland,24,White (NH),-78.1,,9.0,,5.42,,,True
+2019,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Massachusetts,25,Asian (NH),,,,,,0.0,True,
+2019,Massachusetts,25,Black or African American (NH),479.8,,51.6,,24.64,,,True
+2019,Massachusetts,25,Hispanic or Latino,,,,,,,True,True
+2019,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Massachusetts,25,White (NH),-19.6,,48.4,,2.92,,,True
+2019,Michigan,26,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Michigan,26,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Michigan,26,Black or African American (NH),316.9,252.5,66.7,56.4,74.75,6.41,,
+2019,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2019,Michigan,26,Two or more races (NH),,,,,,,True,True
+2019,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Michigan,26,White (NH),-49.8,-34.2,33.3,43.6,8.32,1.2,,
+2019,Minnesota,27,Indigenous (NH),,,,,,,True,True
+2019,Minnesota,27,Asian (NH),,,,,,,True,True
+2019,Minnesota,27,Black or African American (NH),285.4,,39.7,,53.75,,,True
+2019,Minnesota,27,Hispanic or Latino,,,,,,,True,True
+2019,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Minnesota,27,White (NH),-10.7,48.1,60.3,100.0,9.15,1.25,,
+2019,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Mississippi,28,Asian (NH),,,,,,,True,True
+2019,Mississippi,28,Black or African American (NH),74.3,16.8,72.5,48.6,74.44,5.83,,
+2019,Mississippi,28,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,Mississippi,28,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Mississippi,28,White (NH),-44.1,4.5,27.5,51.4,24.01,5.23,,
+2019,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Missouri,29,Asian (NH),,,,,,,True,True
+2019,Missouri,29,Black or African American (NH),326.7,410.4,57.6,68.9,157.16,22.68,,
+2019,Missouri,29,Hispanic or Latino,,,,,,,True,True
+2019,Missouri,29,Two or more races (NH),,,,,,,True,True
+2019,Missouri,29,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2019,Missouri,29,White (NH),-41.2,-56.9,42.4,31.1,21.19,1.92,,
+2019,Montana,30,Indigenous (NH),,,,,,,True,True
+2019,Montana,30,Asian (NH),-100.0,,0.0,,0.0,,,True
+2019,Montana,30,Black or African American (NH),,,,,,0.0,True,
+2019,Montana,30,Hispanic or Latino,,,,,,0.0,True,
+2019,Montana,30,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2019,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Montana,30,White (NH),28.7,,100.0,,21.98,,,True
+2019,Nebraska,31,Indigenous (NH),,,,,,0.0,True,
+2019,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Nebraska,31,Black or African American (NH),473.3,,34.4,,89.16,,,True
+2019,Nebraska,31,Hispanic or Latino,,,,,,0.0,True,
+2019,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2019,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Nebraska,31,White (NH),-3.0,,65.6,,13.46,,,True
+2019,Nevada,32,Indigenous (NH),,,,,,0.0,True,
+2019,Nevada,32,Asian (NH),,,,,,0.0,True,
+2019,Nevada,32,Black or African American (NH),152.8,,26.8,,35.45,,,True
+2019,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2019,Nevada,32,Two or more races (NH),,,,,,,True,True
+2019,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Nevada,32,White (NH),114.7,,73.2,,28.6,,,True
+2019,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2019,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2019,New Hampshire,33,Hispanic or Latino,,,,,,,True,True
+2019,New Hampshire,33,Two or more races (NH),,,,,,0.0,True,
+2019,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,New Hampshire,33,White (NH),19.0,,100.0,,14.04,0.0,,
+2019,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New Jersey,34,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New Jersey,34,Black or African American (NH),651.9,651.9,100.0,100.0,38.36,4.63,,
+2019,New Jersey,34,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,New Jersey,34,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New Jersey,34,White (NH),,,,,,,True,True
+2019,New Mexico,35,Indigenous (NH),,,,,,,True,True
+2019,New Mexico,35,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,New Mexico,35,Black or African American (NH),,,,,,,True,True
+2019,New Mexico,35,Hispanic or Latino,,62.1,,100.0,,5.0,True,
+2019,New Mexico,35,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New Mexico,35,White (NH),336.7,,100.0,,33.82,,,True
+2019,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New York,36,Asian (NH),,,,,,,True,True
+2019,New York,36,Black or African American (NH),334.0,240.1,63.8,50.0,21.17,1.85,,
+2019,New York,36,Hispanic or Latino,,,,,,,True,True
+2019,New York,36,Two or more races (NH),,,,,,,True,True
+2019,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,New York,36,White (NH),-24.4,4.4,36.2,50.0,3.65,0.57,,
+2019,North Carolina,37,Indigenous (NH),,,,,,,True,True
+2019,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,North Carolina,37,Black or African American (NH),180.8,213.4,62.9,70.2,57.85,6.38,,
+2019,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2019,North Carolina,37,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,North Carolina,37,White (NH),-27.8,-42.0,37.1,29.8,14.48,1.18,,
+2019,North Dakota,38,Indigenous (NH),,,,,0.0,0.0,,
+2019,North Dakota,38,Asian (NH),,,,,0.0,0.0,,
+2019,North Dakota,38,Black or African American (NH),,,,,0.0,0.0,,
+2019,North Dakota,38,Hispanic or Latino,,,,,0.0,0.0,,
+2019,North Dakota,38,Two or more races (NH),,,,,,0.0,True,
+2019,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2019,North Dakota,38,White (NH),,,,,,,True,True
+2019,Ohio,39,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Ohio,39,Asian (NH),,,,,,,True,True
+2019,Ohio,39,Black or African American (NH),272.4,213.8,56.6,47.7,87.79,7.92,,
+2019,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2019,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Ohio,39,White (NH),-38.4,-25.7,43.4,52.3,13.3,1.87,,
+2019,Oklahoma,40,Indigenous (NH),,,,,,,True,True
+2019,Oklahoma,40,Asian (NH),-100.0,,0.0,,0.0,,,True
+2019,Oklahoma,40,Black or African American (NH),457.9,,42.4,,90.63,,,True
+2019,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2019,Oklahoma,40,Two or more races (NH),,,,,,,True,True
+2019,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2019,Oklahoma,40,White (NH),11.2,93.1,57.6,100.0,20.17,5.26,,
+2019,Oregon,41,Indigenous (NH),,,,,,0.0,True,
+2019,Oregon,41,Asian (NH),,,,,,0.0,True,
+2019,Oregon,41,Black or African American (NH),,,,,,0.0,True,
+2019,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2019,Oregon,41,Two or more races (NH),,,,,,0.0,True,
+2019,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Oregon,41,White (NH),58.5,,100.0,,20.47,,,True
+2019,Pennsylvania,42,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2019,Pennsylvania,42,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Pennsylvania,42,Black or African American (NH),376.0,296.9,61.4,51.2,83.07,6.45,,
+2019,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2019,Pennsylvania,42,Two or more races (NH),,,,,,,True,True
+2019,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2019,Pennsylvania,42,White (NH),-41.2,-25.7,38.6,48.8,10.0,1.21,,
+2019,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2019,Rhode Island,44,Asian (NH),,,,,0.0,0.0,,
+2019,Rhode Island,44,Black or African American (NH),,,,,0.0,,,True
+2019,Rhode Island,44,Hispanic or Latino,,,,,0.0,0.0,,
+2019,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2019,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2019,Rhode Island,44,White (NH),,,,,,0.0,True,
+2019,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,South Carolina,45,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,South Carolina,45,Black or African American (NH),137.5,51.5,69.6,44.4,88.36,6.13,,
+2019,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2019,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,South Carolina,45,White (NH),-44.1,2.2,30.4,55.6,20.13,4.13,,
+2019,South Dakota,46,Indigenous (NH),,,,,,,True,True
+2019,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2019,South Dakota,46,Hispanic or Latino,,,,,,0.0,True,
+2019,South Dakota,46,Two or more races (NH),,,,,,0.0,True,
+2019,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,South Dakota,46,White (NH),41.6,,100.0,,22.18,,,True
+2019,Tennessee,47,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Tennessee,47,Black or African American (NH),209.0,158.2,58.4,48.8,82.99,7.35,,
+2019,Tennessee,47,Hispanic or Latino,,,,,,,True,True
+2019,Tennessee,47,Two or more races (NH),,,,,,,True,True
+2019,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Tennessee,47,White (NH),-35.7,-20.9,41.6,51.2,17.43,2.25,,
+2019,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Texas,48,Asian (NH),-40.4,,2.8,,8.37,,,True
+2019,Texas,48,Black or African American (NH),305.8,257.5,48.7,42.9,49.34,6.74,,
+2019,Texas,48,Hispanic or Latino,,,,,,,True,True
+2019,Texas,48,Two or more races (NH),,,,,,,True,True
+2019,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2019,Texas,48,White (NH),55.9,83.6,48.5,57.1,18.8,3.47,,
+2019,Utah,49,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Utah,49,Asian (NH),,,,,,,True,True
+2019,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2019,Utah,49,Hispanic or Latino,,,,,,,True,True
+2019,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2019,Utah,49,White (NH),36.1,36.1,100.0,100.0,17.22,2.05,,
+2019,Vermont,50,Indigenous (NH),,,,,0.0,0.0,,
+2019,Vermont,50,Asian (NH),,,,,0.0,0.0,,
+2019,Vermont,50,Black or African American (NH),,,,,,0.0,True,
+2019,Vermont,50,Hispanic or Latino,,,,,0.0,0.0,,
+2019,Vermont,50,Two or more races (NH),,,,,0.0,0.0,,
+2019,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2019,Vermont,50,White (NH),,,,,,,True,True
+2019,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Virginia,51,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Virginia,51,Black or African American (NH),184.4,235.2,56.6,66.7,51.53,7.01,,
+2019,Virginia,51,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,Virginia,51,Two or more races (NH),,,,,,,True,True
+2019,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Virginia,51,White (NH),-17.8,-36.9,43.4,33.3,14.59,1.32,,
+2019,Washington,53,Indigenous (NH),,,,,,,True,True
+2019,Washington,53,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Washington,53,Black or African American (NH),488.4,,25.3,,51.55,,,True
+2019,Washington,53,Hispanic or Latino,,,,,,,True,True
+2019,Washington,53,Two or more races (NH),,,,,,,True,True
+2019,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2019,Washington,53,White (NH),36.1,82.1,74.7,100.0,12.44,1.43,,
+2019,West Virginia,54,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,West Virginia,54,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,West Virginia,54,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2019,West Virginia,54,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,West Virginia,54,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2019,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,West Virginia,54,White (NH),12.9,12.9,100.0,100.0,20.5,3.13,,
+2019,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2019,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0,True,
+2019,Wisconsin,55,Black or African American (NH),342.7,,39.4,,56.74,,,True
+2019,Wisconsin,55,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2019,Wisconsin,55,Two or more races (NH),,,,,,,True,True
+2019,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2019,Wisconsin,55,White (NH),-12.6,44.3,60.6,100.0,9.19,1.37,,
+2019,Wyoming,56,Indigenous (NH),,,,,,,True,True
+2019,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Wyoming,56,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2019,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2019,Wyoming,56,White (NH),30.5,,100.0,,32.03,,,True
+2020,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Alabama,01,Black or African American (NH),139.4,79.1,68.7,51.4,105.32,5.87,,
+2020,Alabama,01,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2020,Alabama,01,Two or more races (NH),,,,,,,True,True
+2020,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Alabama,01,White (NH),-44.7,-14.1,31.3,48.6,24.98,2.81,,
+2020,Alaska,02,Indigenous (NH),228.9,,61.5,,121.03,,,True
+2020,Alaska,02,Asian (NH),,,,,,,True,True
+2020,Alaska,02,Black or African American (NH),,,,,,0.0,True,
+2020,Alaska,02,Hispanic or Latino,,,,,,,True,True
+2020,Alaska,02,Two or more races (NH),,,,,,,True,True
+2020,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2020,Alaska,02,White (NH),-19.3,,38.5,,25.07,,,True
+2020,Arizona,04,Indigenous (NH),178.7,,13.1,,40.0,,,True
+2020,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Arizona,04,Black or African American (NH),457.7,713.5,29.0,42.3,75.19,13.11,,
+2020,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2020,Arizona,04,Two or more races (NH),,,,,,,True,True
+2020,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Arizona,04,White (NH),48.1,47.6,57.9,57.7,18.8,2.4,,
+2020,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Arkansas,05,Asian (NH),-100.0,,0.0,,0.0,,,True
+2020,Arkansas,05,Black or African American (NH),219.2,222.6,56.5,57.1,119.87,19.16,,
+2020,Arkansas,05,Hispanic or Latino,,,,,,,True,True
+2020,Arkansas,05,Two or more races (NH),,,,,,,True,True
+2020,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Arkansas,05,White (NH),-29.5,-30.5,43.5,42.9,26.49,4.13,,
+2020,California,06,Indigenous (NH),,,,,,,True,True
+2020,California,06,Asian (NH),-44.1,,7.1,,3.89,,,True
+2020,California,06,Black or African American (NH),940.0,934.0,52.0,51.7,64.31,6.73,,
+2020,California,06,Hispanic or Latino,,,,,,,True,True
+2020,California,06,Two or more races (NH),86.8,,9.9,,17.63,,,True
+2020,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2020,California,06,White (NH),24.5,94.0,31.0,48.3,7.81,1.26,,
+2020,Colorado,08,Indigenous (NH),,,,,,,True,True
+2020,Colorado,08,Asian (NH),-100.0,,0.0,,0.0,,,True
+2020,Colorado,08,Black or African American (NH),462.8,,24.2,,87.67,,,True
+2020,Colorado,08,Hispanic or Latino,,,,,,,True,True
+2020,Colorado,08,Two or more races (NH),,,,,,,True,True
+2020,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Colorado,08,White (NH),37.1,80.8,75.8,100.0,20.55,3.16,,
+2020,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Connecticut,09,Black or African American (NH),762.1,,100.0,,59.57,,,True
+2020,Connecticut,09,Hispanic or Latino,,,,,,,True,True
+2020,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Connecticut,09,White (NH),,,,,,,True,True
+2020,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Delaware,10,Black or African American (NH),296.8,,100.0,,104.25,,,True
+2020,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2020,Delaware,10,Two or more races (NH),,,,,,0.0,True,
+2020,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Delaware,10,White (NH),,,,,,,True,True
+2020,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,District of Columbia,11,Black or African American (NH),90.8,,100.0,,200.01,,,True
+2020,District of Columbia,11,Hispanic or Latino,,,,,,,True,True
+2020,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Florida,12,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Florida,12,Asian (NH),,,,,,,True,True
+2020,Florida,12,Black or African American (NH),232.8,159.2,66.9,52.1,76.09,5.71,,
+2020,Florida,12,Hispanic or Latino,,,,,,,True,True
+2020,Florida,12,Two or more races (NH),,,,,,,True,True
+2020,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Florida,12,White (NH),-20.8,14.6,33.1,47.9,16.65,2.52,,
+2020,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Georgia,13,Asian (NH),,,,,,,True,True
+2020,Georgia,13,Black or African American (NH),114.9,113.4,72.2,71.7,71.98,7.71,,
+2020,Georgia,13,Hispanic or Latino,-77.6,,3.5,,10.0,,,True
+2020,Georgia,13,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Georgia,13,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Georgia,13,White (NH),-42.6,-33.1,24.3,28.3,18.4,2.41,,
+2020,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2020,Hawaii,15,Asian (NH),,,,,0.0,0.0,,
+2020,Hawaii,15,Black or African American (NH),,,,,0.0,0.0,,
+2020,Hawaii,15,Hispanic or Latino,,,,,0.0,,,True
+2020,Hawaii,15,Two or more races (NH),,,,,,0.0,True,
+2020,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2020,Hawaii,15,White (NH),,,,,,0.0,True,
+2020,Idaho,16,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Idaho,16,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Idaho,16,Black or African American (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Idaho,16,Hispanic or Latino,25.9,,23.8,,29.0,,,True
+2020,Idaho,16,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Idaho,16,White (NH),2.4,34.4,76.2,100.0,20.67,3.81,,
+2020,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Illinois,17,Asian (NH),,,,,,,True,True
+2020,Illinois,17,Black or African American (NH),458.2,315.7,85.4,63.6,147.26,14.39,,
+2020,Illinois,17,Hispanic or Latino,,-16.2,,21.2,,3.0,True,
+2020,Illinois,17,Two or more races (NH),,,,,,,True,True
+2020,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Illinois,17,White (NH),-70.9,-69.7,14.6,15.2,7.57,1.04,,
+2020,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Indiana,18,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Indiana,18,Black or African American (NH),398.2,314.2,56.3,46.8,186.98,15.97,,
+2020,Indiana,18,Hispanic or Latino,,,,,,,True,True
+2020,Indiana,18,Two or more races (NH),,,,,,,True,True
+2020,Indiana,18,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Indiana,18,White (NH),-36.5,-22.7,43.7,53.2,21.65,2.99,,
+2020,Iowa,19,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Iowa,19,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Iowa,19,Black or African American (NH),505.5,1718.2,33.3,100.0,92.35,24.35,,
+2020,Iowa,19,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2020,Iowa,19,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Iowa,19,White (NH),-12.1,,66.7,,12.15,,,True
+2020,Kansas,20,Indigenous (NH),,,,,,,True,True
+2020,Kansas,20,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Kansas,20,Black or African American (NH),359.0,,28.0,,92.2,,,True
+2020,Kansas,20,Hispanic or Latino,,,,,,,True,True
+2020,Kansas,20,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Kansas,20,White (NH),10.6,53.6,72.0,100.0,23.86,3.45,,
+2020,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Kentucky,21,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Kentucky,21,Black or African American (NH),394.6,390.2,45.5,45.1,145.24,24.43,,
+2020,Kentucky,21,Hispanic or Latino,,,,,,,True,True
+2020,Kentucky,21,Two or more races (NH),,,,,,,True,True
+2020,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Kentucky,21,White (NH),-28.9,-28.4,54.5,54.9,22.75,3.56,,
+2020,Louisiana,22,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2020,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Louisiana,22,Black or African American (NH),144.3,118.2,87.2,77.9,148.8,13.45,,
+2020,Louisiana,22,Hispanic or Latino,,,,,,,True,True
+2020,Louisiana,22,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Louisiana,22,White (NH),-74.1,-55.3,12.8,22.1,15.95,2.75,,
+2020,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Maine,23,Black or African American (NH),,,,,,0.0,True,
+2020,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2020,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Maine,23,White (NH),14.2,,100.0,,13.91,,,True
+2020,Maryland,24,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Maryland,24,Asian (NH),,,,,,,True,True
+2020,Maryland,24,Black or African American (NH),192.7,230.0,88.7,100.0,90.48,4.04,,
+2020,Maryland,24,Hispanic or Latino,,,,,,,True,True
+2020,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Maryland,24,White (NH),-71.6,,11.3,,8.3,,,True
+2020,Massachusetts,25,Indigenous (NH),,,,,,0.0,True,
+2020,Massachusetts,25,Asian (NH),,,,,,0.0,True,
+2020,Massachusetts,25,Black or African American (NH),595.5,,61.9,,41.63,,,True
+2020,Massachusetts,25,Hispanic or Latino,,,,,,,True,True
+2020,Massachusetts,25,Two or more races (NH),,,,,,0.0,True,
+2020,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Massachusetts,25,White (NH),-36.1,,38.1,,3.27,,,True
+2020,Michigan,26,Indigenous (NH),,,,,,,True,True
+2020,Michigan,26,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Michigan,26,Black or African American (NH),309.9,321.7,66.0,67.9,105.85,10.25,,
+2020,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2020,Michigan,26,Two or more races (NH),,,,,,,True,True
+2020,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Michigan,26,White (NH),-48.4,-51.3,34.0,32.1,11.98,1.18,,
+2020,Minnesota,27,Indigenous (NH),,,,,,,True,True
+2020,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Minnesota,27,Black or African American (NH),365.4,861.5,48.4,100.0,63.53,8.67,,
+2020,Minnesota,27,Hispanic or Latino,,,,,,,True,True
+2020,Minnesota,27,Two or more races (NH),,,,,,,True,True
+2020,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Minnesota,27,White (NH),-22.8,,51.6,,7.84,,,True
+2020,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Mississippi,28,Black or African American (NH),91.3,70.6,79.4,70.8,99.87,11.71,,
+2020,Mississippi,28,Hispanic or Latino,,,,,,,True,True
+2020,Mississippi,28,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2020,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Mississippi,28,White (NH),-57.8,-40.2,20.6,29.2,21.61,4.1,,
+2020,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Missouri,29,Black or African American (NH),338.5,352.6,59.2,61.1,194.56,23.45,,
+2020,Missouri,29,Hispanic or Latino,,,,,,,True,True
+2020,Missouri,29,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Missouri,29,White (NH),-42.8,-45.4,40.8,38.9,24.1,2.82,,
+2020,Montana,30,Indigenous (NH),,,,,,,True,True
+2020,Montana,30,Asian (NH),,,,,,0.0,True,
+2020,Montana,30,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Montana,30,Hispanic or Latino,,,,,,0.0,True,
+2020,Montana,30,Two or more races (NH),,,,,,,True,True
+2020,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Montana,30,White (NH),28.9,,100.0,,36.49,,,True
+2020,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2020,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Nebraska,31,Black or African American (NH),583.6,,41.7,,82.34,,,True
+2020,Nebraska,31,Hispanic or Latino,,,,,,,True,True
+2020,Nebraska,31,Two or more races (NH),,,,,,,True,True
+2020,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Nebraska,31,White (NH),-12.9,,58.3,,9.04,,,True
+2020,Nevada,32,Indigenous (NH),,,,,,0.0,True,
+2020,Nevada,32,Asian (NH),,,,,,0.0,True,
+2020,Nevada,32,Black or African American (NH),297.2,,42.9,,68.5,,,True
+2020,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2020,Nevada,32,Two or more races (NH),,,,,,,True,True
+2020,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2020,Nevada,32,White (NH),67.4,,57.1,,26.85,,,True
+2020,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Hampshire,33,Hispanic or Latino,,,,,,,True,True
+2020,New Hampshire,33,Two or more races (NH),,,,,,0.0,True,
+2020,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Hampshire,33,White (NH),19.8,,100.0,,13.37,,,True
+2020,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Jersey,34,Asian (NH),,,,,,,True,True
+2020,New Jersey,34,Black or African American (NH),470.9,,76.5,,47.47,,,True
+2020,New Jersey,34,Hispanic or Latino,,,,,,,True,True
+2020,New Jersey,34,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,New Jersey,34,White (NH),-47.5,,23.5,,4.37,,,True
+2020,New Mexico,35,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,New Mexico,35,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,New Mexico,35,Black or African American (NH),,,,,,,True,True
+2020,New Mexico,35,Hispanic or Latino,,,,,,,True,True
+2020,New Mexico,35,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,New Mexico,35,White (NH),314.9,314.9,100.0,100.0,31.09,8.72,,
+2020,New York,36,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,New York,36,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,New York,36,Black or African American (NH),397.3,571.1,74.1,100.0,44.18,3.19,,
+2020,New York,36,Hispanic or Latino,,,,,,,True,True
+2020,New York,36,Two or more races (NH),,,,,,,True,True
+2020,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,New York,36,White (NH),-45.1,,25.9,,4.73,,,True
+2020,North Carolina,37,Indigenous (NH),,,,,,,True,True
+2020,North Carolina,37,Asian (NH),,,,,,,True,True
+2020,North Carolina,37,Black or African American (NH),176.5,143.4,61.1,53.8,75.39,9.77,,
+2020,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2020,North Carolina,37,Two or more races (NH),,,,,,,True,True
+2020,North Carolina,37,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,North Carolina,37,White (NH),-22.8,-8.3,38.9,46.2,20.33,3.68,,
+2020,North Dakota,38,Indigenous (NH),,,,,,,True,True
+2020,North Dakota,38,Asian (NH),,,,,0.0,0.0,,
+2020,North Dakota,38,Black or African American (NH),,,,,0.0,,,True
+2020,North Dakota,38,Hispanic or Latino,,,,,,0.0,True,
+2020,North Dakota,38,Two or more races (NH),,,,,,0.0,True,
+2020,North Dakota,38,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2020,North Dakota,38,White (NH),,,,,,,True,True
+2020,Ohio,39,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Ohio,39,Black or African American (NH),332.9,302.0,65.8,61.1,141.06,14.51,,
+2020,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2020,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Ohio,39,White (NH),-50.9,-44.2,34.2,38.9,14.46,2.02,,
+2020,Oklahoma,40,Indigenous (NH),24.7,,12.1,,40.09,,,True
+2020,Oklahoma,40,Asian (NH),,,,,,,True,True
+2020,Oklahoma,40,Black or African American (NH),201.3,,22.9,,81.59,,,True
+2020,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2020,Oklahoma,40,Two or more races (NH),-21.0,-100.0,7.9,0.0,33.81,0.0,,
+2020,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Oklahoma,40,White (NH),11.5,95.3,57.1,100.0,33.0,3.45,,
+2020,Oregon,41,Indigenous (NH),,,,,,0.0,True,
+2020,Oregon,41,Asian (NH),,,,,,,True,True
+2020,Oregon,41,Black or African American (NH),,,,,,,True,True
+2020,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2020,Oregon,41,Two or more races (NH),,,,,,,True,True
+2020,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2020,Oregon,41,White (NH),60.0,,100.0,,16.39,,,True
+2020,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Pennsylvania,42,Asian (NH),,,,,,,True,True
+2020,Pennsylvania,42,Black or African American (NH),449.6,362.8,70.9,59.7,132.84,12.35,,
+2020,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2020,Pennsylvania,42,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Pennsylvania,42,White (NH),-55.4,-38.2,29.1,40.3,10.27,1.65,,
+2020,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2020,Rhode Island,44,Asian (NH),,,,,0.0,0.0,,
+2020,Rhode Island,44,Black or African American (NH),,,,,,0.0,True,
+2020,Rhode Island,44,Hispanic or Latino,,,,,,0.0,True,
+2020,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2020,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2020,Rhode Island,44,White (NH),,,,,,0.0,True,
+2020,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,South Carolina,45,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,South Carolina,45,Black or African American (NH),131.9,120.5,66.8,63.5,105.72,12.4,,
+2020,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2020,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,South Carolina,45,White (NH),-37.9,-31.8,33.2,36.5,26.78,3.84,,
+2020,South Dakota,46,Indigenous (NH),303.4,,47.6,,110.19,,,True
+2020,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,South Dakota,46,Black or African American (NH),,,,,,,True,True
+2020,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2020,South Dakota,46,Two or more races (NH),,,,,,0.0,True,
+2020,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,South Dakota,46,White (NH),-26.3,,52.4,,15.75,,,True
+2020,Tennessee,47,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Tennessee,47,Black or African American (NH),256.8,254.6,66.0,65.6,118.24,14.59,,
+2020,Tennessee,47,Hispanic or Latino,,,,,,,True,True
+2020,Tennessee,47,Two or more races (NH),,,,,,,True,True
+2020,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Tennessee,47,White (NH),-46.2,-45.6,34.0,34.4,17.6,2.24,,
+2020,Texas,48,Indigenous (NH),,,,,,,True,True
+2020,Texas,48,Asian (NH),-25.0,,3.6,,13.75,,,True
+2020,Texas,48,Black or African American (NH),322.8,222.0,52.0,39.6,69.09,6.63,,
+2020,Texas,48,Hispanic or Latino,,,,,,,True,True
+2020,Texas,48,Two or more races (NH),,,,,,,True,True
+2020,Texas,48,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2020,Texas,48,White (NH),42.3,93.6,44.4,60.4,22.75,3.99,,
+2020,Utah,49,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Utah,49,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Utah,49,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2020,Utah,49,Hispanic or Latino,,,,,,,True,True
+2020,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Utah,49,White (NH),38.1,38.1,100.0,100.0,14.34,2.91,,
+2020,Vermont,50,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Vermont,50,Asian (NH),-100.0,,0.0,,0.0,,,True
+2020,Vermont,50,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Vermont,50,Hispanic or Latino,,,,,,0.0,True,
+2020,Vermont,50,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Vermont,50,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Vermont,50,White (NH),13.1,,100.0,,17.38,,,True
+2020,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Virginia,51,Asian (NH),,,,,,,True,True
+2020,Virginia,51,Black or African American (NH),223.7,177.8,64.1,55.0,75.61,8.73,,
+2020,Virginia,51,Hispanic or Latino,,,,,,,True,True
+2020,Virginia,51,Two or more races (NH),,,,,,,True,True
+2020,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Virginia,51,White (NH),-30.8,-13.3,35.9,45.0,15.55,2.73,,
+2020,Washington,53,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Washington,53,Asian (NH),,-100.0,,0.0,,0.0,True,
+2020,Washington,53,Black or African American (NH),474.4,,24.7,,65.85,,,True
+2020,Washington,53,Hispanic or Latino,,,,,,,True,True
+2020,Washington,53,Two or more races (NH),,,,,,,True,True
+2020,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,Washington,53,White (NH),39.4,85.2,75.3,100.0,16.58,1.85,,
+2020,West Virginia,54,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,West Virginia,54,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,West Virginia,54,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2020,West Virginia,54,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,West Virginia,54,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,West Virginia,54,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2020,West Virginia,54,White (NH),13.5,13.5,100.0,100.0,21.91,4.07,,
+2020,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2020,Wisconsin,55,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Wisconsin,55,Black or African American (NH),470.1,666.7,49.6,66.7,117.82,17.77,,
+2020,Wisconsin,55,Hispanic or Latino,,,,,,,True,True
+2020,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2020,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2020,Wisconsin,55,White (NH),-26.9,-51.7,50.4,33.3,12.26,1.13,,
+2020,Wyoming,56,Indigenous (NH),,,,,,0.0,True,
+2020,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Wyoming,56,Hispanic or Latino,,,,,,0.0,True,
+2020,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2020,Wyoming,56,White (NH),30.4,,100.0,,34.84,,,True
+2021,Alabama,01,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Alabama,01,Black or African American (NH),176.2,136.0,79.0,67.5,123.35,16.1,,
+2021,Alabama,01,Hispanic or Latino,,,,,,,True,True
+2021,Alabama,01,Two or more races (NH),,,,,,,True,True
+2021,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Alabama,01,White (NH),-62.8,-42.4,21.0,32.5,16.67,3.93,,
+2021,Alaska,02,Indigenous (NH),119.5,,40.6,,97.8,,,True
+2021,Alaska,02,Asian (NH),,,,,,0.0,True,
+2021,Alaska,02,Black or African American (NH),,,,,,0.0,True,
+2021,Alaska,02,Hispanic or Latino,,,,,,,True,True
+2021,Alaska,02,Two or more races (NH),,,,,,,True,True
+2021,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Alaska,02,White (NH),26.1,,59.4,,47.6,,,True
+2021,Arizona,04,Indigenous (NH),153.2,,11.9,,43.46,,,True
+2021,Arizona,04,Asian (NH),,,,,,,True,True
+2021,Arizona,04,Black or African American (NH),385.2,,26.2,,80.22,,,True
+2021,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2021,Arizona,04,Two or more races (NH),115.9,,9.5,,46.33,,,True
+2021,Arizona,04,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Arizona,04,White (NH),34.7,157.1,52.4,100.0,20.3,2.25,,
+2021,Arkansas,05,Indigenous (NH),,,,,,,True,True
+2021,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Arkansas,05,Black or African American (NH),232.8,200.0,58.9,53.1,126.19,13.64,,
+2021,Arkansas,05,Hispanic or Latino,,,,,,,True,True
+2021,Arkansas,05,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Arkansas,05,White (NH),-33.1,-23.6,41.1,46.9,24.75,3.47,,
+2021,California,06,Indigenous (NH),,,,,,,True,True
+2021,California,06,Asian (NH),-37.0,,8.0,,5.09,,,True
+2021,California,06,Black or African American (NH),1042.0,1206.0,57.1,65.3,82.44,7.3,,
+2021,California,06,Hispanic or Latino,,,,,,,True,True
+2021,California,06,Two or more races (NH),9.3,,5.9,,11.85,,,True
+2021,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2021,California,06,White (NH),17.9,41.1,29.0,34.7,8.72,0.79,,
+2021,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Colorado,08,Asian (NH),,,,,,,True,True
+2021,Colorado,08,Black or African American (NH),306.8,,17.9,,63.04,,,True
+2021,Colorado,08,Hispanic or Latino,,,,,,,True,True
+2021,Colorado,08,Two or more races (NH),,,,,,,True,True
+2021,Colorado,08,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Colorado,08,White (NH),50.6,83.5,82.1,100.0,21.76,2.06,,
+2021,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Connecticut,09,Asian (NH),,,,,,0.0,True,
+2021,Connecticut,09,Black or African American (NH),494.9,,69.6,,71.91,,,True
+2021,Connecticut,09,Hispanic or Latino,,,,,,,True,True
+2021,Connecticut,09,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Connecticut,09,White (NH),-41.4,,30.4,,6.32,,,True
+2021,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Delaware,10,Black or African American (NH),293.7,,100.0,,120.61,,,True
+2021,Delaware,10,Hispanic or Latino,,,,,,0.0,True,
+2021,Delaware,10,Two or more races (NH),,,,,,0.0,True,
+2021,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Delaware,10,White (NH),,,,,,0.0,True,
+2021,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,District of Columbia,11,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,District of Columbia,11,Black or African American (NH),91.6,,100.0,,144.56,,,True
+2021,District of Columbia,11,Hispanic or Latino,,,,,,,True,True
+2021,District of Columbia,11,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,District of Columbia,11,White (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Florida,12,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Florida,12,Asian (NH),,,,,,,True,True
+2021,Florida,12,Black or African American (NH),232.7,217.6,66.2,63.2,69.47,7.05,,
+2021,Florida,12,Hispanic or Latino,,,,,,,True,True
+2021,Florida,12,Two or more races (NH),,,,,,,True,True
+2021,Florida,12,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Florida,12,White (NH),-18.8,-11.5,33.8,36.8,15.46,1.97,,
+2021,Georgia,13,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Georgia,13,Asian (NH),,,,,,,True,True
+2021,Georgia,13,Black or African American (NH),123.7,101.8,75.4,68.0,77.77,9.95,,
+2021,Georgia,13,Hispanic or Latino,,,,,,,True,True
+2021,Georgia,13,Two or more races (NH),,,,,,,True,True
+2021,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Georgia,13,White (NH),-41.3,-23.6,24.6,32.0,19.01,3.76,,
+2021,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2021,Hawaii,15,Asian (NH),,,,,,0.0,True,
+2021,Hawaii,15,Black or African American (NH),,,,,0.0,0.0,,
+2021,Hawaii,15,Hispanic or Latino,,,,,,0.0,True,
+2021,Hawaii,15,Two or more races (NH),,,,,,0.0,True,
+2021,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2021,Hawaii,15,White (NH),,,,,,0.0,True,
+2021,Idaho,16,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Idaho,16,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Idaho,16,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2021,Idaho,16,Hispanic or Latino,,,,,,,True,True
+2021,Idaho,16,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Idaho,16,White (NH),35.3,35.3,100.0,100.0,17.54,3.49,,
+2021,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Illinois,17,Asian (NH),,,,,,,True,True
+2021,Illinois,17,Black or African American (NH),457.5,420.3,85.3,79.6,168.45,20.95,,
+2021,Illinois,17,Hispanic or Latino,,,,,,,True,True
+2021,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Illinois,17,White (NH),-70.6,-59.2,14.7,20.4,8.59,1.64,,
+2021,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Indiana,18,Asian (NH),,,,,,,True,True
+2021,Indiana,18,Black or African American (NH),355.7,200.0,52.4,34.5,164.88,10.37,,
+2021,Indiana,18,Hispanic or Latino,,,,,,,True,True
+2021,Indiana,18,Two or more races (NH),,,,,,,True,True
+2021,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Indiana,18,White (NH),-30.3,-4.1,47.6,65.5,22.37,3.3,,
+2021,Iowa,19,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Iowa,19,Asian (NH),-100.0,,0.0,,0.0,,,True
+2021,Iowa,19,Black or African American (NH),319.3,,23.9,,58.93,,,True
+2021,Iowa,19,Hispanic or Latino,,,,,,,True,True
+2021,Iowa,19,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Iowa,19,White (NH),0.9,32.6,76.1,100.0,12.48,2.16,,
+2021,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Kansas,20,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Kansas,20,Black or African American (NH),268.9,,22.5,,88.66,,,True
+2021,Kansas,20,Hispanic or Latino,18.6,,23.6,,36.0,,,True
+2021,Kansas,20,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Kansas,20,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Kansas,20,White (NH),-16.9,54.1,53.9,100.0,21.23,4.15,,
+2021,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Kentucky,21,Asian (NH),-100.0,,0.0,,0.0,,,True
+2021,Kentucky,21,Black or African American (NH),395.7,482.8,46.1,54.2,162.5,27.48,,
+2021,Kentucky,21,Hispanic or Latino,,,,,,,True,True
+2021,Kentucky,21,Two or more races (NH),,,,,,,True,True
+2021,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Kentucky,21,White (NH),-29.5,-40.1,53.9,45.8,24.65,2.82,,
+2021,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Louisiana,22,Asian (NH),,,,,,,True,True
+2021,Louisiana,22,Black or African American (NH),132.5,123.5,83.0,79.8,149.48,22.33,,
+2021,Louisiana,22,Hispanic or Latino,,,,,,,True,True
+2021,Louisiana,22,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Louisiana,22,White (NH),-65.4,-58.9,17.0,20.2,22.14,4.1,,
+2021,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Maine,23,White (NH),14.7,,100.0,,11.82,,,True
+2021,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Maryland,24,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Maryland,24,Black or African American (NH),187.8,230.0,87.2,100.0,86.53,5.28,,
+2021,Maryland,24,Hispanic or Latino,,,,,,,True,True
+2021,Maryland,24,Two or more races (NH),,,,,,,True,True
+2021,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Maryland,24,White (NH),-67.5,,12.8,,9.12,,,True
+2021,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Massachusetts,25,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Massachusetts,25,Black or African American (NH),567.0,,60.7,,27.23,,,True
+2021,Massachusetts,25,Hispanic or Latino,,,,,,,True,True
+2021,Massachusetts,25,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Massachusetts,25,White (NH),-33.0,,39.3,,2.2,,,True
+2021,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Michigan,26,Asian (NH),,,,,,,True,True
+2021,Michigan,26,Black or African American (NH),318.5,186.4,67.8,46.4,117.36,7.45,,
+2021,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2021,Michigan,26,Two or more races (NH),,,,,,,True,True
+2021,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Michigan,26,White (NH),-51.0,-18.4,32.2,53.6,12.19,2.12,,
+2021,Minnesota,27,Indigenous (NH),,,,,,,True,True
+2021,Minnesota,27,Asian (NH),,,,,,,True,True
+2021,Minnesota,27,Black or African American (NH),379.4,,51.3,,82.31,,,True
+2021,Minnesota,27,Hispanic or Latino,,,,,,0.0,True,
+2021,Minnesota,27,Two or more races (NH),,,,,,,True,True
+2021,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Minnesota,27,White (NH),-26.5,,48.7,,9.34,,,True
+2021,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Mississippi,28,Black or African American (NH),96.9,77.0,81.3,73.1,130.81,17.12,,
+2021,Mississippi,28,Hispanic or Latino,,,,,,,True,True
+2021,Mississippi,28,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Mississippi,28,White (NH),-61.7,-44.9,18.7,26.9,24.61,5.33,,
+2021,Missouri,29,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Missouri,29,Asian (NH),-100.0,,0.0,,0.0,,,True
+2021,Missouri,29,Black or African American (NH),307.5,309.7,54.6,54.9,163.14,24.19,,
+2021,Missouri,29,Hispanic or Latino,,,,,,,True,True
+2021,Missouri,29,Two or more races (NH),,,,,,,True,True
+2021,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Missouri,29,White (NH),-36.1,-36.5,45.4,45.1,23.99,3.75,,
+2021,Montana,30,Indigenous (NH),,,,,,,True,True
+2021,Montana,30,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Montana,30,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2021,Montana,30,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2021,Montana,30,Two or more races (NH),,,,,,,True,True
+2021,Montana,30,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Montana,30,White (NH),29.2,29.2,100.0,100.0,37.92,8.23,,
+2021,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2021,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Nebraska,31,Black or African American (NH),463.9,,34.4,,91.36,,,True
+2021,Nebraska,31,Hispanic or Latino,,,,,,,True,True
+2021,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Nebraska,31,White (NH),-1.4,,65.6,,13.71,,,True
+2021,Nevada,32,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2021,Nevada,32,Asian (NH),,,,,,,True,True
+2021,Nevada,32,Black or African American (NH),412.6,,56.9,,120.69,,,True
+2021,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2021,Nevada,32,Two or more races (NH),,,,,,,True,True
+2021,Nevada,32,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2021,Nevada,32,White (NH),29.8,,43.1,,27.12,,,True
+2021,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,New Hampshire,33,Black or African American (NH),,,,,,0.0,True,
+2021,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2021,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,New Hampshire,33,White (NH),20.3,,100.0,,11.32,,,True
+2021,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New Jersey,34,Asian (NH),,,,,,,True,True
+2021,New Jersey,34,Black or African American (NH),479.1,646.3,77.6,100.0,46.15,5.15,,
+2021,New Jersey,34,Hispanic or Latino,,,,,,,True,True
+2021,New Jersey,34,Two or more races (NH),,,,,,,True,True
+2021,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New Jersey,34,White (NH),-49.4,,22.4,,3.98,,,True
+2021,New Mexico,35,Indigenous (NH),,,,,,,True,True
+2021,New Mexico,35,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New Mexico,35,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2021,New Mexico,35,Hispanic or Latino,,,,,,,True,True
+2021,New Mexico,35,Two or more races (NH),,,,,,,True,True
+2021,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New Mexico,35,White (NH),320.2,320.2,100.0,100.0,29.92,12.58,,
+2021,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New York,36,Asian (NH),,,,,,,True,True
+2021,New York,36,Black or African American (NH),445.9,382.4,80.8,71.4,39.75,4.92,,
+2021,New York,36,Hispanic or Latino,,,,,,,True,True
+2021,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,New York,36,White (NH),-59.2,-39.3,19.2,28.6,2.82,0.62,,
+2021,North Carolina,37,Indigenous (NH),,,,,,,True,True
+2021,North Carolina,37,Asian (NH),,,,,,,True,True
+2021,North Carolina,37,Black or African American (NH),191.0,215.4,64.3,69.7,83.78,13.47,,
+2021,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2021,North Carolina,37,Two or more races (NH),,,,,,,True,True
+2021,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,North Carolina,37,White (NH),-28.7,-39.5,35.7,30.3,19.4,2.59,,
+2021,North Dakota,38,Indigenous (NH),,,,,,,True,True
+2021,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,North Dakota,38,Black or African American (NH),,,,,,,True,True
+2021,North Dakota,38,Hispanic or Latino,-100.0,,0.0,,0.0,,,True
+2021,North Dakota,38,Two or more races (NH),,,,,,0.0,True,
+2021,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,North Dakota,38,White (NH),33.9,,100.0,,17.89,,,True
+2021,Ohio,39,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2021,Ohio,39,Asian (NH),,,,,,,True,True
+2021,Ohio,39,Black or African American (NH),300.7,349.7,61.3,68.8,133.0,18.73,,
+2021,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2021,Ohio,39,Two or more races (NH),,,,,,,True,True
+2021,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Ohio,39,White (NH),-44.2,-55.0,38.7,31.2,16.6,1.88,,
+2021,Oklahoma,40,Indigenous (NH),50.5,,14.3,,39.83,,,True
+2021,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Oklahoma,40,Black or African American (NH),239.0,493.5,26.1,45.7,79.21,21.45,,
+2021,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2021,Oklahoma,40,Two or more races (NH),6.9,-100.0,10.9,0.0,38.66,0.0,,
+2021,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Oklahoma,40,White (NH),-3.9,7.1,48.7,54.3,23.68,3.89,,
+2021,Oregon,41,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2021,Oregon,41,Asian (NH),,,,,,0.0,True,
+2021,Oregon,41,Black or African American (NH),782.6,,20.3,,124.42,,,True
+2021,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2021,Oregon,41,Two or more races (NH),,,,,,,True,True
+2021,Oregon,41,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Oregon,41,White (NH),29.0,,79.7,,17.66,,,True
+2021,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Pennsylvania,42,Asian (NH),,,,,,,True,True
+2021,Pennsylvania,42,Black or African American (NH),445.0,369.8,70.3,60.6,132.24,17.4,,
+2021,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2021,Pennsylvania,42,Two or more races (NH),,,,,,,True,True
+2021,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Pennsylvania,42,White (NH),-54.1,-39.1,29.7,39.4,10.28,2.25,,
+2021,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2021,Rhode Island,44,Asian (NH),,,,,,0.0,True,
+2021,Rhode Island,44,Black or African American (NH),,,,,,0.0,True,
+2021,Rhode Island,44,Hispanic or Latino,,,,,,0.0,True,
+2021,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2021,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2021,Rhode Island,44,White (NH),,,,,,0.0,True,
+2021,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,South Carolina,45,Asian (NH),,,,,,,True,True
+2021,South Carolina,45,Black or African American (NH),144.8,135.0,70.0,67.2,105.11,13.39,,
+2021,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2021,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,South Carolina,45,White (NH),-43.8,-38.6,30.0,32.8,22.49,3.5,,
+2021,South Dakota,46,Indigenous (NH),346.2,,52.2,,130.24,,,True
+2021,South Dakota,46,Asian (NH),,,,,,0.0,True,
+2021,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2021,South Dakota,46,Hispanic or Latino,,,,,,0.0,True,
+2021,South Dakota,46,Two or more races (NH),,,,,,,True,True
+2021,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,South Dakota,46,White (NH),-32.3,,47.8,,15.57,,,True
+2021,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Tennessee,47,Black or African American (NH),251.6,284.2,64.7,70.7,130.4,20.22,,
+2021,Tennessee,47,Hispanic or Latino,,,,,,,True,True
+2021,Tennessee,47,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2021,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Tennessee,47,White (NH),-44.0,-53.5,35.3,29.3,20.0,2.45,,
+2021,Texas,48,Indigenous (NH),,,,,,,True,True
+2021,Texas,48,Asian (NH),-22.9,,3.7,,16.08,,,True
+2021,Texas,48,Black or African American (NH),326.4,318.4,53.3,52.3,81.0,8.37,,
+2021,Texas,48,Hispanic or Latino,,,,,,,True,True
+2021,Texas,48,Two or more races (NH),-20.7,-100.0,2.3,0.0,22.85,0.0,,
+2021,Texas,48,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Texas,48,White (NH),31.3,53.9,40.7,47.7,23.89,3.07,,
+2021,Utah,49,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Utah,49,Asian (NH),,,,,,,True,True
+2021,Utah,49,Black or African American (NH),,,,,,,True,True
+2021,Utah,49,Hispanic or Latino,,,,,,,True,True
+2021,Utah,49,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2021,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Utah,49,White (NH),39.3,39.3,100.0,100.0,16.15,2.2,,
+2021,Vermont,50,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,Vermont,50,White (NH),13.5,,100.0,,15.85,,,True
+2021,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Virginia,51,Asian (NH),,,,,,,True,True
+2021,Virginia,51,Black or African American (NH),230.3,219.7,65.4,63.3,82.82,10.12,,
+2021,Virginia,51,Hispanic or Latino,,,,,,,True,True
+2021,Virginia,51,Two or more races (NH),,,,,,,True,True
+2021,Virginia,51,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Virginia,51,White (NH),-32.8,-28.7,34.6,36.7,16.01,2.26,,
+2021,Washington,53,Indigenous (NH),,,,,,,True,True
+2021,Washington,53,Asian (NH),,,,,,,True,True
+2021,Washington,53,Black or African American (NH),346.5,,19.2,,53.19,,,True
+2021,Washington,53,Hispanic or Latino,,,,,,,True,True
+2021,Washington,53,Two or more races (NH),39.1,,12.1,,24.47,,,True
+2021,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2021,Washington,53,White (NH),28.9,87.6,68.7,100.0,16.17,2.68,,
+2021,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2021,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2021,West Virginia,54,Black or African American (NH),,,,,,,True,True
+2021,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2021,West Virginia,54,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2021,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2021,West Virginia,54,White (NH),13.9,,100.0,,17.36,,,True
+2021,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2021,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0,True,
+2021,Wisconsin,55,Black or African American (NH),526.1,613.6,55.1,62.8,163.4,24.1,,
+2021,Wisconsin,55,Hispanic or Latino,,,,,,,True,True
+2021,Wisconsin,55,Two or more races (NH),,,,,,,True,True
+2021,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wisconsin,55,White (NH),-34.5,-45.8,44.9,37.2,13.54,1.83,,
+2021,Wyoming,56,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wyoming,56,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wyoming,56,Black or African American (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wyoming,56,Hispanic or Latino,,,,,,,True,True
+2021,Wyoming,56,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2021,Wyoming,56,White (NH),31.1,31.1,100.0,100.0,38.72,9.89,,
+2022,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Alabama,01,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Alabama,01,Black or African American (NH),167.4,164.6,76.2,75.4,119.06,16.17,,
+2022,Alabama,01,Hispanic or Latino,,,,,,,True,True
+2022,Alabama,01,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Alabama,01,White (NH),-57.7,-56.2,23.8,24.6,18.84,2.68,,
+2022,Alaska,02,Indigenous (NH),183.6,,51.9,,107.14,,,True
+2022,Alaska,02,Asian (NH),,,,,,0.0,True,
+2022,Alaska,02,Black or African American (NH),,,,,,,True,True
+2022,Alaska,02,Hispanic or Latino,,,,,,0.0,True,
+2022,Alaska,02,Two or more races (NH),,,,,,,True,True
+2022,Alaska,02,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Alaska,02,White (NH),2.6,,48.1,,33.52,,,True
+2022,Arizona,04,Indigenous (NH),215.2,,14.5,,57.34,,,True
+2022,Arizona,04,Asian (NH),,,,,,,True,True
+2022,Arizona,04,Black or African American (NH),387.3,,26.8,,86.76,,,True
+2022,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2022,Arizona,04,Two or more races (NH),,,,,,,True,True
+2022,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Arizona,04,White (NH),52.9,160.4,58.7,100.0,24.32,1.96,,
+2022,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Arkansas,05,Black or African American (NH),272.2,268.8,65.5,64.9,131.65,19.35,,
+2022,Arkansas,05,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2022,Arkansas,05,Two or more races (NH),,,,,,,True,True
+2022,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Arkansas,05,White (NH),-43.6,-42.6,34.5,35.1,19.44,3.01,,
+2022,California,06,Indigenous (NH),,,,,,,True,True
+2022,California,06,Asian (NH),-45.7,,7.0,,3.19,,,True
+2022,California,06,Black or African American (NH),1012.0,1156.0,55.6,62.8,60.5,6.28,,
+2022,California,06,Hispanic or Latino,,,,,,,True,True
+2022,California,06,Two or more races (NH),37.0,,7.4,,10.8,,,True
+2022,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2022,California,06,White (NH),24.0,53.7,30.0,37.2,6.64,0.77,,
+2022,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Colorado,08,Asian (NH),,,,,,,True,True
+2022,Colorado,08,Black or African American (NH),575.6,344.4,30.4,20.0,103.11,21.67,,
+2022,Colorado,08,Hispanic or Latino,,52.9,,50.0,,7.0,True,
+2022,Colorado,08,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Colorado,08,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2022,Colorado,08,White (NH),29.6,-44.1,69.6,30.0,17.66,2.73,,
+2022,Connecticut,09,Indigenous (NH),,,,,,0.0,True,
+2022,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Connecticut,09,Black or African American (NH),332.8,,51.5,,38.02,,,True
+2022,Connecticut,09,Hispanic or Latino,77.0,,48.5,,19.0,,,True
+2022,Connecticut,09,Two or more races (NH),,,,,,0.0,True,
+2022,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Connecticut,09,White (NH),,,,,,,True,True
+2022,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Delaware,10,Black or African American (NH),287.6,,100.0,,64.13,,,True
+2022,Delaware,10,Hispanic or Latino,-100.0,,0.0,,0.0,,,True
+2022,Delaware,10,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Delaware,10,White (NH),,,,,,0.0,True,
+2022,District of Columbia,11,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2022,District of Columbia,11,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,District of Columbia,11,Black or African American (NH),94.6,94.6,100.0,100.0,124.78,20.11,,
+2022,District of Columbia,11,Hispanic or Latino,-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,District of Columbia,11,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,District of Columbia,11,White (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2022,Florida,12,Asian (NH),,,,,,,True,True
+2022,Florida,12,Black or African American (NH),234.2,243.4,65.5,67.3,63.88,7.97,,
+2022,Florida,12,Hispanic or Latino,,,,,,,True,True
+2022,Florida,12,Two or more races (NH),-35.0,,2.6,,17.29,,,True
+2022,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Florida,12,White (NH),-23.0,-20.8,31.8,32.7,13.45,1.84,,
+2022,Georgia,13,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Georgia,13,Asian (NH),,,,,,,True,True
+2022,Georgia,13,Black or African American (NH),126.9,127.8,76.7,77.0,78.73,12.46,,
+2022,Georgia,13,Hispanic or Latino,,,,,,,True,True
+2022,Georgia,13,Two or more races (NH),,,,,,,True,True
+2022,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Georgia,13,White (NH),-43.7,-44.4,23.3,23.0,18.18,3.04,,
+2022,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2022,Hawaii,15,Asian (NH),,,,,,,True,True
+2022,Hawaii,15,Black or African American (NH),,,,,,0.0,True,
+2022,Hawaii,15,Hispanic or Latino,,,,,,0.0,True,
+2022,Hawaii,15,Two or more races (NH),,,,,,,True,True
+2022,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2022,Hawaii,15,White (NH),,,,,0.0,,,True
+2022,Idaho,16,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2022,Idaho,16,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Idaho,16,Black or African American (NH),,,,,,,True,True
+2022,Idaho,16,Hispanic or Latino,,,,,,,True,True
+2022,Idaho,16,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2022,Idaho,16,White (NH),36.4,36.4,100.0,100.0,21.65,2.92,,
+2022,Illinois,17,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Illinois,17,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Illinois,17,Black or African American (NH),443.1,553.6,83.1,100.0,136.02,21.17,,
+2022,Illinois,17,Hispanic or Latino,,,,,,,True,True
+2022,Illinois,17,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Illinois,17,White (NH),-66.1,,16.9,,8.15,,,True
+2022,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Indiana,18,Asian (NH),,,,,,,True,True
+2022,Indiana,18,Black or African American (NH),392.2,404.3,57.1,58.5,145.55,16.74,,
+2022,Indiana,18,Hispanic or Latino,,,,,,,True,True
+2022,Indiana,18,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Indiana,18,White (NH),-36.7,-38.8,42.9,41.5,16.51,2.04,,
+2022,Iowa,19,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Iowa,19,Asian (NH),,,,,,0.0,True,
+2022,Iowa,19,Black or African American (NH),474.6,,33.9,,99.87,,,True
+2022,Iowa,19,Hispanic or Latino,,,,,,,True,True
+2022,Iowa,19,Two or more races (NH),,,,,,,True,True
+2022,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Iowa,19,White (NH),-11.7,,66.1,,13.32,,,True
+2022,Kansas,20,Indigenous (NH),,,,,,,True,True
+2022,Kansas,20,Asian (NH),,,,,,,True,True
+2022,Kansas,20,Black or African American (NH),249.2,,21.3,,58.22,,,True
+2022,Kansas,20,Hispanic or Latino,,,,,,,True,True
+2022,Kansas,20,Two or more races (NH),,,,,,,True,True
+2022,Kansas,20,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2022,Kansas,20,White (NH),21.6,,78.7,,21.4,,,True
+2022,Kentucky,21,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Kentucky,21,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Kentucky,21,Black or African American (NH),402.2,269.9,46.7,34.4,134.31,11.56,,
+2022,Kentucky,21,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2022,Kentucky,21,Two or more races (NH),,,,,,,True,True
+2022,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Kentucky,21,White (NH),-29.9,-13.7,53.3,65.6,20.15,2.71,,
+2022,Louisiana,22,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Louisiana,22,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Louisiana,22,Black or African American (NH),131.8,130.4,82.3,81.8,138.4,21.19,,
+2022,Louisiana,22,Hispanic or Latino,,,,,,,True,True
+2022,Louisiana,22,Two or more races (NH),,,,,,,True,True
+2022,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Louisiana,22,White (NH),-63.9,-62.9,17.7,18.2,21.66,3.41,,
+2022,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2022,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Maine,23,Black or African American (NH),,,,,,0.0,True,
+2022,Maine,23,Hispanic or Latino,,,,,,0.0,True,
+2022,Maine,23,Two or more races (NH),,,,,,0.0,True,
+2022,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Maine,23,White (NH),15.3,,100.0,,10.84,,,True
+2022,Maryland,24,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Maryland,24,Asian (NH),,,,,,,True,True
+2022,Maryland,24,Black or African American (NH),189.1,231.1,87.3,100.0,81.16,9.69,,
+2022,Maryland,24,Hispanic or Latino,,,,,,,True,True
+2022,Maryland,24,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Maryland,24,White (NH),-67.4,,12.7,,8.58,,,True
+2022,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Massachusetts,25,Asian (NH),,,,,,0.0,True,
+2022,Massachusetts,25,Black or African American (NH),393.5,,45.9,,27.31,,,True
+2022,Massachusetts,25,Hispanic or Latino,,,,,,,True,True
+2022,Massachusetts,25,Two or more races (NH),,,,,,0.0,True,
+2022,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Massachusetts,25,White (NH),-6.4,,54.1,,4.06,,,True
+2022,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Michigan,26,Asian (NH),,,,,,,True,True
+2022,Michigan,26,Black or African American (NH),267.9,318.5,59.6,67.8,86.88,11.58,,
+2022,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2022,Michigan,26,Two or more races (NH),,,,,,,True,True
+2022,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Michigan,26,White (NH),-38.2,-50.8,40.4,32.2,12.72,1.36,,
+2022,Minnesota,27,Indigenous (NH),,,,,,,True,True
+2022,Minnesota,27,Asian (NH),-100.0,,0.0,,0.0,,,True
+2022,Minnesota,27,Black or African American (NH),334.5,295.5,47.8,43.5,65.92,6.92,,
+2022,Minnesota,27,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2022,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Minnesota,27,White (NH),-20.5,-14.0,52.2,56.5,9.04,1.51,,
+2022,Mississippi,28,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Mississippi,28,Black or African American (NH),92.9,79.6,79.3,73.8,104.75,15.97,,
+2022,Mississippi,28,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2022,Mississippi,28,Two or more races (NH),,,,,,,True,True
+2022,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Mississippi,28,White (NH),-57.6,-46.3,20.7,26.2,22.29,4.79,,
+2022,Missouri,29,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Missouri,29,Black or African American (NH),333.8,332.3,57.7,57.5,204.04,22.86,,
+2022,Missouri,29,Hispanic or Latino,-49.4,,4.1,,26.0,,,True
+2022,Missouri,29,Two or more races (NH),,,,,,,True,True
+2022,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Missouri,29,White (NH),-46.3,-40.1,38.1,42.5,23.75,3.16,,
+2022,Montana,30,Indigenous (NH),,,,,,,True,True
+2022,Montana,30,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Montana,30,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2022,Montana,30,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2022,Montana,30,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Montana,30,White (NH),29.4,29.4,100.0,100.0,24.74,6.56,,
+2022,Nebraska,31,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Nebraska,31,Black or African American (NH),,,,,,,True,True
+2022,Nebraska,31,Hispanic or Latino,,,,,,,True,True
+2022,Nebraska,31,Two or more races (NH),,,,,,,True,True
+2022,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Nebraska,31,White (NH),51.5,,100.0,,21.46,,,True
+2022,Nevada,32,Indigenous (NH),,,,,,0.0,True,
+2022,Nevada,32,Asian (NH),,,,,,,True,True
+2022,Nevada,32,Black or African American (NH),267.0,,42.2,,61.4,,,True
+2022,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2022,Nevada,32,Two or more races (NH),,,,,,0.0,True,
+2022,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2022,Nevada,32,White (NH),80.6,,57.8,,25.77,,,True
+2022,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,,,True
+2022,New Hampshire,33,Hispanic or Latino,,,,,,0.0,True,
+2022,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2022,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,New Hampshire,33,White (NH),20.9,,100.0,,11.19,,,True
+2022,New Jersey,34,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,New Jersey,34,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,New Jersey,34,Black or African American (NH),464.9,646.3,75.7,100.0,44.46,4.44,,
+2022,New Jersey,34,Hispanic or Latino,,,,,,,True,True
+2022,New Jersey,34,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,New Jersey,34,White (NH),-44.4,,24.3,,4.31,,,True
+2022,New Mexico,35,Indigenous (NH),,,,,,,True,True
+2022,New Mexico,35,Asian (NH),,,,,,0.0,True,
+2022,New Mexico,35,Black or African American (NH),,,,,,,True,True
+2022,New Mexico,35,Hispanic or Latino,,,,,,,True,True
+2022,New Mexico,35,Two or more races (NH),,,,,,0.0,True,
+2022,New Mexico,35,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,New Mexico,35,White (NH),323.7,,100.0,,33.88,,,True
+2022,New York,36,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,New York,36,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,New York,36,Black or African American (NH),389.1,385.7,71.9,71.4,33.59,5.07,,
+2022,New York,36,Hispanic or Latino,,,,,,,True,True
+2022,New York,36,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,New York,36,White (NH),-40.1,-39.0,28.1,28.6,3.83,0.64,,
+2022,North Carolina,37,Indigenous (NH),236.4,,3.7,,99.42,,,True
+2022,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,North Carolina,37,Black or African American (NH),215.8,229.4,69.8,72.8,85.44,13.02,,
+2022,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2022,North Carolina,37,Two or more races (NH),,,,,,,True,True
+2022,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,North Carolina,37,White (NH),-46.6,-45.2,26.5,27.2,13.55,2.17,,
+2022,North Dakota,38,Indigenous (NH),,,,,,0.0,True,
+2022,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,North Dakota,38,Black or African American (NH),-100.0,,0.0,,0.0,,,True
+2022,North Dakota,38,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2022,North Dakota,38,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2022,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,North Dakota,38,White (NH),34.8,,100.0,,21.69,,,True
+2022,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Ohio,39,Asian (NH),,,,,,,True,True
+2022,Ohio,39,Black or African American (NH),305.8,323.9,62.9,65.7,126.75,16.23,,
+2022,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2022,Ohio,39,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Ohio,39,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Ohio,39,White (NH),-46.1,-50.1,37.1,34.3,14.8,1.91,,
+2022,Oklahoma,40,Indigenous (NH),33.3,,12.4,,25.75,,,True
+2022,Oklahoma,40,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Oklahoma,40,Black or African American (NH),216.7,494.9,24.7,46.4,56.32,17.32,,
+2022,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2022,Oklahoma,40,Two or more races (NH),,,,,,,True,True
+2022,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Oklahoma,40,White (NH),25.5,7.0,62.9,53.6,22.86,3.1,,
+2022,Oregon,41,Indigenous (NH),,,,,,0.0,True,
+2022,Oregon,41,Asian (NH),-100.0,,0.0,,0.0,,,True
+2022,Oregon,41,Black or African American (NH),1045.8,,27.5,,192.72,,,True
+2022,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2022,Oregon,41,Two or more races (NH),,,,,,,True,True
+2022,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2022,Oregon,41,White (NH),18.9,,72.5,,19.15,,,True
+2022,Pennsylvania,42,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Pennsylvania,42,Asian (NH),,,,,,,True,True
+2022,Pennsylvania,42,Black or African American (NH),439.1,320.3,69.0,53.8,117.3,12.37,,
+2022,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2022,Pennsylvania,42,Two or more races (NH),,,,,,,True,True
+2022,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Pennsylvania,42,White (NH),-51.7,-28.0,31.0,46.2,9.77,2.11,,
+2022,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2022,Rhode Island,44,Asian (NH),,,,,0.0,0.0,,
+2022,Rhode Island,44,Black or African American (NH),,,,,,,True,True
+2022,Rhode Island,44,Hispanic or Latino,,,,,,,True,True
+2022,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2022,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2022,Rhode Island,44,White (NH),,,,,0.0,0.0,,
+2022,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,South Carolina,45,Asian (NH),,,,,,,True,True
+2022,South Carolina,45,Black or African American (NH),146.8,179.8,69.6,78.9,86.35,17.48,,
+2022,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2022,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,South Carolina,45,White (NH),-43.1,-60.5,30.4,21.1,18.7,2.48,,
+2022,South Dakota,46,Indigenous (NH),301.7,,46.2,,128.78,,,True
+2022,South Dakota,46,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2022,South Dakota,46,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2022,South Dakota,46,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2022,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,South Dakota,46,White (NH),-23.1,,53.8,,19.59,,,True
+2022,Tennessee,47,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Tennessee,47,Black or African American (NH),231.3,256.0,60.3,64.8,120.67,16.15,,
+2022,Tennessee,47,Hispanic or Latino,-52.0,,6.0,,24.0,,,True
+2022,Tennessee,47,Two or more races (NH),,,,,,,True,True
+2022,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Tennessee,47,White (NH),-46.4,-44.0,33.7,35.2,18.68,2.54,,
+2022,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Texas,48,Asian (NH),-64.0,,1.8,,6.53,,,True
+2022,Texas,48,Black or African American (NH),348.8,298.4,57.0,50.6,72.1,8.17,,
+2022,Texas,48,Hispanic or Latino,,,,,,,True,True
+2022,Texas,48,Two or more races (NH),,,,,,,True,True
+2022,Texas,48,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2022,Texas,48,White (NH),33.9,60.9,41.1,49.4,20.47,3.3,,
+2022,Utah,49,Indigenous (NH),,,,,,,True,True
+2022,Utah,49,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Utah,49,Black or African American (NH),,,,,,,True,True
+2022,Utah,49,Hispanic or Latino,,,,,,,True,True
+2022,Utah,49,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Utah,49,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2022,Utah,49,White (NH),41.0,41.0,100.0,100.0,15.56,1.65,,
+2022,Vermont,50,Indigenous (NH),,,,,,0.0,True,
+2022,Vermont,50,Asian (NH),,,,,0.0,0.0,,
+2022,Vermont,50,Black or African American (NH),,,,,,0.0,True,
+2022,Vermont,50,Hispanic or Latino,,,,,,0.0,True,
+2022,Vermont,50,Two or more races (NH),,,,,0.0,0.0,,
+2022,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2022,Vermont,50,White (NH),,,,,,,True,True
+2022,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2022,Virginia,51,Asian (NH),,,,,,,True,True
+2022,Virginia,51,Black or African American (NH),256.6,219.2,70.6,63.2,90.19,11.51,,
+2022,Virginia,51,Hispanic or Latino,,,,,,,True,True
+2022,Virginia,51,Two or more races (NH),,,,,,,True,True
+2022,Virginia,51,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2022,Virginia,51,White (NH),-42.4,-27.8,29.4,36.8,13.83,2.6,,
+2022,Washington,53,Indigenous (NH),,,,,,,True,True
+2022,Washington,53,Asian (NH),,,,,,,True,True
+2022,Washington,53,Black or African American (NH),511.4,,26.9,,49.42,,,True
+2022,Washington,53,Hispanic or Latino,,,,,,,True,True
+2022,Washington,53,Two or more races (NH),,,,,,,True,True
+2022,Washington,53,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2022,Washington,53,White (NH),39.8,,73.1,,11.63,,,True
+2022,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2022,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,West Virginia,54,Black or African American (NH),,,,,,0.0,True,
+2022,West Virginia,54,Hispanic or Latino,-100.0,,0.0,,0.0,0.0,,
+2022,West Virginia,54,Two or more races (NH),,,,,,0.0,True,
+2022,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,West Virginia,54,White (NH),14.3,,100.0,,14.93,,,True
+2022,Wisconsin,55,Indigenous (NH),,,,,,,True,True
+2022,Wisconsin,55,Asian (NH),,-100.0,,0.0,,0.0,True,
+2022,Wisconsin,55,Black or African American (NH),650.0,526.1,66.0,55.1,135.27,24.32,,
+2022,Wisconsin,55,Hispanic or Latino,,,,,,,True,True
+2022,Wisconsin,55,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2022,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2022,Wisconsin,55,White (NH),-50.2,-34.3,34.0,44.9,7.01,2.56,,
+2022,Wyoming,56,Indigenous (NH),,,,,,0.0,True,
+2022,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Wyoming,56,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Wyoming,56,Hispanic or Latino,,,,,,,True,True
+2022,Wyoming,56,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2022,Wyoming,56,White (NH),31.6,,100.0,,47.09,,,True
+2023,Alabama,01,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Alabama,01,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Alabama,01,Black or African American (NH),173.9,113.1,77.5,60.3,111.03,14.66,,
+2023,Alabama,01,Hispanic or Latino,,,,,,,True,True
+2023,Alabama,01,Two or more races (NH),,,,,,,True,True
+2023,Alabama,01,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Alabama,01,White (NH),-59.9,-29.2,22.5,39.7,16.26,4.89,,
+2023,Alaska,02,Indigenous (NH),,,,,,,True,True
+2023,Alaska,02,Asian (NH),,,,,,,True,True
+2023,Alaska,02,Black or African American (NH),,,,,,0.0,True,
+2023,Alaska,02,Hispanic or Latino,,,,,,,True,True
+2023,Alaska,02,Two or more races (NH),,,,,,,True,True
+2023,Alaska,02,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2023,Alaska,02,White (NH),,,,,,,True,True
+2023,Arizona,04,Indigenous (NH),226.7,,14.7,,39.95,,,True
+2023,Arizona,04,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Arizona,04,Black or African American (NH),389.3,1685.7,27.4,100.0,60.27,14.74,,
+2023,Arizona,04,Hispanic or Latino,,,,,,,True,True
+2023,Arizona,04,Two or more races (NH),,,,,,,True,True
+2023,Arizona,04,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Arizona,04,White (NH),52.0,,57.9,,16.5,,,True
+2023,Arkansas,05,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Arkansas,05,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Arkansas,05,Black or African American (NH),270.9,224.6,64.9,56.8,105.88,20.29,,
+2023,Arkansas,05,Hispanic or Latino,,,,,,,True,True
+2023,Arkansas,05,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2023,Arkansas,05,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Arkansas,05,White (NH),-42.4,-29.1,35.1,43.2,15.97,4.43,,
+2023,California,06,Indigenous (NH),,,,,,,True,True
+2023,California,06,Asian (NH),-38.2,9.2,8.1,14.3,3.15,1.0,,
+2023,California,06,Black or African American (NH),820.0,550.0,46.0,32.5,44.28,5.91,,
+2023,California,06,Hispanic or Latino,,,,,,,True,True
+2023,California,06,Two or more races (NH),20.0,207.3,6.6,16.9,8.26,2.79,,
+2023,California,06,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2023,California,06,White (NH),65.1,52.9,39.3,36.4,7.67,1.39,,
+2023,Colorado,08,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Colorado,08,Asian (NH),,,,,,,True,True
+2023,Colorado,08,Black or African American (NH),541.3,,29.5,,84.41,,,True
+2023,Colorado,08,Hispanic or Latino,,,,,,,True,True
+2023,Colorado,08,Two or more races (NH),,,,,,,True,True
+2023,Colorado,08,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Colorado,08,White (NH),33.3,89.0,70.5,100.0,15.25,2.49,,
+2023,Connecticut,09,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Connecticut,09,Asian (NH),-100.0,,0.0,,0.0,,,True
+2023,Connecticut,09,Black or African American (NH),733.3,,100.0,,40.1,,,True
+2023,Connecticut,09,Hispanic or Latino,,,,,,,True,True
+2023,Connecticut,09,Two or more races (NH),,,,,,0.0,True,
+2023,Connecticut,09,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Connecticut,09,White (NH),,,,,,,True,True
+2023,Delaware,10,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Delaware,10,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Delaware,10,Black or African American (NH),284.6,,100.0,,48.53,,,True
+2023,Delaware,10,Hispanic or Latino,,,,,,0.0,True,
+2023,Delaware,10,Two or more races (NH),,,,,,0.0,True,
+2023,Delaware,10,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Delaware,10,White (NH),,,,,,0.0,True,
+2023,District of Columbia,11,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,District of Columbia,11,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,District of Columbia,11,Black or African American (NH),96.9,96.9,100.0,100.0,191.84,29.52,,
+2023,District of Columbia,11,Hispanic or Latino,,,,,,,True,True
+2023,District of Columbia,11,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,District of Columbia,11,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,District of Columbia,11,White (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Florida,12,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2023,Florida,12,Asian (NH),,,,,,,True,True
+2023,Florida,12,Black or African American (NH),226.8,260.8,63.4,70.0,60.36,8.22,,
+2023,Florida,12,Hispanic or Latino,,,,,,,True,True
+2023,Florida,12,Two or more races (NH),-26.8,,3.0,,18.22,,,True
+2023,Florida,12,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Florida,12,White (NH),-18.0,-26.8,33.6,30.0,13.83,1.67,,
+2023,Georgia,13,Indigenous (NH),,,,,,,True,True
+2023,Georgia,13,Asian (NH),,,,,,,True,True
+2023,Georgia,13,Black or African American (NH),125.1,141.1,76.1,81.5,72.38,11.3,,
+2023,Georgia,13,Hispanic or Latino,,,,,,,True,True
+2023,Georgia,13,Two or more races (NH),,,,,,,True,True
+2023,Georgia,13,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Georgia,13,White (NH),-41.7,-54.9,23.9,18.5,17.41,2.11,,
+2023,Hawaii,15,Indigenous (NH),,,,,0.0,0.0,,
+2023,Hawaii,15,Asian (NH),,,,,0.0,0.0,,
+2023,Hawaii,15,Black or African American (NH),,,,,0.0,0.0,,
+2023,Hawaii,15,Hispanic or Latino,,,,,,,True,True
+2023,Hawaii,15,Two or more races (NH),,,,,,,True,True
+2023,Hawaii,15,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2023,Hawaii,15,White (NH),,,,,0.0,0.0,,
+2023,Idaho,16,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Idaho,16,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Idaho,16,Black or African American (NH),,-100.0,,0.0,,0.0,True,
+2023,Idaho,16,Hispanic or Latino,,,,,,,True,True
+2023,Idaho,16,Two or more races (NH),,,,,,,True,True
+2023,Idaho,16,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Idaho,16,White (NH),37.7,37.7,100.0,100.0,22.57,5.3,,
+2023,Illinois,17,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Illinois,17,Asian (NH),,,,,,,True,True
+2023,Illinois,17,Black or African American (NH),427.5,358.8,80.7,70.2,115.87,20.57,,
+2023,Illinois,17,Hispanic or Latino,,-37.9,,15.7,,3.0,True,
+2023,Illinois,17,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2023,Illinois,17,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Illinois,17,White (NH),-61.2,-71.8,19.3,14.0,8.05,1.26,,
+2023,Indiana,18,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Indiana,18,Asian (NH),,,,,,,True,True
+2023,Indiana,18,Black or African American (NH),372.9,376.3,55.8,56.2,137.19,21.87,,
+2023,Indiana,18,Hispanic or Latino,,,,,,,True,True
+2023,Indiana,18,Two or more races (NH),,,,,,,True,True
+2023,Indiana,18,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Indiana,18,White (NH),-34.4,-35.0,44.2,43.8,16.58,2.99,,
+2023,Iowa,19,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Iowa,19,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Iowa,19,Black or African American (NH),409.8,,31.1,,72.85,,,True
+2023,Iowa,19,Hispanic or Latino,,,,,,,True,True
+2023,Iowa,19,Two or more races (NH),,,,,,,True,True
+2023,Iowa,19,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Iowa,19,White (NH),-7.4,34.4,68.9,100.0,11.21,2.03,,
+2023,Kansas,20,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Kansas,20,Asian (NH),,,,,,,True,True
+2023,Kansas,20,Black or African American (NH),477.0,,35.2,,112.95,,,True
+2023,Kansas,20,Hispanic or Latino,,,,,,,True,True
+2023,Kansas,20,Two or more races (NH),,,,,,,True,True
+2023,Kansas,20,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Kansas,20,White (NH),0.5,55.0,64.8,100.0,20.57,2.46,,
+2023,Kentucky,21,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Kentucky,21,Asian (NH),,,,,,,True,True
+2023,Kentucky,21,Black or African American (NH),346.8,278.7,42.0,35.6,114.33,16.72,,
+2023,Kentucky,21,Hispanic or Latino,,,,,,,True,True
+2023,Kentucky,21,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Kentucky,21,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Kentucky,21,White (NH),-23.3,-14.8,58.0,64.4,20.99,3.77,,
+2023,Louisiana,22,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Louisiana,22,Asian (NH),,,,,,,True,True
+2023,Louisiana,22,Black or African American (NH),137.6,144.4,84.1,86.5,145.73,20.4,,
+2023,Louisiana,22,Hispanic or Latino,,,,,,,True,True
+2023,Louisiana,22,Two or more races (NH),,,,,,,True,True
+2023,Louisiana,22,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Louisiana,22,White (NH),-67.4,-72.3,15.9,13.5,20.12,2.3,,
+2023,Maine,23,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Maine,23,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Maine,23,Black or African American (NH),,,,,,0.0,True,
+2023,Maine,23,Hispanic or Latino,,,,,,0.0,True,
+2023,Maine,23,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2023,Maine,23,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Maine,23,White (NH),15.9,,100.0,,15.43,,,True
+2023,Maryland,24,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Maryland,24,Asian (NH),,,,,,,True,True
+2023,Maryland,24,Black or African American (NH),198.0,232.2,89.7,100.0,65.85,8.78,,
+2023,Maryland,24,Hispanic or Latino,,,,,,,True,True
+2023,Maryland,24,Two or more races (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Maryland,24,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Maryland,24,White (NH),-73.2,,10.3,,5.55,,,True
+2023,Massachusetts,25,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Massachusetts,25,Asian (NH),,,,,,0.0,True,
+2023,Massachusetts,25,Black or African American (NH),531.6,,60.0,,28.81,,,True
+2023,Massachusetts,25,Hispanic or Latino,,,,,,,True,True
+2023,Massachusetts,25,Two or more races (NH),,,,,,0.0,True,
+2023,Massachusetts,25,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Massachusetts,25,White (NH),-29.6,,40.0,,2.46,,,True
+2023,Michigan,26,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Michigan,26,Asian (NH),,,,,,,True,True
+2023,Michigan,26,Black or African American (NH),256.2,251.2,57.7,56.9,71.36,10.8,,
+2023,Michigan,26,Hispanic or Latino,,,,,,,True,True
+2023,Michigan,26,Two or more races (NH),,,,,,,True,True
+2023,Michigan,26,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Michigan,26,White (NH),-35.1,-33.9,42.3,43.1,11.25,2.03,,
+2023,Minnesota,27,Indigenous (NH),,,,,,,True,True
+2023,Minnesota,27,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Minnesota,27,Black or African American (NH),397.3,,56.2,,68.54,,,True
+2023,Minnesota,27,Hispanic or Latino,,,,,,,True,True
+2023,Minnesota,27,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2023,Minnesota,27,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Minnesota,27,White (NH),-32.8,53.4,43.8,100.0,6.98,1.18,,
+2023,Mississippi,28,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Mississippi,28,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Mississippi,28,Black or African American (NH),103.2,95.1,83.3,80.0,113.94,18.68,,
+2023,Mississippi,28,Hispanic or Latino,,-100.0,,0.0,,0.0,True,
+2023,Mississippi,28,Two or more races (NH),,,,,,,True,True
+2023,Mississippi,28,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Mississippi,28,White (NH),-65.6,-58.8,16.7,20.0,18.55,3.93,,
+2023,Missouri,29,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Missouri,29,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Missouri,29,Black or African American (NH),351.9,353.4,60.1,60.3,156.41,22.51,,
+2023,Missouri,29,Hispanic or Latino,,,,,,,True,True
+2023,Missouri,29,Two or more races (NH),,,,,,,True,True
+2023,Missouri,29,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Missouri,29,White (NH),-43.6,-43.8,39.9,39.7,18.21,2.78,,
+2023,Montana,30,Indigenous (NH),,,,,,,True,True
+2023,Montana,30,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Montana,30,Black or African American (NH),,,,,,0.0,True,
+2023,Montana,30,Hispanic or Latino,,,,,,0.0,True,
+2023,Montana,30,Two or more races (NH),,,,,,0.0,True,
+2023,Montana,30,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Montana,30,White (NH),29.5,,100.0,,16.07,,,True
+2023,Nebraska,31,Indigenous (NH),,,,,,0.0,True,
+2023,Nebraska,31,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Nebraska,31,Black or African American (NH),,,,,,,True,True
+2023,Nebraska,31,Hispanic or Latino,,,,,,,True,True
+2023,Nebraska,31,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Nebraska,31,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Nebraska,31,White (NH),52.9,,100.0,,16.82,,,True
+2023,Nevada,32,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Nevada,32,Asian (NH),,,,,,,True,True
+2023,Nevada,32,Black or African American (NH),424.1,,60.8,,100.39,,,True
+2023,Nevada,32,Hispanic or Latino,,,,,,,True,True
+2023,Nevada,32,Two or more races (NH),,,,,,,True,True
+2023,Nevada,32,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Nevada,32,White (NH),26.0,,39.2,,20.2,,,True
+2023,New Hampshire,33,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Hampshire,33,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Hampshire,33,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Hampshire,33,Hispanic or Latino,-100.0,,0.0,,0.0,,,True
+2023,New Hampshire,33,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Hampshire,33,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Hampshire,33,White (NH),21.2,,100.0,,11.37,,,True
+2023,New Jersey,34,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Jersey,34,Asian (NH),,,,,,0.0,True,
+2023,New Jersey,34,Black or African American (NH),646.3,,100.0,,25.62,,,True
+2023,New Jersey,34,Hispanic or Latino,,,,,,,True,True
+2023,New Jersey,34,Two or more races (NH),,,,,,,True,True
+2023,New Jersey,34,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Jersey,34,White (NH),,,,,,,True,True
+2023,New Mexico,35,Indigenous (NH),170.0,,27.0,,44.56,,,True
+2023,New Mexico,35,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Mexico,35,Black or African American (NH),,,,,,0.0,True,
+2023,New Mexico,35,Hispanic or Latino,,,,,,,True,True
+2023,New Mexico,35,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2023,New Mexico,35,Native Hawaiian and Pacific Islander (NH),,,,,,0.0,True,
+2023,New Mexico,35,White (NH),212.0,,73.0,,46.02,,,True
+2023,New York,36,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,New York,36,Asian (NH),,,,,,,True,True
+2023,New York,36,Black or African American (NH),395.2,356.8,72.3,66.7,25.03,3.47,,
+2023,New York,36,Hispanic or Latino,,,,,,,True,True
+2023,New York,36,Two or more races (NH),,,,,,,True,True
+2023,New York,36,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,New York,36,White (NH),-40.7,-28.7,27.7,33.3,2.77,0.54,,
+2023,North Carolina,37,Indigenous (NH),250.0,,3.5,,91.61,,,True
+2023,North Carolina,37,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,North Carolina,37,Black or African American (NH),179.2,222.6,61.7,71.3,73.05,12.03,,
+2023,North Carolina,37,Hispanic or Latino,,,,,,,True,True
+2023,North Carolina,37,Two or more races (NH),-33.3,,3.2,,25.75,,,True
+2023,North Carolina,37,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,North Carolina,37,White (NH),-36.0,-41.7,31.5,28.7,15.56,2.18,,
+2023,North Dakota,38,Indigenous (NH),,,,,,,True,True
+2023,North Dakota,38,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,North Dakota,38,Black or African American (NH),,,,,,,True,True
+2023,North Dakota,38,Hispanic or Latino,,,,,,,True,True
+2023,North Dakota,38,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2023,North Dakota,38,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,North Dakota,38,White (NH),36.4,,100.0,,15.25,,,True
+2023,Ohio,39,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Ohio,39,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Ohio,39,Black or African American (NH),288.5,281.4,60.6,59.5,99.14,16.45,,
+2023,Ohio,39,Hispanic or Latino,,,,,,,True,True
+2023,Ohio,39,Two or more races (NH),,,,,,,True,True
+2023,Ohio,39,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Ohio,39,White (NH),-42.4,-40.8,39.4,40.5,12.83,2.55,,
+2023,Oklahoma,40,Indigenous (NH),30.8,,11.9,,23.42,,,True
+2023,Oklahoma,40,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Oklahoma,40,Black or African American (NH),129.5,280.8,17.9,29.7,38.32,14.56,,
+2023,Oklahoma,40,Hispanic or Latino,,,,,,,True,True
+2023,Oklahoma,40,Two or more races (NH),,,,,,,True,True
+2023,Oklahoma,40,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Oklahoma,40,White (NH),41.5,41.7,70.2,70.3,24.04,5.42,,
+2023,Oregon,41,Indigenous (NH),,,,,,0.0,True,
+2023,Oregon,41,Asian (NH),,,,,,,True,True
+2023,Oregon,41,Black or African American (NH),548.0,,16.2,,110.31,,,True
+2023,Oregon,41,Hispanic or Latino,,,,,,,True,True
+2023,Oregon,41,Two or more races (NH),116.2,,14.7,,42.79,,,True
+2023,Oregon,41,Native Hawaiian and Pacific Islander (NH),,,,,,,True,True
+2023,Oregon,41,White (NH),14.6,,69.1,,18.27,,,True
+2023,Pennsylvania,42,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Pennsylvania,42,Asian (NH),,,,,,,True,True
+2023,Pennsylvania,42,Black or African American (NH),352.0,474.0,57.4,72.9,89.53,12.84,,
+2023,Pennsylvania,42,Hispanic or Latino,,,,,,,True,True
+2023,Pennsylvania,42,Two or more races (NH),,,,,,,True,True
+2023,Pennsylvania,42,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Pennsylvania,42,White (NH),-33.2,-57.5,42.6,27.1,12.34,0.95,,
+2023,Rhode Island,44,Indigenous (NH),,,,,0.0,0.0,,
+2023,Rhode Island,44,Asian (NH),,,,,0.0,0.0,,
+2023,Rhode Island,44,Black or African American (NH),,,,,0.0,,,True
+2023,Rhode Island,44,Hispanic or Latino,,,,,,0.0,True,
+2023,Rhode Island,44,Two or more races (NH),,,,,0.0,0.0,,
+2023,Rhode Island,44,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2023,Rhode Island,44,White (NH),,,,,,,True,True
+2023,South Carolina,45,Indigenous (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,South Carolina,45,Asian (NH),,,,,,,True,True
+2023,South Carolina,45,Black or African American (NH),150.5,143.4,69.9,67.9,87.36,11.27,,
+2023,South Carolina,45,Hispanic or Latino,,,,,,,True,True
+2023,South Carolina,45,Two or more races (NH),,-100.0,,0.0,,0.0,True,
+2023,South Carolina,45,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,South Carolina,45,White (NH),-43.5,-39.8,30.1,32.1,18.49,2.79,,
+2023,South Dakota,46,Indigenous (NH),,,,,,,True,True
+2023,South Dakota,46,Asian (NH),,,,,,0.0,True,
+2023,South Dakota,46,Black or African American (NH),-100.0,,0.0,,0.0,0.0,,
+2023,South Dakota,46,Hispanic or Latino,,,,,,0.0,True,
+2023,South Dakota,46,Two or more races (NH),-100.0,,0.0,,0.0,0.0,,
+2023,South Dakota,46,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,South Dakota,46,White (NH),43.9,,100.0,,15.22,0.0,,
+2023,Tennessee,47,Indigenous (NH),-100.0,,0.0,,0.0,,,True
+2023,Tennessee,47,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Tennessee,47,Black or African American (NH),270.6,233.3,66.7,60.0,135.84,18.0,,
+2023,Tennessee,47,Hispanic or Latino,,,,,,,True,True
+2023,Tennessee,47,Two or more races (NH),,,,,,,True,True
+2023,Tennessee,47,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,,,True
+2023,Tennessee,47,White (NH),-46.9,-36.2,33.3,40.0,18.5,3.45,,
+2023,Texas,48,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Texas,48,Asian (NH),-27.5,,3.7,,10.65,,,True
+2023,Texas,48,Black or African American (NH),281.4,317.1,49.2,53.8,51.26,8.75,,
+2023,Texas,48,Hispanic or Latino,,,,,,,True,True
+2023,Texas,48,Two or more races (NH),,,,,,,True,True
+2023,Texas,48,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Texas,48,White (NH),55.1,52.5,47.0,46.2,19.54,3.18,,
+2023,Utah,49,Indigenous (NH),,,,,,,True,True
+2023,Utah,49,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Utah,49,Black or African American (NH),,,,,,,True,True
+2023,Utah,49,Hispanic or Latino,,,,,,,True,True
+2023,Utah,49,Two or more races (NH),,,,,,,True,True
+2023,Utah,49,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Utah,49,White (NH),42.7,42.7,100.0,100.0,12.91,2.14,,
+2023,Vermont,50,Indigenous (NH),,,,,0.0,0.0,,
+2023,Vermont,50,Asian (NH),,,,,0.0,0.0,,
+2023,Vermont,50,Black or African American (NH),,,,,0.0,0.0,,
+2023,Vermont,50,Hispanic or Latino,,,,,0.0,0.0,,
+2023,Vermont,50,Two or more races (NH),,,,,0.0,0.0,,
+2023,Vermont,50,Native Hawaiian and Pacific Islander (NH),,,,,0.0,0.0,,
+2023,Vermont,50,White (NH),,,,,,,True,True
+2023,Virginia,51,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Virginia,51,Asian (NH),,-100.0,,0.0,,0.0,True,
+2023,Virginia,51,Black or African American (NH),236.5,276.1,66.3,74.1,72.99,10.78,,
+2023,Virginia,51,Hispanic or Latino,,,,,,,True,True
+2023,Virginia,51,Two or more races (NH),,,,,,,True,True
+2023,Virginia,51,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Virginia,51,White (NH),-33.5,-48.9,33.7,25.9,13.71,1.47,,
+2023,Washington,53,Indigenous (NH),,,,,,,True,True
+2023,Washington,53,Asian (NH),,,,,,,True,True
+2023,Washington,53,Black or African American (NH),488.9,,26.5,,70.45,,,True
+2023,Washington,53,Hispanic or Latino,,,,,,,True,True
+2023,Washington,53,Two or more races (NH),14.6,,10.2,,19.43,,,True
+2023,Washington,53,Native Hawaiian and Pacific Islander (NH),,-100.0,,0.0,,0.0,True,
+2023,Washington,53,White (NH),22.9,94.2,63.3,100.0,14.93,2.24,,
+2023,West Virginia,54,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,West Virginia,54,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,West Virginia,54,Black or African American (NH),,,,,,,True,True
+2023,West Virginia,54,Hispanic or Latino,,,,,,0.0,True,
+2023,West Virginia,54,Two or more races (NH),,,,,,,True,True
+2023,West Virginia,54,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,West Virginia,54,White (NH),14.5,,100.0,,14.94,,,True
+2023,Wisconsin,55,Indigenous (NH),,-100.0,,0.0,,0.0,True,
+2023,Wisconsin,55,Asian (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Wisconsin,55,Black or African American (NH),478.7,568.5,51.5,59.5,110.78,19.9,,
+2023,Wisconsin,55,Hispanic or Latino,,,,,,,True,True
+2023,Wisconsin,55,Two or more races (NH),-100.0,,0.0,,0.0,,,True
+2023,Wisconsin,55,Native Hawaiian and Pacific Islander (NH),-100.0,-100.0,0.0,0.0,0.0,0.0,,
+2023,Wisconsin,55,White (NH),-28.7,-40.4,48.5,40.5,10.53,1.77,,
+2023,Wyoming,56,Indigenous (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Wyoming,56,Asian (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Wyoming,56,Black or African American (NH),,,,,,0.0,True,
+2023,Wyoming,56,Hispanic or Latino,,,,,,,True,True
+2023,Wyoming,56,Two or more races (NH),,,,,,0.0,True,
+2023,Wyoming,56,Native Hawaiian and Pacific Islander (NH),-100.0,,0.0,,0.0,0.0,,
+2023,Wyoming,56,White (NH),31.9,,100.0,,44.64,,,True
+2018,Arizona,04,Unknown race,,,,,,,True,
+2018,California,06,Unknown race,,,,,,,True,
+2018,Florida,12,Unknown race,,,,,,,True,
+2018,Illinois,17,Unknown race,,,,,,,True,
+2018,Indiana,18,Unknown race,,,,,,,True,
+2018,Iowa,19,Unknown race,,,,,,,True,
+2018,Kansas,20,Unknown race,,,,,,,True,
+2018,Massachusetts,25,Unknown race,,,,,,,True,
+2018,Mississippi,28,Unknown race,,,,,,,True,
+2018,Missouri,29,Unknown race,,,,,,,True,
+2018,New York,36,Unknown race,,,,,,,True,
+2018,North Carolina,37,Unknown race,,,,,,,True,
+2018,Ohio,39,Unknown race,,,,,,,True,
+2018,Oklahoma,40,Unknown race,,,,,,,,True
+2018,Rhode Island,44,Unknown race,,,,,,,True,
+2019,Alabama,01,Unknown race,,,,,,,True,
+2019,California,06,Unknown race,,,,,,,True,
+2019,Colorado,08,Unknown race,,,,,,,True,
+2019,Delaware,10,Unknown race,,,,,,,True,
+2019,Kansas,20,Unknown race,,,,,,,True,
+2019,Maryland,24,Unknown race,,,,,,,True,
+2019,Massachusetts,25,Unknown race,,,,,,,True,
+2019,New York,36,Unknown race,,,,,,,True,
+2019,Pennsylvania,42,Unknown race,,,,,,,True,
+2019,Texas,48,Unknown race,,,,,,,True,
+2019,Virginia,51,Unknown race,,,,,,,,True
+2020,Alabama,01,Unknown race,,,,,,,True,
+2020,Colorado,08,Unknown race,,,,,,,True,True
+2020,District of Columbia,11,Unknown race,,,,,,,True,
+2020,Illinois,17,Unknown race,,,,,,,True,
+2020,Kansas,20,Unknown race,,,,,,,True,
+2020,Michigan,26,Unknown race,,,,,,,True,
+2020,Minnesota,27,Unknown race,,,,,,,True,
+2020,New York,36,Unknown race,,,,,,,True,
+2020,Pennsylvania,42,Unknown race,,,,,,,True,True
+2020,Virginia,51,Unknown race,,,,,,,True,
+2021,Arizona,04,Unknown race,,,,,,,True,
+2021,Arkansas,05,Unknown race,,,,,,,True,
+2021,California,06,Unknown race,,,,,,,,True
+2021,Kansas,20,Unknown race,,,,,,,True,True
+2021,Minnesota,27,Unknown race,,,,,,,,True
+2021,New York,36,Unknown race,,,,,,,True,
+2021,Pennsylvania,42,Unknown race,,,,,,,True,
+2021,Virginia,51,Unknown race,,,,,,,,True
+2022,Arizona,04,Unknown race,,,,,,,True,
+2022,Kansas,20,Unknown race,,,,,,,True,True
+2022,Maine,23,Unknown race,,,,,,,True,
+2022,Missouri,29,Unknown race,,,,,,,True,
+2022,New York,36,Unknown race,,,,,,,True,
+2023,California,06,Unknown race,,,,,,,True,
+2023,Colorado,08,Unknown race,,,,,,,,True
+2023,Illinois,17,Unknown race,,,,,,,True,True
+2023,Iowa,19,Unknown race,,,,,,,True,
+2023,Kansas,20,Unknown race,,,,,,,True,True
+2023,Michigan,26,Unknown race,,,,,,,True,
+2023,New York,36,Unknown race,,,,,,,,True
+2023,North Dakota,38,Unknown race,,,,,,,,True
+2023,Texas,48,Unknown race,,,,,,,True,
+2018,Alabama,01,All,0.0,0.0,100.0,100.0,39.83,4.3,,
+2018,Alaska,02,All,0.0,0.0,100.0,100.0,42.81,,,True
+2018,Arizona,04,All,0.0,0.0,100.0,100.0,23.54,2.56,,
+2018,Arkansas,05,All,0.0,0.0,100.0,100.0,30.86,3.27,,
+2018,California,06,All,0.0,0.0,100.0,100.0,12.31,1.2,,
+2018,Colorado,08,All,0.0,0.0,100.0,100.0,23.55,3.4,,
+2018,Connecticut,09,All,0.0,0.0,100.0,100.0,4.84,,,True
+2018,Delaware,10,All,0.0,0.0,100.0,100.0,28.18,,,True
+2018,District of Columbia,11,All,0.0,0.0,100.0,100.0,53.81,7.89,,
+2018,Florida,12,All,0.0,0.0,100.0,100.0,21.21,2.2,,
+2018,Georgia,13,All,0.0,0.0,100.0,100.0,26.67,3.11,,
+2018,Hawaii,15,All,0.0,0.0,100.0,100.0,,0.0,True,
+2018,Idaho,16,All,0.0,0.0,100.0,100.0,27.33,2.7,,
+2018,Illinois,17,All,0.0,0.0,100.0,100.0,24.34,2.98,,
+2018,Indiana,18,All,0.0,0.0,100.0,100.0,25.56,3.43,,
+2018,Iowa,19,All,0.0,0.0,100.0,100.0,12.56,1.78,,
+2018,Kansas,20,All,0.0,0.0,100.0,100.0,24.07,2.41,,
+2018,Kentucky,21,All,0.0,0.0,100.0,100.0,22.58,2.88,,
+2018,Louisiana,22,All,0.0,0.0,100.0,100.0,43.95,4.83,,
+2018,Maine,23,All,0.0,0.0,100.0,100.0,11.31,,,True
+2018,Maryland,24,All,0.0,0.0,100.0,100.0,23.87,2.09,,
+2018,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.02,,,True
+2018,Michigan,26,All,0.0,0.0,100.0,100.0,21.37,2.31,,
+2018,Minnesota,27,All,0.0,0.0,100.0,100.0,13.74,1.54,,
+2018,Mississippi,28,All,0.0,0.0,100.0,100.0,45.04,4.95,,
+2018,Missouri,29,All,0.0,0.0,100.0,100.0,33.7,5.29,,
+2018,Montana,30,All,0.0,0.0,100.0,100.0,18.6,,,True
+2018,Nebraska,31,All,0.0,0.0,100.0,100.0,12.94,,,True
+2018,Nevada,32,All,0.0,0.0,100.0,100.0,27.16,3.19,,
+2018,New Hampshire,33,All,0.0,0.0,100.0,100.0,13.99,,,True
+2018,New Jersey,34,All,0.0,0.0,100.0,100.0,8.99,0.67,,
+2018,New Mexico,35,All,0.0,0.0,100.0,100.0,39.29,3.52,,
+2018,New York,36,All,0.0,0.0,100.0,100.0,7.63,0.81,,
+2018,North Carolina,37,All,0.0,0.0,100.0,100.0,22.01,2.69,,
+2018,North Dakota,38,All,0.0,0.0,100.0,100.0,12.28,,,True
+2018,Ohio,39,All,0.0,0.0,100.0,100.0,23.36,2.89,,
+2018,Oklahoma,40,All,0.0,0.0,100.0,100.0,19.08,3.45,,
+2018,Oregon,41,All,0.0,0.0,100.0,100.0,15.41,2.76,,
+2018,Pennsylvania,42,All,0.0,0.0,100.0,100.0,23.4,2.07,,
+2018,Rhode Island,44,All,0.0,0.0,100.0,100.0,,,True,True
+2018,South Carolina,45,All,0.0,0.0,100.0,100.0,34.86,3.88,,
+2018,South Dakota,46,All,0.0,0.0,100.0,100.0,28.31,,,True
+2018,Tennessee,47,All,0.0,0.0,100.0,100.0,35.71,4.24,,
+2018,Texas,48,All,0.0,0.0,100.0,100.0,19.37,2.52,,
+2018,Utah,49,All,0.0,0.0,100.0,100.0,15.52,3.01,,
+2018,Vermont,50,All,0.0,0.0,100.0,100.0,,0.0,True,
+2018,Virginia,51,All,0.0,0.0,100.0,100.0,24.04,2.51,,
+2018,Washington,53,All,0.0,0.0,100.0,100.0,17.95,2.05,,
+2018,West Virginia,54,All,0.0,0.0,100.0,100.0,21.31,,,True
+2018,Wisconsin,55,All,0.0,0.0,100.0,100.0,16.68,1.33,,
+2018,Wyoming,56,All,0.0,0.0,100.0,100.0,36.49,,,True
+2019,Alabama,01,All,0.0,0.0,100.0,100.0,38.15,3.95,,
+2019,Alaska,02,All,0.0,0.0,100.0,100.0,42.54,6.1,,
+2019,Arizona,04,All,0.0,0.0,100.0,100.0,22.4,2.13,,
+2019,Arkansas,05,All,0.0,0.0,100.0,100.0,36.68,3.28,,
+2019,California,06,All,0.0,0.0,100.0,100.0,11.59,1.25,,
+2019,Colorado,08,All,0.0,0.0,100.0,100.0,21.67,3.42,,
+2019,Connecticut,09,All,0.0,0.0,100.0,100.0,6.45,,,True
+2019,Delaware,10,All,0.0,0.0,100.0,100.0,16.79,,,True
+2019,District of Columbia,11,All,0.0,0.0,100.0,100.0,68.32,,,True
+2019,Florida,12,All,0.0,0.0,100.0,100.0,21.79,2.22,,
+2019,Georgia,13,All,0.0,0.0,100.0,100.0,29.4,3.11,,
+2019,Hawaii,15,All,0.0,0.0,100.0,100.0,,,True,True
+2019,Idaho,16,All,0.0,0.0,100.0,100.0,20.6,,,True
+2019,Illinois,17,All,0.0,0.0,100.0,100.0,24.16,3.51,,
+2019,Indiana,18,All,0.0,0.0,100.0,100.0,26.93,3.06,,
+2019,Iowa,19,All,0.0,0.0,100.0,100.0,13.17,2.34,,
+2019,Kansas,20,All,0.0,0.0,100.0,100.0,22.53,3.56,,
+2019,Kentucky,21,All,0.0,0.0,100.0,100.0,21.63,3.09,,
+2019,Louisiana,22,All,0.0,0.0,100.0,100.0,44.36,5.14,,
+2019,Maine,23,All,0.0,0.0,100.0,100.0,13.87,,,True
+2019,Maryland,24,All,0.0,0.0,100.0,100.0,29.05,1.79,,
+2019,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.06,,,True
+2019,Michigan,26,All,0.0,0.0,100.0,100.0,19.22,2.15,,
+2019,Minnesota,27,All,0.0,0.0,100.0,100.0,12.77,1.61,,
+2019,Mississippi,28,All,0.0,0.0,100.0,100.0,45.35,5.14,,
+2019,Missouri,29,All,0.0,0.0,100.0,100.0,39.43,5.17,,
+2019,Montana,30,All,0.0,0.0,100.0,100.0,24.94,4.81,,
+2019,Nebraska,31,All,0.0,0.0,100.0,100.0,16.72,,,True
+2019,Nevada,32,All,0.0,0.0,100.0,100.0,24.12,1.87,,
+2019,New Hampshire,33,All,0.0,0.0,100.0,100.0,14.18,,,True
+2019,New Jersey,34,All,0.0,0.0,100.0,100.0,8.18,0.88,,
+2019,New Mexico,35,All,0.0,0.0,100.0,100.0,36.86,5.24,,
+2019,New York,36,All,0.0,0.0,100.0,100.0,6.37,0.69,,
+2019,North Carolina,37,All,0.0,0.0,100.0,100.0,24.78,2.43,,
+2019,North Dakota,38,All,0.0,0.0,100.0,100.0,,,True,True
+2019,Ohio,39,All,0.0,0.0,100.0,100.0,23.93,2.75,,
+2019,Oklahoma,40,All,0.0,0.0,100.0,100.0,25.53,4.19,,
+2019,Oregon,41,All,0.0,0.0,100.0,100.0,17.84,1.16,,
+2019,Pennsylvania,42,All,0.0,0.0,100.0,100.0,20.43,2.05,,
+2019,Rhode Island,44,All,0.0,0.0,100.0,100.0,,,True,True
+2019,South Carolina,45,All,0.0,0.0,100.0,100.0,40.33,4.31,,
+2019,South Dakota,46,All,0.0,0.0,100.0,100.0,24.22,,,True
+2019,Tennessee,47,All,0.0,0.0,100.0,100.0,30.64,3.04,,
+2019,Texas,48,All,0.0,0.0,100.0,100.0,20.9,2.85,,
+2019,Utah,49,All,0.0,0.0,100.0,100.0,17.39,1.83,,
+2019,Vermont,50,All,0.0,0.0,100.0,100.0,,,True,True
+2019,Virginia,51,All,0.0,0.0,100.0,100.0,21.18,2.25,,
+2019,Washington,53,All,0.0,0.0,100.0,100.0,15.19,1.63,,
+2019,West Virginia,54,All,0.0,0.0,100.0,100.0,22.71,2.77,,
+2019,Wisconsin,55,All,0.0,0.0,100.0,100.0,14.74,1.81,,
+2019,Wyoming,56,All,0.0,0.0,100.0,100.0,26.81,,,True
+2020,Alabama,01,All,0.0,0.0,100.0,100.0,48.85,3.36,,
+2020,Alaska,02,All,0.0,0.0,100.0,100.0,46.33,8.32,,
+2020,Arizona,04,All,0.0,0.0,100.0,100.0,25.27,3.44,,
+2020,Arkansas,05,All,0.0,0.0,100.0,100.0,42.11,6.37,,
+2020,California,06,All,0.0,0.0,100.0,100.0,15.15,1.61,,
+2020,Colorado,08,All,0.0,0.0,100.0,100.0,24.35,4.21,,
+2020,Connecticut,09,All,0.0,0.0,100.0,100.0,10.91,,,True
+2020,Delaware,10,All,0.0,0.0,100.0,100.0,34.78,,,True
+2020,District of Columbia,11,All,0.0,0.0,100.0,100.0,89.21,7.91,,
+2020,Florida,12,All,0.0,0.0,100.0,100.0,26.93,3.09,,
+2020,Georgia,13,All,0.0,0.0,100.0,100.0,35.59,3.85,,
+2020,Hawaii,15,All,0.0,0.0,100.0,100.0,,,True,True
+2020,Idaho,16,All,0.0,0.0,100.0,100.0,21.99,3.49,,
+2020,Illinois,17,All,0.0,0.0,100.0,100.0,32.79,3.56,,
+2020,Indiana,18,All,0.0,0.0,100.0,100.0,38.66,4.24,,
+2020,Iowa,19,All,0.0,0.0,100.0,100.0,16.54,2.29,,
+2020,Kansas,20,All,0.0,0.0,100.0,100.0,33.06,4.77,,
+2020,Kentucky,21,All,0.0,0.0,100.0,100.0,35.07,5.26,,
+2020,Louisiana,22,All,0.0,0.0,100.0,100.0,65.25,6.34,,
+2020,Maine,23,All,0.0,0.0,100.0,100.0,13.94,,,True
+2020,Maryland,24,All,0.0,0.0,100.0,100.0,35.18,1.87,,
+2020,Massachusetts,25,All,0.0,0.0,100.0,100.0,8.92,,,True
+2020,Michigan,26,All,0.0,0.0,100.0,100.0,26.53,2.89,,
+2020,Minnesota,27,All,0.0,0.0,100.0,100.0,13.87,2.1,,
+2020,Mississippi,28,All,0.0,0.0,100.0,100.0,54.16,7.15,,
+2020,Missouri,29,All,0.0,0.0,100.0,100.0,46.66,5.38,,
+2020,Montana,30,All,0.0,0.0,100.0,100.0,36.67,4.27,,
+2020,Nebraska,31,All,0.0,0.0,100.0,100.0,13.92,2.66,,
+2020,Nevada,32,All,0.0,0.0,100.0,100.0,27.13,3.59,,
+2020,New Hampshire,33,All,0.0,0.0,100.0,100.0,12.87,,,True
+2020,New Jersey,34,All,0.0,0.0,100.0,100.0,11.1,0.63,,
+2020,New Mexico,35,All,0.0,0.0,100.0,100.0,36.2,5.25,,
+2020,New York,36,All,0.0,0.0,100.0,100.0,11.32,0.76,,
+2020,North Carolina,37,All,0.0,0.0,100.0,100.0,31.93,4.7,,
+2020,North Dakota,38,All,0.0,0.0,100.0,100.0,12.49,,,True
+2020,Ohio,39,All,0.0,0.0,100.0,100.0,32.18,3.69,,
+2020,Oklahoma,40,All,0.0,0.0,100.0,100.0,35.46,4.15,,
+2020,Oregon,41,All,0.0,0.0,100.0,100.0,19.22,1.83,,
+2020,Pennsylvania,42,All,0.0,0.0,100.0,100.0,27.37,3.04,,
+2020,Rhode Island,44,All,0.0,0.0,100.0,100.0,11.11,0.0,,
+2020,South Carolina,45,All,0.0,0.0,100.0,100.0,47.8,5.9,,
+2020,South Dakota,46,All,0.0,0.0,100.0,100.0,26.02,,,True
+2020,Tennessee,47,All,0.0,0.0,100.0,100.0,37.96,4.5,,
+2020,Texas,48,All,0.0,0.0,100.0,100.0,27.52,3.51,,
+2020,Utah,49,All,0.0,0.0,100.0,100.0,18.57,3.26,,
+2020,Vermont,50,All,0.0,0.0,100.0,100.0,16.59,,,True
+2020,Virginia,51,All,0.0,0.0,100.0,100.0,28.1,3.51,,
+2020,Washington,53,All,0.0,0.0,100.0,100.0,20.46,1.65,,
+2020,West Virginia,54,All,0.0,0.0,100.0,100.0,22.74,3.59,,
+2020,Wisconsin,55,All,0.0,0.0,100.0,100.0,19.55,2.71,,
+2020,Wyoming,56,All,0.0,0.0,100.0,100.0,34.21,,,True
+2021,Alabama,01,All,0.0,0.0,100.0,100.0,48.92,7.18,,
+2021,Alaska,02,All,0.0,0.0,100.0,100.0,57.58,,,True
+2021,Arizona,04,All,0.0,0.0,100.0,100.0,28.85,3.57,,
+2021,Arkansas,05,All,0.0,0.0,100.0,100.0,42.55,4.82,,
+2021,California,06,All,0.0,0.0,100.0,100.0,16.99,1.66,,
+2021,Colorado,08,All,0.0,0.0,100.0,100.0,28.55,3.78,,
+2021,Connecticut,09,All,0.0,0.0,100.0,100.0,14.45,1.37,,
+2021,Delaware,10,All,0.0,0.0,100.0,100.0,46.82,,,True
+2021,District of Columbia,11,All,0.0,0.0,100.0,100.0,59.75,,,True
+2021,Florida,12,All,0.0,0.0,100.0,100.0,25.62,2.87,,
+2021,Georgia,13,All,0.0,0.0,100.0,100.0,39.6,5.28,,
+2021,Hawaii,15,All,0.0,0.0,100.0,100.0,7.37,,,True
+2021,Idaho,16,All,0.0,0.0,100.0,100.0,17.95,2.79,,
+2021,Illinois,17,All,0.0,0.0,100.0,100.0,36.6,4.62,,
+2021,Indiana,18,All,0.0,0.0,100.0,100.0,37.43,4.01,,
+2021,Iowa,19,All,0.0,0.0,100.0,100.0,13.92,2.71,,
+2021,Kansas,20,All,0.0,0.0,100.0,100.0,28.77,5.96,,
+2021,Kentucky,21,All,0.0,0.0,100.0,100.0,38.8,5.28,,
+2021,Louisiana,22,All,0.0,0.0,100.0,100.0,68.72,10.17,,
+2021,Maine,23,All,0.0,0.0,100.0,100.0,10.43,,,True
+2021,Maryland,24,All,0.0,0.0,100.0,100.0,34.99,2.62,,
+2021,Massachusetts,25,All,0.0,0.0,100.0,100.0,5.28,,,True
+2021,Michigan,26,All,0.0,0.0,100.0,100.0,28.64,2.97,,
+2021,Minnesota,27,All,0.0,0.0,100.0,100.0,17.32,1.67,,
+2021,Mississippi,28,All,0.0,0.0,100.0,100.0,68.02,9.96,,
+2021,Missouri,29,All,0.0,0.0,100.0,100.0,40.17,6.27,,
+2021,Montana,30,All,0.0,0.0,100.0,100.0,41.96,7.22,,
+2021,Nebraska,31,All,0.0,0.0,100.0,100.0,15.83,3.09,,
+2021,Nevada,32,All,0.0,0.0,100.0,100.0,36.17,2.59,,
+2021,New Hampshire,33,All,0.0,0.0,100.0,100.0,10.36,,,True
+2021,New Jersey,34,All,0.0,0.0,100.0,100.0,11.17,1.23,,
+2021,New Mexico,35,All,0.0,0.0,100.0,100.0,45.46,5.13,,
+2021,New York,36,All,0.0,0.0,100.0,100.0,10.21,1.26,,
+2021,North Carolina,37,All,0.0,0.0,100.0,100.0,34.82,5.13,,
+2021,North Dakota,38,All,0.0,0.0,100.0,100.0,19.52,,,True
+2021,Ohio,39,All,0.0,0.0,100.0,100.0,32.94,4.67,,
+2021,Oklahoma,40,All,0.0,0.0,100.0,100.0,30.65,4.98,,
+2021,Oregon,41,All,0.0,0.0,100.0,100.0,20.9,1.97,,
+2021,Pennsylvania,42,All,0.0,0.0,100.0,100.0,27.28,4.14,,
+2021,Rhode Island,44,All,0.0,0.0,100.0,100.0,12.03,0.0,,
+2021,South Carolina,45,All,0.0,0.0,100.0,100.0,45.17,6.32,,
+2021,South Dakota,46,All,0.0,0.0,100.0,100.0,29.89,,,True
+2021,Tennessee,47,All,0.0,0.0,100.0,100.0,42.11,5.53,,
+2021,Texas,48,All,0.0,0.0,100.0,100.0,30.47,3.49,,
+2021,Utah,49,All,0.0,0.0,100.0,100.0,18.07,2.11,,
+2021,Vermont,50,All,0.0,0.0,100.0,100.0,13.85,,,True
+2021,Virginia,51,All,0.0,0.0,100.0,100.0,29.71,4.01,,
+2021,Washington,53,All,0.0,0.0,100.0,100.0,18.61,2.68,,
+2021,West Virginia,54,All,0.0,0.0,100.0,100.0,20.38,,,True
+2021,Wisconsin,55,All,0.0,0.0,100.0,100.0,26.71,3.69,,
+2021,Wyoming,56,All,0.0,0.0,100.0,100.0,32.1,9.06,,
+2022,Alabama,01,All,0.0,0.0,100.0,100.0,47.91,6.29,,
+2022,Alaska,02,All,0.0,0.0,100.0,100.0,43.02,6.2,,
+2022,Arizona,04,All,0.0,0.0,100.0,100.0,30.56,3.7,,
+2022,Arkansas,05,All,0.0,0.0,100.0,100.0,39.48,5.8,,
+2022,California,06,All,0.0,0.0,100.0,100.0,13.16,1.52,,
+2022,Colorado,08,All,0.0,0.0,100.0,100.0,27.08,5.05,,
+2022,Connecticut,09,All,0.0,0.0,100.0,100.0,11.61,1.37,,
+2022,Delaware,10,All,0.0,0.0,100.0,100.0,24.55,,,True
+2022,District of Columbia,11,All,0.0,0.0,100.0,100.0,46.85,11.14,,
+2022,Florida,12,All,0.0,0.0,100.0,100.0,24.88,3.02,,
+2022,Georgia,13,All,0.0,0.0,100.0,100.0,38.66,6.06,,
+2022,Hawaii,15,All,0.0,0.0,100.0,100.0,,,True,True
+2022,Idaho,16,All,0.0,0.0,100.0,100.0,22.79,2.99,,
+2022,Illinois,17,All,0.0,0.0,100.0,100.0,29.86,4.29,,
+2022,Indiana,18,All,0.0,0.0,100.0,100.0,32.08,3.64,,
+2022,Iowa,19,All,0.0,0.0,100.0,100.0,19.26,2.18,,
+2022,Kansas,20,All,0.0,0.0,100.0,100.0,25.23,3.86,,
+2022,Kentucky,21,All,0.0,0.0,100.0,100.0,30.44,3.24,,
+2022,Louisiana,22,All,0.0,0.0,100.0,100.0,63.98,9.47,,
+2022,Maine,23,All,0.0,0.0,100.0,100.0,12.71,,,True
+2022,Maryland,24,All,0.0,0.0,100.0,100.0,32.12,3.73,,
+2022,Massachusetts,25,All,0.0,0.0,100.0,100.0,6.73,0.89,,
+2022,Michigan,26,All,0.0,0.0,100.0,100.0,24.57,3.33,,
+2022,Minnesota,27,All,0.0,0.0,100.0,100.0,14.66,1.99,,
+2022,Mississippi,28,All,0.0,0.0,100.0,100.0,55.48,9.19,,
+2022,Missouri,29,All,0.0,0.0,100.0,100.0,47.01,5.57,,
+2022,Montana,30,All,0.0,0.0,100.0,100.0,32.0,5.92,,
+2022,Nebraska,31,All,0.0,0.0,100.0,100.0,20.75,2.07,,
+2022,Nevada,32,All,0.0,0.0,100.0,100.0,28.16,2.59,,
+2022,New Hampshire,33,All,0.0,0.0,100.0,100.0,10.91,,,True
+2022,New Jersey,34,All,0.0,0.0,100.0,100.0,10.91,0.79,,
+2022,New Mexico,35,All,0.0,0.0,100.0,100.0,37.35,6.74,,
+2022,New York,36,All,0.0,0.0,100.0,100.0,8.87,1.24,,
+2022,North Carolina,37,All,0.0,0.0,100.0,100.0,32.13,4.72,,
+2022,North Dakota,38,All,0.0,0.0,100.0,100.0,18.42,,,True
+2022,Ohio,39,All,0.0,0.0,100.0,100.0,30.5,4.01,,
+2022,Oklahoma,40,All,0.0,0.0,100.0,100.0,24.13,4.97,,
+2022,Oregon,41,All,0.0,0.0,100.0,100.0,20.58,1.77,,
+2022,Pennsylvania,42,All,0.0,0.0,100.0,100.0,25.47,3.77,,
+2022,Rhode Island,44,All,0.0,0.0,100.0,100.0,,,True,True
+2022,South Carolina,45,All,0.0,0.0,100.0,100.0,38.05,6.52,,
+2022,South Dakota,46,All,0.0,0.0,100.0,100.0,27.26,4.52,,
+2022,Tennessee,47,All,0.0,0.0,100.0,100.0,38.74,5.05,,
+2022,Texas,48,All,0.0,0.0,100.0,100.0,27.21,3.94,,
+2022,Utah,49,All,0.0,0.0,100.0,100.0,16.13,1.91,,
+2022,Vermont,50,All,0.0,0.0,100.0,100.0,,,True,True
+2022,Virginia,51,All,0.0,0.0,100.0,100.0,29.55,3.97,,
+2022,Washington,53,All,0.0,0.0,100.0,100.0,17.37,2.04,,
+2022,West Virginia,54,All,0.0,0.0,100.0,100.0,18.77,,,True
+2022,Wisconsin,55,All,0.0,0.0,100.0,100.0,18.7,4.36,,
+2022,Wyoming,56,All,0.0,0.0,100.0,100.0,41.84,,,True
+2023,Alabama,01,All,0.0,0.0,100.0,100.0,45.3,7.43,,
+2023,Alaska,02,All,0.0,0.0,100.0,100.0,36.5,5.7,,
+2023,Arizona,04,All,0.0,0.0,100.0,100.0,24.56,4.11,,
+2023,Arkansas,05,All,0.0,0.0,100.0,100.0,31.06,6.52,,
+2023,California,06,All,0.0,0.0,100.0,100.0,12.07,1.86,,
+2023,Colorado,08,All,0.0,0.0,100.0,100.0,25.13,4.28,,
+2023,Connecticut,09,All,0.0,0.0,100.0,100.0,9.5,1.52,,
+2023,Delaware,10,All,0.0,0.0,100.0,100.0,24.27,,,True
+2023,District of Columbia,11,All,0.0,0.0,100.0,100.0,71.42,15.8,,
+2023,Florida,12,All,0.0,0.0,100.0,100.0,22.06,3.01,,
+2023,Georgia,13,All,0.0,0.0,100.0,100.0,36.05,5.12,,
+2023,Hawaii,15,All,0.0,0.0,100.0,100.0,,,True,True
+2023,Idaho,16,All,0.0,0.0,100.0,100.0,20.53,4.28,,
+2023,Illinois,17,All,0.0,0.0,100.0,100.0,27.14,4.58,,
+2023,Indiana,18,All,0.0,0.0,100.0,100.0,30.82,5.1,,
+2023,Iowa,19,All,0.0,0.0,100.0,100.0,13.64,2.47,,
+2023,Kansas,20,All,0.0,0.0,100.0,100.0,26.03,4.32,,
+2023,Kentucky,21,All,0.0,0.0,100.0,100.0,30.24,4.72,,
+2023,Louisiana,22,All,0.0,0.0,100.0,100.0,66.01,8.81,,
+2023,Maine,23,All,0.0,0.0,100.0,100.0,16.67,,,True
+2023,Maryland,24,All,0.0,0.0,100.0,100.0,26.48,3.3,,
+2023,Massachusetts,25,All,0.0,0.0,100.0,100.0,7.35,0.75,,
+2023,Michigan,26,All,0.0,0.0,100.0,100.0,21.24,3.6,,
+2023,Minnesota,27,All,0.0,0.0,100.0,100.0,13.54,1.61,,
+2023,Mississippi,28,All,0.0,0.0,100.0,100.0,58.31,9.71,,
+2023,Missouri,29,All,0.0,0.0,100.0,100.0,36.54,5.46,,
+2023,Montana,30,All,0.0,0.0,100.0,100.0,22.29,4.67,,
+2023,Nebraska,31,All,0.0,0.0,100.0,100.0,17.26,2.91,,
+2023,Nevada,32,All,0.0,0.0,100.0,100.0,27.4,4.37,,
+2023,New Hampshire,33,All,0.0,0.0,100.0,100.0,9.57,,,True
+2023,New Jersey,34,All,0.0,0.0,100.0,100.0,8.04,1.05,,
+2023,New Mexico,35,All,0.0,0.0,100.0,100.0,51.89,7.31,,
+2023,New York,36,All,0.0,0.0,100.0,100.0,7.05,1.11,,
+2023,North Carolina,37,All,0.0,0.0,100.0,100.0,30.37,4.37,,
+2023,North Dakota,38,All,0.0,0.0,100.0,100.0,17.2,5.96,,
+2023,Ohio,39,All,0.0,0.0,100.0,100.0,24.79,4.62,,
+2023,Oklahoma,40,All,0.0,0.0,100.0,100.0,23.85,5.69,,
+2023,Oregon,41,All,0.0,0.0,100.0,100.0,23.82,2.16,,
+2023,Pennsylvania,42,All,0.0,0.0,100.0,100.0,22.87,2.59,,
+2023,Rhode Island,44,All,0.0,0.0,100.0,100.0,,,True,True
+2023,South Carolina,45,All,0.0,0.0,100.0,100.0,39.6,4.89,,
+2023,South Dakota,46,All,0.0,0.0,100.0,100.0,23.72,,,True
+2023,Tennessee,47,All,0.0,0.0,100.0,100.0,39.86,6.11,,
+2023,Texas,48,All,0.0,0.0,100.0,100.0,24.66,3.66,,
+2023,Utah,49,All,0.0,0.0,100.0,100.0,16.22,2.79,,
+2023,Vermont,50,All,0.0,0.0,100.0,100.0,,,True,True
+2023,Virginia,51,All,0.0,0.0,100.0,100.0,26.16,3.08,,
+2023,Washington,53,All,0.0,0.0,100.0,100.0,18.65,2.73,,
+2023,West Virginia,54,All,0.0,0.0,100.0,100.0,16.46,,,True
+2023,Wisconsin,55,All,0.0,0.0,100.0,100.0,19.8,3.44,,
+2023,Wyoming,56,All,0.0,0.0,100.0,100.0,39.72,,,True

--- a/python/tests/datasources/test_cdc_wisqars_youth.py
+++ b/python/tests/datasources/test_cdc_wisqars_youth.py
@@ -18,11 +18,16 @@ def _load_csv_as_df_from_data_dir(*args, **kwargs):
     directory, filename = args
     use_cols = kwargs["usecols"]
 
+    # No na_values for the "--" suppression sentinel here, matching production:
+    # load_wisqars_as_df_from_data_dir() needs the literal string to detect suppression before
+    # convert_columns_to_numeric() coerces it to NaN. Population dtype is likewise left unforced
+    # (matching production): pandas' C parser can't combine an explicit float dtype with the
+    # thousands="," separator when "--" sentinels are also present in the column, and youth's
+    # Population column (unlike black_men's) has real suppressed rows.
     df = pd.read_csv(
         os.path.join(TEST_DIR, directory, filename),
         usecols=use_cols,
-        na_values=["--"],
-        dtype={"Year": str, "Population": float},
+        dtype={"Year": str},
         thousands=",",
     )
 


### PR DESCRIPTION
## Summary
- `cdc_wisqars_youth.py` now passes `detect_suppression=True` when loading source data for both topics (young adults, youth), so WISQARS's `"--"` sentinel for unreliable/small counts produces tri-state `gun_deaths_young_adults_per_100k_is_suppressed` / `gun_deaths_youth_per_100k_is_suppressed` columns instead of being silently coerced to NaN with no distinction from real absence (mirrors `cdc_wisqars.py` from #5107 and `cdc_wisqars_black_men.py` from #5117).
- Youth is the only WISQARS source that combines race+ethnicity via `combine_race_ethnicity()` (the age/urbanicity sources use a different pivot-based combine path). That shared helper only preserved columns explicitly listed in `count_cols_to_sum`, so a raw `is_suppressed` flag would have been silently dropped for the race_and_ethnicity breakdown. Extends `combine_race_ethnicity()` (`ingestion/dataset_utils.py`) with an optional `is_suppressed_col` param: a combined bucket (e.g. summed Hispanic or Unknown rows) is flagged suppressed if any constituent was suppressed, mirroring `condense_age_groups()`'s precedent, and its numerator/rate are nulled out (never the population denominator). Backward compatible: the other three real callers (`maternal_mortality.py`, `cdc_restricted_local.py`, `cdc_wonder_utils.py`) don't pass the new param, so their behavior is unchanged.
- Fixes the test's local CSV mock loader two ways, matching production: stops pre-converting `"--"` to NaN via `na_values`, and stops forcing `Population` to `float` dtype. That forced dtype combined with `thousands=","` breaks as soon as a `"--"` sentinel is also present in the column, which youth's Population data has (black_men's doesn't, which is why the same forced dtype worked unmodified there).
- Regenerates golden CSVs; combined race/ethnicity buckets that absorbed a suppressed sub-bucket now correctly show NaN counts/rates and `is_suppressed=True`.

Closes #5108

## Impact
- Enables downstream consumers (UI, analytics) to distinguish "unreliable small counts" (WISQARS policy: < 20 unweighted, < 1,200 weighted, or CV > 30%) from "no data," improving data accuracy for disparity claims in the Youth gun violence datasource.

## Test plan
- [x] `pytest python/tests/datasources/test_cdc_wisqars_youth.py` — 2 passed
- [x] `pytest python/tests/` — 217 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
