### PR TITLE
Retry transient Census API failures, allow single-year precache DAG runs

### DIFF
--- a/.github/workflows/dagAcsConditionPreCache.yml
+++ b/.github/workflows/dagAcsConditionPreCache.yml
@@ -4,7 +4,17 @@ name: DAG - ACS_CONDITION (PRE CACHE)
 
 on:
   workflow_dispatch:
+    inputs:
+      year:
+        description: "Single year to ingest (e.g. 2024). Leave blank to ingest all years 2012-2024."
+        required: false
+        type: string
   workflow_call:
+    inputs:
+      year:
+        description: "Single year to ingest (e.g. 2024). Leave blank to ingest all years 2012-2024."
+        required: false
+        type: string
 
 env:
   WORKFLOW_ID: "ACS_CONDITION"
@@ -20,6 +30,7 @@ jobs:
 
       # Ingest data to GCS (Cache ACS source into tmp JSON in buckets)
       - name: Ingest ACS condition data 2012
+        if: ${{ inputs.year == '' || inputs.year == '2012' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -29,6 +40,7 @@ jobs:
           year: "2012"
 
       - name: Ingest ACS condition data 2013
+        if: ${{ inputs.year == '' || inputs.year == '2013' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -38,6 +50,7 @@ jobs:
           year: "2013"
 
       - name: Ingest ACS condition data 2014
+        if: ${{ inputs.year == '' || inputs.year == '2014' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -47,6 +60,7 @@ jobs:
           year: "2014"
 
       - name: Ingest ACS condition data 2015
+        if: ${{ inputs.year == '' || inputs.year == '2015' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -56,6 +70,7 @@ jobs:
           year: "2015"
 
       - name: Ingest ACS condition data 2016
+        if: ${{ inputs.year == '' || inputs.year == '2016' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -65,6 +80,7 @@ jobs:
           year: "2016"
 
       - name: Ingest ACS condition data 2017
+        if: ${{ inputs.year == '' || inputs.year == '2017' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -74,6 +90,7 @@ jobs:
           year: "2017"
 
       - name: Ingest ACS condition data 2018
+        if: ${{ inputs.year == '' || inputs.year == '2018' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -83,6 +100,7 @@ jobs:
           year: "2018"
 
       - name: Ingest ACS condition data 2019
+        if: ${{ inputs.year == '' || inputs.year == '2019' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -92,6 +110,7 @@ jobs:
           year: "2019"
 
       - name: Ingest ACS condition data 2020
+        if: ${{ inputs.year == '' || inputs.year == '2020' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -101,6 +120,7 @@ jobs:
           year: "2020"
 
       - name: Ingest ACS condition data 2021
+        if: ${{ inputs.year == '' || inputs.year == '2021' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -110,6 +130,7 @@ jobs:
           year: "2021"
 
       - name: Ingest ACS condition data 2022
+        if: ${{ inputs.year == '' || inputs.year == '2022' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -119,6 +140,7 @@ jobs:
           year: "2022"
 
       - name: Ingest ACS condition data 2023
+        if: ${{ inputs.year == '' || inputs.year == '2023' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}
@@ -128,6 +150,7 @@ jobs:
           year: "2023"
 
       - name: Ingest ACS condition data 2024
+        if: ${{ inputs.year == '' || inputs.year == '2024' }}
         uses: SatcherInstitute/health-equity-tracker/.github/actions/runCacheAcsInGcsPipeline@main
         with:
           service_url: ${{ env.INGESTION_SERVICE_URL }}

--- a/python/ingestion/url_file_to_gcs.py
+++ b/python/ingestion/url_file_to_gcs.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import time
 from google.cloud import storage  # type: ignore
 import google.cloud.exceptions
 import requests
@@ -31,32 +32,43 @@ def url_file_to_gcs(url, url_params, gcs_bucket, dest_filename, census_api_key=N
     return download_first_url_to_gcs([url], gcs_bucket, dest_filename, url_params, census_api_key=census_api_key)
 
 
-def get_first_response(url_list, url_params, validate_json=False, census_api_key=None):
+def get_first_response(
+    url_list, url_params, validate_json=False, census_api_key=None, max_retries=3, initial_backoff=5
+):
     """
     Fetch the first successfully-responding URL from url_list, with optional JSON validation.
 
     When validate_json=True, calls response.json() to verify the response body is valid JSON.
-    If JSON parsing fails, logs the error and retries the next URL (same as HTTP errors).
+    If JSON parsing fails, logs the error and moves on to the next URL (retrying the same URL
+    won't fix a permanently malformed body).
+
+    Network-level failures (connection errors, timeouts, 5xx/4xx HTTP errors) are retried against
+    the same URL with exponential backoff before moving on to the next URL, since these are often
+    transient (e.g. the Census API dropping connections under request volume).
 
     For Census API URLs, automatically adds the api_key param if census_api_key is provided.
     Returns None if all URLs fail.
     """
     for url in url_list:
-        try:
-            params = url_params.copy() if url_params else {}
-            # Census Bureau API requires an API key param for all requests
-            if census_api_key and "census.gov" in url.lower():
-                params["key"] = census_api_key
+        params = url_params.copy() if url_params else {}
+        # Census Bureau API requires an API key param for all requests
+        if census_api_key and "census.gov" in url.lower():
+            params["key"] = census_api_key
 
-            file_from_url = requests.get(url, params=params, timeout=120)
-            file_from_url.raise_for_status()
-            if validate_json:
-                file_from_url.json()
-            return file_from_url
-        except requests.HTTPError as err:
-            logging.error("HTTP error for url %s: %s", url, err)
-        except ValueError as err:
-            logging.error("Non-JSON response body from url %s: %s", url, err)
+        for attempt in range(max_retries):
+            try:
+                file_from_url = requests.get(url, params=params, timeout=120)
+                file_from_url.raise_for_status()
+                if validate_json:
+                    file_from_url.json()
+                return file_from_url
+            except requests.exceptions.RequestException as err:
+                logging.error("Request error for url %s (attempt %d/%d): %s", url, attempt + 1, max_retries, err)
+                if attempt < max_retries - 1:
+                    time.sleep(initial_backoff * (2**attempt))
+            except ValueError as err:
+                logging.error("Non-JSON response body from url %s: %s", url, err)
+                break
     return None
 
 

--- a/python/ingestion/url_file_to_gcs.py
+++ b/python/ingestion/url_file_to_gcs.py
@@ -62,13 +62,16 @@ def get_first_response(
                 if validate_json:
                     file_from_url.json()
                 return file_from_url
+            except ValueError as err:
+                # requests.exceptions.JSONDecodeError subclasses both ValueError and
+                # RequestException, so this must be checked first: a malformed body won't
+                # be fixed by retrying the same URL.
+                logging.error("Non-JSON response body from url %s: %s", url, err)
+                break
             except requests.exceptions.RequestException as err:
                 logging.error("Request error for url %s (attempt %d/%d): %s", url, attempt + 1, max_retries, err)
                 if attempt < max_retries - 1:
                     time.sleep(initial_backoff * (2**attempt))
-            except ValueError as err:
-                logging.error("Non-JSON response body from url %s: %s", url, err)
-                break
     return None
 
 

--- a/python/tests/ingestion/test_url_file_to_gcs.py
+++ b/python/tests/ingestion/test_url_file_to_gcs.py
@@ -185,3 +185,15 @@ class URLFileToGCSTest(unittest.TestCase):
         self.assertIsNone(result)
         self.assertEqual(mock_get.call_count, 3)
         self.assertEqual(mock_sleep.call_count, 2)
+
+    def testGetFirstResponse_JsonDecodeErrorNotRetried(self):
+        """requests.exceptions.JSONDecodeError (a ValueError+RequestException subclass) moves on
+        without retrying, since it's not a transient network failure."""
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "<html>", 0)
+        with patch("requests.get", return_value=response) as mock_get, patch("time.sleep") as mock_sleep:
+            result = url_file_to_gcs.get_first_response(["https://testurl.com"], {}, validate_json=True)
+        self.assertIsNone(result)
+        self.assertEqual(mock_get.call_count, 1)
+        mock_sleep.assert_not_called()

--- a/python/tests/ingestion/test_url_file_to_gcs.py
+++ b/python/tests/ingestion/test_url_file_to_gcs.py
@@ -2,6 +2,7 @@ import json
 import unittest
 from unittest.mock import Mock, patch
 import google.cloud.exceptions
+import requests
 from ingestion import url_file_to_gcs
 
 
@@ -162,3 +163,25 @@ class URLFileToGCSTest(unittest.TestCase):
         with patch("requests.get", return_value=html_response):
             result = url_file_to_gcs.get_first_response(["https://testurl.com"], {})
         self.assertIsNotNone(result)
+
+    def testGetFirstResponse_RetriesTransientConnectionError(self):
+        """A ConnectionError/ReadTimeout on the same URL is retried, not treated as permanent failure."""
+        good_response = MockResponse(b'{"key": "value"}', json_data={"key": "value"})
+        with patch(
+            "requests.get",
+            side_effect=[requests.exceptions.ConnectionError("Remote end closed connection"), good_response],
+        ) as mock_get, patch("time.sleep") as mock_sleep:
+            result = url_file_to_gcs.get_first_response(["https://testurl.com"], {}, validate_json=True)
+        self.assertIsNotNone(result)
+        self.assertEqual(mock_get.call_count, 2)
+        mock_sleep.assert_called_once()
+
+    def testGetFirstResponse_GivesUpAfterMaxRetries(self):
+        """Persistent connection errors on one URL exhaust retries and return None."""
+        with patch("requests.get", side_effect=requests.exceptions.ReadTimeout("Read timed out")) as mock_get, patch(
+            "time.sleep"
+        ) as mock_sleep:
+            result = url_file_to_gcs.get_first_response(["https://testurl.com"], {}, max_retries=3, initial_backoff=1)
+        self.assertIsNone(result)
+        self.assertEqual(mock_get.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)


### PR DESCRIPTION
## Why

While pulling real 2023/2024 ACS condition data for #5140, `dagAcsConditionPreCache.yml` failed three times in a row on infra-test, each time with a different transient network error hitting `api.census.gov`:

1. `ConnectionError` / `RemoteDisconnected` on year 2023 (after 2012-2022 succeeded)
2. `ReadTimeoutError` on year 2012 (a year that had already succeeded once)
3. `ReadTimeoutError` on year 2014

Root cause: `get_first_response` in `url_file_to_gcs.py` only caught `requests.HTTPError` and `ValueError`. It never caught `ConnectionError` or `Timeout`, so any transient network blip against the Census API propagated all the way up through `upload_to_gcs()` as an unhandled exception, which `run_ingestion/main.py` turns into a bare `HTTP 400` with no body — aborting the *entire year's* ingestion (all measure × race × county-level combinations), not just the one failed request.

Separately, retrying a failed run meant replaying all 13 years sequentially from 2012, multiplying Census API load on every retry attempt and increasing the odds of hitting another transient failure before ever reaching the years that actually needed re-ingesting.

## What changed

- `python/ingestion/url_file_to_gcs.py`: `get_first_response` now catches `requests.exceptions.RequestException` (covers `ConnectionError`, `Timeout`, `HTTPError`, etc.) and retries the same URL up to `max_retries` times with exponential backoff before moving to the next URL in `url_list`. Non-JSON response bodies (`ValueError`) still move on immediately — retrying the same URL won't fix a permanently malformed body.
- `.github/workflows/dagAcsConditionPreCache.yml`: added an optional `year` input to `workflow_dispatch`/`workflow_call`. Left blank, the workflow behaves exactly as before (ingests all years 2012-2024). Set to a single year (e.g. `2023`), only that year's step runs, via a per-step `if:` condition.
- `python/tests/ingestion/test_url_file_to_gcs.py`: two new tests covering the retry-then-succeed and retry-exhausted-then-give-up paths.

## Next steps (in order)

1. **This PR** merges and deploys to infra-test (code) — no data changes, just reliability.
2. Push to the `infra-test` git branch so the DAG workflow file changes are live there too (`git push origin HEAD:infra-test -f`), since a `main` merge auto-deploys *code* to infra-test but does not update the separate `infra-test` git ref that `workflow_dispatch --ref infra-test` reads from.
3. Re-run `dagAcsConditionPreCache.yml --ref infra-test -f year=2023` and `-f year=2024` individually, now with retry protection and without replaying all 13 years.
4. Continue #5140: pull the real cached JSON and replace the 36 placeholder `2024-*.json` fixtures.

Related: #5140
