### PR TITLE
Extend flagged-insight triage to cover production

### DIFF
--- a/.github/workflows/cronReviewFlaggedInsights.yml
+++ b/.github/workflows/cronReviewFlaggedInsights.yml
@@ -1,8 +1,9 @@
 # Fails when an AI insight has been flagged by a site visitor but not yet triaged by the
-# team. The job authenticates to GCP with the deployer service account, then runs the
-# review script in --ci mode against the flagged-insights bucket. A red X on this workflow
-# (surfaced via the badge in README.md) is the team's signal to run:
-#   scripts/review_flagged_insights.sh --review
+# team. Checks both the test and production flagged-insights buckets. A red X on this
+# workflow (surfaced via the badge in README.md) is the team's signal to run:
+#   scripts/review_flagged_insights.sh --review                              (test)
+#   scripts/review_flagged_insights.sh --review -p het-infra-prod-f6 \
+#     -b het-prod-flagged-insights -c het-prod-insights-cache                (prod)
 name: CRON Review Flagged AI Insights
 
 on:
@@ -32,11 +33,29 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.TEST_PROJECT_ID }}
-      - name: Review flagged insights (CI check)
+      - name: Check test environment for untriaged flags
+        id: check-test
+        # continue-on-error so the prod check always runs even if test has unhandled flags.
+        continue-on-error: true
         # Pass the buckets explicitly rather than relying on the script's defaults, so the
         # CI contract is visible here and a future default change can't silently break this.
         run: >-
           ./scripts/review_flagged_insights.sh --ci
+          --label test
           -p "${{ secrets.TEST_PROJECT_ID }}"
           -b het-flagged-insights
           -c het-insights-cache
+      - name: Check production environment for untriaged flags
+        id: check-prod
+        continue-on-error: true
+        run: >-
+          ./scripts/review_flagged_insights.sh --ci
+          --label prod
+          -p het-infra-prod-f6
+          -b het-prod-flagged-insights
+          -c het-prod-insights-cache
+      - name: Fail if any environment has unhandled flags
+        if: steps.check-test.outcome == 'failure' || steps.check-prod.outcome == 'failure'
+        run: |
+          echo "One or more environments have unhandled flagged insights (see output above)."
+          exit 1

--- a/scripts/review_flagged_insights.sh
+++ b/scripts/review_flagged_insights.sh
@@ -60,6 +60,7 @@ DEST_CACHE_BUCKET="$DEFAULT_DEST_CACHE_BUCKET"
 
 MODE="list" # list | review | ci | switch-status | disable-serving | enable-serving | disable-generation | enable-generation | sync-cache
 DRY_RUN=true
+LABEL="" # optional environment label for --ci output (e.g. "test" or "prod")
 
 GENERATION_SWITCH="insights-generation-disabled"
 SERVING_SWITCH="insights-serving-disabled"
@@ -95,6 +96,7 @@ Options:
   --dest-flagged DEST_FLAGGED     Destination flagged-insights bucket (default: $DEFAULT_DEST_FLAGGED_BUCKET)
   --dest-cache DEST_CACHE         Destination insights-cache bucket (default: $DEFAULT_DEST_CACHE_BUCKET)
   --execute            With --sync-cache: actually copy (default is dry-run)
+  --label LABEL        Prefix each --ci output line with [LABEL] (e.g. "test" or "prod")
   -h, --help           Show this help and exit
 
 Kill switch notes:
@@ -136,6 +138,7 @@ while [[ $# -gt 0 ]]; do
         --enable-generation) MODE="enable-generation"; shift ;;
         --sync-cache) MODE="sync-cache"; shift ;;
         --execute) DRY_RUN=false; shift ;;
+        --label) require_value "$1" "$#"; LABEL="$2"; shift 2 ;;
         -p) require_value "$1" "$#"; PROJECT_ID="$2"; shift 2 ;;
         -b) require_value "$1" "$#"; FLAGGED_BUCKET="$2"; shift 2 ;;
         -c) require_value "$1" "$#"; CACHE_BUCKET="$2"; shift 2 ;;
@@ -538,6 +541,7 @@ fi
 
 # --- Mode: ci ---
 if [[ "$MODE" == "ci" ]]; then
+    prefix="${LABEL:+"[$LABEL] "}"
     unhandled=0
     for f in "${FILES[@]}"; do
         status=$(jq -r '.status // ""' "$f")
@@ -545,16 +549,16 @@ if [[ "$MODE" == "ci" ]]; then
             unhandled=$(( unhandled + 1 ))
             key=$(jq -r '.key // ""' "$f")
             reason=$(jq -r '.reason // ""' "$f")
-            echo "UNHANDLED: reason=$reason key=$key"
+            echo "${prefix}UNHANDLED: reason=$reason key=$key"
         fi
     done
     if [[ "$unhandled" -gt 0 ]]; then
         echo
-        echo "$unhandled unhandled flagged insight(s) awaiting team review."
-        echo "Run: scripts/review_flagged_insights.sh --review"
+        echo "${prefix}${unhandled} unhandled flagged insight(s) awaiting team review."
+        echo "${prefix}Run: scripts/review_flagged_insights.sh --review -p $PROJECT_ID -b $FLAGGED_BUCKET -c $CACHE_BUCKET"
         exit 1
     fi
-    echo "No unhandled flagged insights. All clear."
+    echo "${prefix}No unhandled flagged insights. All clear."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

- Extend the weekly cron check to cover both test and production flagged-insights buckets
- Add `--label` flag to `review_flagged_insights.sh --ci` mode to identify which environment each flag came from
- Update the workflow to run both checks with `continue-on-error: true`, then a final gate step

## Impact

Ensures flagged insights from production site visitors are surfaced to the team in the same weekly triage prompt, with clear environment labeling for prioritization.

## Test plan

- [x] Script: `--label` flag prefixes each UNHANDLED line and Run command with [test] or [prod]
- [x] Workflow: test and prod steps both run even if one has unhandled flags; final step fails job if either did
- [x] IAM: CI credential granted read access to the prod flagged-insights bucket

Closes #5061

🤖 Generated with [Claude Code](https://claude.com/claude-code)
