### PR TITLE
fix(e2e): scope poverty test's csv-download locator

### DIFF
--- a/frontend/playwright-tests/poverty.spec.ts
+++ b/frontend/playwright-tests/poverty.spec.ts
@@ -30,7 +30,12 @@ test('Poverty', async ({ page }) => {
     )
     .getByText('Add or remove columns by')
     .click()
-  await page.getByText('View and download full .csv').click()
+  await page
+    .locator(
+      '[id="Rates-of-poverty-over-time-in-the-United-States-by-race/ethnicity-alt-table-view1"]',
+    )
+    .getByText('View and download full .csv')
+    .click()
   await page
     .locator('#rate-chart')
     .getByRole('heading', {


### PR DESCRIPTION
## Summary
- Nightly `E2E_DEV` run on main failed on `poverty.spec.ts`: [run 31748715280](https://github.com/SatcherInstitute/health-equity-tracker/actions/runs/31748715280)
- The page now renders two alt-table-view cards ("Rates of poverty over time" and "Relative inequity for poverty") that both contain "View and download full .csv" text, so the unscoped `getByText()` matched two elements and hit Playwright's strict-mode violation
- Scoped the locator to the same table container used by the preceding "Add or remove columns by" click

## Test plan
- [ ] `npm run e2e poverty` against a running dev server
