### PR TITLE
docs(methodology): add ACS Poverty and Uninsurance documentation

### DIFF
--- a/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
+++ b/frontend/src/pages/Methodology/methodologyContent/methodologyRouteConfigs.tsx
@@ -351,6 +351,10 @@ export const methodologyRouteConfigs: RouteConfig[] = [
     component: <SdohLink />,
     subLinks: [
       { label: 'Data Sourcing', path: 'sdoh-data-sourcing' },
+      {
+        label: 'Poverty and Uninsurance (ACS)',
+        path: 'sdoh-acs-data-sourcing',
+      },
       { label: 'Demographics', path: 'demographic-stratification' },
       { label: 'Data Sources', path: 'sdoh-data-sources' },
       { label: 'Key Terms', path: 'sdoh-key-terms' },

--- a/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
@@ -17,6 +17,9 @@ import StripedTable from '../methodologyComponents/StripedTable'
 import { PDOH_RESOURCES } from '../methodologyContent/ResourcesData'
 import { buildTopicsString } from './linkUtils'
 
+const ACS_CONDITION_EARLIEST_YEAR = '2012'
+const ACS_CONDITION_CURRENT_YEAR = '2022'
+
 const sdohDataSources = [
   dataSourceMetadataMap.acs,
   dataSourceMetadataMap.ahr,
@@ -67,6 +70,49 @@ function SdohLink() {
           <a href={urlMap.censusVoting}>U.S. Census</a>.
         </p>
         <NoteBrfss />
+
+        <h3
+          className='mt-12 font-medium text-title'
+          id='sdoh-acs-data-sourcing'
+        >
+          Poverty and Uninsurance: American Community Survey
+        </h3>
+        <p>
+          Data on <HetTerm>poverty</HetTerm> and{' '}
+          <HetTerm>uninsured people</HetTerm> comes directly from the{' '}
+          <a href={urlMap.acs5}>
+            American Community Survey (ACS) 5-year estimates
+          </a>
+          , a continuous survey conducted by the U.S. Census Bureau. The ACS
+          collects information annually from approximately 3.5 million addresses
+          and publishes 5-year rolling estimates to provide reliable data at the
+          national, state, and county levels.
+        </p>
+        <p>
+          <strong>Poverty</strong> is measured using ACS table series B17001
+          (Poverty Status in the Past 12 Months by Sex by Age), which identifies
+          individuals whose household income fell below the federal poverty
+          threshold in the prior 12 months. Race-stratified counts are drawn
+          from race-specific variants of this table (e.g., B17001A for White
+          alone, B17001B for Black or African American alone).
+        </p>
+        <p>
+          <strong>Health insurance coverage</strong> is measured using ACS table
+          series C27001 (Health Insurance Coverage Status by Age), which
+          identifies individuals without any comprehensive health insurance
+          plan. The ACS definition excludes plans that cover only specific
+          conditions (e.g., cancer policies, long-term care) and does not count
+          dental, vision, life, or disability insurance as comprehensive
+          coverage. Race-stratified counts are drawn from race-specific table
+          variants (e.g., C27001A for White alone, C27001B for Black or African
+          American alone).
+        </p>
+        <p>
+          The tracker uses ACS 5-year estimates from{' '}
+          {ACS_CONDITION_EARLIEST_YEAR} through {ACS_CONDITION_CURRENT_YEAR},
+          covering national, state, and county geographies broken down by
+          race/ethnicity, age, and sex.
+        </p>
 
         <AhrMetrics category='social-determinants' />
 

--- a/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
@@ -70,6 +70,7 @@ function SdohLink() {
           <a href={urlMap.censusVoting}>U.S. Census</a>.
         </p>
         <NoteBrfss />
+        <AhrMetrics category='social-determinants' />
 
         <h3
           className='mt-12 font-medium text-title'
@@ -113,8 +114,6 @@ function SdohLink() {
           covering national, state, and county geographies broken down by
           race/ethnicity, age, and sex.
         </p>
-
-        <AhrMetrics category='social-determinants' />
 
         <h3
           className='mt-12 font-medium text-title'

--- a/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
+++ b/frontend/src/pages/Methodology/methodologySections/SdohLink.tsx
@@ -19,6 +19,7 @@ import { buildTopicsString } from './linkUtils'
 
 const ACS_CONDITION_EARLIEST_YEAR = '2012'
 const ACS_CONDITION_CURRENT_YEAR = '2022'
+const ACS_CONDITION_CURRENT_YEAR_RANGE_START = '2018'
 
 const sdohDataSources = [
   dataSourceMetadataMap.acs,
@@ -84,29 +85,42 @@ function SdohLink() {
           <a href={urlMap.acs5}>
             American Community Survey (ACS) 5-year estimates
           </a>
-          , a continuous survey conducted by the U.S. Census Bureau. The ACS
-          collects information annually from approximately 3.5 million addresses
-          and publishes 5-year rolling estimates to provide reliable data at the
-          national, state, and county levels.
+          , a continuous survey conducted by the U.S. Census Bureau and
+          collected annually, then pooled into 5-year rolling estimates to
+          provide reliable data at the national, state, and county levels. For
+          example, the {ACS_CONDITION_CURRENT_YEAR} release covers data pooled
+          from {ACS_CONDITION_CURRENT_YEAR_RANGE_START}–
+          {ACS_CONDITION_CURRENT_YEAR}, not calendar year{' '}
+          {ACS_CONDITION_CURRENT_YEAR} alone.
         </p>
         <p>
           <strong>Poverty</strong> is measured using ACS table series B17001
           (Poverty Status in the Past 12 Months by Sex by Age), which identifies
-          individuals whose household income fell below the federal poverty
-          threshold in the prior 12 months. Race-stratified counts are drawn
-          from race-specific variants of this table (e.g., B17001A for White
-          alone, B17001B for Black or African American alone).
+          individuals whose income in the past 12 months was below the federal
+          poverty level. Race-stratified counts are drawn from race-specific
+          variants of this table (e.g., B17001A for White alone, B17001B for
+          Black or African American alone).
         </p>
         <p>
           <strong>Health insurance coverage</strong> is measured using ACS table
-          series C27001 (Health Insurance Coverage Status by Age), which
-          identifies individuals without any comprehensive health insurance
-          plan. The ACS definition excludes plans that cover only specific
-          conditions (e.g., cancer policies, long-term care) and does not count
-          dental, vision, life, or disability insurance as comprehensive
-          coverage. Race-stratified counts are drawn from race-specific table
-          variants (e.g., C27001A for White alone, C27001B for Black or African
-          American alone).
+          series B27001 (Health Insurance Coverage Status by Sex by Age) for the
+          overall, sex-, and age-stratified breakdowns, and C27001A–I (Health
+          Insurance Coverage Status by Age, by race) for race-stratified counts
+          (e.g., C27001A for White alone, C27001B for Black or African American
+          alone). Both series identify individuals without any comprehensive
+          health insurance plan. The ACS definition excludes plans that cover
+          only specific conditions (e.g., cancer policies, long-term care) and
+          does not count dental, vision, life, or disability insurance as
+          comprehensive coverage.
+        </p>
+        <p>
+          For each of these tables, rates are calculated using the table's own
+          population universe as the denominator, the sum of everyone with and
+          without the condition in that specific table, rather than the ACS's
+          general population totals. This is why the tracker exposes{' '}
+          <HetTerm>poverty_pop_estimated_total</HetTerm> and{' '}
+          <HetTerm>uninsured_pop_estimated_total</HetTerm> as separate
+          denominators from overall population figures.
         </p>
         <p>
           The tracker uses ACS 5-year estimates from{' '}


### PR DESCRIPTION
**Preview:** [SDOH methodology with ACS section](https://deploy-preview-5135--health-equity-tracker.netlify.app/methodology/topic-categories/sdoh#sdoh-acs-data-sourcing)

## Summary

- Add comprehensive ACS methodology documentation to SDOH methodology page
- Document poverty measurement via ACS B17001 table series and 5-year estimates
- Document health insurance coverage (uninsurance) via ACS B27001 (sex/age) and C27001A-I (race-stratified) table series
- Explain that rates use each table's own population universe as the denominator, not general ACS population totals
- Include data year coverage (2012–2022) and demographic breakdowns available, with a concrete example of the pooled 5-year window
- Add sidebar navigation link for direct access to ACS methodology section

## Impact

Resolves missing methodology documentation for Poverty and Uninsurance topics. These SDOH indicators come from ACS 5-year estimates (Census Bureau) rather than from AHR/CHR/BRFSS, and now have detailed documentation matching the data sourcing methodology for other topics. All claims in the new section were checked directly against `python/datasources/acs_condition.py`.

Follow-up #5136 tracks bumping the pipeline to a newer ACS vintage (currently hardcoded to 2018-2022; 2019-2023 and 2020-2024 are both already released) — out of scope for this docs PR.

## Test plan

- [x] New ACS methodology section renders and links correctly
- [x] Navigation sidebar includes new "Poverty and Uninsurance (ACS)" sublink
- [x] Section appears between general Data Sourcing and Demographics in SDOH page
- [x] TypeScript type-check passes
- [x] Biome formatting passes

Closes #2872

🤖 Generated with [Claude Code](https://claude.com/claude-code)
