### PR TITLE
Drop hardcoded ACS year from map card; refresh ACS vintage in metadata

### DIFF
--- a/frontend/src/cards/ui/GeoContext.test.ts
+++ b/frontend/src/cards/ui/GeoContext.test.ts
@@ -21,9 +21,7 @@ describe('test getTotalACSPopulationPhrase()', () => {
     const normalPopPhrase = getTotalACSPopulationPhrase(
       /* data */ nationalACSPopData,
     )
-    expect(normalPopPhrase).toEqual(
-      'Total population: 328,016,242 (from ACS 2022)',
-    )
+    expect(normalPopPhrase).toEqual('Total population: 328,016,242 (from ACS)')
   })
 })
 

--- a/frontend/src/cards/ui/geoContextHelpers.ts
+++ b/frontend/src/cards/ui/geoContextHelpers.ts
@@ -9,7 +9,7 @@ export function getTotalACSPopulationPhrase(populationData: HetRow[]): string {
     rawPop != null && !isNaN(rawPop)
       ? rawPop.toLocaleString()
       : DATA_UNAVAILABLE
-  return `Total population: ${popAllCount} (from ACS 2022)`
+  return `Total population: ${popAllCount} (from ACS)`
 }
 
 export function getSubPopulationPhrase(

--- a/frontend/src/data/config/DatasetMetadataAcs.ts
+++ b/frontend/src/data/config/DatasetMetadataAcs.ts
@@ -47,226 +47,226 @@ export type DatasetIdAcs =
 export const DatasetMetadataMapAcs: Record<DatasetIdAcs, DatasetMetadata> = {
   'acs_population-race_county_current': {
     name: 'Population by race/ethnicity and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-race_state_current': {
     name: 'Population by race/ethnicity and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-race_national_current': {
     name: 'Population by race/ethnicity nationally',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-age_county_current': {
     name: 'Population by age and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-age_state_current': {
     name: 'Population by age and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-age_national_current': {
     name: 'Population by age nationally',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-sex_county_current': {
     name: 'Population by sex and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-sex_state_current': {
     name: 'Population by sex and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-sex_national_current': {
     name: 'Population by sex nationally',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
   'acs_population-race_county_historical': {
     name: 'Annual population by race/ethnicity and county',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-race_state_historical': {
     name: 'Annual population by race/ethnicity and state',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-race_national_historical': {
     name: 'Annual population by race/ethnicity nationally',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-age_county_historical': {
     name: 'Annual population by age and county',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-age_state_historical': {
     name: 'Annual population by age and state',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-age_national_historical': {
     name: 'Annual population by age nationally',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-sex_county_historical': {
     name: 'Annual population by sex and county',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-sex_state_historical': {
     name: 'Annual population by sex and state',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_population-sex_national_historical': {
     name: 'Annual population by sex nationally',
-    original_data_sourced: '2009-2022',
+    original_data_sourced: '2009-2024',
     source_id: 'acs',
   },
   'acs_condition-age_county_historical': {
     name: 'Health insurance and poverty, yearly, by age and county',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-age_state_historical': {
     name: 'Health insurance and poverty, yearly, by age and state',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-age_national_historical': {
     name: 'Health insurance and poverty, yearly, by age at the national level',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-sex_county_historical': {
     name: 'Health insurance and poverty, yearly, by sex and county',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-sex_state_historical': {
     name: 'Health insurance and poverty, yearly, by sex and state',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-sex_national_historical': {
     name: 'Health insurance and poverty, yearly, by sex at the national level',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-race_and_ethnicity_county_historical': {
     name: 'Health insurance and poverty, yearly, by race and county',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-race_and_ethnicity_state_historical': {
     name: 'Health insurance and poverty, yearly, by race and state',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-race_and_ethnicity_national_historical': {
     name: 'Health insurance and poverty, yearly, by race at the national level',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
   'acs_condition-age_county_current': {
     name: 'Health insurance and poverty, yearly, by age and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-age_state_current': {
     name: 'Health insurance and poverty, yearly, by age and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-age_national_current': {
     name: 'Health insurance and poverty, yearly, by age at the national level',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-sex_county_current': {
     name: 'Health insurance and poverty, yearly, by sex and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-sex_state_current': {
     name: 'Health insurance and poverty, yearly, by sex and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-sex_national_current': {
     name: 'Health insurance and poverty, yearly, by sex at the national level',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-race_and_ethnicity_county_current': {
     name: 'Health insurance and poverty, yearly, by race and county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-race_and_ethnicity_state_current': {
     name: 'Health insurance and poverty, yearly, by race and state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-race_and_ethnicity_national_current': {
     name: 'Health insurance and poverty, yearly, by race at the national level',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_county_historical': {
     name: 'Health insurance and poverty, yearly, by county',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_county_current': {
     name: 'Health insurance and poverty, yearly, by county',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_state_historical': {
     name: 'Health insurance and poverty, yearly, by state',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_state_current': {
     name: 'Health insurance and poverty, yearly, by state',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_national_historical': {
     name: 'Health insurance and poverty, yearly, at the national level',
-    original_data_sourced: '2012-2022',
+    original_data_sourced: '2012-2024',
     source_id: 'acs',
   },
 
   'acs_condition-alls_national_current': {
     name: 'Health insurance and poverty, yearly, at the national level',
-    original_data_sourced: '2022',
+    original_data_sourced: '2024',
     source_id: 'acs',
   },
 }


### PR DESCRIPTION
## Summary

- Drop the hardcoded `2022` year from the map card's population phrase, leaving `(from ACS)` — the card footer already states the vintage from dataset metadata, so the inline year duplicated and drifted on every vintage bump
- Update all `original_data_sourced` values in `DatasetMetadataAcs.ts` to reflect the 2024 vintage: `2022` → `2024`, `2009-2022` → `2009-2024`, `2012-2022` → `2012-2024`

## Impact

Removes a source of data-attribution drift. Frontends that consume ACS vintage now read it from a single source: the dataset metadata that is authoritative. This prevents silent label mismatches when a vintage constant is bumped in the backend. Follows the pattern already used by `getSubPopulationPhrase`, which parameterizes its source label rather than hardcoding it.

## Test plan

- [x] `npx vitest run src/cards/ui/GeoContext.test.ts` — 4 passed
- [x] `npx vitest run src/cards/ui/Sources.test.ts` — 3 passed

Closes #5182
