### PR TITLE
Align AI insight prompts with visualized data

### DIFF
--- a/server/insight_descriptor.go
+++ b/server/insight_descriptor.go
@@ -171,12 +171,21 @@ func renderInsightPrompt(d *insightDescriptor) (string, error) {
 		return buildCardInsightPrompt(d.HashID, d.Topic, d.Location, demographic, dataSection, d.Context, shape), nil
 
 	case insightKindContrast:
+		// Derive the highlighted group from URL params so the prompt can focus on
+		// what the user is actually looking at. group1 drives compare-vars (same
+		// place, different topics); if both groups are set and differ, we leave the
+		// focus empty and let the model decide.
+		group1, group2 := parseGroupParams(d.URLParams)
+		activeGroup := group1
+		if group2 != "" && group2 != group1 {
+			activeGroup = ""
+		}
 		section := func(v *insightView) string {
 			return formatDataRows(v.Rows, d.HashID, d.DemographicType, v.MetricConfig,
 				insightDataOptions{BudgetBytes: insightBudgetContrast})
 		}
-		return buildContrastPrompt(d.ViewA.Topic, d.ViewB.Topic, d.ViewA.Location, d.ViewB.Location,
-			demographic, section(d.ViewA), section(d.ViewB)), nil
+		return buildContrastPrompt(d.HashID, d.ViewA.Topic, d.ViewB.Topic, d.ViewA.Location, d.ViewB.Location,
+			demographic, section(d.ViewA), section(d.ViewB), activeGroup), nil
 
 	case insightKindReport:
 		s := d.Sections

--- a/server/insight_prompt.go
+++ b/server/insight_prompt.go
@@ -543,14 +543,20 @@ func buildPrompt(hashID, topic, location, demographicLabel, dataSection, activeD
 
 	if mapChartIDs[hashID] {
 		// Each data row is labeled `Place (Group)`, and an "All" row gives the
-		// overall rate for that place. Tell the model which group the user is
-		// currently highlighting so it can lead with that story.
+		// overall rate for that place. Maps are a geographic visualization, so the
+		// insight focuses on place-level disparity. When the user has highlighted a
+		// specific group, that group's geographic pattern is the lens.
 		focus := ""
 		if activeDemographicGroup != "" && activeDemographicGroup != insightGroupAll {
-			focus = fmt.Sprintf(" The map currently highlights the %s group, so lead with that group and use the \"All\" baseline for comparison.", activeDemographicGroup)
+			focus = fmt.Sprintf(" The map currently highlights the %s group — use that group's rates to describe the geographic pattern, with \"All\" as the baseline.", activeDemographicGroup)
 		}
-		return fmt.Sprintf("This is a choropleth map showing %s in %s by %s. Each data row is labeled with its place and %s group; an \"All\" row gives the overall rate for that place.%s%s\n\nWrite a single sentence at an 8th grade reading level that highlights the most important health equity disparity — either a geographic gap between places or a gap between %s groups within a place — and captures why it matters for real people. Focus on the \"so what\", not the chart mechanics.",
-			topic, location, demographicLabel, demographicLabel, focus, dataBlock, demographicLabel)
+		return fmt.Sprintf("This is a choropleth map showing %s in %s by %s. Each data row is labeled with its place and %s group; an \"All\" row gives the overall rate for that place.%s%s\n\nWrite a single sentence at an 8th grade reading level that captures the geographic disparity — which places have the highest and lowest rates — and what that concentration means for the people who live there. Focus on the \"so what\", not the chart mechanics.",
+			topic, location, demographicLabel, demographicLabel, focus, dataBlock)
+	}
+
+	if hashID == "rate-chart" {
+		return fmt.Sprintf("This is a bar chart showing %s rates in %s by %s group.%s\n\nWrite a single sentence at an 8th grade reading level that names which group faces the highest rate, how much higher it is compared to others, and what that demographic disparity means for real people. Focus on the \"so what\", not the chart mechanics.",
+			topic, location, demographicLabel, dataBlock)
 	}
 
 	if hashID == "rates-over-time" {
@@ -656,7 +662,45 @@ func buildCardInsightPrompt(hashID, topic, location, demographicLabel, dataSecti
 		activeGroup, peerSummary != nil, tableShape) + singleInsightOutputRule
 }
 
-func buildContrastPrompt(topic1, topic2, location1, location2, demographic, data1, data2 string) string {
+// decodeGroupParam reverses the browser's getGroupParamFromDemographicGroup
+// encoding so the server can read the selected demographic group from URL params
+// without a frontend change. The encoding is four deterministic substitutions;
+// race-code shorthand (e.g. "Black (NH)") is left as-is because the model's
+// plain-language rules already map it to the correct data-row label.
+func decodeGroupParam(param string) string {
+	if param == "" {
+		return ""
+	}
+	return strings.NewReplacer(
+		".NH", " (NH)",
+		"_", " ",
+		"~", "/",
+		"PLUS", "+",
+	).Replace(param)
+}
+
+// parseGroupParams returns the decoded group1 and group2 values from a
+// URLSearchParams string (e.g. "group1=Black.NH&group2=Black.NH").
+func parseGroupParams(urlParams string) (group1, group2 string) {
+	for _, pair := range strings.Split(urlParams, "&") {
+		k, v, ok := strings.Cut(pair, "=")
+		if !ok {
+			continue
+		}
+		switch k {
+		case "group1":
+			group1 = decodeGroupParam(v)
+		case "group2":
+			group2 = decodeGroupParam(v)
+		}
+	}
+	return
+}
+
+func buildContrastPrompt(hashID, topic1, topic2, location1, location2, demographic, data1, data2, activeDemographicGroup string) string {
+	isMap := mapChartIDs[hashID]
+	hasActiveGroup := activeDemographicGroup != "" && !groupIsAll(activeDemographicGroup)
+
 	var setup, viewALabel, viewBLabel, guidance string
 
 	switch {
@@ -665,13 +709,33 @@ func buildContrastPrompt(topic1, topic2, location1, location2, demographic, data
 		setup = fmt.Sprintf("Two side-by-side charts show the same health metric — %s — across %s groups, in two different places.", topic1, demographic)
 		viewALabel = fmt.Sprintf("View A (%s)", location1)
 		viewBLabel = fmt.Sprintf("View B (%s)", location2)
-		guidance = "Focus on what comparing these two places reveals that either view alone does not — for example, whether disparities within one place exceed disparities between places, or whether the same patterns recur at different geographic scales."
+		if isMap {
+			guidance = "These are maps. Focus on the geographic patterns within each place — which areas have the highest rates — and whether the same geographic concentrations appear in both places."
+			if hasActiveGroup {
+				guidance += fmt.Sprintf(" Both maps are currently highlighting the %s group. Use that group's data as the geographic lens.", activeDemographicGroup)
+			}
+		} else {
+			guidance = "Focus on what comparing these two places reveals that either view alone does not — for example, whether disparities within one place exceed disparities between places, or whether the same patterns recur at different geographic scales."
+			if hasActiveGroup {
+				guidance += fmt.Sprintf(" Both charts are currently highlighting the %s group. Center the sentence on how %s fares in each place.", activeDemographicGroup, activeDemographicGroup)
+			}
+		}
 	case location1 == location2:
 		// compare-vars: same place, different topics
 		setup = fmt.Sprintf("Two side-by-side charts show %s, one for %s and one for %s, across %s groups.", location1, topic1, topic2, demographic)
 		viewALabel = fmt.Sprintf("View A (%s)", topic1)
 		viewBLabel = fmt.Sprintf("View B (%s)", topic2)
-		guidance = "Focus on whether the same groups bear the heaviest burden across both topics, or where the patterns diverge — and what that suggests about the underlying drivers of inequity."
+		if isMap {
+			guidance = "These are maps. Focus on the geographic pattern for each condition — which places carry the highest rates — and whether the same places face a heavy burden for both topics."
+			if hasActiveGroup {
+				guidance += fmt.Sprintf(" Both maps are currently highlighting the %s group. Use that group's geographic rates as the primary lens for the comparison.", activeDemographicGroup)
+			}
+		} else {
+			guidance = "Focus on whether the same groups bear the heaviest burden across both topics, or where the patterns diverge — and what that suggests about the underlying drivers of inequity."
+			if hasActiveGroup {
+				guidance += fmt.Sprintf(" Both charts are currently highlighting the %s group. The sentence must center on %s's burden across both metrics. Only name a different group if it shows a striking divergence that is directly visible in the data.", activeDemographicGroup, activeDemographicGroup)
+			}
+		}
 	default:
 		setup = fmt.Sprintf("Two side-by-side charts compare %s in %s with %s in %s, across %s groups.", topic1, location1, topic2, location2, demographic)
 		viewALabel = fmt.Sprintf("View A (%s in %s)", topic1, location1)

--- a/server/insight_prompt.go
+++ b/server/insight_prompt.go
@@ -547,7 +547,7 @@ func buildPrompt(hashID, topic, location, demographicLabel, dataSection, activeD
 		// insight focuses on place-level disparity. When the user has highlighted a
 		// specific group, that group's geographic pattern is the lens.
 		focus := ""
-		if activeDemographicGroup != "" && activeDemographicGroup != insightGroupAll {
+		if activeDemographicGroup != "" && !groupIsAll(activeDemographicGroup) {
 			focus = fmt.Sprintf(" The map currently highlights the %s group — use that group's rates to describe the geographic pattern, with \"All\" as the baseline.", activeDemographicGroup)
 		}
 		return fmt.Sprintf("This is a choropleth map showing %s in %s by %s. Each data row is labeled with its place and %s group; an \"All\" row gives the overall rate for that place.%s%s\n\nWrite a single sentence at an 8th grade reading level that captures the geographic disparity — which places have the highest and lowest rates — and what that concentration means for the people who live there. Focus on the \"so what\", not the chart mechanics.",
@@ -664,9 +664,11 @@ func buildCardInsightPrompt(hashID, topic, location, demographicLabel, dataSecti
 
 // decodeGroupParam reverses the browser's getGroupParamFromDemographicGroup
 // encoding so the server can read the selected demographic group from URL params
-// without a frontend change. The encoding is four deterministic substitutions;
-// race-code shorthand (e.g. "Black (NH)") is left as-is because the model's
-// plain-language rules already map it to the correct data-row label.
+// without a frontend change. The encoding is four deterministic substitutions
+// applied to ASCII-safe characters ('.', '_', '~', and alphanumerics only), so
+// the output never contains '%XX' percent-encoded bytes and url.QueryUnescape
+// is not needed. Race-code shorthand (e.g. "Black (NH)") is left as-is because
+// the model's plain-language rules already map it to the correct data-row label.
 func decodeGroupParam(param string) string {
 	if param == "" {
 		return ""
@@ -737,6 +739,8 @@ func buildContrastPrompt(hashID, topic1, topic2, location1, location2, demograph
 			}
 		}
 	default:
+		// Different topics AND different places. The browser does not emit this
+		// combination today, so isMap and hasActiveGroup guidance are not needed.
 		setup = fmt.Sprintf("Two side-by-side charts compare %s in %s with %s in %s, across %s groups.", topic1, location1, topic2, location2, demographic)
 		viewALabel = fmt.Sprintf("View A (%s in %s)", topic1, location1)
 		viewBLabel = fmt.Sprintf("View B (%s in %s)", topic2, location2)

--- a/server/insight_prompt.go
+++ b/server/insight_prompt.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"sort"
 	"strconv"
 	"strings"
@@ -664,21 +665,25 @@ func buildCardInsightPrompt(hashID, topic, location, demographicLabel, dataSecti
 
 // decodeGroupParam reverses the browser's getGroupParamFromDemographicGroup
 // encoding so the server can read the selected demographic group from URL params
-// without a frontend change. The encoding is four deterministic substitutions
-// applied to ASCII-safe characters ('.', '_', '~', and alphanumerics only), so
-// the output never contains '%XX' percent-encoded bytes and url.QueryUnescape
-// is not needed. Race-code shorthand (e.g. "Black (NH)") is left as-is because
-// the model's plain-language rules already map it to the correct data-row label.
+// without a frontend change. URLSearchParams.toString() percent-encodes the
+// tilde character (~) as %7E, so url.QueryUnescape must be applied first to
+// restore it before the four custom substitutions run. Race-code shorthand
+// (e.g. "Black (NH)") is left as-is because the model's plain-language rules
+// already map it to the correct data-row label.
 func decodeGroupParam(param string) string {
 	if param == "" {
 		return ""
+	}
+	unescaped, err := url.QueryUnescape(param)
+	if err != nil {
+		unescaped = param
 	}
 	return strings.NewReplacer(
 		".NH", " (NH)",
 		"_", " ",
 		"~", "/",
 		"PLUS", "+",
-	).Replace(param)
+	).Replace(unescaped)
 }
 
 // parseGroupParams returns the decoded group1 and group2 values from a

--- a/server/testdata/insight_prompts/contrast_compare_geos_active_group.json
+++ b/server/testdata/insight_prompts/contrast_compare_geos_active_group.json
@@ -1,0 +1,34 @@
+{
+  "kind": "contrast",
+  "why": "Compare-geo (same topic, different places) with a specific group selected. The active group from urlParams restricts the guidance to that group's geographic comparison.",
+  "hashId": "rate-map",
+  "demographicType": "race_and_ethnicity",
+  "urlPathname": "/exploredata",
+  "urlParams": "mls=1.hiv-3.00-5.13&mlp=comparegeos&group1=Black.NH&group2=Black.NH",
+  "viewA": {
+    "topic": "HIV diagnoses",
+    "location": "Georgia",
+    "metricConfig": {
+      "metricId": "hiv_diagnoses_per_100k",
+      "shortLabel": "cases per 100k"
+    },
+    "rows": [
+      { "fips_name": "Fulton County", "race_and_ethnicity": "All", "hiv_diagnoses_per_100k": 31.2 },
+      { "fips_name": "Fulton County", "race_and_ethnicity": "Black or African American (NH)", "hiv_diagnoses_per_100k": 58.4 },
+      { "fips_name": "DeKalb County", "race_and_ethnicity": "All", "hiv_diagnoses_per_100k": 22.7 },
+      { "fips_name": "DeKalb County", "race_and_ethnicity": "Black or African American (NH)", "hiv_diagnoses_per_100k": 41.3 }
+    ]
+  },
+  "viewB": {
+    "topic": "HIV diagnoses",
+    "location": "Vermont",
+    "metricConfig": {
+      "metricId": "hiv_diagnoses_per_100k",
+      "shortLabel": "cases per 100k"
+    },
+    "rows": [
+      { "fips_name": "Chittenden County", "race_and_ethnicity": "All", "hiv_diagnoses_per_100k": 4.1 },
+      { "fips_name": "Chittenden County", "race_and_ethnicity": "Black or African American (NH)", "hiv_diagnoses_per_100k": 11.9 }
+    ]
+  }
+}

--- a/server/testdata/insight_prompts/contrast_compare_geos_active_group.prompt.txt
+++ b/server/testdata/insight_prompts/contrast_compare_geos_active_group.prompt.txt
@@ -1,14 +1,16 @@
-This is a choropleth map showing HIV diagnoses in Georgia by race/ethnicity. Each data row is labeled with its place and race/ethnicity group; an "All" row gives the overall rate for that place. The map currently highlights the Black or African American (NH) group — use that group's rates to describe the geographic pattern, with "All" as the baseline.
+Two side-by-side charts show the same health metric — HIV diagnoses — across race/ethnicity groups, in two different places.
 
-Data:
-- Fulton County (All): 41.2 cases per 100k
-- Fulton County (Black or African American (NH)): 68.9 cases per 100k
-- DeKalb County (All): 37.5 cases per 100k
-- DeKalb County (Black or African American (NH)): 55.1 cases per 100k
-- Chatham County (All): 22.8 cases per 100k
-- Chatham County (Black or African American (NH)): 40.3 cases per 100k
+View A (Georgia) data:
+- Fulton County (All): 31.2 cases per 100k
+- Fulton County (Black or African American (NH)): 58.4 cases per 100k
+- DeKalb County (All): 22.7 cases per 100k
+- DeKalb County (Black or African American (NH)): 41.3 cases per 100k
 
-Write a single sentence at an 8th grade reading level that captures the geographic disparity — which places have the highest and lowest rates — and what that concentration means for the people who live there. Focus on the "so what", not the chart mechanics.
+View B (Vermont) data:
+- Chittenden County (All): 4.1 cases per 100k
+- Chittenden County (Black or African American (NH)): 11.9 cases per 100k
+
+Write one sentence at an 8th grade reading level that contrasts these two views. These are maps. Focus on the geographic patterns within each place — which areas have the highest rates — and whether the same geographic concentrations appear in both places. Both maps are currently highlighting the Black (NH) group. Use that group's data as the geographic lens. Name the places or groups involved. Use only facts present in the data; do not introduce additional statistics, causal explanations, or place-specific facts that are not shown.
 
 WRITING RULES, follow these strictly:
 - Reason from the exact numbers in the data, then round hard for the reader: "nearly 40%", "about 1 in 3", "over 3 times higher". Drop the decimal places from any rate or percentage.

--- a/server/testdata/insight_prompts/contrast_compare_vars_active_group.json
+++ b/server/testdata/insight_prompts/contrast_compare_vars_active_group.json
@@ -1,0 +1,36 @@
+{
+  "kind": "contrast",
+  "why": "Compare-vars (same place, different topics) with a specific group selected. The active group is read from the urlParams field and injected into the prompt as a focus instruction.",
+  "hashId": "rate-map",
+  "demographicType": "race_and_ethnicity",
+  "urlPathname": "/exploredata",
+  "urlParams": "mls=1.avoided_care-3.severe_maternal_morbidity-5.00&mlp=comparevars&group1=Black.NH&group2=Black.NH",
+  "viewA": {
+    "topic": "Care avoidance due to cost",
+    "location": "the United States",
+    "metricConfig": {
+      "metricId": "avoided_care_pct_rate",
+      "shortLabel": "% of adults"
+    },
+    "rows": [
+      { "fips_name": "Alabama", "race_and_ethnicity": "All", "avoided_care_pct_rate": 14.2 },
+      { "fips_name": "Alabama", "race_and_ethnicity": "Black or African American (NH)", "avoided_care_pct_rate": 18.1 },
+      { "fips_name": "Georgia", "race_and_ethnicity": "All", "avoided_care_pct_rate": 13.8 },
+      { "fips_name": "Georgia", "race_and_ethnicity": "Black or African American (NH)", "avoided_care_pct_rate": 19.4 }
+    ]
+  },
+  "viewB": {
+    "topic": "Severe maternal morbidity",
+    "location": "the United States",
+    "metricConfig": {
+      "metricId": "severe_maternal_morbidity_per_100k",
+      "shortLabel": "cases per 100k deliveries"
+    },
+    "rows": [
+      { "fips_name": "Alabama", "race_and_ethnicity": "All", "severe_maternal_morbidity_per_100k": 122 },
+      { "fips_name": "Alabama", "race_and_ethnicity": "Black or African American (NH)", "severe_maternal_morbidity_per_100k": 198 },
+      { "fips_name": "Georgia", "race_and_ethnicity": "All", "severe_maternal_morbidity_per_100k": 118 },
+      { "fips_name": "Georgia", "race_and_ethnicity": "Black or African American (NH)", "severe_maternal_morbidity_per_100k": 211 }
+    ]
+  }
+}

--- a/server/testdata/insight_prompts/contrast_compare_vars_active_group.prompt.txt
+++ b/server/testdata/insight_prompts/contrast_compare_vars_active_group.prompt.txt
@@ -1,14 +1,18 @@
-This is a choropleth map showing HIV diagnoses in Georgia by race/ethnicity. Each data row is labeled with its place and race/ethnicity group; an "All" row gives the overall rate for that place. The map currently highlights the Black or African American (NH) group — use that group's rates to describe the geographic pattern, with "All" as the baseline.
+Two side-by-side charts show the United States, one for Care avoidance due to cost and one for Severe maternal morbidity, across race/ethnicity groups.
 
-Data:
-- Fulton County (All): 41.2 cases per 100k
-- Fulton County (Black or African American (NH)): 68.9 cases per 100k
-- DeKalb County (All): 37.5 cases per 100k
-- DeKalb County (Black or African American (NH)): 55.1 cases per 100k
-- Chatham County (All): 22.8 cases per 100k
-- Chatham County (Black or African American (NH)): 40.3 cases per 100k
+View A (Care avoidance due to cost) data:
+- Alabama (All): 14.2 % of adults
+- Alabama (Black or African American (NH)): 18.1 % of adults
+- Georgia (All): 13.8 % of adults
+- Georgia (Black or African American (NH)): 19.4 % of adults
 
-Write a single sentence at an 8th grade reading level that captures the geographic disparity — which places have the highest and lowest rates — and what that concentration means for the people who live there. Focus on the "so what", not the chart mechanics.
+View B (Severe maternal morbidity) data:
+- Alabama (All): 122 cases per 100k deliveries
+- Alabama (Black or African American (NH)): 198 cases per 100k deliveries
+- Georgia (All): 118 cases per 100k deliveries
+- Georgia (Black or African American (NH)): 211 cases per 100k deliveries
+
+Write one sentence at an 8th grade reading level that contrasts these two views. These are maps. Focus on the geographic pattern for each condition — which places carry the highest rates — and whether the same places face a heavy burden for both topics. Both maps are currently highlighting the Black (NH) group. Use that group's geographic rates as the primary lens for the comparison. Name the places or groups involved. Use only facts present in the data; do not introduce additional statistics, causal explanations, or place-specific facts that are not shown.
 
 WRITING RULES, follow these strictly:
 - Reason from the exact numbers in the data, then round hard for the reader: "nearly 40%", "about 1 in 3", "over 3 times higher". Drop the decimal places from any rate or percentage.


### PR DESCRIPTION
## Summary

- Server now parses highlighted demographic group (`group1`, `group2`) from URL parameters in the insight request descriptor
- Differentiates contrast insight guidance based on chart type: maps focus on geographic disparity with highlighted group as geographic lens; non-maps retain group-burden framing  
- Adds explicit geographic framing for map cards: "which places have the highest and lowest rates"
- Adds explicit demographic framing for rate-chart cards: "which group faces the highest rate, how much higher"
- Insight prompts now align with chart intent rather than generating insights about invisible data

## Impact

Fixes contrast insights that generated cross-group divergences (e.g., Indigenous Tennessee care avoidance vs. Black maternal morbidity) when user highlighted a specific demographic group on maps. Ensures insights reason from visible data: maps focus on geographic concentration, rate charts on demographic burden, time series on temporal change.

## Test plan

- [x] All 236 Go tests pass (`(cd server && go test ./...)`)
- [x] New contrast fixtures verify group parsing from URL params flows through prompts to guidance instructions
- [x] Existing contrast and card fixtures verified unchanged (one fixture regenerated for geographic guidance change)

Closes #5220

🤖 Generated with [Claude Code](https://claude.com/claude-code)
