### PR TITLE
Add E2E coverage for AI insight rendering

### DIFF
--- a/frontend/playwright-tests/insights.ci.spec.ts
+++ b/frontend/playwright-tests/insights.ci.spec.ts
@@ -1,0 +1,43 @@
+// CI-level spec: asserts that an AI insight actually renders — text appears,
+// the disclosure line is present, and the highlighted phrase is in the text.
+// Runs on every PR push via E2E_CI (Chromium only).
+//
+// The feature flag is armed as a URL param so CI's vite-preview build (which
+// never sets VITE_SHOW_INSIGHT_GENERATION in its env) still exercises the full
+// insight path for this one tab.
+//
+// The test targets incarceration by race, a stable view on the dev backend. If
+// the insight is not yet in cache, generation runs once and caches it. If quota
+// is exhausted that run, the test fails loudly — which is the correct signal.
+import { expect, test } from './utils/fixtures'
+
+const INSIGHT_URL =
+  '/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
+
+test('card insight renders text, disclosure, and highlight', async ({
+  page,
+}) => {
+  await page.goto(INSIGHT_URL, { waitUntil: 'domcontentloaded' })
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+
+  await page.getByLabel('Generate insight').first().click()
+
+  // The status div is the insight container. Its absence is the silent failure
+  // this test exists to catch, so there is no isVisible guard here.
+  const insightCard = page.locator('div[role="status"]').first()
+  await expect(insightCard).toBeVisible({ timeout: 30_000 })
+
+  // Text must be non-empty — a silently empty section is the failure mode.
+  const text = await insightCard.locator('p.font-bold').textContent()
+  expect(text?.trim().length).toBeGreaterThan(0)
+
+  // Disclosure line must appear exactly as written in the component.
+  await expect(insightCard).toContainText('AI-generated. Verify with chart data.')
+
+  // The highlighted phrase renders as a green span inside the bold text.
+  await expect(
+    insightCard.locator('span.font-semibold.text-dark-green'),
+  ).toBeVisible()
+})

