### PR TITLE
fix: add CENSUS_API_KEY env to gcs_to_bq Cloud Run service

### DIFF
--- a/config/run.tf
+++ b/config/run.tf
@@ -74,6 +74,16 @@ resource "google_cloud_run_service" "gcs_to_bq_service" {
             }
           }
         }
+        env {
+          name = "CENSUS_API_KEY"
+          value_from {
+            secret_key_ref {
+              # Secret is created/rotated manually in Secret Manager (see secrets.tf).
+              name = "census-api-key"
+              key  = "latest"
+            }
+          }
+        }
 
         resources {
           limits = {


### PR DESCRIPTION
## Summary

- Add missing CENSUS_API_KEY environment variable to the gcs_to_bq Cloud Run service in config/run.tf
- Mounts the Census API key secret from Secret Manager so ACS datasources can authenticate with Census Bureau API
- Completes the Census API key integration (Python code merged in #5145)

## Impact

Enables ACS data pipeline to authenticate with Census API. Combined with #5145, this unblocks the ACS 2020-2024 vintage update (PR #5137).

## Test plan

- [x] DAG run 32296444549 on infra-test completed successfully after code + infra changes deployed

Closes #5138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
