### PR TITLE
docs(config): record that test and prod use separate Gemini projects

### DIFF
--- a/config/secrets.tf
+++ b/config/secrets.tf
@@ -32,6 +32,11 @@
 # Language API, and is API-restricted to that one API. It is server-side only and is
 # never shipped to the browser.
 #
+# Test and prod are issued from DIFFERENT Generative Language projects on purpose.
+# Free-tier quota is granted per project per model, so a shared project would let
+# internal testing spend the public site's daily allowance. Keep them separate when
+# rotating either key.
+#
 # census-api-key is required for Census Bureau API requests (free registration). It is read
 # via os.getenv("CENSUS_API_KEY") by BOTH Cloud Run services, so BOTH runtime service
 # accounts need the accessor role in every project (see run.tf): the ingestion runner


### PR DESCRIPTION
## Summary

Documents that test and prod Generative Language projects are intentionally separate to preserve quota isolation.

## Details

Free-tier quota is granted per GCP project per model. A shared project between dev/test and production would allow internal testing to exhaust the public site's daily generation allowance. Separate projects give each environment its own full quota.

Closes #5201
