### PR TITLE
Make prod feature-flag-free by construction

### DIFF
--- a/cspell.config.json
+++ b/cspell.config.json
@@ -682,6 +682,8 @@
 		"Unrepr",
 		"unreq",
 		"unrequested",
+		"unreviewed",
+		"unlaunched",
 		"unsentenced",
 		"unpadded",
 		"unstripped",

--- a/frontend/.env.prod
+++ b/frontend/.env.prod
@@ -2,6 +2,13 @@
 # PRODUCTION ENVIRONMENT
 # ------------------------------------------------------------------------------
 # Configuration for the production site healthequitytracker.org using het-infra-prod backend
+#
+# NEVER add a VITE_SHOW_* feature flag to this file. Launching a feature means
+# deleting its flag gate from the code, not switching the flag on for everyone.
+# src/featureFlags.ts ignores env flags entirely when VITE_DEPLOY_CONTEXT is prod,
+# so a line here does nothing but mislead, and a unit test fails if one appears.
+# To preview an unlaunched feature against real prod data, pass the flag as a URL
+# param instead: it arms that browser tab only.
 
 # Deployment context identifier
 VITE_DEPLOY_CONTEXT=prod

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -206,6 +206,20 @@ Read it with `flag('VITE_SHOW_MY_FEATURE')`. The identical string appears in the
 
 One rule covers env values and params alike: present, non-empty, and not `0` means on. A param **overrides** the env for that browser tab only, so `?VITE_SHOW_INSIGHT_GENERATION=0` is how you see the prod experience on dev.
 
+### Prod is param-only, always
+
+**A feature is launched by deleting its flag gate from the code, never by turning the flag on in `.env.prod`.** The flag exists to let a feature ship dark and be previewed; once it is meant for everyone, the `flag()` call and the `.env` lines come out and the feature is simply the product. A flag left in place on prod is not a launch, it is an unreviewed conditional serving the public.
+
+Three things enforce that, in order of how early they catch you:
+
+- `.env.prod` carries a header comment saying not to, so the rule is visible at the point of temptation.
+- A unit test in `src/featureFlags.test.ts` reads the committed `.env.prod` and fails if any `VITE_SHOW_*` line appears in it.
+- `featureFlags.ts` ignores the env side outright when `VITE_DEPLOY_CONTEXT` is `prod`. This is the backstop that the test cannot be: it also covers a flag set in Netlify's own environment, where nothing is committed to review.
+
+The user-visible reason is the indicator. Any flag on, from any source, renders the 🧑🏽‍🔬 in the toolbar — correct for a preview tab, and completely wrong on the public site for every visitor.
+
+URL params are unaffected on prod. `?VITE_SHOW_MY_FEATURE=1` still arms the flag for that one browser tab against real prod data, which is the supported way to demo or verify an unlaunched feature in production.
+
 Vite emits `import.meta.env` as a whole object literal, so the computed lookup `ENV[key]` resolves fine at runtime. What does *not* work is enumeration: a var not set in that environment's `.env` is absent from the object entirely, so `describeFeatureFlags()` can only name the env flags that are **on**. Overrides supply the rest, including any forced off.
 
 Flag params are **stripped from the URL** once read, because `setMadLibWithParam` rebuilds the query from a fixed allowlist on every mode change. Left in place they would vanish on the first mode switch while the flag stayed on, so the URL would stop describing the state. `sessionStorage` is the single source of truth instead, which also means a link someone copies or screenshots does not arm a flag for anyone else.

--- a/frontend/src/featureFlags.test.ts
+++ b/frontend/src/featureFlags.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { armFeatureFlagOverridesFromUrl } from './featureFlags'
 
 function visit(url: string) {
@@ -159,6 +162,28 @@ describe('describeFeatureFlags', () => {
     })
   })
 
