### PR TITLE
docs: note that datasource changes require a DAG rerun

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,13 +49,19 @@ run_ingestion/  →  GCS bucket  →  run_gcs_to_bq/  →  BigQuery  →  export
 
 Each backend microservice is a Docker container triggered by Cloud Run. GitHub Actions workflows in `.github/workflows/dag*.yml` orchestrate the pipeline runs (one DAG per data source).
 
+**A `python/datasources/` or `python/ingestion/` change has no effect until its DAG runs.** Merging or deploying the code alone does not regenerate BigQuery/GCS data — the pipeline only reprocesses a source when its `dag*.yml` workflow is actually triggered. After any change that alters what a `DataSource.write_to_bq()` produces (new columns, new detection/suppression logic, changed transforms), rerun the matching DAG; otherwise dev/prod keep serving stale data even though the new code is live.
+
 **Testing backend changes:** Push your branch to the shared `infra-test` branch to trigger a GCP deployment:
 
 ```bash
 git push origin HEAD:infra-test -f
 ```
 
-Then run the relevant DAG workflow from GitHub Actions against the test project.
+This deploys the service code only — it does **not** run the pipeline. Then separately trigger the relevant DAG workflow against the test project:
+
+```bash
+gh workflow run dag<Source>.yml --ref infra-test
+```
 
 ## Git Workflow
 

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -27,6 +27,8 @@ tests/         Integration tests — many load real fixture CSVs from repo-root 
 2. Register in `python/datasources/data_sources.py`
 3. Add DAG workflow `.github/workflows/dag<Source>.yml`
 
+**Changing an existing data source's output?** Editing `write_to_bq()` or a shared `ingestion/` helper does not regenerate any data by itself — the matching `dag<Source>.yml` workflow must be run (`gh workflow run dag<Source>.yml --ref infra-test` for testing, or against `main` post-merge) before the change reaches BigQuery/GCS. See root `CLAUDE.md` → Backend Data Pipeline.
+
 ## Key files
 
 | Purpose | Path |


### PR DESCRIPTION
## Summary

- Note in root `CLAUDE.md` and `python/CLAUDE.md` that a `python/datasources/` or `ingestion/` change has no effect until its matching DAG workflow is run
- Clarify that pushing to `infra-test` deploys service code only, not data

## Impact

- Prevents a repeat of losing track of stale dev data after a datasource change lands but its DAG isn't rerun (surfaced while testing #5127's HIV suppression wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
