### PR TITLE
docs(python): document ACS vintage year bump process

### DIFF
--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -29,6 +29,27 @@ tests/         Integration tests — many load real fixture CSVs from repo-root 
 
 **Changing an existing data source's output?** Editing `write_to_bq()` or a shared `ingestion/` helper does not regenerate any data by itself — the matching `dag<Source>.yml` workflow must be run (`gh workflow run dag<Source>.yml --ref infra-test` for testing, or against `main` post-merge) before the change reaches BigQuery/GCS. See root `CLAUDE.md` → Backend Data Pipeline.
 
+## Bumping the ACS vintage year
+
+When a new ACS vintage lands in BigQuery and is ready for use, follow these steps in order:
+
+1. **Update `ACS_CURRENT_YEAR`** in `python/ingestion/merge_utils.py` (line 9). This constant controls which year's population table is used as the denominator for every datasource that calls `_merge_pop()` (CAWP, AHR, etc.).
+
+2. **Regenerate the committed population CSVs.** `merge_utils._merge_pop()` reads `python/ingestion/acs_population/*.csv` directly at runtime as static snapshots. Nothing regenerates them automatically. After the `dagAcsPopulation.yml` DAG run completes for the target project, re-run:
+
+   ```bash
+   source .venv/bin/activate
+   pip install python/ingestion/
+   # dev project (het-infra-test-05):
+   python python/ingestion/acs_population/refresh_historical_csvs.py
+   # prod project (requires both flags):
+   python python/ingestion/acs_population/refresh_historical_csvs.py --project <prod-project-id> --prod
+   ```
+
+   Commit the resulting CSV diff alongside the `ACS_CURRENT_YEAR` bump. Until this diff is committed, the new vintage year is not usable as a population denominator even if the BigQuery tables are current.
+
+3. **Re-run affected DAGs.** Datasources that merge population (e.g. AHR, CAWP) must be re-ingested after the CSV refresh so their BigQuery/GCS outputs reflect the updated denominators.
+
 ## Key files
 
 | Purpose | Path |
@@ -37,3 +58,5 @@ tests/         Integration tests — many load real fixture CSVs from repo-root 
 | BigQuery/GCS utilities | `ingestion/gcs_to_bq_util.py` |
 | Shared data transforms | `ingestion/dataset_utils.py` |
 | Shared type definitions | `ingestion/het_types.py` |
+| ACS population CSV snapshots | `ingestion/acs_population/*.csv` |
+| ACS population CSV refresh script | `ingestion/acs_population/refresh_historical_csvs.py` |

--- a/python/CLAUDE.md
+++ b/python/CLAUDE.md
@@ -33,9 +33,11 @@ tests/         Integration tests — many load real fixture CSVs from repo-root 
 
 When a new ACS vintage lands in BigQuery and is ready for use, follow these steps in order:
 
-1. **Update `ACS_CURRENT_YEAR`** in `python/ingestion/merge_utils.py` (line 9). This constant controls which year's population table is used as the denominator for every datasource that calls `_merge_pop()` (CAWP, AHR, etc.).
+1. **Update `ACS_CURRENT_YEAR`** in `python/ingestion/merge_utils.py` (line 9). This constant is the upper bound of ACS coverage for every datasource that calls `_merge_pop()` (CAWP, AHR, etc.): rows within `ACS_EARLIEST_YEAR`–`ACS_CURRENT_YEAR` merge against their own year, and rows after it are clamped down to `ACS_CURRENT_YEAR`. Both paths read the `_historical` population table, so bumping the constant is what lets a newer vintage be used at all.
 
-2. **Regenerate the committed population CSVs.** `merge_utils._merge_pop()` reads `python/ingestion/acs_population/*.csv` directly at runtime as static snapshots. Nothing regenerates them automatically. After the `dagAcsPopulation.yml` DAG run completes for the target project, re-run:
+2. **Refresh the ACS source cache, then rebuild the BigQuery tables.** Run `dagAcsPopulationPreCache.yml` first — `dagAcsPopulation.yml` reads pre-cached ACS responses out of the GCS landing bucket rather than fetching them, so on a vintage bump those cached files are stale by definition and skipping the pre-cache either fails the run or silently reprocesses the old vintage. Only once the pre-cache finishes, run `dagAcsPopulation.yml`. (The pre-cache repeats a Census API ingestion across every year, so expect it to be slow and watch for rate limiting.)
+
+3. **Regenerate the committed population CSVs.** `merge_utils._merge_pop()` reads `python/ingestion/acs_population/*.csv` directly at runtime as static snapshots. Nothing regenerates them automatically. After the `dagAcsPopulation.yml` run completes for the target project, re-run:
 
    ```bash
    source .venv/bin/activate
@@ -48,7 +50,7 @@ When a new ACS vintage lands in BigQuery and is ready for use, follow these step
 
    Commit the resulting CSV diff alongside the `ACS_CURRENT_YEAR` bump. Until this diff is committed, the new vintage year is not usable as a population denominator even if the BigQuery tables are current.
 
-3. **Re-run affected DAGs.** Datasources that merge population (e.g. AHR, CAWP) must be re-ingested after the CSV refresh so their BigQuery/GCS outputs reflect the updated denominators.
+4. **Re-run affected DAGs.** Datasources that merge population (e.g. AHR, CAWP) must be re-ingested after the CSV refresh so their BigQuery/GCS outputs reflect the updated denominators.
 
 ## Key files
 


### PR DESCRIPTION
## Summary
Adds a "Bumping the ACS vintage year" section to `python/CLAUDE.md` that documents the three-step process required when a new ACS vintage is ready for use:
1. Update `ACS_CURRENT_YEAR` in `merge_utils.py`
2. Regenerate and commit the population CSV snapshots via `refresh_historical_csvs.py`
3. Re-run affected datasource DAGs (CAWP, AHR, etc)

Also updates the "Key files" table to point to the population snapshot directory and refresh script.

Closes #5141 (documentation portion).

Remaining hands-on work (#5156, #5157) requires BigQuery access and is tracked separately under the ACS 2024 milestone.

## Test plan
- [x] Docs are clear and complete
- [x] Script commands copy-paste correctly
- [x] Key files table updated

🤖 Generated with Claude Code
