### PR TITLE
fix(a11y): forced-colors support and simpler ARIA patterns

### DIFF
--- a/frontend/playwright-tests/wihe.ci.spec.ts
+++ b/frontend/playwright-tests/wihe.ci.spec.ts
@@ -20,7 +20,7 @@ test('Default Guides tab is loaded on /whatishealthequity', async ({
 }) => {
   await page.goto('/whatishealthequity', { waitUntil: 'commit' })
 
-  const guidesTab = await page.getByRole('button', {
+  const guidesTab = await page.getByRole('tab', {
     name: 'Data Visualization Guides',
   })
   await expect(guidesTab).toHaveText('Data Visualization Guides')

--- a/frontend/playwright-tests/wihe.ci.spec.ts
+++ b/frontend/playwright-tests/wihe.ci.spec.ts
@@ -20,7 +20,7 @@ test('Default Guides tab is loaded on /whatishealthequity', async ({
 }) => {
   await page.goto('/whatishealthequity', { waitUntil: 'commit' })
 
-  const guidesTab = await page.getByRole('tab', {
+  const guidesTab = await page.getByRole('button', {
     name: 'Data Visualization Guides',
   })
   await expect(guidesTab).toHaveText('Data Visualization Guides')

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -281,18 +281,24 @@ button[data-action="back"]:focus {
 
 /* Windows forced-colors (High Contrast) mode */
 @media (forced-colors: active) {
+	/* Named aliases so the intent is obvious at each use site */
+	:root {
+		--a11y-contrast-border: ButtonText;
+		--a11y-contrast-selected: Highlight;
+		--a11y-contrast-disabled: GrayText;
+	}
+
 	/* Buttons without explicit borders become invisible when backgrounds are stripped */
 	button:not([disabled]),
-	[role="button"]:not([disabled]),
-	[role="tab"]:not([disabled]) {
-		border: 1px solid ButtonText !important;
+	[role="button"]:not([disabled]) {
+		border: 1px solid var(--a11y-contrast-border) !important;
 	}
 
 	/* Selected and pressed states: outline replaces stripped background-color cues */
 	[aria-selected="true"],
 	[aria-pressed="true"],
 	.Mui-selected {
-		outline: 3px solid Highlight !important;
+		outline: 3px solid var(--a11y-contrast-selected) !important;
 		outline-offset: -3px;
 	}
 
@@ -300,7 +306,7 @@ button[data-action="back"]:focus {
 	button[disabled],
 	[aria-disabled="true"],
 	.Mui-disabled {
-		color: GrayText !important;
-		border-color: GrayText !important;
+		color: var(--a11y-contrast-disabled) !important;
+		border-color: var(--a11y-contrast-disabled) !important;
 	}
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -278,3 +278,29 @@ button[data-action="back"]:focus {
 		opacity: 1;
 	}
 }
+
+/* Windows forced-colors (High Contrast) mode */
+@media (forced-colors: active) {
+	/* Buttons without explicit borders become invisible when backgrounds are stripped */
+	button:not([disabled]),
+	[role="button"]:not([disabled]),
+	[role="tab"]:not([disabled]) {
+		border: 1px solid ButtonText !important;
+	}
+
+	/* Selected and pressed states: outline replaces stripped background-color cues */
+	[aria-selected="true"],
+	[aria-pressed="true"],
+	.Mui-selected {
+		outline: 3px solid Highlight !important;
+		outline-offset: -3px;
+	}
+
+	/* Disabled elements use system GrayText */
+	button[disabled],
+	[aria-disabled="true"],
+	.Mui-disabled {
+		color: GrayText !important;
+		border-color: GrayText !important;
+	}
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -289,8 +289,9 @@ button[data-action="back"]:focus {
 	}
 
 	/* Buttons without explicit borders become invisible when backgrounds are stripped */
-	button:not([disabled]),
-	[role="button"]:not([disabled]) {
+	button:not([disabled]):not([aria-disabled="true"]),
+	[role="button"]:not([disabled]):not([aria-disabled="true"]),
+	[role="menuitem"]:not([disabled]) {
 		border: 1px solid var(--a11y-contrast-border) !important;
 	}
 

--- a/frontend/src/pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu.tsx
@@ -23,7 +23,7 @@ export default function WIHECardMenu({
   onTabChange,
 }: WIHECardMenuProps) {
   return (
-    <nav className='mb-4 flex justify-center'>
+    <nav role='tablist' className='mb-4 flex justify-center'>
       <HetTabButton
         isActiveTab={activeTab === 'guides'}
         onClick={() => onTabChange('guides')}
@@ -50,6 +50,8 @@ interface HetTabButtonProps {
 function HetTabButton(props: HetTabButtonProps) {
   return (
     <button
+      role='tab'
+      aria-selected={props.isActiveTab}
       className={`mx-2 cursor-pointer rounded rounded-sm px-8 py-4 text-center font-sans-title font-semibold text-title no-underline ${props.isActiveTab ? 'cursor-auto border-0 bg-methodology-green text-alt-black shadow-raised' : 'border border-divider-gray bg-alt-white text-alt-green'}`}
       type='button'
       onClick={props.onClick}

--- a/frontend/src/pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/wiheComponents/WIHECardMenu.tsx
@@ -23,7 +23,7 @@ export default function WIHECardMenu({
   onTabChange,
 }: WIHECardMenuProps) {
   return (
-    <nav role='tablist' className='mb-4 flex justify-center'>
+    <nav className='mb-4 flex justify-center'>
       <HetTabButton
         isActiveTab={activeTab === 'guides'}
         onClick={() => onTabChange('guides')}
@@ -50,8 +50,7 @@ interface HetTabButtonProps {
 function HetTabButton(props: HetTabButtonProps) {
   return (
     <button
-      role='tab'
-      aria-selected={props.isActiveTab}
+      aria-pressed={props.isActiveTab}
       className={`mx-2 cursor-pointer rounded rounded-sm px-8 py-4 text-center font-sans-title font-semibold text-title no-underline ${props.isActiveTab ? 'cursor-auto border-0 bg-methodology-green text-alt-black shadow-raised' : 'border border-divider-gray bg-alt-white text-alt-green'}`}
       type='button'
       onClick={props.onClick}

--- a/frontend/src/styles/HetComponents/HetExpandableBoxButton.tsx
+++ b/frontend/src/styles/HetComponents/HetExpandableBoxButton.tsx
@@ -13,6 +13,7 @@ export default function HetExpandableBoxButton(
   return (
     <button
       type='button'
+      aria-expanded={props.expanded}
       onClick={() => {
         props.setExpanded(!props.expanded)
       }}


### PR DESCRIPTION
**Preview:** [What is Health Equity page](https://deploy-preview-5242--health-equity-tracker.netlify.app/whatishealthequity)

Adds Windows High Contrast mode support by implementing `@media (forced-colors: active)` CSS with named accessibility tokens, and fixes ARIA semantics on toggle buttons by using `aria-pressed` instead of an incomplete tab pattern.

## Summary

- Add `@media (forced-colors: active)` CSS with named `--a11y-contrast-*` tokens for forced-colors system colors (`ButtonText`, `Highlight`, `GrayText`)
- Add `:not([aria-disabled="true"])` exclusion and `[role="menuitem"]` selector to ensure buttons marked disabled (semantically or with aria-disabled) don't receive forced-colors borders
- Replace incomplete `role="tab"` + `aria-selected` pattern with simpler `aria-pressed` on toggle buttons; remove `role="tablist"` from container
- Add `aria-expanded` to `HetExpandableBoxButton` for semantic communication of expanded/collapsed state
- Fixes invisible buttons, invisible toggle states, and invisible selected tabs when Windows forced-colors mode is enabled

## Impact

Improves accessibility for users with Windows High Contrast mode enabled (OS setting: Settings > Personalization > Colors > High Contrast). Changes are zero-impact for normal display — the `@media (forced-colors: active)` block only applies when forced-colors mode is active.

## Test plan

- [x] Axe accessibility scan passes (validates ARIA attributes and semantic structure)
- [x] aria-pressed state toggles correctly on WIHE tab buttons
- [x] aria-expanded state toggles correctly on expandable boxes
- [x] Biome formatting passes
- [x] TypeScript type check passes

Closes #1046

🤖 Generated with [Claude Code](https://claude.com/claude-code)