--- a/frontend/playwright-tests/insights.ci.spec.ts
+++ b/frontend/playwright-tests/insights.ci.spec.ts
@@ -22,7 +22,7 @@ test('card insight renders text, disclosure, and highlight', async ({
   const rateMap = page.locator('#rate-map')
   await rateMap.scrollIntoViewIfNeeded()
 
-  await page.getByLabel('Generate insight').first().click()
+  await rateMap.getByLabel('Generate insight').click()
 
   // The status div is the insight container. Its absence is the silent failure
   // this test exists to catch, so there is no isVisible guard here.
@@ -30,14 +30,14 @@ test('card insight renders text, disclosure, and highlight', async ({
   await expect(insightCard).toBeVisible({ timeout: 30_000 })
 
   // Text must be non-empty — a silently empty section is the failure mode.
-  const text = await insightCard.locator('p.font-bold').textContent()
+  const text = await insightCard.locator('[data-testid="insight-text"]').textContent()
   expect(text?.trim().length).toBeGreaterThan(0)
 
   // Disclosure line must appear exactly as written in the component.
   await expect(insightCard).toContainText('AI-generated. Verify with chart data.')
 
-  // The highlighted phrase renders as a green span inside the bold text.
+  // The highlighted phrase renders as a span inside the bold text.
   await expect(
-    insightCard.locator('span.font-semibold.text-dark-green'),
+    insightCard.locator('[data-testid="insight-highlight"]'),
   ).toBeVisible()
 })

--- a/frontend/playwright-tests/insights.spec.ts
+++ b/frontend/playwright-tests/insights.spec.ts
@@ -12,7 +12,7 @@ const DISPARITY_URL =
   '/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
 
 const COMPARE_URL =
-  '/exploredata?mls=1.incarceration-3.poverty-5.00&mlp=comparevars&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
+  '/exploredata?mls=1.incarceration-3.poverty-5.00&group1=All&mlp=comparevars&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
 
 const REPORT_URL =
   '/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&report-insight=true&VITE_SHOW_INSIGHT_GENERATION=1'
@@ -26,15 +26,15 @@ test('card insight — text, disclosure, and highlight on incarceration report',
 
   const rateMap = page.locator('#rate-map')
   await rateMap.scrollIntoViewIfNeeded()
-  await page.getByLabel('Generate insight').first().click()
+  await rateMap.getByLabel('Generate insight').click()
 
   const card = page.locator('div[role="status"]').first()
   await expect(card).toBeVisible({ timeout: 30_000 })
 
-  const text = await card.locator('p.font-bold').textContent()
+  const text = await card.locator('[data-testid="insight-text"]').textContent()
   expect(text?.trim().length).toBeGreaterThan(0)
   await expect(card).toContainText('AI-generated. Verify with chart data.')
-  await expect(card.locator('span.font-semibold.text-dark-green')).toBeVisible()
+  await expect(card.locator('[data-testid="insight-highlight"]')).toBeVisible()
 })
 
 // --- Contrast insight ---
@@ -55,10 +55,10 @@ test('contrast insight — compare mode renders text and highlight', async ({
     .first()
   await expect(contrastCard).toBeVisible({ timeout: 30_000 })
 
-  const text = await contrastCard.locator('p.font-bold').textContent()
+  const text = await contrastCard.locator('[data-testid="insight-text"]').textContent()
   expect(text?.trim().length).toBeGreaterThan(0)
   await expect(
-    contrastCard.locator('span.font-semibold.text-dark-green'),
+    contrastCard.locator('[data-testid="insight-highlight"]'),
   ).toBeVisible()
 })
 
@@ -108,7 +108,7 @@ test('flag control — popover opens, reason enables submit, popover closes on s
 
   const rateMap = page.locator('#rate-map')
   await rateMap.scrollIntoViewIfNeeded()
-  await page.getByLabel('Generate insight').first().click()
+  await rateMap.getByLabel('Generate insight').click()
 
   const card = page.locator('div[role="status"]').first()
   await expect(card).toBeVisible({ timeout: 30_000 })

--- a/frontend/playwright-tests/insights.spec.ts
+++ b/frontend/playwright-tests/insights.spec.ts
@@ -1,0 +1,130 @@
+// Nightly-only: covers the three insight surfaces (card, contrast, report)
+// and the flag control. All tests arm the feature flag via URL param so they
+// work on any environment — including prod, where VITE_SHOW_INSIGHT_GENERATION
+// is never set in the env file. The flag control test is skipped on prod
+// because flagging deletes the cached key and writes to the flagged bucket.
+import { expect, test } from './utils/fixtures'
+
+const IS_PROD =
+  process.env.E2E_BASE_URL?.includes('healthequitytracker.org') ?? false
+
+const DISPARITY_URL =
+  '/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
+
+const COMPARE_URL =
+  '/exploredata?mls=1.incarceration-3.poverty-5.00&mlp=comparevars&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1'
+
+const REPORT_URL =
+  '/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&report-insight=true&VITE_SHOW_INSIGHT_GENERATION=1'
+
+// --- Card insight ---
+
+test('card insight — text, disclosure, and highlight on incarceration report', async ({
+  page,
+}) => {
+  await page.goto(DISPARITY_URL, { waitUntil: 'domcontentloaded' })
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+  await page.getByLabel('Generate insight').first().click()
+
+  const card = page.locator('div[role="status"]').first()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+
+  const text = await card.locator('p.font-bold').textContent()
+  expect(text?.trim().length).toBeGreaterThan(0)
+  await expect(card).toContainText('AI-generated. Verify with chart data.')
+  await expect(card.locator('span.font-semibold.text-dark-green')).toBeVisible()
+})
+
+// --- Contrast insight ---
+
+test('contrast insight — compare mode renders text and highlight', async ({
+  page,
+}) => {
+  await page.goto(COMPARE_URL, { waitUntil: 'domcontentloaded' })
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+  await page.getByLabel('Comparison insights').first().click()
+
+  // ContrastInsightSection renders role="status" with an aria-label that names
+  // the section (e.g. "Rate map comparison insight").
+  const contrastCard = page
+    .locator('[role="status"][aria-label*="comparison insight"]')
+    .first()
+  await expect(contrastCard).toBeVisible({ timeout: 30_000 })
+
+  const text = await contrastCard.locator('p.font-bold').textContent()
+  expect(text?.trim().length).toBeGreaterThan(0)
+  await expect(
+    contrastCard.locator('span.font-semibold.text-dark-green'),
+  ).toBeVisible()
+})
+
+// --- Report insight (four sections) ---
+
+test('report insight — all four sections render non-empty text', async ({
+  page,
+}) => {
+  await page.goto(REPORT_URL, { waitUntil: 'domcontentloaded' })
+
+  // InsightReportCard generates automatically on open and wraps its content in
+  // a region. Wait for generation to finish (loading text disappears).
+  await expect(
+    page.getByText('Reviewing all charts with AI...'),
+  ).toBeHidden({ timeout: 30_000 })
+
+  const reportRegion = page.getByRole('region', { name: 'Report insights' })
+  await expect(reportRegion).toBeVisible()
+
+  // Each section label renders as an uppercase span inside the region.
+  for (const label of [
+    'Key Findings',
+    'Location Comparison',
+    'Demographic Insights',
+    'What This Means',
+  ]) {
+    await expect(reportRegion.getByText(label, { exact: false })).toBeVisible()
+  }
+
+  // The report disclosure line must appear.
+  await expect(
+    page.getByText('AI-generated. Verify with chart data.'),
+  ).toBeVisible()
+})
+
+// --- Flag control ---
+
+test('flag control — popover opens, reason enables submit, popover closes on submission', async ({
+  page,
+}) => {
+  test.skip(
+    IS_PROD,
+    'flagging deletes cache entries and writes to the flagged bucket — must not run against prod',
+  )
+
+  await page.goto(DISPARITY_URL, { waitUntil: 'domcontentloaded' })
+
+  const rateMap = page.locator('#rate-map')
+  await rateMap.scrollIntoViewIfNeeded()
+  await page.getByLabel('Generate insight').first().click()
+
+  const card = page.locator('div[role="status"]').first()
+  await expect(card).toBeVisible({ timeout: 30_000 })
+
+  // Open the flag popover.
+  await card.getByText('Report harmful or inaccurate content').click()
+
+  // Submit is disabled until a reason is chosen.
+  const submit = page.getByRole('button', { name: 'Submit report' })
+  await expect(submit).toBeDisabled()
+
+  await page.getByLabel('Inaccurate').click()
+  await expect(submit).toBeEnabled()
+
+  await submit.click()
+
+  // The popover closes after a successful submission.
+  await expect(submit).toBeHidden({ timeout: 10_000 })
+})

--- a/frontend/playwright-tests/insights.spec.ts
+++ b/frontend/playwright-tests/insights.spec.ts
@@ -57,6 +57,7 @@ test('contrast insight — compare mode renders text and highlight', async ({
 
   const text = await contrastCard.locator('[data-testid="insight-text"]').textContent()
   expect(text?.trim().length).toBeGreaterThan(0)
+  await expect(contrastCard).toContainText('AI-generated. Verify with chart data.')
   await expect(
     contrastCard.locator('[data-testid="insight-highlight"]'),
   ).toBeVisible()
@@ -78,14 +79,20 @@ test('report insight — all four sections render non-empty text', async ({
   const reportRegion = page.getByRole('region', { name: 'Report insights' })
   await expect(reportRegion).toBeVisible()
 
-  // Each section label renders as an uppercase span inside the region.
+  // Each section label renders as an uppercase span inside the region with
+  // non-empty text content below it.
   for (const label of [
     'Key Findings',
     'Location Comparison',
     'Demographic Insights',
     'What This Means',
   ]) {
-    await expect(reportRegion.getByText(label, { exact: false })).toBeVisible()
+    const sectionLabel = reportRegion.getByText(label, { exact: false })
+    await expect(sectionLabel).toBeVisible()
+    // Assert this section has rendered text content (not just a label).
+    const sectionContent = sectionLabel.locator('..').locator('p')
+    const contentText = await sectionContent.textContent()
+    expect(contentText?.trim().length).toBeGreaterThan(0)
   }
 
   // The report disclosure line must appear.

--- a/frontend/src/cards/ui/InsightVisualizationCard.tsx
+++ b/frontend/src/cards/ui/InsightVisualizationCard.tsx
@@ -356,7 +356,10 @@ export default function InsightVisualizationCard({
       case 'idle':
         return insight ? (
           <>
-            <p className='m-0 font-bold text-alt-dark leading-snug'>
+            <p
+              data-testid='insight-text'
+              className='m-0 font-bold text-alt-dark leading-snug'
+            >
               <HetHighlightedText section={insight} />
             </p>
             <p className='m-0 mt-2 text-alt-dark text-smallest'>

--- a/frontend/src/reports/ContrastInsightSection.tsx
+++ b/frontend/src/reports/ContrastInsightSection.tsx
@@ -201,7 +201,10 @@ export default function ContrastInsightSection({
         </div>
       ) : contrastInsight ? (
         <div className='rounded-md bg-footer-color p-3'>
-          <p className='m-0 font-bold text-alt-dark leading-snug'>
+          <p
+            data-testid='insight-text'
+            className='m-0 font-bold text-alt-dark leading-snug'
+          >
             <HetHighlightedText section={contrastInsight} />
           </p>
           <p className='m-0 mt-2 text-alt-dark text-smallest'>

--- a/frontend/src/styles/HetComponents/HetHighlightSpan.tsx
+++ b/frontend/src/styles/HetComponents/HetHighlightSpan.tsx
@@ -39,6 +39,7 @@ export default function HetHighlightSpan({
   return (
     <span
       ref={spanRef}
+      data-testid='insight-highlight'
       className={`font-semibold text-dark-green ${className ?? ''}`}
       style={{
         animation:


### PR DESCRIPTION
**Preview:** [Incarceration disparity with insight flag armed](https://deploy-preview-5218--health-equity-tracker.netlify.app/exploredata?mls=1.incarceration-3.00&group1=All&mlp=disparity&dt1=prison&VITE_SHOW_INSIGHT_GENERATION=1)

## Summary

- Add `insights.ci.spec.ts`: asserts a card insight renders with non-empty text, the disclosure line, and the green highlight phrase — runs on every PR push and fails loudly if the section is silently empty
- Add `insights.spec.ts` (nightly): covers all three insight surfaces (card, contrast, report modal) plus the flag control end to end; flag test skipped on prod since flagging writes to the flagged bucket
- Add `data-testid` attributes to insight components so tests decouple from Tailwind class names

## Impact

- Before this PR: nothing fails if insight rendering breaks — 5 distinct failure modes (origin rejection, exhausted ceiling, suppressed key, malformed response, serving kill switch) all produce a silent empty section with no automated signal
- After: the CI spec catches render failures on every PR; the nightly spec catches regressions across all surfaces post-launch

## Test plan

- [x] `insights.ci.spec.ts` passes against dev backend (1 test, 8s)
- [x] `insights.spec.ts` — all 4 nightly tests pass (card, contrast, report, flag control), 11s
- [x] Assertions do not use `isVisible()` guards — the absence of content is a hard failure, not a soft pass
- [x] Card insight test asserts text, disclosure, and highlight
- [x] Contrast insight test asserts text, disclosure, and highlight
- [x] Report insight test asserts all 4 section labels and their text content is non-empty
- [x] Flag control test skips on prod (`IS_PROD` guard)

Closes #5215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
