### PR TITLE
Name the subpopulation on severe maternal morbidity cards

### DIFF
--- a/frontend/src/data/config/MetricConfigMaternalHealth.ts
+++ b/frontend/src/data/config/MetricConfigMaternalHealth.ts
@@ -95,6 +95,11 @@ export const SEVERE_MATERNAL_MORBIDITY_METRICS: DataTypeConfig[] = [
       ],
     },
     dataTableTitle: 'Summary for severe maternal morbidity',
+    // No ageSubPopulationLabel on purpose. AHR bounds this measure by the
+    // delivery hospitalization, not by age, and its own age buckets are open at
+    // both ends (<20 through 35+), so any "Ages X-Y" here would be invented.
+    // The sibling maternal_mortality label is real: that source models ages 10-54.
+    otherSubPopulationLabel: 'Birthing People',
     metrics: {
       per100k: {
         timeSeriesCadence: 'yearly',


### PR DESCRIPTION
**Preview:** [SMM map card, Black highlighted](https://deploy-preview-5233--health-equity-tracker.netlify.app/exploredata?mls=1.severe_maternal_morbidity&mlp=disparity&demo=race_and_ethnicity&group1=Black.NH)

## Summary

Highlighting a race group on the severe maternal morbidity map card produced a subtitle naming only the race group. The sibling maternal mortality card reads "New Mothers, Black or African American (NH), Ages 10-54".

`generateSubtitle` (`charts/utils.ts:63`) joins `[otherSubPopulationLabel, activeGroupLabel, ageSubPopulationLabel]`. `SEVERE_MATERNAL_MORBIDITY_METRICS` set neither label, so the first and last slots were empty and only the group name survived.

## Why only one of the two labels is set

`otherSubPopulationLabel: 'Birthing People'` is added. `ageSubPopulationLabel` is deliberately left off, and the config carries a comment saying why.

Maternal mortality's `'Ages 10-54'` is a real property of its source: births and deaths were both modeled over ages 10 to 54. Severe maternal morbidity has no equivalent. AHR publishes it as "significant life-threatening maternal complications during delivery per 10,000 delivery hospitalizations" — bounded by the delivery, not by age — and the age buckets we ingest are open at both ends (`<20`, `20-24`, `25-29`, `30-34`, `35+`, see `graphql_ahr.py:51`). Any "Ages X-Y" in that slot would be invented rather than sourced.

The comment matters more than the one-line change: the asymmetry with the card directly above it otherwise reads as an oversight, and the obvious "fix" is to make up a range.

## Wording

"Birthing People" is the phrasing already used in this config's own definition text ("...serious short- or long-term consequences to women and birthing people's health"), so the card and the definition agree.

## Blast radius

Three call sites read these fields. Only the subtitle changes:

- `charts/utils.ts:63` — `generateSubtitle`, the intended change
- `cards/ui/geoContextHelpers.ts:23` — returns `''` early when the config has no `rateDenominatorMetric`. SMM is rate-only by design (AHR gives no delivery-count denominator by race), so this path stays inert and no "Total population of..." phrase appears
- `cards/ui/DemographicGroupMenu.tsx:136` and `cards/RateBarChartCard.tsx:172` — read `ageSubPopulationLabel` only, which is unset

## Test plan

- [ ] Map card subtitle reads "Birthing People, Black or African American (NH)" with a race group highlighted
- [ ] No "Total population of Birthing People" phrase appears anywhere, since SMM has no rate denominator
- [ ] Maternal mortality subtitle is unchanged
- [x] No existing spec asserts the old SMM subtitle (grepped `playwright-tests/` and `src/`)
