### PR TITLE
fix(pr skill): run black via pre-commit to avoid local venv version drift

### DIFF
--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -103,10 +103,12 @@ Backend PRs have no browser preview and no Playwright step, so `pytest` **is** t
 
 `black` and `pylint` are the static-check parallel to Biome/tsc; the pre-commit hook already ran them, but run them here too so a hook that was skipped or an unstaged file can't slip through.
 
+Run `black` through `pre-commit`, not a bare `black --check`. The repo pins `black==22.10.0` in `.pre-commit-config.yaml`, but a dev venv's `pip install black` has no such pin and silently drifts to whatever is latest — a newer local `black` then flags unrelated pre-existing code as needing reformat, producing false positives unrelated to this PR's diff. `pre-commit run` always uses the pinned version regardless of what's in the venv.
+
 ```bash
 # Return to repo root first — Step 2 (frontend) may have left us in frontend/
 cd "$(git rev-parse --show-toplevel)" && source .venv/bin/activate
-black --check python/ exporter/
+pre-commit run black --files $(git diff origin/main --name-only -- '*.py')
 pylint <changed-package>            # e.g. exporter or python/datasources
 ```
 


### PR DESCRIPTION
## Summary
- Local `black --check` in the `/pr` skill used whatever `black` was pip-installed in the dev venv, which has no version pin and drifts from the repo's pinned `22.10.0` (`.pre-commit-config.yaml`). A newer local black (e.g. 26.5.1) then flags unrelated pre-existing code as needing reformat, producing false-positive diffs unrelated to the PR being worked on — surfaced during PR #5123's `/pr` run against 10 unrelated files.
- Fixed by running `pre-commit run black --files <changed .py files>` instead, which always resolves to the pinned version regardless of venv state. Verified this passes clean on the files that previously false-flagged.

## Test plan
- [x] `pre-commit run black --files python/ingestion/cdc_hiv_utils.py python/datasources/phrma.py python/datasources/acs_population.py exporter/main.py` — passed (previously flagged by bare `black --check`)
