### PR TITLE
fix(ingestion): validate JSON content type for JSON file destinations in url_file_to_gcs

### DIFF
--- a/python/ingestion/url_file_to_gcs.py
+++ b/python/ingestion/url_file_to_gcs.py
@@ -13,7 +13,7 @@ def local_file_path(filename):
     return f"/tmp/{filename}"
 
 
-def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename):
+def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename, check_json=None):
     """
     Attempts to download a file from a url and upload as a
     blob to the given GCS bucket.
@@ -24,24 +24,31 @@ def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename):
       gcs_bucket: Name of the GCS bucket to upload to (without gs://).
       dest_filename: What to name the downloaded file in GCS.
         Include the file extension.
+      check_json: Whether to validate that the downloaded content is valid JSON.
 
     Returns: A boolean indication of a file diff
     """
-    return download_first_url_to_gcs([url], gcs_bucket, dest_filename, url_params)
+    return download_first_url_to_gcs([url], gcs_bucket, dest_filename, url_params, check_json=check_json)
 
 
-def get_first_response(url_list, url_params):
+def get_first_response(url_list, url_params, check_json=False):
     for url in url_list:
         try:
             file_from_url = requests.get(url, params=url_params, timeout=120)
             file_from_url.raise_for_status()
+            if check_json:
+                try:
+                    file_from_url.json()
+                except Exception as err:
+                    logging.error("Failed to parse JSON response for url %s: %s", url, err)
+                    continue
             return file_from_url
         except requests.HTTPError as err:
             logging.error("HTTP error for url %s: %s", url, err)
     return None
 
 
-def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=None):
+def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=None, check_json=None):
     """
     Iterates over the list of potential URLs that may point to the data
     source until one of the URLs succeeds in downloading. If no URL succeeds,
@@ -53,12 +60,17 @@ def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=No
       dest_filename: What to name the downloaded file in GCS.
         Include the file extension.
       url_params: URL parameters to be passed to requests.get().
+      check_json: Whether to validate that the downloaded content is valid JSON.
+        Defaults to True if dest_filename ends with .json, otherwise False.
 
       Returns:
         files_are_diff: A boolean indication of a file diff
     """
     if url_params is None:
         url_params = {}
+
+    if check_json is None:
+        check_json = dest_filename.endswith(".json")
 
     # Establish connection to valid GCS bucket
     try:
@@ -69,7 +81,7 @@ def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=No
         return
 
     # Find a valid file in the URL list or exit
-    file_from_url = get_first_response(url_list, url_params)
+    file_from_url = get_first_response(url_list, url_params, check_json=check_json)
     if file_from_url is None:
         logging.error("No file could be found for intended destination: %s", dest_filename)
         return

--- a/python/tests/ingestion/test_url_file_to_gcs.py
+++ b/python/tests/ingestion/test_url_file_to_gcs.py
@@ -9,13 +9,17 @@ class MockResponse:
         self.content = content
 
     def __enter__(self):
-        pass
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
     def raise_for_status(self):
         pass
+
+    def json(self):
+        import json
+        return json.loads(self.content.decode("utf-8"))
 
 
 def write_to_file(file_to_write, contents):
@@ -81,3 +85,49 @@ class URLFileToGCSTest(unittest.TestCase):
             )
 
             self.assertTrue(result)
+
+    def testDownloadFirstUrlToGcs_JsonDestination_ValidJson(self):
+        valid_json = b'{"status": "ok", "count": 42}'
+        with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(
+            "requests.get"
+        ) as mock_requests_get:
+            initialize_mocks(mock_storage_client, mock_requests_get, valid_json, b"old data")
+
+            result = url_file_to_gcs.download_first_url_to_gcs(
+                ["https://testurl.com/data.json"], "test_bucket", "data.json"
+            )
+
+            self.assertTrue(result)
+
+    def testDownloadFirstUrlToGcs_JsonDestination_NonJsonHtmlError_Ignored(self):
+        html_error = b'<html><body>Missing Key Redirect</body></html>'
+        with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(
+            "requests.get"
+        ) as mock_requests_get:
+            initialize_mocks(mock_storage_client, mock_requests_get, html_error, b"old data")
+
+            result = url_file_to_gcs.download_first_url_to_gcs(
+                ["https://testurl.com/missing_key.html"], "test_bucket", "data.json"
+            )
+
+            self.assertIsNone(result)
+
+    def testDownloadFirstUrlToGcs_FallbackToValidSecondUrlWhenFirstIsInvalidJson(self):
+        html_error = MockResponse(b'<html>404 Not Found HTML</html>')
+        valid_json = MockResponse(b'{"key": "value"}')
+
+        with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(
+            "requests.get"
+        ) as mock_requests_get:
+            mock_requests_get.side_effect = [html_error, valid_json]
+            mock_storage_instance = mock_storage_client.return_value
+            mock_blob = Mock(**{"download_to_file.side_effect": lambda f: write_to_file(f, b"old")})
+            mock_storage_instance.get_bucket.return_value = Mock(**{"blob.return_value": mock_blob})
+
+            result = url_file_to_gcs.download_first_url_to_gcs(
+                ["https://badurl.com", "https://goodurl.com"], "test_bucket", "output.json"
+            )
+
+            self.assertTrue(result)
+            self.assertEqual(mock_requests_get.call_count, 2)
+            mock_blob.upload_from_filename.assert_called_once()

