### PR TITLE
chore(skills): open /pr and /merge with PR summary

### DIFF
--- a/.claude/skills/merge/SKILL.md
+++ b/.claude/skills/merge/SKILL.md
@@ -14,7 +14,7 @@ The user may pass a PR number as an argument (e.g. `/merge 4764`). If none is gi
 ## Step 1 — Identify the PR and derive fork remote
 
 ```bash
-gh pr view [<number>] --json number,title,headRefName,baseRefName,state
+gh pr view [<number>] --json number,title,body,headRefName,baseRefName,state
 ```
 
 Confirm:
@@ -22,6 +22,8 @@ Confirm:
 - `baseRefName` is `main`
 
 If the PR is already merged or closed: print a message and stop.
+
+**Output one sentence describing what this PR does** — plainest possible language, no jargon. Read the title and body to derive it. Say it as your first line of output so the user immediately knows you're merging the right thing.
 
 Derive the personal fork remote:
 

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -22,6 +22,8 @@ gh pr view <number> --json number,title,body,headRefName,baseRefName
 
 If no open PR is found: print an error and stop.
 
+**Before doing anything else, output one sentence describing what this PR does** — the plainest possible language, no jargon. Read the title and body to derive it. Example: "This PR adds the (NH) footnote to maternal mortality cards by setting contains_nh on the race dataset entries." Say it as your first line of output so the user immediately knows you're working on the right thing.
+
 **Check out the PR's branch before doing anything else.** When a PR number is passed, the working tree is often still on `main` (or another branch). Every later step — Biome, tsc, the behind-main merge check, review fixes — must run against the PR's own branch, so switch to it now:
 
 ```bash


### PR DESCRIPTION
Both /pr and /merge skills now open with a one-sentence plain-language description of what the PR does, so the user immediately knows you're working on the right thing.

## Summary

- /pr: Before any checks, output what the PR does in plainest language
- /merge: Before force-merging, output what the PR does in plainest language
- Example: "This PR adds the (NH) footnote to maternal mortality cards" instead of just launching into technical checks

## Impact

Improves clarity and confirmation for high-consequence operations (/merge especially). User sees exactly what they're about to merge before any irreversible action.

## Test plan

- [x] Skill files update correctly
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
