### PR TITLE
feat: add Census API key support to ACS datasources

### DIFF
--- a/config/secrets.tf
+++ b/config/secrets.tf
@@ -22,12 +22,20 @@
 #     --role="roles/secretmanager.secretAccessor" --project=$PROJECT_ID
 #
 # Secrets and their consumers:
-#   ahr-api-key        -> gcs_to_bq runner  (America's Health Rankings ingestion)
-#   gemini-api-key     -> data-server-runner SA / Go server  (AI insight generation)
-#   webflow-api-token  -> data-server-runner SA / Go server  (CMS blog read access)
+#   ahr-api-key           -> gcs_to_bq runner  (America's Health Rankings ingestion)
+#   census-api-key        -> gcs_to_bq runner  (US Census Bureau ACS API)
+#   gemini-api-key        -> data-server-runner SA / Go server  (AI insight generation)
+#   webflow-api-token     -> data-server-runner SA / Go server  (CMS blog read access)
+#   sentry-auth-token     -> auto-deployer SA (via GitHub Actions)  (frontend source map uploads)
 #
 # gemini-api-key is issued from a separate GCP project dedicated to the Generative
 # Language API, and is API-restricted to that one API. It is server-side only and is
 # never shipped to the browser.
+#
+# census-api-key is required for Census Bureau API requests (free registration).
+# It is passed to url_file_to_gcs.py via os.getenv("CENSUS_API_KEY") by the gcs_to_bq runner.
+#
+# sentry-auth-token is fetched by GitHub Actions workflows via the deployer service
+# account. See deployInfraTest.yml and testBackendChangesInfraTest.yml for usage.
 
 /* [END] Secret Manager Setup */

--- a/python/datasources/acs_condition.py
+++ b/python/datasources/acs_condition.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 from datasources.data_source import DataSource
 from ingestion import url_file_to_gcs, gcs_to_bq_util, census
@@ -323,6 +324,8 @@ class AcsCondition(DataSource):
         # writes the data to the GCS bucket and sees if file diff is changed
 
         file_diff = False
+        census_api_key = os.getenv("CENSUS_API_KEY")
+
         for measure, acs_item in acs_items.items():
             for prefix, race in acs_item.prefix_map.items():
                 for county_level in [True, False]:
@@ -333,6 +336,7 @@ class AcsCondition(DataSource):
                             params,
                             bucket,
                             self.get_filename_race(measure, race, county_level, year),
+                            census_api_key=census_api_key,
                         )
                         or file_diff
                     )
@@ -345,6 +349,7 @@ class AcsCondition(DataSource):
                         params,
                         bucket,
                         self.get_filename_sex(measure, county_level, year),
+                        census_api_key=census_api_key,
                     )
                     or file_diff
                 )

--- a/python/datasources/acs_population.py
+++ b/python/datasources/acs_population.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd  # type: ignore
 import ingestion.standardized_columns as std_col
 from ingestion.standardized_columns import Race
@@ -383,7 +384,10 @@ class ACSPopulationIngester:
             cols = list(group_vars.keys())
             url_params = get_census_params(cols, self.county_level)
             filename = self.get_filename(concept)
-            concept_file_diff = url_file_to_gcs.url_file_to_gcs(self.base_acs_url, url_params, gcs_bucket, filename)
+            census_api_key = os.getenv("CENSUS_API_KEY")
+            concept_file_diff = url_file_to_gcs.url_file_to_gcs(
+                self.base_acs_url, url_params, gcs_bucket, filename, census_api_key=census_api_key
+            )
             file_diff = file_diff or concept_file_diff
 
         return file_diff

--- a/python/datasources/acs_population.py
+++ b/python/datasources/acs_population.py
@@ -378,13 +378,13 @@ class ACSPopulationIngester:
         file_diff = False
         concepts = list(self.sex_by_age_concepts_to_race.keys())
         concepts.append(self.hispanic_by_race_concept)
+        census_api_key = os.getenv("CENSUS_API_KEY")
 
         for concept in concepts:
             group_vars = get_vars_for_group(concept, var_map, 2)
             cols = list(group_vars.keys())
             url_params = get_census_params(cols, self.county_level)
             filename = self.get_filename(concept)
-            census_api_key = os.getenv("CENSUS_API_KEY")
             concept_file_diff = url_file_to_gcs.url_file_to_gcs(
                 self.base_acs_url, url_params, gcs_bucket, filename, census_api_key=census_api_key
             )

--- a/python/ingestion/url_file_to_gcs.py
+++ b/python/ingestion/url_file_to_gcs.py
@@ -13,7 +13,7 @@ def local_file_path(filename):
     return f"/tmp/{filename}"
 
 
