### PR TITLE
fix: detect DAG rewrites via GCS generation, cut staleness to 30s

### DIFF
--- a/server/CLAUDE.md
+++ b/server/CLAUDE.md
@@ -49,7 +49,9 @@ go test ./...
 The server handles all traffic on a single port:
 
 - **Data requests** (`/dataset`, `/metadata`): served from GCS via a 150 MB byte-aware LRU
-  cache with a 2-hour TTL. NDJSON files are converted to JSON arrays on the fly.
+  cache with a 2-hour TTL. On each cache hit, GCS metadata is checked every 30 seconds to detect
+  DAG rewrites (via generation number change); `/dataset` responses carry `Cache-Control: no-cache`
+  and `ETag: <generation>` to let browsers revalidate cheaply. NDJSON files are converted to JSON arrays on the fly.
 - **AI insights** (`/insight`): the caller posts what the view is showing (kind, hash ID,
   topic, location, metric configs, rendered rows, URL pathname and params). The server renders
   the prompt from those templates, derives the cache key from the rendered text, then checks a

--- a/server/cache.go
+++ b/server/cache.go
@@ -11,10 +11,15 @@ const (
 	cacheTTL      = 2 * time.Hour
 )
 
+// checkInterval is a var so tests can set it to 0 to force generation checks.
+var checkInterval = 30 * time.Second
+
 type cacheEntry struct {
-	key     string
-	data    []byte
-	expires time.Time
+	key        string
+	data       []byte
+	expires    time.Time
+	generation int64
+	checkedAt  time.Time
 }
 
 // byteCache is a thread-safe byte-aware LRU cache with per-entry TTL.
