### PR TITLE
fix(skills): catch issues never referenced in a PR body

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -128,7 +128,14 @@ gh issue view <n> --json number,title,body,state
   ```
 - **Not obviously resolved** (referenced in passing, partial progress, a "found while working on this" aside): leave it — it's a candidate for Step 7, not a silent Done move. Don't guess.
 
-Skip this step entirely if there are no issue references at all in the PR body.
+**Also check for issues never mentioned in the body at all.** A PR body can be completely silent on the issue it was tackled from (no `Closes`, no bare `#NNNN` — this has happened: PR #5129 resolved #5127 without referencing it anywhere). Text-scanning the body alone misses this, so cross-check the board directly:
+
+```bash
+gh api graphql -f query='{ organization(login: "SatcherInstitute") { projectV2(number: 5) { items(first: 100) { nodes { id fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } content { ... on Issue { number title state } } } } } } }' \
+  --jq '.data.organization.projectV2.items.nodes[] | select(.fieldValueByName.name == "In Progress") | .content'
+```
+
+For each "In Progress" issue, compare its title and scope against the merged PR's title and diff. A close title match or a diff that visibly implements the issue's stated scope is a candidate even with zero textual reference — use the same judgement as above (read the issue body, compare to the actual changed files) before closing it. Do not close on title similarity alone; confirm the diff actually does what the issue describes.
 
 ---
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -447,7 +447,12 @@ Update the PR title (under 70 chars) and body. **Read the existing PR body first
 - **Summary bullets:** Keep the existing bullets if they still accurately describe the diff. Only add, remove, or rewrite bullets when the diff has changed significantly since they were written. Do not replace a well-written human summary with a generic one.
 - **Test plan:** Use the audited checklist from Step 5 (checked state preserved). Do not regenerate from scratch.
 - **Impact:** Always aim to quantify what the PR improves — see Impact rules below.
-- **Issue links:** Preserve any existing issue-closing keywords (`Closes`, `Fixes`, `Resolves`, `Fix`, `Close`, `Resolve` — GitHub recognizes all of these) followed by `#NNNN`.
+- **Issue links:** Preserve any existing issue-closing keywords (`Closes`, `Fixes`, `Resolves`, `Fix`, `Close`, `Resolve` — GitHub recognizes all of these) followed by `#NNNN`. If none are present, check whether this PR should have one before writing the body — a PR opened from `/tackle` work or matching an open issue's title/scope has silently shipped without a `Closes #NNNN` before (PR #5129 resolved #5127 with zero reference to it anywhere in the body, so `/merge`'s board sync missed it until a human noticed):
+  ```bash
+  gh api graphql -f query='{ organization(login: "SatcherInstitute") { projectV2(number: 5) { items(first: 100) { nodes { fieldValueByName(name: "Status") { ... on ProjectV2ItemFieldSingleSelectValue { name } } content { ... on Issue { number title assignees(first: 5) { nodes { login } } } } } } } } }' \
+    --jq '.data.organization.projectV2.items.nodes[] | select(.fieldValueByName.name == "In Progress") | .content'
+  ```
+  If an "In Progress" issue's title/scope clearly matches this PR's diff (read the issue body, don't go on title alone), add `Closes #NNNN` to the body.
 - **Bot-generated blocks:** Preserve per the rule below.
 
 Keep the description **short and focused** — a few tight bullets, no padding.


### PR DESCRIPTION
## Summary

- `/merge` Step 6 only scanned `#NNNN` references already present in the PR body, so it missed closing an issue entirely when the PR never mentioned it (PR #5129 resolved #5127 with zero reference anywhere in the body)
- Add a board cross-check against "In Progress" issues so `/merge` catches this after the fact, comparing issue title/scope to the merged diff before closing
- Add the same check to `/pr` Step 6 so a `Closes #NNNN` gets added to the body before the PR ships, catching the gap at the source

## Impact

- No user-facing impact — internal skill/workflow tooling only
