### PR TITLE
Never let Sentry source map upload fail the build

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,13 +40,11 @@ export default defineConfig(({ mode }) => {
               project: 'health-equity-tracker',
               authToken: process.env.SENTRY_AUTH_TOKEN,
               sourcemaps: { filesToDeleteAfterUpload: ['./build/**/*.map'] },
-              // Without this the plugin throws and fails the build. Source maps
-              // are a debugging aid and must never be able to block a deploy.
+              // Without this the plugin throws and fails the build. Sentry
+              // release tracking is a debugging aid and must never be able to
+              // block a deploy. Covers release creation and source map upload.
               errorHandler: (err) => {
-                console.warn(
-                  '[sentry] source map upload failed, continuing build:',
-                  err,
-                )
+                console.warn('[sentry] step failed, continuing build:', err)
               },
             }),
           ]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -40,6 +40,14 @@ export default defineConfig(({ mode }) => {
               project: 'health-equity-tracker',
               authToken: process.env.SENTRY_AUTH_TOKEN,
               sourcemaps: { filesToDeleteAfterUpload: ['./build/**/*.map'] },
+              // Without this the plugin throws and fails the build. Source maps
+              // are a debugging aid and must never be able to block a deploy.
+              errorHandler: (err) => {
+                console.warn(
+                  '[sentry] source map upload failed, continuing build:',
+                  err,
+                )
+              },
             }),
           ]
         : []),


### PR DESCRIPTION
## Summary

`sentryVitePlugin` throws by default when release creation or source map upload fails, which stops the bundle and fails the deploy. This adds an `errorHandler` so those failures warn and the build continues.

Found while auditing what the next production release would ship. Source maps are a debugging aid and should never be able to block a release.

## Why this path is untested today

`deployInfraTest.yml` passes `secrets.SENTRY_AUTH_TOKEN`, but that secret does not exist on this repo, so it resolves to an empty string. The latest dev deploy log builds with:

```
--build-arg="SENTRY_AUTH_TOKEN="
```

The empty value makes `vite.config.ts` skip the plugin entirely, so no dev build has ever run the upload. The production repo does have a real `SENTRY_AUTH_TOKEN` and its workflow passes it through, which means the first build to ever exercise this code path would be a production build, with a token never validated in CI.

## Test plan

Built locally with a deliberately invalid token to force the failure.

**Before this change** the plugin throws on the very first step (`sentry-cli releases new`) and the build dies.

**After this change** the build completes with exit code 0 and logs:

```
[sentry] source map upload failed, continuing build: Error: Command failed:
  .../sentry-cli releases new 02fcbd7bb9e880af1b74e654f16449b6bdd5d089
error: API request failed
    sentry reported an error: Invalid token (http status: 401)
...
built in 22.67s
```

- [x] `npx tsc --noEmit` passes
- [x] `npx biome check vite.config.ts` passes
- [x] Build succeeds with an invalid `SENTRY_AUTH_TOKEN` (exit 0, warning logged)
- [x] Build succeeds with no `SENTRY_AUTH_TOKEN` (plugin skipped, unchanged behavior)

## Follow-up

Dev should actually exercise this path so prod is not the first run. Either add a `SENTRY_AUTH_TOKEN` secret to this repo, or drop the unused reference from `deployInfraTest.yml` and `testBackendChangesInfraTest.yml` so the workflow stops implying a capability it does not have. Noted in the issue.

Closes #5161
