### PR TITLE
fix(a11y): eliminate duplicate IDs and broken ARIA references

### DIFF
--- a/frontend/src/cards/ui/DemographicGroupMenu.tsx
+++ b/frontend/src/cards/ui/DemographicGroupMenu.tsx
@@ -144,7 +144,6 @@ function DemographicGroupMenu(props: DemographicGroupMenuProps) {
       <label
         className='flex items-center px-2 py-1.5 text-small'
         htmlFor={`groupMenu${props?.idSuffix ?? ''}`}
-        aria-hidden={true}
       >
         {demOption}:
       </label>
@@ -166,9 +165,7 @@ function DemographicGroupMenu(props: DemographicGroupMenuProps) {
       </Button>
 
       <MenuPopover
-        aria-labelledby={`#groupMenu${props?.idSuffix ?? ''}`}
         popover={firstMenu}
-        aria-expanded='true'
         items={oneLevelMenu ? Object.values(props.options)[0] : props.options}
         onClick={(event: React.MouseEvent<HTMLElement>, value) => {
           if (oneLevelMenu) {

--- a/frontend/src/pages/FAQs/FaqsPage.tsx
+++ b/frontend/src/pages/FAQs/FaqsPage.tsx
@@ -12,7 +12,7 @@ export default function FaqsPage() {
 
       <section
         id='main-content'
-        aria-labelledby='main-content'
+        aria-labelledby='main'
         tabIndex={-1}
         className='mx-auto flex w-svw max-w-lgplus flex-col justify-center px-8 py-16'
       >

--- a/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
+++ b/frontend/src/pages/WhatIsHealthEquity/WhatIsHealthEquityPage.tsx
@@ -19,7 +19,7 @@ export default function WhatIsHealthEquityPage() {
 
       <section
         id='main-content'
-        aria-labelledby='main-content'
+        aria-labelledby='main'
         tabIndex={-1}
         className='mx-auto flex w-svw max-w-lgplus flex-col justify-center px-8 py-16'
       >
@@ -71,7 +71,7 @@ export default function WhatIsHealthEquityPage() {
         </div>
       </section>
       <section
-        aria-labelledby='learning-section'
+        aria-label='Trending Topics'
         id='learning-section'
         className='bg-white-smoke'
       >
@@ -100,7 +100,7 @@ export default function WhatIsHealthEquityPage() {
       </section>
 
       <section
-        aria-labelledby='select-faqs'
+        aria-label='Frequently Asked Questions'
         className='mx-auto flex w-svw max-w-lgplus items-center justify-center px-8 py-16 xl:px-0'
       >
         <FaqSection />

--- a/frontend/src/pages/ui/SimpleSelect.tsx
+++ b/frontend/src/pages/ui/SimpleSelect.tsx
@@ -3,6 +3,7 @@ import FormControl from '@mui/material/FormControl'
 import InputLabel from '@mui/material/InputLabel'
 import MenuItem from '@mui/material/MenuItem'
 import Select, { type SelectChangeEvent } from '@mui/material/Select'
+import { useId } from 'react'
 
 const MIN_TOP_LABEL_WIDTH = 110
 
@@ -22,13 +23,14 @@ export default function SimpleSelect<ListItemType>(
     props.setSelected(event.target.value as ListItemType)
   }
 
+  const uid = useId()
   const value = Object.values(props.optionsMap).includes(props.selected)
     ? props.selected
     : ''
 
-  const safeLabel = props.label.replace(' ', '-')
-  const labelId = `${safeLabel}-select-label`
-  const id = `${safeLabel}-select`
+  const safeLabel = props.label.replaceAll(' ', '-')
+  const labelId = `${uid}-${safeLabel}-select-label`
+  const id = `${uid}-${safeLabel}-select`
 
   return (
     <FormControl

--- a/frontend/src/styles/HetComponents/HetAccordion.tsx
+++ b/frontend/src/styles/HetComponents/HetAccordion.tsx
@@ -3,7 +3,7 @@ import Accordion from '@mui/material/Accordion'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import type React from 'react'
-import { useState } from 'react'
+import { useId, useState } from 'react'
 
 interface AccordionData {
   question: string
@@ -28,6 +28,7 @@ const HetAccordion: React.FC<HetAccordionProps> = ({
   headingLevelOverride,
 }) => {
   const [expandedIndex, setExpandedIndex] = useState<number | null>(null)
+  const uid = useId()
 
   const handleChange =
     (index: number) => (_event: React.SyntheticEvent, isExpanded: boolean) => {
@@ -49,8 +50,8 @@ const HetAccordion: React.FC<HetAccordionProps> = ({
     >
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
-        aria-controls={`panel-content-${index}`}
-        id={`panel-header-${index}`}
+        aria-controls={`${uid}-panel-content-${index}`}
+        id={`${uid}-panel-header-${index}`}
         className={`${
           expandedIndex === index
             ? 'rounded-t-md bg-hover-alt-green'


### PR DESCRIPTION
**Preview:** [FAQs page with accordion accessibility fixes](https://deploy-preview-5243--health-equity-tracker.netlify.app/faqs)

This PR eliminates duplicate element IDs and fixes broken aria-labelledby references across accordions, selects, demographic menus, and landmark sections.

## Summary

- `HetAccordion`: added `useId()` prefix to prevent duplicate `panel-header-0` IDs across multiple FAQ groups
- `SimpleSelect`: added `useId()` prefix and fixed `replaceAll(' ', '-')` for labels with multiple spaces, preventing ID collisions in compare/mobile views
- `DemographicGroupMenu`: removed `aria-hidden` from visible label; cleaned up dead `aria-labelledby` with erroneous `#` prefix
- `WhatIsHealthEquityPage` and `FaqsPage`: fixed landmark sections using `aria-labelledby` pointing to their own IDs (self-referential, invalid HTML); replaced orphaned aria-labelledby references with valid aria-label assignments

## Impact

Improves screen reader accessibility and fixes invalid HTML. Sections now have proper accessible names, accordion and select IDs are unique across the page, and no broken aria-labelledby references. Complies with WCAG 4.1.2 Name, Role, Value.

## Test plan

- [x] TypeScript type check passes
- [x] Biome lint and format pass

Closes #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)
