### PR TITLE
fix(e2e): scope 'age' locator in hiv_care spec

### DIFF
--- a/frontend/playwright-tests/hiv_care.spec.ts
+++ b/frontend/playwright-tests/hiv_care.spec.ts
@@ -34,7 +34,7 @@ test('HIV Linkage To Care', async ({ page }) => {
     .locator('#rate-chart')
     .getByRole('heading', { name: 'People diagnosed with HIV,' })
     .click()
-  await page.getByText('age', { exact: true }).click()
+  await page.locator('#rate-chart').getByText('age', { exact: true }).click()
   await page
     .locator('#rate-chart')
     .getByRole('img', { name: 'Linkage to HIV care in the' })


### PR DESCRIPTION
## Summary

- Scoped the unscoped 'age' locator to `#rate-chart` to fix strict-mode violation where it matched both chart axes

## Impact

- Fixes flaky E2E test that blocks post-merge nightly run

## Test plan

- [x] hiv_care.spec.ts runs without strict-mode violation

Closes #5150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