@@ -38,26 +43,33 @@ func newByteCache(maxBytes int64, ttl time.Duration) *byteCache {
 }
 
 func (c *byteCache) get(key string) ([]byte, bool) {
+	data, _, _, ok := c.getWithMeta(key)
+	return data, ok
+}
+
+// getWithMeta returns cached data plus generation and checkedAt, all read under the lock.
+func (c *byteCache) getWithMeta(key string) (data []byte, generation int64, checkedAt time.Time, ok bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	el, ok := c.items[key]
-	if !ok {
-		return nil, false
+	el, elOk := c.items[key]
+	if !elOk {
+		return
 	}
 	entry := el.Value.(*cacheEntry)
 	if time.Now().After(entry.expires) {
 		c.removeElement(el)
-		return nil, false
+		return
 	}
 	c.ll.MoveToFront(el)
-	return entry.data, true
+	return entry.data, entry.generation, entry.checkedAt, true
 }
 
-func (c *byteCache) set(key string, data []byte) {
+func (c *byteCache) set(key string, data []byte, generation int64) {
 	// Ignore items larger than the entire cache budget
 	if int64(len(data)) > c.maxBytes {
 		return
 	}
+	now := time.Now()
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if el, ok := c.items[key]; ok {
@@ -65,7 +77,9 @@ func (c *byteCache) set(key string, data []byte) {
 		entry := el.Value.(*cacheEntry)
 		c.size -= int64(len(entry.data))
 		entry.data = data
-		entry.expires = time.Now().Add(c.ttl)
+		entry.expires = now.Add(c.ttl)
+		entry.generation = generation
+		entry.checkedAt = now
 		c.size += int64(len(data))
 		// Re-enforce byte budget after updating existing entry
 		for c.size > c.maxBytes && c.ll.Len() > 0 {
@@ -73,12 +87,21 @@ func (c *byteCache) set(key string, data []byte) {
 		}
 		return
 	}
-	entry := &cacheEntry{key: key, data: data, expires: time.Now().Add(c.ttl)}
+	entry := &cacheEntry{key: key, data: data, expires: now.Add(c.ttl), generation: generation, checkedAt: now}
 	el := c.ll.PushFront(entry)
 	c.items[key] = el
 	c.size += int64(len(data))
 	for c.size > c.maxBytes && c.ll.Len() > 0 {
 		c.removeElement(c.ll.Back())
+	}
+}
+
+// touch updates checkedAt for an existing entry to suppress redundant GCS metadata calls.
+func (c *byteCache) touch(key string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if el, ok := c.items[key]; ok {
+		el.Value.(*cacheEntry).checkedAt = time.Now()
 	}
 }
 

--- a/server/gcs.go
+++ b/server/gcs.go
@@ -32,6 +32,30 @@ func downloadBlob(ctx context.Context, bucket, name string) ([]byte, error) {
 	return io.ReadAll(r)
 }
 
+// downloadBlobWithGeneration fetches an object and returns its GCS generation number
+// alongside the bytes, so callers get data and generation in a single round trip.
+func downloadBlobWithGeneration(ctx context.Context, bucket, name string) ([]byte, int64, error) {
+	r, err := getGCSClient().Bucket(bucket).Object(name).NewReader(ctx)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer r.Close()
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, 0, err
+	}
+	return data, r.Attrs.Generation, nil
+}
+
+// getGCSGeneration issues a metadata-only request to read the current generation number.
+func getGCSGeneration(ctx context.Context, bucket, name string) (int64, error) {
+	attrs, err := getGCSClient().Bucket(bucket).Object(name).Attrs(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return attrs.Generation, nil
+}
+
 func uploadBlob(ctx context.Context, bucket, name string, data []byte, contentType string) error {
 	w := getGCSClient().Bucket(bucket).Object(name).NewWriter(ctx)
 	w.ContentType = contentType

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -10,29 +11,61 @@ import (
 	"time"
 )
 
-const cacheControlHeader = "public, max-age=7200"
+// no-cache + ETag lets browsers revalidate on every request while still getting
+// cheap 304s when the data has not changed. The previous max-age=7200 meant a
+// browser that fetched before a DAG rerun held the old payload for two hours
+// regardless of what the server did.
+const cacheControlHeader = "no-cache"
 
 var datasetCache = newByteCache(maxCacheBytes, cacheTTL)
 
-// gcsDownload is the function used to fetch blobs from GCS. Tests replace it
-// with a mock so that metadataHandler and datasetHandler can be exercised
-// through the real code path without needing a GCS connection.
-var gcsDownload = func(ctx context.Context, bucket, name string) ([]byte, error) {
-	return downloadBlob(ctx, bucket, name)
+// gcsDownload fetches an object and its GCS generation number in one round trip.
+// Tests replace it with a mock.
+var gcsDownload = func(ctx context.Context, bucket, name string) ([]byte, int64, error) {
+	return downloadBlobWithGeneration(ctx, bucket, name)
 }
 
-func cachedDownload(ctx context.Context, bucket, name string) ([]byte, error) {
-	if data, ok := datasetCache.get(name); ok {
-		return data, nil
+// gcsGeneration fetches only the GCS generation number (metadata-only request).
+// Tests replace it with a mock.
+var gcsGeneration = func(ctx context.Context, bucket, name string) (int64, error) {
+	return getGCSGeneration(ctx, bucket, name)
+}
+
+// cachedDownload returns cached bytes and the GCS generation number for the object.
+// On a cache hit it checks GCS metadata every checkInterval to detect DAG rewrites
+// without waiting out the full cacheTTL.
+func cachedDownload(ctx context.Context, bucket, name string) ([]byte, int64, error) {
+	if data, gen, checkedAt, ok := datasetCache.getWithMeta(name); ok {
+		if time.Since(checkedAt) < checkInterval {
+			return data, gen, nil
+		}
+		currentGen, err := gcsGeneration(ctx, bucket, name)
+		if err != nil {
+			// Serve stale rather than error on a transient metadata failure.
+			return data, gen, nil
+		}
+		if currentGen == gen {
+			datasetCache.touch(name)
+			return data, gen, nil
+		}
+		// Object was rewritten by a DAG run; fetch the new version.
+		dlCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		newData, _, fetchErr := gcsDownload(dlCtx, bucket, name)
+		if fetchErr != nil {
+			return nil, 0, fetchErr
+		}
+		datasetCache.set(name, newData, currentGen)
+		return newData, currentGen, nil
 	}
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	dlCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	data, err := gcsDownload(ctx, bucket, name)
+	data, gen, err := gcsDownload(dlCtx, bucket, name)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	datasetCache.set(name, data)
-	return data, nil
+	datasetCache.set(name, data, gen)
+	return data, gen, nil
 }
 
 // ndjsonToArray converts NDJSON bytes to a JSON array, preserving each line verbatim.
@@ -76,7 +109,7 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 func metadataHandler(w http.ResponseWriter, r *http.Request) {
 	bucket := os.Getenv("GCS_BUCKET")
 	filename := os.Getenv("METADATA_FILENAME")
-	data, err := cachedDownload(r.Context(), bucket, filename)
+	data, _, err := cachedDownload(r.Context(), bucket, filename)
 	if err != nil {
 		log.Printf("metadata error: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -99,15 +132,21 @@ func datasetHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	bucket := os.Getenv("GCS_BUCKET")
-	data, err := cachedDownload(r.Context(), bucket, name)
+	data, gen, err := cachedDownload(r.Context(), bucket, name)
 	if err != nil {
 		log.Printf("dataset error for %q: %v", name, err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
 	}
+	etag := fmt.Sprintf(`"%d"`, gen)
 	w.Header().Set("Content-Disposition", "attachment; filename="+name)
 	w.Header().Set("Vary", "Accept-Encoding")
 	w.Header().Set("Cache-Control", cacheControlHeader)
+	w.Header().Set("ETag", etag)
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
 	if strings.HasSuffix(name, ".csv") {
 		w.Header().Set("Content-Type", "text/csv")
 		w.Write(data)

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -41,7 +41,8 @@ func cachedDownload(ctx context.Context, bucket, name string) ([]byte, int64, er
 		}
 		currentGen, err := gcsGeneration(ctx, bucket, name)
 		if err != nil {
-			// Serve stale rather than error on a transient metadata failure.
+			// Serve stale on transient metadata failure; touch so we don't hammer GCS every request.
+			datasetCache.touch(name)
 			return data, gen, nil
 		}
 		if currentGen == gen {
@@ -51,12 +52,13 @@ func cachedDownload(ctx context.Context, bucket, name string) ([]byte, int64, er
 		// Object was rewritten by a DAG run; fetch the new version.
 		dlCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
-		newData, _, fetchErr := gcsDownload(dlCtx, bucket, name)
+		newData, actualGen, fetchErr := gcsDownload(dlCtx, bucket, name)
 		if fetchErr != nil {
-			return nil, 0, fetchErr
+			// Serve stale rather than 500 — cache still holds a consistent data/generation pair.
+			return data, gen, nil
 		}
-		datasetCache.set(name, newData, currentGen)
-		return newData, currentGen, nil
+		datasetCache.set(name, newData, actualGen)
+		return newData, actualGen, nil
 	}
 	dlCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()

--- a/server/main_test.go
+++ b/server/main_test.go
@@ -26,20 +26,28 @@ var testNDJSON = []byte(
 var testCSV = []byte("label1,label2,label3\nvalueA,valueB,valueC\nvalueD,valueE,valueF\n")
 
 type mockGCS struct {
-	data map[string][]byte
-	err  error
-	hits int
+	data       map[string][]byte
+	err        error
+	hits       int
+	generation int64
 }
 
-func (m *mockGCS) download(_, name string) ([]byte, error) {
+func (m *mockGCS) download(_, name string) ([]byte, int64, error) {
 	m.hits++
 	if m.err != nil {
-		return nil, m.err
+		return nil, 0, m.err
 	}
 	if d, ok := m.data[name]; ok {
-		return d, nil
+		return d, m.generation, nil
 	}
-	return nil, &mockNotFoundError{name: name}
+	return nil, 0, &mockNotFoundError{name: name}
+}
+
+func (m *mockGCS) getGeneration(_, name string) (int64, error) {
+	if _, ok := m.data[name]; !ok {
+		return 0, &mockNotFoundError{name: name}
+	}
+	return m.generation, nil
 }
 
 type mockNotFoundError struct{ name string }
@@ -54,8 +62,11 @@ func newTestRouter(t *testing.T, mock *mockGCS) http.Handler {
 	t.Setenv("GCS_BUCKET", "test-bucket")
 	t.Setenv("METADATA_FILENAME", "test_data.ndjson")
 	datasetCache = newByteCache(maxCacheBytes, cacheTTL)
-	gcsDownload = func(_ context.Context, bucket, name string) ([]byte, error) {
+	gcsDownload = func(_ context.Context, bucket, name string) ([]byte, int64, error) {
 		return mock.download(bucket, name)
+	}
+	gcsGeneration = func(_ context.Context, bucket, name string) (int64, error) {
+		return mock.getGeneration(bucket, name)
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /metadata", metadataHandler)
@@ -193,7 +204,7 @@ func TestNdjsonToArray(t *testing.T) {
 
 func TestByteCacheTTLExpiry(t *testing.T) {
 	c := newByteCache(1024, 10*time.Millisecond)
-	c.set("key", []byte("value"))
+	c.set("key", []byte("value"), 1)
 	if _, ok := c.get("key"); !ok {
 		t.Fatal("expected cache hit before TTL")
 	}
@@ -205,13 +216,71 @@ func TestByteCacheTTLExpiry(t *testing.T) {
 
 func TestByteCacheEviction(t *testing.T) {
 	c := newByteCache(5, time.Hour)
-	c.set("a", []byte("12345"))
-	c.set("b", []byte("67890")) // should evict "a"
+	c.set("a", []byte("12345"), 1)
+	c.set("b", []byte("67890"), 1) // should evict "a"
 	if _, ok := c.get("a"); ok {
 		t.Error("expected 'a' to be evicted")
 	}
 	if _, ok := c.get("b"); !ok {
 		t.Error("expected 'b' to be present")
+	}
+}
+
+func TestCachedDownloadRefetchesOnGenerationChange(t *testing.T) {
+	updated := []byte(`{"col":"new"}` + "\n")
+	mock := &mockGCS{
+		data:       map[string][]byte{"test_dataset": testNDJSON},
+		generation: 1,
+	}
+	h := newTestRouter(t, mock)
+
+	// Prime the cache.
+	rr := get(h, "/dataset?name=test_dataset")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	if mock.hits != 1 {
+		t.Fatalf("expected 1 GCS download, got %d", mock.hits)
+	}
+
+	// Force the generation check path by setting checkInterval to 0.
+	old := checkInterval
+	checkInterval = 0
+	defer func() { checkInterval = old }()
+
+	// Simulate a DAG rerun: new data and a new generation in GCS.
+	mock.data["test_dataset"] = updated
+	mock.generation = 2
+
+	rr = get(h, "/dataset?name=test_dataset")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 after generation change, got %d", rr.Code)
+	}
+	if mock.hits != 2 {
+		t.Errorf("expected 2 GCS downloads after generation change, got %d", mock.hits)
+	}
+	if !strings.Contains(rr.Body.String(), "new") {
+		t.Error("expected response to contain updated data")
+	}
+}
+
+func TestCachedDownloadSkipsGCSWhenGenerationUnchanged(t *testing.T) {
+	mock := &mockGCS{
+		data:       map[string][]byte{"test_dataset": testNDJSON},
+		generation: 1,
+	}
+	h := newTestRouter(t, mock)
+
+	get(h, "/dataset?name=test_dataset")
+
+	old := checkInterval
+	checkInterval = 0
+	defer func() { checkInterval = old }()
+
+	// Same generation, same data — should not re-download.
+	get(h, "/dataset?name=test_dataset")
+	if mock.hits != 1 {
+		t.Errorf("expected 1 GCS download (generation unchanged), got %d", mock.hits)
 	}
 }
 


### PR DESCRIPTION
Server detects DAG rewrites within 30 seconds by checking GCS generation number, eliminating the 2-hour staleness window for production fixes.

The `/api/dataset` endpoint now checks GCS object generation every 30s; if it has changed, the object is re-fetched immediately. Combined with `Cache-Control: no-cache` + `ETag: <generation>` on the response, both the server-side staleness window (30s) and the browser-side window (previously 2h) are eliminated.

## Summary

- `cachedDownload` verifies GCS generation every 30s; re-fetches if changed
- `downloadBlobWithGeneration` gets data + generation in one round trip via `Reader.Attrs.Generation`
- Server responses carry `ETag: <generation>` and `Cache-Control: no-cache`; browsers get 304 Not Modified on revalidation
- On metadata check or re-download transient failure, serves cached data instead of 500 for availability
- Two new tests: generation-change detection and unchanged-generation fast path

## Impact

Production data fixes are now visible to users within 30 seconds instead of 2 hours. Repeat browser visits after a DAG rerun avoid downloading unchanged payloads (304 Not Modified). Metadata timeouts and transient GCS errors no longer block dataset serving.

## Test plan

- [x] `go test ./...` in server/ — all tests pass
- [x] Generation-change detection verified by TestCachedDownloadRefetchesOnGenerationChange
- [x] Unchanged-generation caching verified by TestCachedDownloadSkipsGCSWhenGenerationUnchanged
- [x] ETag/304 behavior wired (datasetHandler sets ETag, checks If-None-Match)
- [x] CodeRabbit fixes: use actual generation from gcsDownload; serve stale on re-download failure

Closes #5173

🤖 Generated with [Claude Code](https://claude.com/claude-code)