--- a/python/tests/ingestion/test_url_file_to_gcs.py
+++ b/python/tests/ingestion/test_url_file_to_gcs.py
@@ -1,12 +1,14 @@
 import unittest
 from unittest.mock import Mock, patch
 import google.cloud.exceptions
+import requests
 from ingestion import url_file_to_gcs
 
 
 class MockResponse:
-    def __init__(self, content):
+    def __init__(self, content, status_code=200):
         self.content = content
+        self.status_code = status_code
 
     def __enter__(self):
         return self
@@ -15,10 +17,15 @@ class MockResponse:
         pass
 
     def raise_for_status(self):
-        pass
+        if 400 <= self.status_code:
+            raise requests.HTTPError(
+                f"{self.status_code} response",
+                response=self,
+            )
 
     def json(self):
         import json
+
         return json.loads(self.content.decode("utf-8"))
 
 
@@ -43,6 +50,21 @@ def initialize_mocks(mock_storage_client, mock_requests_get, response_data, gcs_
 
 
 class URLFileToGCSTest(unittest.TestCase):
+    @patch("requests.get")
+    def testGetFirstResponse_HttpError_FallsBackToNextUrl(self, mock_requests_get):
+        error_response = MockResponse(b"Service unavailable", status_code=503)
+        valid_response = MockResponse(b'{"status": "ok"}')
+        mock_requests_get.side_effect = [error_response, valid_response]
+
+        result = url_file_to_gcs.get_first_response(
+            ["https://badurl.com", "https://goodurl.com"],
+            {},
+            check_json=False,
+        )
+
+        self.assertIs(result, valid_response)
+        self.assertEqual(mock_requests_get.call_count, 2)
+
     def testDownloadFirstUrlToGcs_SameFile(self):
         test_data = b"fake data"
         with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(
@@ -100,7 +122,7 @@ class URLFileToGCSTest(unittest.TestCase):
             self.assertTrue(result)
 
     def testDownloadFirstUrlToGcs_JsonDestination_NonJsonHtmlError_Ignored(self):
-        html_error = b'<html><body>Missing Key Redirect</body></html>'
+        html_error = b"<html><body>Missing Key Redirect</body></html>"
         with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(
             "requests.get"
         ) as mock_requests_get:
@@ -113,7 +135,7 @@ class URLFileToGCSTest(unittest.TestCase):
             self.assertIsNone(result)
 
     def testDownloadFirstUrlToGcs_FallbackToValidSecondUrlWhenFirstIsInvalidJson(self):
-        html_error = MockResponse(b'<html>404 Not Found HTML</html>')
+        html_error = MockResponse(b"<html>404 Not Found HTML</html>")
         valid_json = MockResponse(b'{"key": "value"}')
 
         with patch("ingestion.url_file_to_gcs.storage.Client") as mock_storage_client, patch(


### PR DESCRIPTION
## Problem
In `python/ingestion/url_file_to_gcs.py`, `get_first_response()` only checked HTTP status via `file_from_url.raise_for_status()`. When upstream providers (such as Census key-walls) return HTTP 200 with an HTML error page (e.g. redirected to `missing_key.html`), `url_file_to_gcs` would cache the invalid HTML content to GCS as if it were valid JSON (#5139).

## Solution
- Add `check_json` parameter to `get_first_response()`, `download_first_url_to_gcs()`, and `url_file_to_gcs()`.
- Automatically default `check_json=True` when `dest_filename` ends with `.json`.
- When `check_json` is enabled, attempt to parse `file_from_url.json()`; if it fails, log an error and try subsequent fallback URLs in `url_list` or return `None` (preventing upload of non-JSON error pages to GCS).
- Add unit tests in `python/tests/ingestion/test_url_file_to_gcs.py` covering valid JSON ingest, rejection of non-JSON HTML error responses, and fallback URL handling.

Fixes #5139
