### PR TITLE
fix(cdc-hiv): add missing is_suppressed columns to age-adjust schema

### DIFF
--- a/python/datasources/age_adjust_cdc_hiv.py
+++ b/python/datasources/age_adjust_cdc_hiv.py
@@ -10,7 +10,7 @@ from ingestion import gcs_to_bq_util
 from ingestion.gcs_to_bq_util import BQ_STRING, BQ_FLOAT
 from ingestion.dataset_utils import ratio_round_to_None
 
-from ingestion.constants import NATIONAL_LEVEL, STATE_LEVEL
+from ingestion.constants import NATIONAL_LEVEL, STATE_LEVEL, BQ_BOOLEAN
 
 REFERENCE_POPULATION = Race.ALL.value
 BASE_POPULATION = Race.WHITE_NH.value
@@ -83,6 +83,12 @@ class AgeAdjustCDCHiv(DataSource):
                 std_col.HIV_CARE_POPULATION: BQ_FLOAT,
                 std_col.HIV_PREP_POPULATION: BQ_FLOAT,
                 "hiv_deaths_ratio_age_adjusted": BQ_FLOAT,
+                "hiv_deaths_per_100k_is_suppressed": BQ_BOOLEAN,
+                "hiv_diagnoses_per_100k_is_suppressed": BQ_BOOLEAN,
+                "hiv_prevalence_per_100k_is_suppressed": BQ_BOOLEAN,
+                "hiv_care_linkage_is_suppressed": BQ_BOOLEAN,
+                "hiv_prep_coverage_is_suppressed": BQ_BOOLEAN,
+                "hiv_stigma_index_is_suppressed": BQ_BOOLEAN,
             }
 
             gcs_to_bq_util.add_df_to_bq(df, dataset, table_name, column_types=col_types)


### PR DESCRIPTION
## Summary
- `age_adjust_cdc_hiv.py` merges `race_and_ethnicity_{geo}_current` into an age-adjusted death-ratio table using a hardcoded `col_types` schema passed to `add_df_to_bq`
- #5123 added 6 `_is_suppressed` boolean columns to that source table, but this file's schema was never updated to match
- Result: every write to `*-with_age_adjust` fails with `ValueError: Column types did not match frame columns`, confirmed via GCP Cloud Logging on the `infra-test` DAG run
- Fix: add the 6 missing columns to `col_types` as `BQ_BOOLEAN`, matching the existing pattern in `cdc_hiv_utils.py`

## Impact
- Unblocks age-adjusted HIV death ratio table writes on every CDC HIV DAG run since #5123 merged. Data was stale/missing until this fix ships.

## Test plan
- [x] `pytest python/tests/datasources/test_age_adjustment_cdc_hiv.py` — 1 passed
- [x] `black` / `pylint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