+  test('a prod env flag reads off, and a param still turns it on', async () => {
+    vi.stubEnv('VITE_DEPLOY_CONTEXT', 'prod')
+    vi.stubEnv('VITE_SHOW_LEAKED_TO_PROD', '1')
+
+    const onProd = await loadFlagsAt('/exploredata')
+    expect(onProd.flag('VITE_SHOW_LEAKED_TO_PROD')).toBe(false)
+    expect(onProd.ANY_FEATURE_FLAG_ON).toBe(false)
+
+    sessionStorage.clear()
+    const withParam = await loadFlagsAt(
+      '/exploredata?VITE_SHOW_LEAKED_TO_PROD=1',
+    )
+    expect(withParam.flag('VITE_SHOW_LEAKED_TO_PROD')).toBe(true)
+  })
+
+  test('the same env flag reads on outside prod', async () => {
+    vi.stubEnv('VITE_DEPLOY_CONTEXT', 'dev')
+    vi.stubEnv('VITE_SHOW_LEAKED_TO_PROD', '1')
+    const { flag } = await loadFlagsAt('/exploredata')
+    expect(flag('VITE_SHOW_LEAKED_TO_PROD')).toBe(true)
+  })
+
   test('sorts by key and excludes non-flag env vars', async () => {
     vi.stubEnv('VITE_SHOW_ZEBRA', '1')
     vi.stubEnv('VITE_SHOW_APPLE', '1')
@@ -171,4 +196,24 @@ describe('describeFeatureFlags', () => {
     expect(keys).not.toContain('VITE_BASE_API_URL')
     expect(keys).toEqual([...keys].sort())
   })
+})
+
+// Prod ignores env flags at runtime, so a line here is inert rather than harmful.
+// It is still wrong, and the reason it is wrong does not show up in review: whoever
+// adds it is reaching for the wrong tool, because launching a feature means
+// deleting its flag gate, not switching the flag on for everyone. Failing here
+// says that at the moment the line is written.
+test('no feature flag is declared in .env.prod', () => {
+  // Resolved from this module rather than the cwd, and via node:path rather than
+  // the URL constructor, which jsdom overrides to resolve against the page origin.
+  const envProd = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '.env.prod'),
+    'utf8',
+  )
+
+  const declared = envProd
+    .split('\n')
+    .filter((line) => /^\s*(export\s+)?VITE_SHOW_/.test(line))
+
+  expect(declared).toEqual([])
 })

--- a/frontend/src/featureFlags.ts
+++ b/frontend/src/featureFlags.ts
@@ -20,6 +20,14 @@ const OVERRIDE_STORAGE_KEY = 'featureFlagOverrides'
 // resolves fine. An unset var is simply absent, which reads as off.
 const ENV = import.meta.env as unknown as Record<string, string | undefined>
 
+// Launching a feature means deleting its flag gate, never switching the flag on
+// for everyone, so an env-set flag on prod is always a mistake — and a loud one,
+// since it would show the 🧑🏽‍🔬 indicator to every public visitor. Prod therefore
+// ignores the env side outright, which also covers a flag set in Netlify's own
+// environment rather than in a committed .env file. Params still work, so a
+// single tab can still preview an unlaunched feature against real prod data.
+const ENV_FLAGS_IGNORED = ENV.VITE_DEPLOY_CONTEXT === 'prod'
+
 // One rule for both env values and URL params: present, non-empty, and not '0'.
 function parseFlagValue(raw: string | undefined): boolean {
   return raw !== undefined && raw !== '' && raw !== '0'
@@ -87,7 +95,7 @@ const FLAG_OVERRIDES = armFeatureFlagOverridesFromUrl()
 // Keyed by the env var name so the identical string reads across the .env file,
 // the URL param, and the call site.
 export function flag(key: FeatureFlagKey): boolean {
-  return FLAG_OVERRIDES[key] ?? parseFlagValue(ENV[key])
+  return FLAG_OVERRIDES[key] ?? (!ENV_FLAGS_IGNORED && parseFlagValue(ENV[key]))
 }
 
 // An unset var is absent from import.meta.env, so the env side can only name the


### PR DESCRIPTION
## Summary

Launching a feature means deleting its flag gate from the code, not switching the flag on for everyone. A `VITE_SHOW_*` line in `.env.prod` is therefore always a mistake, and since #5209 it is a visible one: any armed flag renders the 🧑🏽‍🔬 indicator in the toolbar, which would show to every public visitor of healthequitytracker.org.

Three layers, in the order they catch you:

- **`.env.prod` header comment** states the rule at the point of temptation.
- **A unit test** reads the committed `.env.prod` and fails if any `VITE_SHOW_*` line appears.
- **`featureFlags.ts` ignores env flags entirely when `VITE_DEPLOY_CONTEXT` is `prod`.** This is the backstop the test cannot be, since it also covers a flag set in Netlify's own environment, where nothing is committed for a reviewer to see.

URL params are unaffected on prod. `?VITE_SHOW_MY_FEATURE=1` still arms a flag for one browser tab against real prod data, which stays the supported way to demo an unlaunched feature in production.

The rationale and all three layers are documented in a new "Prod is param-only, always" subsection of `frontend/CLAUDE.md`.

## Test plan

- [x] `npx vitest run src/featureFlags.test.ts` — 19 passed
- [x] Planted `VITE_SHOW_TEMP_CHECK=1` in `.env.prod` and confirmed the new test fails, then reverted
- [x] Unit test covers both directions of the runtime guard: an env flag reads off under `VITE_DEPLOY_CONTEXT=prod` (and does not light the indicator), reads on under `dev`, and a URL param still turns it on under `prod`
