### PR TITLE
fix: add contains_nh to maternal mortality race dataset entries

### DIFF
--- a/frontend/src/data/config/DatasetMetadataMaternalHealthCategory.ts
+++ b/frontend/src/data/config/DatasetMetadataMaternalHealthCategory.ts
@@ -18,21 +18,25 @@ export const DatasetMetadataMapMaternalHealthCategory: Record<
     name: 'Maternal Mortality, by race, nationally',
     original_data_sourced: '2019',
     source_id: 'maternal_health',
+    contains_nh: true,
   },
   'maternal_mortality_data-race_and_ethnicity_national_historical': {
     name: 'Maternal Mortality, by race, nationally',
     original_data_sourced: '1999 - 2019',
     source_id: 'maternal_health',
+    contains_nh: true,
   },
   'maternal_mortality_data-race_and_ethnicity_state_current': {
     name: 'Maternal Mortality, by race and state',
     original_data_sourced: '2019',
     source_id: 'maternal_health',
+    contains_nh: true,
   },
   'maternal_mortality_data-race_and_ethnicity_state_historical': {
     name: 'Maternal Mortality, by race and state',
     original_data_sourced: '1999 - 2019',
     source_id: 'maternal_health',
+    contains_nh: true,
   },
   'maternal_mortality_data-alls_national_current': {
     name: 'Maternal Mortality, nationally',


### PR DESCRIPTION
The (NH) footnote was not displaying on maternal mortality cards even though the race categories use NH codes.

The card footer checks `DatasetMetadataMap[id]?.contains_nh`. All eight MM dataset entries were missing this flag, so the footnote check always failed. Compare with AHR datasets, which all correctly have `contains_nh: true`.

## Summary

- Add `contains_nh: true` to four race-stratified MM dataset entries in `DatasetMetadataMaternalHealthCategory.ts`
- Alls entries correctly remain without the flag (no NH breakdown by definition)

## Impact

Maternal mortality cards now display the (NH) footnote consistently with other topics using NH race categories.

## Test plan

- [x] TypeScript type check passes
- [x] Biome lint passes

Closes #5225

🤖 Generated with [Claude Code](https://claude.com/claude-code)
