### PR TITLE
Correct census-api-key consumer list in secrets.tf

### DIFF
--- a/config/secrets.tf
+++ b/config/secrets.tf
@@ -23,7 +23,7 @@
 #
 # Secrets and their consumers:
 #   ahr-api-key           -> gcs_to_bq runner  (America's Health Rankings ingestion)
-#   census-api-key        -> gcs_to_bq runner  (US Census Bureau ACS API)
+#   census-api-key        -> gcs_to_bq runner AND ingestion runner  (US Census Bureau ACS API)
 #   gemini-api-key        -> data-server-runner SA / Go server  (AI insight generation)
 #   webflow-api-token     -> data-server-runner SA / Go server  (CMS blog read access)
 #   sentry-auth-token     -> auto-deployer SA (via GitHub Actions)  (frontend source map uploads)
@@ -32,8 +32,11 @@
 # Language API, and is API-restricted to that one API. It is server-side only and is
 # never shipped to the browser.
 #
-# census-api-key is required for Census Bureau API requests (free registration).
-# It is passed to url_file_to_gcs.py via os.getenv("CENSUS_API_KEY") by the gcs_to_bq runner.
+# census-api-key is required for Census Bureau API requests (free registration). It is read
+# via os.getenv("CENSUS_API_KEY") by BOTH Cloud Run services, so BOTH runtime service
+# accounts need the accessor role in every project (see run.tf): the ingestion runner
+# (run_ingestion/main.py) and the gcs_to_bq runner (acs_population.py, acs_condition.py).
+# Granting only one of them lets terraform apply succeed in one project and fail in another.
 #
 # sentry-auth-token is fetched by GitHub Actions workflows via the deployer service
 # account. See deployInfraTest.yml and testBackendChangesInfraTest.yml for usage.


### PR DESCRIPTION
## Summary

Comment-only change to `config/secrets.tf`. No Terraform resources, no runtime impact.

The secret/consumer table claimed `census-api-key` was read by the gcs_to_bq runner alone:

```
#   census-api-key        -> gcs_to_bq runner  (US Census Bureau ACS API)
```

`run.tf` actually wires it into **both** Cloud Run services. `os.getenv("CENSUS_API_KEY")` is read by `python/datasources/acs_condition.py`, `python/datasources/acs_population.py` (gcs_to_bq runner) and `run_ingestion/main.py` (ingestion runner).

That omission is what allowed #5159 to go unnoticed: the prod `census-api-key` secret had a `secretAccessor` binding for `gcs-to-bq-runner` but not for `ingestion-runner`, which would have failed `terraform apply` on the next production release. Dev had both, so nothing surfaced the divergence.

This corrects the table and expands the explanatory paragraph to state that both runtime service accounts need the accessor role in every project, and that granting only one lets `terraform apply` succeed in one project and fail in another.

## Context

- Fixes the documentation gap behind #5159 (the IAM binding itself is already corrected in prod).
- #5163 tracks the larger follow-up: moving the IAM bindings themselves into Terraform so drift like this is caught mechanically instead of by comment accuracy.

Refs #5159, #5163

## Test plan

- [x] Comment-only diff; `config/secrets.tf` declares no Terraform resources, so `terraform plan` is unaffected
- [x] Consumer list verified against `run.tf` env blocks and `grep` for `CENSUS_API_KEY` in `python/`
- [x] Pre-commit hooks (cspell) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