-def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename):
+def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename, census_api_key=None):
     """
     Attempts to download a file from a url and upload as a
     blob to the given GCS bucket.
@@ -24,23 +24,31 @@ def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename):
       gcs_bucket: Name of the GCS bucket to upload to (without gs://).
       dest_filename: What to name the downloaded file in GCS.
         Include the file extension.
+      census_api_key: Optional Census API key for Census Bureau endpoints.
 
     Returns: A boolean indication of a file diff
     """
-    return download_first_url_to_gcs([url], gcs_bucket, dest_filename, url_params)
+    return download_first_url_to_gcs([url], gcs_bucket, dest_filename, url_params, census_api_key=census_api_key)
 
 
-def get_first_response(url_list, url_params, validate_json=False):
+def get_first_response(url_list, url_params, validate_json=False, census_api_key=None):
     """
     Fetch the first successfully-responding URL from url_list, with optional JSON validation.
 
     When validate_json=True, calls response.json() to verify the response body is valid JSON.
     If JSON parsing fails, logs the error and retries the next URL (same as HTTP errors).
+
+    For Census API URLs, automatically adds the api_key param if census_api_key is provided.
     Returns None if all URLs fail.
     """
     for url in url_list:
         try:
-            file_from_url = requests.get(url, params=url_params, timeout=120)
+            # Add Census API key if provided and URL is a Census endpoint
+            params = url_params.copy() if url_params else {}
+            if census_api_key and "census.gov" in url:
+                params["key"] = census_api_key
+
+            file_from_url = requests.get(url, params=params, timeout=120)
             file_from_url.raise_for_status()
             if validate_json:
                 file_from_url.json()
@@ -52,7 +60,7 @@ def get_first_response(url_list, url_params, validate_json=False):
     return None
 
 
-def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=None):
+def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=None, census_api_key=None):
     """
     Iterates over the list of potential URLs that may point to the data
     source until one of the URLs succeeds in downloading. If no URL succeeds,
@@ -62,12 +70,16 @@ def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=No
     valid JSON before caching. Non-JSON responses are treated as failures and
     trigger a retry to the next URL in url_list.
 
+    For Census API URLs, automatically adds the api_key param if census_api_key
+    is provided (e.g. for Census Bureau ACS data).
+
     Parameters:
       url_list: List of URLs where the file may be found.
       gcs_bucket: Name of the GCS bucket to upload to (without gs://).
       dest_filename: What to name the downloaded file in GCS.
         Include the file extension. .json extension triggers JSON validation.
       url_params: URL parameters to be passed to requests.get().
+      census_api_key: Optional Census API key for Census Bureau endpoints.
 
       Returns:
         files_are_diff: A boolean indication of a file diff
@@ -85,7 +97,7 @@ def download_first_url_to_gcs(url_list, gcs_bucket, dest_filename, url_params=No
 
     # Find a valid file in the URL list or exit (with JSON validation for .json files)
     validate_json = dest_filename.endswith(".json")
-    file_from_url = get_first_response(url_list, url_params, validate_json=validate_json)
+    file_from_url = get_first_response(url_list, url_params, validate_json=validate_json, census_api_key=census_api_key)
     if file_from_url is None:
         logging.error("No file could be found for intended destination: %s", dest_filename)
         return

--- a/python/ingestion/url_file_to_gcs.py
+++ b/python/ingestion/url_file_to_gcs.py
@@ -43,9 +43,9 @@ def get_first_response(url_list, url_params, validate_json=False, census_api_key
     """
     for url in url_list:
         try:
-            # Add Census API key if provided and URL is a Census endpoint
             params = url_params.copy() if url_params else {}
-            if census_api_key and "census.gov" in url:
+            # Census Bureau API requires an API key param for all requests
+            if census_api_key and "census.gov" in url.lower():
                 params["key"] = census_api_key
 
             file_from_url = requests.get(url, params=params, timeout=120)


### PR DESCRIPTION
## Summary

- Add optional `census_api_key` parameter to `get_first_response()`, `url_file_to_gcs()`, and `download_first_url_to_gcs()` in url_file_to_gcs.py
- Automatically append api_key param to Census API requests when key is provided
- Update acs_population.py and acs_condition.py to read CENSUS_API_KEY from environment and pass to url_file_to_gcs functions
- Update config/secrets.tf to document all runtime secrets (including new `census-api-key` and `sentry-auth-token`) and their consumers

## Impact

Enables Census API authentication for ACS data ingestion. Census now requires API keys for all requests. This unblocks the ACS 2020-2024 vintage pipeline update. Also consolidates secret documentation that was previously scattered.

## Test plan

- [x] All 18 ACS tests pass (pytest python/tests/datasources/test_acs_*.py)
- [ ] After merge + infra-test deploy: DAG runs complete successfully with real 2024 data

Closes #5138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
