### PR TITLE
fix: complete Census API key integration

### DIFF
--- a/config/run.tf
+++ b/config/run.tf
@@ -17,6 +17,17 @@ resource "google_cloud_run_service" "ingestion_service" {
       containers {
         image = format("gcr.io/%s/%s@%s", var.project_id, var.ingestion_image_name, var.ingestion_image_digest)
 
+        env {
+          name = "CENSUS_API_KEY"
+          value_from {
+            secret_key_ref {
+              # Secret is created/rotated manually in Secret Manager (see secrets.tf).
+              name = "census-api-key"
+              key  = "latest"
+            }
+          }
+        }
+
         resources {
           limits = {
             memory = "4G"

--- a/run_ingestion/Dockerfile
+++ b/run_ingestion/Dockerfile
@@ -24,4 +24,4 @@ RUN pip install ./python/datasources
 # webserver, with one worker process and 8 threads.
 # For environments with multiple CPU cores, increase the number of workers
 # to be equal to the cores available.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 --chdir run_ingestion main:app
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 --chdir run_ingestion main:app# Rebuild trigger: 1787187922

--- a/run_ingestion/main.py
+++ b/run_ingestion/main.py
@@ -61,6 +61,11 @@ def ingest_data_to_gcs(event):
     workflow_id = attrs.pop("id")
     gcs_bucket = attrs.pop("gcs_bucket")
 
+    # Add Census API key from environment if available
+    census_api_key = os.getenv("CENSUS_API_KEY")
+    if census_api_key:
+        attrs["census_api_key"] = census_api_key
+
     logging.info("Data ingestion received message: %s", workflow_id)
 
     if workflow_id not in DATA_SOURCES_DICT.keys():


### PR DESCRIPTION
## Summary

Completes the Census API key integration by:
- Mounting CENSUS_API_KEY env var on data-ingestion-service Cloud Run
- Reading and passing CENSUS_API_KEY from environment to datasources  
- Triggering container rebuild to deploy code changes

These fixes enable ACS datasources to authenticate with Census API for data ingestion.

## Related Issues

Closes #5138 (partial - infrastructure piece)
Unblocks #5137 (ACS vintage update to 2020-2024)

## Test Plan

- [x] DAG run 32296444549 on infra-test succeeded with Census API authentication
- [x] ACS Condition and Population pre-cache workflows successfully cached data from Census API
- [x] ACS Condition and Population main DAGs successfully processed cached data

🤖 Generated with Claude Code